### PR TITLE
vanilla, remove add-context-parameter and context-client-method-parameter option

### DIFF
--- a/Generate.ps1
+++ b/Generate.ps1
@@ -70,7 +70,7 @@ if (Test-Path ./vanilla-tests/src/main) {
     "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/constants.json --namespace=fixtures.constants",
     "--version=$AUTOREST_CORE_VERSION --use=./ vanilla-tests/swagger/lro.md",
     "--version=$AUTOREST_CORE_VERSION --use=./ vanilla-tests/swagger/custom-http-exception-mapping.md"
-) | ForEach-Object -Parallel $generateScript
+) | ForEach-Object -Parallel $generateScript -UseNewRunspace
 
 if (Test-Path ./vanilla-tests/swagger/CoverageReporter.java) {
     Move-Item ./vanilla-tests/swagger/CoverageReporter.java ./vanilla-tests/src/main/java/fixtures/report/CoverageReporter.java -Force
@@ -91,7 +91,7 @@ if (Test-Path ./vanilla-tests/swagger/CoverageReporter.java) {
     "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/security-info.json --namespace=fixtures.securityinfo",
     "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/special-header.json --namespace=fixtures.specialheader",
     "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/required-fields-as-ctor-args-transformation.json --namespace=fixtures.requiredfieldsascotrargstransformation --required-fields-as-ctor-args=true --output-model-immutable"
-) | ForEach-Object -Parallel $generateScript
+) | ForEach-Object -Parallel $generateScript -UseNewRunspace
 
 # Azure
 @(
@@ -101,7 +101,7 @@ if (Test-Path ./vanilla-tests/swagger/CoverageReporter.java) {
     "$AZURE_ARGUMENTS --input-file=$SWAGGER_PATH/azure-parameter-grouping.json --namespace=fixtures.azureparametergrouping --payload-flattening-threshold=1",
     "$AZURE_ARGUMENTS --input-file=$SWAGGER_PATH/subscriptionId-apiVersion.json --namespace=fixtures.subscriptionidapiversion --payload-flattening-threshold=1",
     "$AZURE_ARGUMENTS --input-file=$SWAGGER_PATH/azure-report.json --namespace=fixtures.azurereport --payload-flattening-threshold=1"
-) | ForEach-Object -Parallel $generateScript
+) | ForEach-Object -Parallel $generateScript -UseNewRunspace
 
 #  "$ARM_ARGUMENTS --input-file=$SWAGGER_PATH/lro.json --namespace=fixtures.lro"
 #  "$ARM_ARGUMENTS --input-file=$SWAGGER_PATH/lro-parameterized-endpoints.json --namespace=fixtures.lroparameterizedendpoints"
@@ -135,7 +135,7 @@ Remove-Item ./protocol-tests/src/samples -Recurse -Force
     "$PROTOCOL_ARGUMENTS --input-file=protocol-tests/swagger/endpoint-lro.json --namespace=fixtures.endpointlro",
     "--version=$AUTOREST_CORE_VERSION --use=./ protocol-tests/swagger/dpg-customization.md",
     "--version=$AUTOREST_CORE_VERSION --use=./ protocol-tests/swagger/custom-http-exception-mapping.md"
-) | ForEach-Object -Parallel $generateScript
+) | ForEach-Object -Parallel $generateScript -UseNewRunspace
 
 New-Item ./protocol-tests/src/main/java/fixtures/headexceptions/models -ItemType Directory -Force
 Copy-Item -Path ./protocol-tests/swagger/CustomizedException.java -Destination ./protocol-tests/src/main/java/fixtures/headexceptions/models/CustomizedException.java -Force
@@ -148,7 +148,7 @@ Remove-Item ./protocol-resilience-test/llcupdate1/src/main -Recurse -Force
 @(
     "$PROTOCOL_RESILIENCE_ARGUMENTS --input-file=$SWAGGER_PATH/dpg-initial.json --namespace=fixtures.llcresi --output-folder=protocol-resilience-test/llcinitial",
     "$PROTOCOL_RESILIENCE_ARGUMENTS --input-file=$SWAGGER_PATH/dpg-update1.json --namespace=fixtures.llcresi --output-folder=protocol-resilience-test/llcupdate1"
-) | ForEach-Object -Parallel $generateScript
+) | ForEach-Object -Parallel $generateScript -UseNewRunspace
 
 Remove-Item ./protocol-resilience-test/llcinitial/src/main/java/module-info.java -Force
 Remove-Item ./protocol-resilience-test/llcupdate1/src/main/java/module-info.java -Force
@@ -165,6 +165,6 @@ Remove-Item ./partial-update-tests/generated/src/main/java/module-info.java -For
     "--use:. docs/samples/specification/azure_key_credential/readme.md",
     "--use:. docs/samples/specification/basic/readme.md",
     "--use:. docs/samples/specification/management/readme.md"
-) | ForEach-Object -Parallel $generateScript
+) | ForEach-Object -Parallel $generateScript -UseNewRunspace
 
 exit $ExitCode

--- a/Generate.ps1
+++ b/Generate.ps1
@@ -1,6 +1,6 @@
 $AUTOREST_CORE_VERSION = "3.8.4"
-$VANILLA_ARGUMENTS = "--version=$AUTOREST_CORE_VERSION --java --use=. --output-folder=vanilla-tests --sync-methods=all --client-side-validations --add-context-parameter --required-parameter-client-methods --license-header=MICROSOFT_MIT_SMALL"
-$AZURE_ARGUMENTS = "--version=$AUTOREST_CORE_VERSION --java --use=. --output-folder=azure-tests --sync-methods=all --client-side-validations --add-context-parameter --required-parameter-client-methods --license-header=MICROSOFT_MIT_SMALL"
+$VANILLA_ARGUMENTS = "--version=$AUTOREST_CORE_VERSION --java --use=. --output-folder=vanilla-tests --sync-methods=all --client-side-validations --required-parameter-client-methods --license-header=MICROSOFT_MIT_SMALL"
+$AZURE_ARGUMENTS = "--version=$AUTOREST_CORE_VERSION --java --use=. --output-folder=azure-tests --sync-methods=all --client-side-validations --required-parameter-client-methods --license-header=MICROSOFT_MIT_SMALL"
 # $ARM_ARGUMENTS = "--version=$AUTOREST_CORE_VERSION --java --use=. --output-folder=azure-tests --azure-arm --fluent=lite --regenerate-pom=false"
 $PROTOCOL_ARGUMENTS = "--version=$AUTOREST_CORE_VERSION --java --use=. --output-folder=protocol-tests --data-plane --generate-samples"
 $PROTOCOL_RESILIENCE_ARGUMENTS = "--version=$AUTOREST_CORE_VERSION --java --use=. --data-plane"
@@ -32,18 +32,18 @@ if (Test-Path ./vanilla-tests/src/main) {
 @(
     "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/additionalProperties.json --namespace=fixtures.additionalproperties",
     "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-array.json --namespace=fixtures.bodyarray",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-boolean.json --namespace=fixtures.bodyboolean --context-client-method-parameter --client-logger",
+    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-boolean.json --namespace=fixtures.bodyboolean --client-logger",
     "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-boolean.quirks.json --namespace=fixtures.bodyboolean.quirks",
     "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-complex.json --namespace=fixtures.bodycomplex --required-fields-as-ctor-args --client-logger --output-model-immutable --generate-tests",
     "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-complex.json --namespace=fixtures.streamstyleserialization --enable-sync-stack --stream-style-serialization --required-fields-as-ctor-args --client-logger --pass-discriminator-to-child-deserialization",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-file.json --namespace=fixtures.bodyfile --context-client-method-parameter",
+    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-file.json --namespace=fixtures.bodyfile",
     "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-string.json --namespace=fixtures.bodystring --generate-client-interfaces",
     "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/custom-baseUrl.json --namespace=fixtures.custombaseuri",
     "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/custom-baseUrl-more-options.json --namespace=fixtures.custombaseuri.moreoptions",
     "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/head.json --namespace=fixtures.head",
     "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/head-exceptions.json --namespace=fixtures.headexceptions",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/header.json --namespace=fixtures.header --context-client-method-parameter",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/header.json --namespace=fixtures.nonamedresponsetypes --context-client-method-parameter --generic-response-type",
+    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/header.json --namespace=fixtures.header",
+    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/header.json --namespace=fixtures.nonamedresponsetypes --generic-response-type",
     "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-dictionary.json --namespace=fixtures.bodydictionary --generate-sync-async-clients --generate-send-request-method",
     "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-duration.json --namespace=fixtures.bodyduration",
     "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-integer.json --namespace=fixtures.bodyinteger",
@@ -70,7 +70,7 @@ if (Test-Path ./vanilla-tests/src/main) {
     "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/constants.json --namespace=fixtures.constants",
     "--version=$AUTOREST_CORE_VERSION --use=./ vanilla-tests/swagger/lro.md",
     "--version=$AUTOREST_CORE_VERSION --use=./ vanilla-tests/swagger/custom-http-exception-mapping.md"
-) | ForEach-Object -Parallel $generateScript -UseNewRunspace
+) | ForEach-Object -Parallel $generateScript
 
 if (Test-Path ./vanilla-tests/swagger/CoverageReporter.java) {
     Move-Item ./vanilla-tests/swagger/CoverageReporter.java ./vanilla-tests/src/main/java/fixtures/report/CoverageReporter.java -Force
@@ -91,17 +91,17 @@ if (Test-Path ./vanilla-tests/swagger/CoverageReporter.java) {
     "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/security-info.json --namespace=fixtures.securityinfo",
     "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/special-header.json --namespace=fixtures.specialheader",
     "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/required-fields-as-ctor-args-transformation.json --namespace=fixtures.requiredfieldsascotrargstransformation --required-fields-as-ctor-args=true --output-model-immutable"
-) | ForEach-Object -Parallel $generateScript -UseNewRunspace
+) | ForEach-Object -Parallel $generateScript
 
 # Azure
 @(
-    "$AZURE_ARGUMENTS --input-file=$SWAGGER_PATH/paging.json --namespace=fixtures.paging --payload-flattening-threshold=1 --generate-sync-async-clients --context-client-method-parameter",
+    "$AZURE_ARGUMENTS --input-file=$SWAGGER_PATH/paging.json --namespace=fixtures.paging --payload-flattening-threshold=1 --generate-sync-async-clients",
     "$AZURE_ARGUMENTS --input-file=$SWAGGER_PATH/custom-baseUrl-paging.json --namespace=fixtures.custombaseuri.paging --payload-flattening-threshold=1",
-    "$AZURE_ARGUMENTS --input-file=$SWAGGER_PATH/azure-special-properties.json --namespace=fixtures.azurespecials --payload-flattening-threshold=1 --context-client-method-parameter",
+    "$AZURE_ARGUMENTS --input-file=$SWAGGER_PATH/azure-special-properties.json --namespace=fixtures.azurespecials --payload-flattening-threshold=1",
     "$AZURE_ARGUMENTS --input-file=$SWAGGER_PATH/azure-parameter-grouping.json --namespace=fixtures.azureparametergrouping --payload-flattening-threshold=1",
     "$AZURE_ARGUMENTS --input-file=$SWAGGER_PATH/subscriptionId-apiVersion.json --namespace=fixtures.subscriptionidapiversion --payload-flattening-threshold=1",
     "$AZURE_ARGUMENTS --input-file=$SWAGGER_PATH/azure-report.json --namespace=fixtures.azurereport --payload-flattening-threshold=1"
-) | ForEach-Object -Parallel $generateScript -UseNewRunspace
+) | ForEach-Object -Parallel $generateScript
 
 #  "$ARM_ARGUMENTS --input-file=$SWAGGER_PATH/lro.json --namespace=fixtures.lro"
 #  "$ARM_ARGUMENTS --input-file=$SWAGGER_PATH/lro-parameterized-endpoints.json --namespace=fixtures.lroparameterizedendpoints"
@@ -135,7 +135,7 @@ Remove-Item ./protocol-tests/src/samples -Recurse -Force
     "$PROTOCOL_ARGUMENTS --input-file=protocol-tests/swagger/endpoint-lro.json --namespace=fixtures.endpointlro",
     "--version=$AUTOREST_CORE_VERSION --use=./ protocol-tests/swagger/dpg-customization.md",
     "--version=$AUTOREST_CORE_VERSION --use=./ protocol-tests/swagger/custom-http-exception-mapping.md"
-) | ForEach-Object -Parallel $generateScript -UseNewRunspace
+) | ForEach-Object -Parallel $generateScript
 
 New-Item ./protocol-tests/src/main/java/fixtures/headexceptions/models -ItemType Directory -Force
 Copy-Item -Path ./protocol-tests/swagger/CustomizedException.java -Destination ./protocol-tests/src/main/java/fixtures/headexceptions/models/CustomizedException.java -Force
@@ -148,7 +148,7 @@ Remove-Item ./protocol-resilience-test/llcupdate1/src/main -Recurse -Force
 @(
     "$PROTOCOL_RESILIENCE_ARGUMENTS --input-file=$SWAGGER_PATH/dpg-initial.json --namespace=fixtures.llcresi --output-folder=protocol-resilience-test/llcinitial",
     "$PROTOCOL_RESILIENCE_ARGUMENTS --input-file=$SWAGGER_PATH/dpg-update1.json --namespace=fixtures.llcresi --output-folder=protocol-resilience-test/llcupdate1"
-) | ForEach-Object -Parallel $generateScript -UseNewRunspace
+) | ForEach-Object -Parallel $generateScript
 
 Remove-Item ./protocol-resilience-test/llcinitial/src/main/java/module-info.java -Force
 Remove-Item ./protocol-resilience-test/llcupdate1/src/main/java/module-info.java -Force
@@ -165,6 +165,6 @@ Remove-Item ./partial-update-tests/generated/src/main/java/module-info.java -For
     "--use:. docs/samples/specification/azure_key_credential/readme.md",
     "--use:. docs/samples/specification/basic/readme.md",
     "--use:. docs/samples/specification/management/readme.md"
-) | ForEach-Object -Parallel $generateScript -UseNewRunspace
+) | ForEach-Object -Parallel $generateScript
 
 exit $ExitCode

--- a/azure-tests/src/main/java/fixtures/azureparametergrouping/ParameterGroupings.java
+++ b/azure-tests/src/main/java/fixtures/azureparametergrouping/ParameterGroupings.java
@@ -159,6 +159,38 @@ public final class ParameterGroupings {
      * Post a bunch of required parameters grouped.
      *
      * @param parameterGroupingPostRequiredParameters Parameter group.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> postRequiredWithResponseAsync(
+            ParameterGroupingPostRequiredParameters parameterGroupingPostRequiredParameters, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (parameterGroupingPostRequiredParameters == null) {
+            return Mono.error(
+                    new IllegalArgumentException(
+                            "Parameter parameterGroupingPostRequiredParameters is required and cannot be null."));
+        } else {
+            parameterGroupingPostRequiredParameters.validate();
+        }
+        final String accept = "application/json";
+        String customHeader = parameterGroupingPostRequiredParameters.getCustomHeader();
+        Integer query = parameterGroupingPostRequiredParameters.getQuery();
+        String path = parameterGroupingPostRequiredParameters.getPath();
+        int body = parameterGroupingPostRequiredParameters.getBody();
+        return service.postRequired(this.client.getHost(), customHeader, query, path, body, accept, context);
+    }
+
+    /**
+     * Post a bunch of required parameters grouped.
+     *
+     * @param parameterGroupingPostRequiredParameters Parameter group.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -174,6 +206,24 @@ public final class ParameterGroupings {
      * Post a bunch of required parameters grouped.
      *
      * @param parameterGroupingPostRequiredParameters Parameter group.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> postRequiredAsync(
+            ParameterGroupingPostRequiredParameters parameterGroupingPostRequiredParameters, Context context) {
+        return postRequiredWithResponseAsync(parameterGroupingPostRequiredParameters, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Post a bunch of required parameters grouped.
+     *
+     * @param parameterGroupingPostRequiredParameters Parameter group.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -181,8 +231,8 @@ public final class ParameterGroupings {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> postRequiredWithResponse(
-            ParameterGroupingPostRequiredParameters parameterGroupingPostRequiredParameters) {
-        return postRequiredWithResponseAsync(parameterGroupingPostRequiredParameters).block();
+            ParameterGroupingPostRequiredParameters parameterGroupingPostRequiredParameters, Context context) {
+        return postRequiredWithResponseAsync(parameterGroupingPostRequiredParameters, context).block();
     }
 
     /**
@@ -195,7 +245,7 @@ public final class ParameterGroupings {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postRequired(ParameterGroupingPostRequiredParameters parameterGroupingPostRequiredParameters) {
-        postRequiredWithResponse(parameterGroupingPostRequiredParameters);
+        postRequiredWithResponse(parameterGroupingPostRequiredParameters, Context.NONE);
     }
 
     /**
@@ -236,6 +286,40 @@ public final class ParameterGroupings {
      * Post a bunch of optional parameters grouped.
      *
      * @param parameterGroupingPostOptionalParameters Parameter group.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> postOptionalWithResponseAsync(
+            ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (parameterGroupingPostOptionalParameters != null) {
+            parameterGroupingPostOptionalParameters.validate();
+        }
+        final String accept = "application/json";
+        String customHeaderInternal = null;
+        if (parameterGroupingPostOptionalParameters != null) {
+            customHeaderInternal = parameterGroupingPostOptionalParameters.getCustomHeader();
+        }
+        String customHeader = customHeaderInternal;
+        Integer queryInternal = null;
+        if (parameterGroupingPostOptionalParameters != null) {
+            queryInternal = parameterGroupingPostOptionalParameters.getQuery();
+        }
+        Integer query = queryInternal;
+        return service.postOptional(this.client.getHost(), customHeader, query, accept, context);
+    }
+
+    /**
+     * Post a bunch of optional parameters grouped.
+     *
+     * @param parameterGroupingPostOptionalParameters Parameter group.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -264,6 +348,24 @@ public final class ParameterGroupings {
      * Post a bunch of optional parameters grouped.
      *
      * @param parameterGroupingPostOptionalParameters Parameter group.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> postOptionalAsync(
+            ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters, Context context) {
+        return postOptionalWithResponseAsync(parameterGroupingPostOptionalParameters, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Post a bunch of optional parameters grouped.
+     *
+     * @param parameterGroupingPostOptionalParameters Parameter group.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -271,8 +373,8 @@ public final class ParameterGroupings {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> postOptionalWithResponse(
-            ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters) {
-        return postOptionalWithResponseAsync(parameterGroupingPostOptionalParameters).block();
+            ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters, Context context) {
+        return postOptionalWithResponseAsync(parameterGroupingPostOptionalParameters, context).block();
     }
 
     /**
@@ -285,7 +387,7 @@ public final class ParameterGroupings {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptional(ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters) {
-        postOptionalWithResponse(parameterGroupingPostOptionalParameters);
+        postOptionalWithResponse(parameterGroupingPostOptionalParameters, Context.NONE);
     }
 
     /**
@@ -297,7 +399,7 @@ public final class ParameterGroupings {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptional() {
         final ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters = null;
-        postOptionalWithResponse(parameterGroupingPostOptionalParameters);
+        postOptionalWithResponse(parameterGroupingPostOptionalParameters, Context.NONE);
     }
 
     /**
@@ -338,6 +440,41 @@ public final class ParameterGroupings {
      * Post a grouped parameters with reserved words.
      *
      * @param parameterGroupingPostReservedWordsParameters Parameter group.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> postReservedWordsWithResponseAsync(
+            ParameterGroupingPostReservedWordsParameters parameterGroupingPostReservedWordsParameters,
+            Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (parameterGroupingPostReservedWordsParameters != null) {
+            parameterGroupingPostReservedWordsParameters.validate();
+        }
+        final String acceptParam = "application/json";
+        String fromInternal = null;
+        if (parameterGroupingPostReservedWordsParameters != null) {
+            fromInternal = parameterGroupingPostReservedWordsParameters.getFrom();
+        }
+        String from = fromInternal;
+        String acceptInternal = null;
+        if (parameterGroupingPostReservedWordsParameters != null) {
+            acceptInternal = parameterGroupingPostReservedWordsParameters.getAccept();
+        }
+        String accept = acceptInternal;
+        return service.postReservedWords(this.client.getHost(), from, accept, acceptParam, context);
+    }
+
+    /**
+     * Post a grouped parameters with reserved words.
+     *
+     * @param parameterGroupingPostReservedWordsParameters Parameter group.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -368,6 +505,25 @@ public final class ParameterGroupings {
      * Post a grouped parameters with reserved words.
      *
      * @param parameterGroupingPostReservedWordsParameters Parameter group.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> postReservedWordsAsync(
+            ParameterGroupingPostReservedWordsParameters parameterGroupingPostReservedWordsParameters,
+            Context context) {
+        return postReservedWordsWithResponseAsync(parameterGroupingPostReservedWordsParameters, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Post a grouped parameters with reserved words.
+     *
+     * @param parameterGroupingPostReservedWordsParameters Parameter group.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -375,8 +531,9 @@ public final class ParameterGroupings {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> postReservedWordsWithResponse(
-            ParameterGroupingPostReservedWordsParameters parameterGroupingPostReservedWordsParameters) {
-        return postReservedWordsWithResponseAsync(parameterGroupingPostReservedWordsParameters).block();
+            ParameterGroupingPostReservedWordsParameters parameterGroupingPostReservedWordsParameters,
+            Context context) {
+        return postReservedWordsWithResponseAsync(parameterGroupingPostReservedWordsParameters, context).block();
     }
 
     /**
@@ -390,7 +547,7 @@ public final class ParameterGroupings {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postReservedWords(
             ParameterGroupingPostReservedWordsParameters parameterGroupingPostReservedWordsParameters) {
-        postReservedWordsWithResponse(parameterGroupingPostReservedWordsParameters);
+        postReservedWordsWithResponse(parameterGroupingPostReservedWordsParameters, Context.NONE);
     }
 
     /**
@@ -402,7 +559,7 @@ public final class ParameterGroupings {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postReservedWords() {
         final ParameterGroupingPostReservedWordsParameters parameterGroupingPostReservedWordsParameters = null;
-        postReservedWordsWithResponse(parameterGroupingPostReservedWordsParameters);
+        postReservedWordsWithResponse(parameterGroupingPostReservedWordsParameters, Context.NONE);
     }
 
     /**
@@ -462,6 +619,57 @@ public final class ParameterGroupings {
      *
      * @param firstParameterGroup Parameter group.
      * @param parameterGroupingPostMultiParamGroupsSecondParamGroup Parameter group.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> postMultiParamGroupsWithResponseAsync(
+            FirstParameterGroup firstParameterGroup,
+            ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup,
+            Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (firstParameterGroup != null) {
+            firstParameterGroup.validate();
+        }
+        if (parameterGroupingPostMultiParamGroupsSecondParamGroup != null) {
+            parameterGroupingPostMultiParamGroupsSecondParamGroup.validate();
+        }
+        final String accept = "application/json";
+        String headerOneInternal = null;
+        if (firstParameterGroup != null) {
+            headerOneInternal = firstParameterGroup.getHeaderOne();
+        }
+        String headerOne = headerOneInternal;
+        Integer queryOneInternal = null;
+        if (firstParameterGroup != null) {
+            queryOneInternal = firstParameterGroup.getQueryOne();
+        }
+        Integer queryOne = queryOneInternal;
+        String headerTwoInternal = null;
+        if (parameterGroupingPostMultiParamGroupsSecondParamGroup != null) {
+            headerTwoInternal = parameterGroupingPostMultiParamGroupsSecondParamGroup.getHeaderTwo();
+        }
+        String headerTwo = headerTwoInternal;
+        Integer queryTwoInternal = null;
+        if (parameterGroupingPostMultiParamGroupsSecondParamGroup != null) {
+            queryTwoInternal = parameterGroupingPostMultiParamGroupsSecondParamGroup.getQueryTwo();
+        }
+        Integer queryTwo = queryTwoInternal;
+        return service.postMultiParamGroups(
+                this.client.getHost(), headerOne, queryOne, headerTwo, queryTwo, accept, context);
+    }
+
+    /**
+     * Post parameters from multiple different parameter groups.
+     *
+     * @param firstParameterGroup Parameter group.
+     * @param parameterGroupingPostMultiParamGroupsSecondParamGroup Parameter group.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -499,6 +707,28 @@ public final class ParameterGroupings {
      *
      * @param firstParameterGroup Parameter group.
      * @param parameterGroupingPostMultiParamGroupsSecondParamGroup Parameter group.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> postMultiParamGroupsAsync(
+            FirstParameterGroup firstParameterGroup,
+            ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup,
+            Context context) {
+        return postMultiParamGroupsWithResponseAsync(
+                        firstParameterGroup, parameterGroupingPostMultiParamGroupsSecondParamGroup, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Post parameters from multiple different parameter groups.
+     *
+     * @param firstParameterGroup Parameter group.
+     * @param parameterGroupingPostMultiParamGroupsSecondParamGroup Parameter group.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -507,10 +737,10 @@ public final class ParameterGroupings {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> postMultiParamGroupsWithResponse(
             FirstParameterGroup firstParameterGroup,
-            ParameterGroupingPostMultiParamGroupsSecondParamGroup
-                    parameterGroupingPostMultiParamGroupsSecondParamGroup) {
+            ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup,
+            Context context) {
         return postMultiParamGroupsWithResponseAsync(
-                        firstParameterGroup, parameterGroupingPostMultiParamGroupsSecondParamGroup)
+                        firstParameterGroup, parameterGroupingPostMultiParamGroupsSecondParamGroup, context)
                 .block();
     }
 
@@ -528,7 +758,8 @@ public final class ParameterGroupings {
             FirstParameterGroup firstParameterGroup,
             ParameterGroupingPostMultiParamGroupsSecondParamGroup
                     parameterGroupingPostMultiParamGroupsSecondParamGroup) {
-        postMultiParamGroupsWithResponse(firstParameterGroup, parameterGroupingPostMultiParamGroupsSecondParamGroup);
+        postMultiParamGroupsWithResponse(
+                firstParameterGroup, parameterGroupingPostMultiParamGroupsSecondParamGroup, Context.NONE);
     }
 
     /**
@@ -542,7 +773,8 @@ public final class ParameterGroupings {
         final FirstParameterGroup firstParameterGroup = null;
         final ParameterGroupingPostMultiParamGroupsSecondParamGroup
                 parameterGroupingPostMultiParamGroupsSecondParamGroup = null;
-        postMultiParamGroupsWithResponse(firstParameterGroup, parameterGroupingPostMultiParamGroupsSecondParamGroup);
+        postMultiParamGroupsWithResponse(
+                firstParameterGroup, parameterGroupingPostMultiParamGroupsSecondParamGroup, Context.NONE);
     }
 
     /**
@@ -585,6 +817,40 @@ public final class ParameterGroupings {
      * Post parameters with a shared parameter group object.
      *
      * @param firstParameterGroup Parameter group.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> postSharedParameterGroupObjectWithResponseAsync(
+            FirstParameterGroup firstParameterGroup, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (firstParameterGroup != null) {
+            firstParameterGroup.validate();
+        }
+        final String accept = "application/json";
+        String headerOneInternal = null;
+        if (firstParameterGroup != null) {
+            headerOneInternal = firstParameterGroup.getHeaderOne();
+        }
+        String headerOne = headerOneInternal;
+        Integer queryOneInternal = null;
+        if (firstParameterGroup != null) {
+            queryOneInternal = firstParameterGroup.getQueryOne();
+        }
+        Integer queryOne = queryOneInternal;
+        return service.postSharedParameterGroupObject(this.client.getHost(), headerOne, queryOne, accept, context);
+    }
+
+    /**
+     * Post parameters with a shared parameter group object.
+     *
+     * @param firstParameterGroup Parameter group.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -612,14 +878,32 @@ public final class ParameterGroupings {
      * Post parameters with a shared parameter group object.
      *
      * @param firstParameterGroup Parameter group.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> postSharedParameterGroupObjectAsync(FirstParameterGroup firstParameterGroup, Context context) {
+        return postSharedParameterGroupObjectWithResponseAsync(firstParameterGroup, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Post parameters with a shared parameter group object.
+     *
+     * @param firstParameterGroup Parameter group.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> postSharedParameterGroupObjectWithResponse(FirstParameterGroup firstParameterGroup) {
-        return postSharedParameterGroupObjectWithResponseAsync(firstParameterGroup).block();
+    public Response<Void> postSharedParameterGroupObjectWithResponse(
+            FirstParameterGroup firstParameterGroup, Context context) {
+        return postSharedParameterGroupObjectWithResponseAsync(firstParameterGroup, context).block();
     }
 
     /**
@@ -632,7 +916,7 @@ public final class ParameterGroupings {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postSharedParameterGroupObject(FirstParameterGroup firstParameterGroup) {
-        postSharedParameterGroupObjectWithResponse(firstParameterGroup);
+        postSharedParameterGroupObjectWithResponse(firstParameterGroup, Context.NONE);
     }
 
     /**
@@ -644,7 +928,7 @@ public final class ParameterGroupings {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postSharedParameterGroupObject() {
         final FirstParameterGroup firstParameterGroup = null;
-        postSharedParameterGroupObjectWithResponse(firstParameterGroup);
+        postSharedParameterGroupObjectWithResponse(firstParameterGroup, Context.NONE);
     }
 
     /**
@@ -682,6 +966,35 @@ public final class ParameterGroupings {
      * Parameter group with a constant. Pass in 'foo' for groupedConstant and 'bar' for groupedParameter.
      *
      * @param grouper Parameter group.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> groupWithConstantWithResponseAsync(Grouper grouper, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (grouper != null) {
+            grouper.validate();
+        }
+        final String groupedConstant = "foo";
+        final String accept = "application/json";
+        String groupedParameterInternal = null;
+        if (grouper != null) {
+            groupedParameterInternal = grouper.getGroupedParameter();
+        }
+        String groupedParameter = groupedParameterInternal;
+        return service.groupWithConstant(this.client.getHost(), groupedConstant, groupedParameter, accept, context);
+    }
+
+    /**
+     * Parameter group with a constant. Pass in 'foo' for groupedConstant and 'bar' for groupedParameter.
+     *
+     * @param grouper Parameter group.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -709,14 +1022,30 @@ public final class ParameterGroupings {
      * Parameter group with a constant. Pass in 'foo' for groupedConstant and 'bar' for groupedParameter.
      *
      * @param grouper Parameter group.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> groupWithConstantAsync(Grouper grouper, Context context) {
+        return groupWithConstantWithResponseAsync(grouper, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Parameter group with a constant. Pass in 'foo' for groupedConstant and 'bar' for groupedParameter.
+     *
+     * @param grouper Parameter group.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> groupWithConstantWithResponse(Grouper grouper) {
-        return groupWithConstantWithResponseAsync(grouper).block();
+    public Response<Void> groupWithConstantWithResponse(Grouper grouper, Context context) {
+        return groupWithConstantWithResponseAsync(grouper, context).block();
     }
 
     /**
@@ -729,7 +1058,7 @@ public final class ParameterGroupings {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void groupWithConstant(Grouper grouper) {
-        groupWithConstantWithResponse(grouper);
+        groupWithConstantWithResponse(grouper, Context.NONE);
     }
 
     /**
@@ -741,6 +1070,6 @@ public final class ParameterGroupings {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void groupWithConstant() {
         final Grouper grouper = null;
-        groupWithConstantWithResponse(grouper);
+        groupWithConstantWithResponse(grouper, Context.NONE);
     }
 }

--- a/azure-tests/src/main/java/fixtures/azurereport/AutoRestReportServiceForAzure.java
+++ b/azure-tests/src/main/java/fixtures/azurereport/AutoRestReportServiceForAzure.java
@@ -151,6 +151,26 @@ public final class AutoRestReportServiceForAzure {
      *
      * @param qualifier If specified, qualifies the generated report further (e.g. '2.7' vs '3.5' in for Python). The
      *     only effect is, that generators that run all tests several times, can distinguish the generated reports.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return test coverage report along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Integer>>> getReportWithResponseAsync(String qualifier, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getReport(this.getHost(), qualifier, accept, context);
+    }
+
+    /**
+     * Get test coverage report.
+     *
+     * @param qualifier If specified, qualifies the generated report further (e.g. '2.7' vs '3.5' in for Python). The
+     *     only effect is, that generators that run all tests several times, can distinguish the generated reports.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -179,14 +199,31 @@ public final class AutoRestReportServiceForAzure {
      *
      * @param qualifier If specified, qualifies the generated report further (e.g. '2.7' vs '3.5' in for Python). The
      *     only effect is, that generators that run all tests several times, can distinguish the generated reports.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return test coverage report on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Integer>> getReportAsync(String qualifier, Context context) {
+        return getReportWithResponseAsync(qualifier, context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get test coverage report.
+     *
+     * @param qualifier If specified, qualifies the generated report further (e.g. '2.7' vs '3.5' in for Python). The
+     *     only effect is, that generators that run all tests several times, can distinguish the generated reports.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return test coverage report along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Integer>> getReportWithResponse(String qualifier) {
-        return getReportWithResponseAsync(qualifier).block();
+    public Response<Map<String, Integer>> getReportWithResponse(String qualifier, Context context) {
+        return getReportWithResponseAsync(qualifier, context).block();
     }
 
     /**
@@ -201,7 +238,7 @@ public final class AutoRestReportServiceForAzure {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Integer> getReport(String qualifier) {
-        return getReportWithResponse(qualifier).getValue();
+        return getReportWithResponse(qualifier, Context.NONE).getValue();
     }
 
     /**
@@ -214,6 +251,6 @@ public final class AutoRestReportServiceForAzure {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Integer> getReport() {
         final String qualifier = null;
-        return getReportWithResponse(qualifier).getValue();
+        return getReportWithResponse(qualifier, Context.NONE).getValue();
     }
 }

--- a/azure-tests/src/main/java/fixtures/custombaseuri/paging/Pagings.java
+++ b/azure-tests/src/main/java/fixtures/custombaseuri/paging/Pagings.java
@@ -127,6 +127,38 @@ public final class Pagings {
      * A paging operation that combines custom url, paging and partial URL and expect to concat after host.
      *
      * @param accountName Account Name.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<PagedResponse<Product>> getPagesPartialUrlSinglePageAsync(String accountName, Context context) {
+        if (accountName == null) {
+            return Mono.error(new IllegalArgumentException("Parameter accountName is required and cannot be null."));
+        }
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getPagesPartialUrl(accountName, this.client.getHost(), accept, context)
+                .map(
+                        res ->
+                                new PagedResponseBase<>(
+                                        res.getRequest(),
+                                        res.getStatusCode(),
+                                        res.getHeaders(),
+                                        res.getValue().getValues(),
+                                        res.getValue().getNextLink(),
+                                        null));
+    }
+
+    /**
+     * A paging operation that combines custom url, paging and partial URL and expect to concat after host.
+     *
+     * @param accountName Account Name.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -137,6 +169,23 @@ public final class Pagings {
         return new PagedFlux<>(
                 () -> getPagesPartialUrlSinglePageAsync(accountName),
                 nextLink -> getPagesPartialUrlNextSinglePageAsync(nextLink, accountName));
+    }
+
+    /**
+     * A paging operation that combines custom url, paging and partial URL and expect to concat after host.
+     *
+     * @param accountName Account Name.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getPagesPartialUrlAsync(String accountName, Context context) {
+        return new PagedFlux<>(
+                () -> getPagesPartialUrlSinglePageAsync(accountName, context),
+                nextLink -> getPagesPartialUrlNextSinglePageAsync(nextLink, accountName, context));
     }
 
     /**
@@ -157,6 +206,21 @@ public final class Pagings {
      * A paging operation that combines custom url, paging and partial URL and expect to concat after host.
      *
      * @param accountName Account Name.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link PagedResponse}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public PagedResponse<Product> getPagesPartialUrlSinglePage(String accountName, Context context) {
+        return getPagesPartialUrlSinglePageAsync(accountName, context).block();
+    }
+
+    /**
+     * A paging operation that combines custom url, paging and partial URL and expect to concat after host.
+     *
+     * @param accountName Account Name.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -165,6 +229,21 @@ public final class Pagings {
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedIterable<Product> getPagesPartialUrl(String accountName) {
         return new PagedIterable<>(getPagesPartialUrlAsync(accountName));
+    }
+
+    /**
+     * A paging operation that combines custom url, paging and partial URL and expect to concat after host.
+     *
+     * @param accountName Account Name.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getPagesPartialUrl(String accountName, Context context) {
+        return new PagedIterable<>(getPagesPartialUrlAsync(accountName, context));
     }
 
     /**
@@ -205,6 +284,39 @@ public final class Pagings {
      * A paging operation that combines custom url, paging and partial URL with next operation.
      *
      * @param accountName Account Name.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<PagedResponse<Product>> getPagesPartialUrlOperationSinglePageAsync(
+            String accountName, Context context) {
+        if (accountName == null) {
+            return Mono.error(new IllegalArgumentException("Parameter accountName is required and cannot be null."));
+        }
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getPagesPartialUrlOperation(accountName, this.client.getHost(), accept, context)
+                .map(
+                        res ->
+                                new PagedResponseBase<>(
+                                        res.getRequest(),
+                                        res.getStatusCode(),
+                                        res.getHeaders(),
+                                        res.getValue().getValues(),
+                                        res.getValue().getNextLink(),
+                                        null));
+    }
+
+    /**
+     * A paging operation that combines custom url, paging and partial URL with next operation.
+     *
+     * @param accountName Account Name.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -215,6 +327,23 @@ public final class Pagings {
         return new PagedFlux<>(
                 () -> getPagesPartialUrlOperationSinglePageAsync(accountName),
                 nextLink -> getPagesPartialUrlOperationNextSinglePageAsync(accountName, nextLink));
+    }
+
+    /**
+     * A paging operation that combines custom url, paging and partial URL with next operation.
+     *
+     * @param accountName Account Name.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getPagesPartialUrlOperationAsync(String accountName, Context context) {
+        return new PagedFlux<>(
+                () -> getPagesPartialUrlOperationSinglePageAsync(accountName, context),
+                nextLink -> getPagesPartialUrlOperationNextSinglePageAsync(accountName, nextLink, context));
     }
 
     /**
@@ -235,6 +364,21 @@ public final class Pagings {
      * A paging operation that combines custom url, paging and partial URL with next operation.
      *
      * @param accountName Account Name.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link PagedResponse}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public PagedResponse<Product> getPagesPartialUrlOperationSinglePage(String accountName, Context context) {
+        return getPagesPartialUrlOperationSinglePageAsync(accountName, context).block();
+    }
+
+    /**
+     * A paging operation that combines custom url, paging and partial URL with next operation.
+     *
+     * @param accountName Account Name.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -243,6 +387,21 @@ public final class Pagings {
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedIterable<Product> getPagesPartialUrlOperation(String accountName) {
         return new PagedIterable<>(getPagesPartialUrlOperationAsync(accountName));
+    }
+
+    /**
+     * A paging operation that combines custom url, paging and partial URL with next operation.
+     *
+     * @param accountName Account Name.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getPagesPartialUrlOperation(String accountName, Context context) {
+        return new PagedIterable<>(getPagesPartialUrlOperationAsync(accountName, context));
     }
 
     /**
@@ -289,6 +448,43 @@ public final class Pagings {
      *
      * @param accountName Account Name.
      * @param nextLink Next link for the list operation.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<PagedResponse<Product>> getPagesPartialUrlOperationNextSinglePageAsync(
+            String accountName, String nextLink, Context context) {
+        if (accountName == null) {
+            return Mono.error(new IllegalArgumentException("Parameter accountName is required and cannot be null."));
+        }
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (nextLink == null) {
+            return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getPagesPartialUrlOperationNext(accountName, this.client.getHost(), nextLink, accept, context)
+                .map(
+                        res ->
+                                new PagedResponseBase<>(
+                                        res.getRequest(),
+                                        res.getStatusCode(),
+                                        res.getHeaders(),
+                                        res.getValue().getValues(),
+                                        res.getValue().getNextLink(),
+                                        null));
+    }
+
+    /**
+     * A paging operation that combines custom url, paging and partial URL.
+     *
+     * @param accountName Account Name.
+     * @param nextLink Next link for the list operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -297,6 +493,23 @@ public final class Pagings {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getPagesPartialUrlOperationNextSinglePage(String accountName, String nextLink) {
         return getPagesPartialUrlOperationNextSinglePageAsync(accountName, nextLink).block();
+    }
+
+    /**
+     * A paging operation that combines custom url, paging and partial URL.
+     *
+     * @param accountName Account Name.
+     * @param nextLink Next link for the list operation.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link PagedResponse}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public PagedResponse<Product> getPagesPartialUrlOperationNextSinglePage(
+            String accountName, String nextLink, Context context) {
+        return getPagesPartialUrlOperationNextSinglePageAsync(accountName, nextLink, context).block();
     }
 
     /**
@@ -344,6 +557,44 @@ public final class Pagings {
      * @param nextLink The URL to get the next list of items
      *     <p>The nextLink parameter.
      * @param accountName Account Name.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<PagedResponse<Product>> getPagesPartialUrlNextSinglePageAsync(
+            String nextLink, String accountName, Context context) {
+        if (nextLink == null) {
+            return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
+        }
+        if (accountName == null) {
+            return Mono.error(new IllegalArgumentException("Parameter accountName is required and cannot be null."));
+        }
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getPagesPartialUrlNext(nextLink, accountName, this.client.getHost(), accept, context)
+                .map(
+                        res ->
+                                new PagedResponseBase<>(
+                                        res.getRequest(),
+                                        res.getStatusCode(),
+                                        res.getHeaders(),
+                                        res.getValue().getValues(),
+                                        res.getValue().getNextLink(),
+                                        null));
+    }
+
+    /**
+     * Get the next page of items.
+     *
+     * @param nextLink The URL to get the next list of items
+     *     <p>The nextLink parameter.
+     * @param accountName Account Name.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -352,5 +603,23 @@ public final class Pagings {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getPagesPartialUrlNextSinglePage(String nextLink, String accountName) {
         return getPagesPartialUrlNextSinglePageAsync(nextLink, accountName).block();
+    }
+
+    /**
+     * Get the next page of items.
+     *
+     * @param nextLink The URL to get the next list of items
+     *     <p>The nextLink parameter.
+     * @param accountName Account Name.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link PagedResponse}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public PagedResponse<Product> getPagesPartialUrlNextSinglePage(
+            String nextLink, String accountName, Context context) {
+        return getPagesPartialUrlNextSinglePageAsync(nextLink, accountName, context).block();
     }
 }

--- a/azure-tests/src/main/java/fixtures/subscriptionidapiversion/Groups.java
+++ b/azure-tests/src/main/java/fixtures/subscriptionidapiversion/Groups.java
@@ -100,6 +100,42 @@ public final class Groups {
      * Provides a resouce group with name 'testgroup101' and location 'West US'.
      *
      * @param resourceGroupName Resource Group name 'testgroup101'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<SampleResourceGroup>> getSampleResourceGroupWithResponseAsync(
+            String resourceGroupName, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (this.client.getSubscriptionId() == null) {
+            return Mono.error(
+                    new IllegalArgumentException(
+                            "Parameter this.client.getSubscriptionId() is required and cannot be null."));
+        }
+        if (resourceGroupName == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter resourceGroupName is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getSampleResourceGroup(
+                this.client.getHost(),
+                this.client.getSubscriptionId(),
+                resourceGroupName,
+                this.client.getApiVersion(),
+                accept,
+                context);
+    }
+
+    /**
+     * Provides a resouce group with name 'testgroup101' and location 'West US'.
+     *
+     * @param resourceGroupName Resource Group name 'testgroup101'.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -115,14 +151,31 @@ public final class Groups {
      * Provides a resouce group with name 'testgroup101' and location 'West US'.
      *
      * @param resourceGroupName Resource Group name 'testgroup101'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<SampleResourceGroup> getSampleResourceGroupAsync(String resourceGroupName, Context context) {
+        return getSampleResourceGroupWithResponseAsync(resourceGroupName, context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Provides a resouce group with name 'testgroup101' and location 'West US'.
+     *
+     * @param resourceGroupName Resource Group name 'testgroup101'.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<SampleResourceGroup> getSampleResourceGroupWithResponse(String resourceGroupName) {
-        return getSampleResourceGroupWithResponseAsync(resourceGroupName).block();
+    public Response<SampleResourceGroup> getSampleResourceGroupWithResponse(String resourceGroupName, Context context) {
+        return getSampleResourceGroupWithResponseAsync(resourceGroupName, context).block();
     }
 
     /**
@@ -136,6 +189,6 @@ public final class Groups {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public SampleResourceGroup getSampleResourceGroup(String resourceGroupName) {
-        return getSampleResourceGroupWithResponse(resourceGroupName).getValue();
+        return getSampleResourceGroupWithResponse(resourceGroupName, Context.NONE).getValue();
     }
 }

--- a/cadl-extension/src/emitter.ts
+++ b/cadl-extension/src/emitter.ts
@@ -15,9 +15,9 @@ import { fileURLToPath } from "url";
 
 export interface EmitterOptions {
   namespace?: string;
-  serviceName?: string;
-  partialUpdate?: boolean;
-  outputDir?: string;
+  "service-name"?: string;
+  "partial-update"?: boolean;
+  "output-dir"?: string;
 }
 
 const EmitterOptionsSchema: JSONSchemaType<EmitterOptions> = {
@@ -25,9 +25,9 @@ const EmitterOptionsSchema: JSONSchemaType<EmitterOptions> = {
   additionalProperties: true,
   properties: {
     namespace: { type: "string", nullable: true },
-    serviceName: { type: "string", nullable: true },
-    partialUpdate: { type: "boolean", nullable: true },
-    outputDir: { type: "string", nullable: true },
+    "service-name": { type: "string", nullable: true },
+    "partial-update": { type: "boolean", nullable: true },
+    "output-dir": { type: "string", nullable: true },
   },
   required: [],
 };
@@ -49,8 +49,8 @@ export async function $onEmit(program: Program, options: EmitterOptions) {
     const moduleRoot = resolvePath(__dirname, "..", "..");
 
     const outputPath =
-      options.outputDir ?? program.compilerOptions.outputDir ?? getNormalizedAbsolutePath("./cadl-output", undefined);
-    options.outputDir = getNormalizedAbsolutePath(outputPath, undefined);
+      options["output-dir"] ?? program.compilerOptions.outputDir ?? getNormalizedAbsolutePath("./cadl-output", undefined);
+    options["output-dir"] = getNormalizedAbsolutePath(outputPath, undefined);
 
     const codeModelFileName = resolvePath(outputPath, "./code-model.yaml");
 

--- a/cadl-extension/src/emitter.ts
+++ b/cadl-extension/src/emitter.ts
@@ -17,7 +17,7 @@ export interface EmitterOptions {
   namespace?: string;
   serviceName?: string;
   partialUpdate?: boolean;
-  outputPath?: string;
+  outputDir?: string;
 }
 
 const EmitterOptionsSchema: JSONSchemaType<EmitterOptions> = {
@@ -27,7 +27,7 @@ const EmitterOptionsSchema: JSONSchemaType<EmitterOptions> = {
     namespace: { type: "string", nullable: true },
     serviceName: { type: "string", nullable: true },
     partialUpdate: { type: "boolean", nullable: true },
-    outputPath: { type: "string", nullable: true },
+    outputDir: { type: "string", nullable: true },
   },
   required: [],
 };
@@ -49,8 +49,8 @@ export async function $onEmit(program: Program, options: EmitterOptions) {
     const moduleRoot = resolvePath(__dirname, "..", "..");
 
     const outputPath =
-      options.outputPath ?? program.compilerOptions.outputPath ?? getNormalizedAbsolutePath("./cadl-output", undefined);
-    options.outputPath = getNormalizedAbsolutePath(outputPath, undefined);
+      options.outputDir ?? program.compilerOptions.outputDir ?? getNormalizedAbsolutePath("./cadl-output", undefined);
+    options.outputDir = getNormalizedAbsolutePath(outputPath, undefined);
 
     const codeModelFileName = resolvePath(outputPath, "./code-model.yaml");
 

--- a/cadl-extension/src/emitter.ts
+++ b/cadl-extension/src/emitter.ts
@@ -14,7 +14,7 @@ import { dirname } from "path";
 import { fileURLToPath } from "url";
 
 export interface EmitterOptions {
-  namespace?: string;
+  "namespace"?: string;
   "service-name"?: string;
   "partial-update"?: boolean;
   "output-dir"?: string;
@@ -24,7 +24,7 @@ const EmitterOptionsSchema: JSONSchemaType<EmitterOptions> = {
   type: "object",
   additionalProperties: true,
   properties: {
-    namespace: { type: "string", nullable: true },
+    "namespace": { type: "string", nullable: true },
     "service-name": { type: "string", nullable: true },
     "partial-update": { type: "boolean", nullable: true },
     "output-dir": { type: "string", nullable: true },
@@ -49,7 +49,9 @@ export async function $onEmit(program: Program, options: EmitterOptions) {
     const moduleRoot = resolvePath(__dirname, "..", "..");
 
     const outputPath =
-      options["output-dir"] ?? program.compilerOptions.outputDir ?? getNormalizedAbsolutePath("./cadl-output", undefined);
+      options["output-dir"] ??
+      program.compilerOptions.outputDir ??
+      getNormalizedAbsolutePath("./cadl-output", undefined);
     options["output-dir"] = getNormalizedAbsolutePath(outputPath, undefined);
 
     const codeModelFileName = resolvePath(outputPath, "./code-model.yaml");

--- a/cadl-extension/src/main/java/com/azure/autorest/CadlPlugin.java
+++ b/cadl-extension/src/main/java/com/azure/autorest/CadlPlugin.java
@@ -103,8 +103,6 @@ public class CadlPlugin extends Javagen {
         SETTINGS_MAP.put("generate-client-as-impl", true);
         SETTINGS_MAP.put("generate-sync-async-clients", true);
         SETTINGS_MAP.put("generate-builder-per-client", true);
-        SETTINGS_MAP.put("add-context-parameter", true);
-        SETTINGS_MAP.put("context-client-method-parameter", true);
         SETTINGS_MAP.put("sync-methods", "all");
 
         SETTINGS_MAP.put("use-default-http-status-code-to-exception-type-mapping", true);

--- a/cadl-extension/src/main/java/com/azure/autorest/CadlPlugin.java
+++ b/cadl-extension/src/main/java/com/azure/autorest/CadlPlugin.java
@@ -60,7 +60,7 @@ public class CadlPlugin extends Javagen {
 
     @Override
     public void writeFile(String fileName, String content, List<Object> sourceMap) {
-        File outputFile = Paths.get(emitterOptions.getOutputPath(), fileName).toAbsolutePath().toFile();
+        File outputFile = Paths.get(emitterOptions.getOutputDir(), fileName).toAbsolutePath().toFile();
         File parentFile = outputFile.getParentFile();
         if (!parentFile.exists()) {
             parentFile.mkdirs();
@@ -76,7 +76,7 @@ public class CadlPlugin extends Javagen {
     public String handlePartialUpdate(String filePath, String generatedContent) {
         if (filePath.endsWith(".java")) { // only handle for .java file
             // check if existingFile exists, if not, no need to handle partial update
-            Path absoluteFilePath = Paths.get(emitterOptions.getOutputPath(), filePath);
+            Path absoluteFilePath = Paths.get(emitterOptions.getOutputDir(), filePath);
             if (Files.exists(absoluteFilePath)) {
                 try {
                     String existingFileContent = new String(Files.readAllBytes(absoluteFilePath));
@@ -132,8 +132,8 @@ public class CadlPlugin extends Javagen {
         super(new MockConnection(), "dummy", "dummy");
         this.emitterOptions = options;
         SETTINGS_MAP.put("namespace", options.getNamespace());
-        if (!CoreUtils.isNullOrEmpty(options.getOutputPath())) {
-            SETTINGS_MAP.put("output-folder", options.getOutputPath());
+        if (!CoreUtils.isNullOrEmpty(options.getOutputDir())) {
+            SETTINGS_MAP.put("output-folder", options.getOutputDir());
         }
         if (!CoreUtils.isNullOrEmpty(options.getServiceName())) {
             SETTINGS_MAP.put("service-name", options.getServiceName());
@@ -143,7 +143,7 @@ public class CadlPlugin extends Javagen {
         }
 
         JavaSettingsAccessor.setHost(this);
-        LOGGER.info("Output folder: {}", options.getOutputPath());
+        LOGGER.info("Output folder: {}", options.getOutputDir());
         LOGGER.info("Namespace: {}", JavaSettings.getInstance().getPackage());
 
         Mappers.setFactory(new CadlMapperFactory());

--- a/cadl-extension/src/main/java/com/azure/cadl/Main.java
+++ b/cadl-extension/src/main/java/com/azure/cadl/Main.java
@@ -99,7 +99,7 @@ public class Main {
             try {
                 formattedSource = formatter.formatSourceAndFixImports(fileContent);
             } catch (Exception e) {
-                LOGGER.error("Failed to format file: {}", emitterOptions.getOutputPath() + filePath, e);
+                LOGGER.error("Failed to format file: {}", emitterOptions.getOutputDir() + filePath, e);
                 // but we continue so user can still check the file and see why format fails
             }
             formattedFiles.put(filePath, formattedSource);
@@ -137,10 +137,10 @@ public class Main {
                 }
 
                 // output path
-                if (CoreUtils.isNullOrEmpty(options.getOutputPath())) {
-                    options.setOutputPath("cadl-tests/cadl-output/");
-                } else if (!options.getOutputPath().endsWith("/")) {
-                    options.setOutputPath(options.getOutputPath() + "/");
+                if (CoreUtils.isNullOrEmpty(options.getOutputDir())) {
+                    options.setOutputDir("cadl-tests/cadl-output/");
+                } else if (!options.getOutputDir().endsWith("/")) {
+                    options.setOutputDir(options.getOutputDir() + "/");
                 }
             } catch (JsonProcessingException e) {
                 LOGGER.info("Read emitter options failed, emitter options json: {}", emitterOptionsJson);
@@ -150,7 +150,7 @@ public class Main {
         if (options == null) {
             // default if emitterOptions fails
             options = new EmitterOptions();
-            options.setOutputPath("cadl-tests/cadl-output/");
+            options.setOutputDir("cadl-tests/cadl-output/");
             if (codeModel.getLanguage().getJava() != null && !CoreUtils.isNullOrEmpty(codeModel.getLanguage().getJava().getNamespace())) {
                 options.setNamespace(codeModel.getLanguage().getJava().getNamespace());
             }

--- a/cadl-extension/src/main/java/com/azure/cadl/model/EmitterOptions.java
+++ b/cadl-extension/src/main/java/com/azure/cadl/model/EmitterOptions.java
@@ -3,6 +3,7 @@
 
 package com.azure.cadl.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
@@ -12,11 +13,15 @@ import java.io.IOException;
 
 public class EmitterOptions {
     @JsonDeserialize(using = EmptyStringToNullDeserializer.class)
+    @JsonProperty(value="namespace")
     private String namespace;
     @JsonDeserialize(using = EmptyStringToNullDeserializer.class)
+    @JsonProperty(value="output-dir")
     private String outputDir;
     @JsonDeserialize(using = EmptyStringToNullDeserializer.class)
+    @JsonProperty(value="service-name")
     private String serviceName;
+    @JsonProperty(value="partial-update")
     private Boolean partialUpdate;
 
     public String getNamespace() {

--- a/cadl-extension/src/main/java/com/azure/cadl/model/EmitterOptions.java
+++ b/cadl-extension/src/main/java/com/azure/cadl/model/EmitterOptions.java
@@ -14,7 +14,7 @@ public class EmitterOptions {
     @JsonDeserialize(using = EmptyStringToNullDeserializer.class)
     private String namespace;
     @JsonDeserialize(using = EmptyStringToNullDeserializer.class)
-    private String outputPath;
+    private String outputDir;
     @JsonDeserialize(using = EmptyStringToNullDeserializer.class)
     private String serviceName;
     private Boolean partialUpdate;
@@ -23,8 +23,8 @@ public class EmitterOptions {
         return namespace;
     }
 
-    public String getOutputPath() {
-        return outputPath;
+    public String getOutputDir() {
+        return outputDir;
     }
 
     public String getServiceName() {
@@ -40,8 +40,8 @@ public class EmitterOptions {
         return this;
     }
 
-    public EmitterOptions setOutputPath(String outputPath) {
-        this.outputPath = outputPath;
+    public EmitterOptions setOutputDir(String outputDir) {
+        this.outputDir = outputDir;
         return this;
     }
 

--- a/cadl-tests/cadl-project.yaml
+++ b/cadl-tests/cadl-project.yaml
@@ -1,3 +1,3 @@
 emitters:
   "@azure-tools/cadl-java":
-    partialUpdate: true
+    partial-update: true

--- a/customization-tests/swagger/README.md
+++ b/customization-tests/swagger/README.md
@@ -30,8 +30,6 @@ generate-client-interfaces: false
 sync-methods: all
 generate-sync-async-clients: true
 license-header: MICROSOFT_MIT_SMALL
-add-context-parameter: true
 models-subpackage: implementation.models
-context-client-method-parameter: true
 customization-class: src/main/java/BodyComplexCustomization.java
 ```

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -118,8 +118,6 @@ public class JavaSettings {
                 getStringValue(host, "custom-types-subpackage", ""),
                 getStringValue(host, "fluent-subpackage", "fluent"),
                 getBooleanValue(host, "required-parameter-client-methods", false),
-                getBooleanValue(host, "add-context-parameter", false),
-                getBooleanValue(host, "context-client-method-parameter", false),
                 getBooleanValue(host, "generate-sync-async-clients", false),
                 getBooleanValue(host, "generate-builder-per-client", false),
                 getStringValue(host, "sync-methods", "essential"),
@@ -215,8 +213,6 @@ public class JavaSettings {
         String customTypesSubpackage,
         String fluentSubpackage,
         boolean requiredParameterClientMethods,
-        boolean addContextParameter,
-        boolean contextClientMethodParameter,
         boolean generateSyncAsyncClients,
         boolean generateBuilderPerClient,
         String syncMethods,
@@ -275,8 +271,6 @@ public class JavaSettings {
         this.customTypesSubpackage = customTypesSubpackage;
         this.fluentSubpackage = fluentSubpackage;
         this.requiredParameterClientMethods = requiredParameterClientMethods;
-        this.addContextParameter = addContextParameter || contextClientMethodParameter;
-        this.contextClientMethodParameter = contextClientMethodParameter;
         this.generateSyncAsyncClients = generateSyncAsyncClients;
         this.generateBuilderPerClient = generateBuilderPerClient;
         this.syncMethods = SyncMethodsGeneration.fromValue(syncMethods);
@@ -614,21 +608,6 @@ public class JavaSettings {
 
     public final boolean isRequiredParameterClientMethods() {
         return requiredParameterClientMethods;
-    }
-
-    /**
-     * Indicates whether the leading com.microsoft.rest.v3.Context parameter should be included in generated methods.
-     */
-    private boolean addContextParameter;
-
-    public final boolean isAddContextParameter() {
-        return addContextParameter;
-    }
-
-    private boolean contextClientMethodParameter;
-
-    public final boolean isContextClientMethodParameter() {
-        return contextClientMethodParameter;
     }
 
     private boolean generateSyncAsyncClients;

--- a/fluentgen/src/test/java/com/azure/autorest/fluent/TestUtils.java
+++ b/fluentgen/src/test/java/com/azure/autorest/fluent/TestUtils.java
@@ -49,8 +49,6 @@ public class TestUtils {
             DEFAULT_SETTINGS.put("namespace", "com.azure.resourcemanager.mock");
             DEFAULT_SETTINGS.put("fluent", "lite");
             DEFAULT_SETTINGS.put("sync-methods", "all");
-            DEFAULT_SETTINGS.put("add-context-parameter", true);
-            DEFAULT_SETTINGS.put("context-client-method-parameter", true);
             DEFAULT_SETTINGS.put("client-side-validations", true);
             DEFAULT_SETTINGS.put("client-logger", true);
             DEFAULT_SETTINGS.put("generate-client-interfaces", true);

--- a/fluentnamer/readme.md
+++ b/fluentnamer/readme.md
@@ -57,8 +57,6 @@ include-x-ms-examples-original-file: true
 license-header: MICROSOFT_MIT_SMALL
 regenerate-pom: true
 sync-methods: all
-add-context-parameter: true
-context-client-method-parameter: true
 client-side-validations: true
 client-logger: true
 generate-client-interfaces: true

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -346,10 +346,8 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                         .methodVisibility(simpleAsyncMethodVisibility)
                         .build());
 
-                    if (settings.isContextClientMethodParameter()) {
-                        builder.methodVisibility(simpleAsyncMethodVisibilityWithContext);
-                        addClientMethodWithContext(methods, builder, parameters, getContextParameter(isProtocolMethod));
-                    }
+                    builder.methodVisibility(simpleAsyncMethodVisibilityWithContext);
+                    addClientMethodWithContext(methods, builder, parameters, getContextParameter(isProtocolMethod));
 
                     JavaSettings.PollingDetails pollingDetails = settings.getPollingConfig(proxyMethod.getOperationId());
 
@@ -612,11 +610,9 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
         }
 
         // Generate an overload with all parameters, optionally include context.
-        if (settings.isContextClientMethodParameter()) {
-            builder.methodVisibility(visibilityFunction.methodVisibility(true, defaultOverloadType, true));
-            addClientMethodWithContext(methods, builder, parameters, pageMethodType, pageMethodName,
-                singlePageReturnValue, details, contextParameter);
-        }
+        builder.methodVisibility(visibilityFunction.methodVisibility(true, defaultOverloadType, true));
+        addClientMethodWithContext(methods, builder, parameters, pageMethodType, pageMethodName,
+            singlePageReturnValue, details, contextParameter);
 
         // If this was the next method there is no further work to be done.
         if (isNextMethod) {
@@ -641,27 +637,25 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                 .build());
         }
 
-        if (settings.isContextClientMethodParameter()) {
-            MethodPageDetails detailsWithContext = details;
-            if (nextMethods != null) {
-                // Match to the nextMethod with Context
-                IType contextWireType = contextParameter.getWireType();
-                nextMethod = nextMethods.stream()
-                    .filter(m -> m.getType() == nextMethodType)
-                    .filter(m -> m.getMethodParameters().stream().anyMatch(p -> contextWireType.equals(p.getClientType())))
-                    .findFirst()
-                    .orElse(null);
+        MethodPageDetails detailsWithContext = details;
+        if (nextMethods != null) {
+            // Match to the nextMethod with Context
+            IType contextWireType = contextParameter.getWireType();
+            nextMethod = nextMethods.stream()
+                .filter(m -> m.getType() == nextMethodType)
+                .filter(m -> m.getMethodParameters().stream().anyMatch(p -> contextWireType.equals(p.getClientType())))
+                .findFirst()
+                .orElse(null);
 
-                if (nextMethod != null) {
-                    detailsWithContext = new MethodPageDetails(CodeNamer.getPropertyName(nextLinkName),
-                        pageableItemName, nextMethod, lroIntermediateType, nextLinkName, itemName);
-                }
+            if (nextMethod != null) {
+                detailsWithContext = new MethodPageDetails(CodeNamer.getPropertyName(nextLinkName),
+                    pageableItemName, nextMethod, lroIntermediateType, nextLinkName, itemName);
             }
-
-            builder.methodVisibility(visibilityFunction.methodVisibility(false, defaultOverloadType, true));
-            addClientMethodWithContext(methods, builder, parameters, pageMethodType, pageMethodName,
-                nextPageReturnValue, detailsWithContext, contextParameter);
         }
+
+        builder.methodVisibility(visibilityFunction.methodVisibility(false, defaultOverloadType, true));
+        addClientMethodWithContext(methods, builder, parameters, pageMethodType, pageMethodName,
+            nextPageReturnValue, detailsWithContext, contextParameter);
     }
 
     private void createSimpleAsyncClientMethods(Operation operation, boolean isProtocolMethod, JavaSettings settings,
@@ -715,10 +709,8 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
         // It is only for sync proxy method, and is usually filtered out in methodVisibility function.
         methods.add(builder.build());
 
-        if (settings.isContextClientMethodParameter()) {
-            builder.methodVisibility(visibilityFunction.methodVisibility(true, defaultOverloadType, true));
-            addClientMethodWithContext(methods, builder, parameters, contextParameter);
-        }
+        builder.methodVisibility(visibilityFunction.methodVisibility(true, defaultOverloadType, true));
+        addClientMethodWithContext(methods, builder, parameters, contextParameter);
 
         // Repeat the same but for simple returns.
         methodName = isSync ? proxyMethod.getName() : proxyMethod.getSimpleAsyncMethodName();
@@ -739,10 +731,8 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                 .build());
         }
 
-        if (settings.isContextClientMethodParameter()) {
-            builder.methodVisibility(visibilityFunction.methodVisibility(false, defaultOverloadType, true));
-            addClientMethodWithContext(methods, builder, parameters, contextParameter);
-        }
+        builder.methodVisibility(visibilityFunction.methodVisibility(false, defaultOverloadType, true));
+        addClientMethodWithContext(methods, builder, parameters, contextParameter);
     }
 
     private static ClientMethodParameter updateClientMethodParameter(ClientMethodParameter clientMethodParameter) {
@@ -788,10 +778,8 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                     .build());
             }
 
-            if (settings.isContextClientMethodParameter()) {
-                builder.methodVisibility(methodVisibility(ClientMethodType.LongRunningBeginAsync, defaultOverloadType, true, isProtocolMethod));
-                addClientMethodWithContext(methods, builder, parameters, getContextParameter(isProtocolMethod));
-            }
+            builder.methodVisibility(methodVisibility(ClientMethodType.LongRunningBeginAsync, defaultOverloadType, true, isProtocolMethod));
+            addClientMethodWithContext(methods, builder, parameters, getContextParameter(isProtocolMethod));
         }
 
         if (settings.getSyncMethods() == JavaSettings.SyncMethodsGeneration.ALL && !settings.isSyncStackEnabled()) {
@@ -812,10 +800,8 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                     .build());
             }
 
-            if (settings.isContextClientMethodParameter()) {
-                builder.methodVisibility(methodVisibility(ClientMethodType.LongRunningBeginSync, defaultOverloadType, true, isProtocolMethod));
-                addClientMethodWithContext(methods, builder, parameters, getContextParameter(isProtocolMethod));
-            }
+            builder.methodVisibility(methodVisibility(ClientMethodType.LongRunningBeginSync, defaultOverloadType, true, isProtocolMethod));
+            addClientMethodWithContext(methods, builder, parameters, getContextParameter(isProtocolMethod));
         }
     }
 
@@ -1046,9 +1032,9 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                     : NOT_GENERATE;
             }
         } else {
-            if (!settings.isSyncStackEnabled() && methodType == ClientMethodType.SimpleSyncRestResponse && settings.isContextClientMethodParameter() && !hasContextParameter) {
+            if (!settings.isSyncStackEnabled() && methodType == ClientMethodType.SimpleSyncRestResponse && !hasContextParameter) {
                 return NOT_GENERATE;
-            } else if (!settings.isSyncStackEnabled() && methodType == ClientMethodType.SimpleSync && settings.isContextClientMethodParameter() && hasContextParameter) {
+            } else if (!settings.isSyncStackEnabled() && methodType == ClientMethodType.SimpleSync && hasContextParameter) {
                 return NOT_GENERATE;
             }
             return VISIBLE;

--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
@@ -211,11 +211,11 @@ public class ProxyMethodMapper implements IMapper<Operation, Map<Request, List<P
                 allParameters.add(requestOptions);
                 parameters.add(requestOptions);
             }
-            if (settings.isAddContextParameter()) {
-                ProxyMethodParameter contextParameter = getContextParameter();
-                allParameters.add(contextParameter);
-                parameters.add(contextParameter);
-            }
+
+            ProxyMethodParameter contextParameter = getContextParameter();
+            allParameters.add(contextParameter);
+            parameters.add(contextParameter);
+
             appendCallbackParameter(parameters, responseBodyType);
             builder.allParameters(allParameters);
             builder.parameters(parameters);

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -682,7 +682,7 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
                 String firstPageArgs = clientMethod.getArgumentList();
                 if (clientMethod.getParameters()
                     .stream()
-                    .noneMatch(param -> param == ClientMethodParameter.CONTEXT_PARAMETER)) {
+                    .noneMatch(p -> p.getClientType() == ClassType.Context)) {
                     nextMethodArgs = nextMethodArgs.replace("context", "Context.NONE");
                     if (!CoreUtils.isNullOrEmpty(firstPageArgs)) {
                         firstPageArgs = firstPageArgs + ", Context.NONE";
@@ -708,7 +708,7 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
                 String firstPageArgs = clientMethod.getArgumentList();
                 if (clientMethod.getParameters()
                     .stream()
-                    .noneMatch(param -> param == ClientMethodParameter.CONTEXT_PARAMETER)) {
+                    .noneMatch(p -> p.getClientType() == ClassType.Context)) {
                     if (!CoreUtils.isNullOrEmpty(firstPageArgs)) {
                         firstPageArgs = firstPageArgs + ", Context.NONE";
                     } else {
@@ -797,7 +797,7 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
             if (CoreUtils.isNullOrEmpty(argumentList)) {
                 // If there are no arguments the argument is Context.NONE
                 argumentList = "Context.NONE";
-            } else if (!clientMethod.getParameters().contains(ClientMethodParameter.CONTEXT_PARAMETER)) {
+            } else if (clientMethod.getParameters().stream().noneMatch(p -> p.getClientType() == ClassType.Context)) {
                 // If the arguments don't contain Context append Context.NONE
                 argumentList += ", Context.NONE";
             }
@@ -827,7 +827,7 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
             if (CoreUtils.isNullOrEmpty(argumentList)) {
                 // If there are no arguments the argument is Context.NONE
                 argumentList = "Context.NONE";
-            } else if (!clientMethod.getParameters().contains(ClientMethodParameter.CONTEXT_PARAMETER)) {
+            } else if (clientMethod.getParameters().stream().noneMatch(p -> p.getClientType() == ClassType.Context)) {
                 // If the arguments don't contain Context append Context.NONE
                 argumentList += ", Context.NONE";
             }

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -794,14 +794,12 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
             addOptionalVariables(function, clientMethod);
 
             String argumentList = clientMethod.getArgumentList();
-            if (settings.isContextClientMethodParameter()) {
-                if (CoreUtils.isNullOrEmpty(argumentList)) {
-                    // If there are no arguments the argument is Context.NONE
-                    argumentList = "Context.NONE";
-                } else if (!clientMethod.getParameters().contains(ClientMethodParameter.CONTEXT_PARAMETER)) {
-                    // If the arguments don't contain Context append Context.NONE
-                    argumentList += ", Context.NONE";
-                }
+            if (CoreUtils.isNullOrEmpty(argumentList)) {
+                // If there are no arguments the argument is Context.NONE
+                argumentList = "Context.NONE";
+            } else if (!clientMethod.getParameters().contains(ClientMethodParameter.CONTEXT_PARAMETER)) {
+                // If the arguments don't contain Context append Context.NONE
+                argumentList += ", Context.NONE";
             }
 
             if (ClassType.StreamResponse.equals(clientMethod.getReturnValue().getType())) {
@@ -826,14 +824,12 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
             addOptionalVariables(function, clientMethod);
 
             String argumentList = clientMethod.getArgumentList();
-            if (settings.isContextClientMethodParameter()) {
-                if (CoreUtils.isNullOrEmpty(argumentList)) {
-                    // If there are no arguments the argument is Context.NONE
-                    argumentList = "Context.NONE";
-                } else if (!clientMethod.getParameters().contains(ClientMethodParameter.CONTEXT_PARAMETER)) {
-                    // If the arguments don't contain Context append Context.NONE
-                    argumentList += ", Context.NONE";
-                }
+            if (CoreUtils.isNullOrEmpty(argumentList)) {
+                // If there are no arguments the argument is Context.NONE
+                argumentList = "Context.NONE";
+            } else if (!clientMethod.getParameters().contains(ClientMethodParameter.CONTEXT_PARAMETER)) {
+                // If the arguments don't contain Context append Context.NONE
+                argumentList += ", Context.NONE";
             }
 
             if (clientMethod.getReturnValue().getType().equals(PrimitiveType.Void)) {
@@ -1028,15 +1024,10 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
             }
 
             String serviceMethodCall = checkAndReplaceParamNameCollision(clientMethod, restAPIMethod, requestOptionsLocal, settings);
-            if (settings.isAddContextParameter()) {
-                if (settings.isContextClientMethodParameter() && contextInParameters(clientMethod)) {
-                    function.line(String.format("return %s", serviceMethodCall));
-                } else {
-                    function.line(String.format("return FluxUtil.withContext(context -> %s)",
-                        serviceMethodCall));
-                }
+            if (contextInParameters(clientMethod)) {
+                function.line(String.format("return %s", serviceMethodCall));
             } else {
-                function.line(String.format("return %s",
+                function.line(String.format("return FluxUtil.withContext(context -> %s)",
                     serviceMethodCall));
             }
             function.indent(() -> {
@@ -1158,14 +1149,10 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
             }
 
             String serviceMethodCall = checkAndReplaceParamNameCollision(clientMethod, restAPIMethod, requestOptionsLocal, settings);
-            if (settings.isAddContextParameter()) {
-                if (settings.isContextClientMethodParameter() && contextInParameters(clientMethod)) {
-                    function.methodReturn(serviceMethodCall);
-                } else {
-                    function.methodReturn(String.format("FluxUtil.withContext(context -> %s)", serviceMethodCall));
-                }
-            } else {
+            if (contextInParameters(clientMethod)) {
                 function.methodReturn(serviceMethodCall);
+            } else {
+                function.methodReturn(String.format("FluxUtil.withContext(context -> %s)", serviceMethodCall));
             }
         });
     }

--- a/javagen/src/main/resources/data-plane.md
+++ b/javagen/src/main/resources/data-plane.md
@@ -9,8 +9,6 @@ generate-client-interfaces: false
 generate-client-as-impl: true
 generate-sync-async-clients: true
 generate-builder-per-client: true
-add-context-parameter: true
-context-client-method-parameter: true
 sync-methods: all
 
 use-default-http-status-code-to-exception-type-mapping: true

--- a/preprocessor/data-plane.md
+++ b/preprocessor/data-plane.md
@@ -9,8 +9,6 @@ generate-client-interfaces: false
 generate-client-as-impl: true
 generate-sync-async-clients: true
 generate-builder-per-client: true
-add-context-parameter: true
-context-client-method-parameter: true
 sync-methods: all
 
 use-default-http-status-code-to-exception-type-mapping: true

--- a/readme.md
+++ b/readme.md
@@ -60,8 +60,6 @@ Settings can be provided on the command line through `--name:value` or in a READ
 |`--generate-builder-per-client`| Requires `--generate-sync-async-clients`, and generates one ClientBuilder for each Client. Default is false.|
 |`--implementation-subpackage=STRING`|The sub-package that the Service client and Method Group client implementation classes will be put into. Default is `implementation`.|
 |`--models-subpackage=STRING`|The sub-package that Enums, Exceptions, and Model types will be put into. Default is `models`.|
-|`--add-context-parameter`|Indicates whether the `com.azure.core.util.Context` parameter should be included in generated proxy methods. Default is false.|
-|`--context-client-method-parameter`|Implies `--add-context-parameter` and indicates whether the `com.azure.core.util.Context` parameter should also be included in generated client methods. Default is false.|
 |`--sync-methods=all\|essential\|none`|Specifies mode for generating sync wrappers. Supported value are <br>&nbsp;&nbsp;`essential` - generates only one sync returning body or header (default) <br>&nbsp;&nbsp;`all` - generates one sync method for each async method<br>&nbsp;&nbsp;`none` - does not generate any sync methods|
 |`--required-parameter-client-methods`|Indicates whether client method overloads with only required parameters should be generated. Default is false.|
 |`--custom-types=COMMA,SEPARATED,STRINGS`|Specifies a list of files to put in the package specified in `--custom-types-subpackage`.|
@@ -87,7 +85,7 @@ Settings can be provided on the command line through `--name:value` or in a READ
 `data-plane` option enables the generator to generate code for minimal data-plane clients.
 
 `data-plane` option will change the default value for some vanilla options.
-For example, `generate-client-interfaces`, `generate-client-as-impl`, `generate-sync-async-clients`, `generate-builder-per-client`, `add-context-parameter`, `context-client-method-parameter` option is by default `true`.
+For example, `generate-client-interfaces`, `generate-client-as-impl`, `generate-sync-async-clients`, `generate-builder-per-client` option is by default `true`.
 `polling` is by default enabled as default settings globally (`polling={}`).
 
 `sdk-integration` option can be used for integrating to [azure-sdk-for-java](https://github.com/Azure/azure-sdk-for-java/).
@@ -122,7 +120,7 @@ Following settings only works when `fluent` option is specified.
 | `--name-for-ungrouped-operations` | String. Name for ungrouped operation group. Default to `ResourceProviders` for Lite. |
 
 `fluent` option will change the default value for some vanilla options.
-For example, `generate-client-interfaces`, `context-client-method-parameter`, `required-parameter-client-methods` option is by default `true`.
+For example, `generate-client-interfaces`, `required-parameter-client-methods` option is by default `true`.
 
 The code formatter would require Java 11+ runtime.
 
@@ -342,12 +340,6 @@ help-content:
       - key: models-subpackage=STRING
         type: string
         description: The sub-package that Enums, Exceptions, and Model types will be put into. Default is `models`.
-      - key: add-context-parameter
-        type: bool
-        description: Indicates whether the `com.azure.core.util.Context` parameter should be included in generated proxy methods. Default is false.
-      - key: context-client-method-parameter
-        type: bool
-        description: Implies `--add-context-parameter` and indicates whether the `com.azure.core.util.Context` parameter should also be included in generated client methods. Default is false.
       - key: sync-methods
         type: string
         description: \[all|essential|none] Specifies mode for generating sync wrappers. Supported value are <br>&nbsp;&nbsp;`essential` - generates only one sync returning body or header (default) <br>&nbsp;&nbsp;`all` - generates one sync method for each async method<br>&nbsp;&nbsp;`none` - does not generate any sync methods

--- a/vanilla-tests/src/main/java/fixtures/additionalproperties/Pets.java
+++ b/vanilla-tests/src/main/java/fixtures/additionalproperties/Pets.java
@@ -137,6 +137,32 @@ public final class Pets {
      * Create a Pet which contains more properties than what is defined.
      *
      * @param createParameters The createParameters parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<PetAPTrue>> createAPTrueWithResponseAsync(PetAPTrue createParameters, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (createParameters == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter createParameters is required and cannot be null."));
+        } else {
+            createParameters.validate();
+        }
+        final String accept = "application/json";
+        return service.createAPTrue(this.client.getHost(), createParameters, accept, context);
+    }
+
+    /**
+     * Create a Pet which contains more properties than what is defined.
+     *
+     * @param createParameters The createParameters parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -151,14 +177,31 @@ public final class Pets {
      * Create a Pet which contains more properties than what is defined.
      *
      * @param createParameters The createParameters parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<PetAPTrue> createAPTrueAsync(PetAPTrue createParameters, Context context) {
+        return createAPTrueWithResponseAsync(createParameters, context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Create a Pet which contains more properties than what is defined.
+     *
+     * @param createParameters The createParameters parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<PetAPTrue> createAPTrueWithResponse(PetAPTrue createParameters) {
-        return createAPTrueWithResponseAsync(createParameters).block();
+    public Response<PetAPTrue> createAPTrueWithResponse(PetAPTrue createParameters, Context context) {
+        return createAPTrueWithResponseAsync(createParameters, context).block();
     }
 
     /**
@@ -172,7 +215,7 @@ public final class Pets {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PetAPTrue createAPTrue(PetAPTrue createParameters) {
-        return createAPTrueWithResponse(createParameters).getValue();
+        return createAPTrueWithResponse(createParameters, Context.NONE).getValue();
     }
 
     /**
@@ -205,6 +248,32 @@ public final class Pets {
      * Create a CatAPTrue which contains more properties than what is defined.
      *
      * @param createParameters The createParameters parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<CatAPTrue>> createCatAPTrueWithResponseAsync(CatAPTrue createParameters, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (createParameters == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter createParameters is required and cannot be null."));
+        } else {
+            createParameters.validate();
+        }
+        final String accept = "application/json";
+        return service.createCatAPTrue(this.client.getHost(), createParameters, accept, context);
+    }
+
+    /**
+     * Create a CatAPTrue which contains more properties than what is defined.
+     *
+     * @param createParameters The createParameters parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -219,14 +288,31 @@ public final class Pets {
      * Create a CatAPTrue which contains more properties than what is defined.
      *
      * @param createParameters The createParameters parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<CatAPTrue> createCatAPTrueAsync(CatAPTrue createParameters, Context context) {
+        return createCatAPTrueWithResponseAsync(createParameters, context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Create a CatAPTrue which contains more properties than what is defined.
+     *
+     * @param createParameters The createParameters parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<CatAPTrue> createCatAPTrueWithResponse(CatAPTrue createParameters) {
-        return createCatAPTrueWithResponseAsync(createParameters).block();
+    public Response<CatAPTrue> createCatAPTrueWithResponse(CatAPTrue createParameters, Context context) {
+        return createCatAPTrueWithResponseAsync(createParameters, context).block();
     }
 
     /**
@@ -240,7 +326,7 @@ public final class Pets {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public CatAPTrue createCatAPTrue(CatAPTrue createParameters) {
-        return createCatAPTrueWithResponse(createParameters).getValue();
+        return createCatAPTrueWithResponse(createParameters, Context.NONE).getValue();
     }
 
     /**
@@ -273,6 +359,32 @@ public final class Pets {
      * Create a Pet which contains more properties than what is defined.
      *
      * @param createParameters The createParameters parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<PetAPObject>> createAPObjectWithResponseAsync(PetAPObject createParameters, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (createParameters == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter createParameters is required and cannot be null."));
+        } else {
+            createParameters.validate();
+        }
+        final String accept = "application/json";
+        return service.createAPObject(this.client.getHost(), createParameters, accept, context);
+    }
+
+    /**
+     * Create a Pet which contains more properties than what is defined.
+     *
+     * @param createParameters The createParameters parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -287,14 +399,31 @@ public final class Pets {
      * Create a Pet which contains more properties than what is defined.
      *
      * @param createParameters The createParameters parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<PetAPObject> createAPObjectAsync(PetAPObject createParameters, Context context) {
+        return createAPObjectWithResponseAsync(createParameters, context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Create a Pet which contains more properties than what is defined.
+     *
+     * @param createParameters The createParameters parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<PetAPObject> createAPObjectWithResponse(PetAPObject createParameters) {
-        return createAPObjectWithResponseAsync(createParameters).block();
+    public Response<PetAPObject> createAPObjectWithResponse(PetAPObject createParameters, Context context) {
+        return createAPObjectWithResponseAsync(createParameters, context).block();
     }
 
     /**
@@ -308,7 +437,7 @@ public final class Pets {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PetAPObject createAPObject(PetAPObject createParameters) {
-        return createAPObjectWithResponse(createParameters).getValue();
+        return createAPObjectWithResponse(createParameters, Context.NONE).getValue();
     }
 
     /**
@@ -341,6 +470,32 @@ public final class Pets {
      * Create a Pet which contains more properties than what is defined.
      *
      * @param createParameters The createParameters parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<PetAPString>> createAPStringWithResponseAsync(PetAPString createParameters, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (createParameters == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter createParameters is required and cannot be null."));
+        } else {
+            createParameters.validate();
+        }
+        final String accept = "application/json";
+        return service.createAPString(this.client.getHost(), createParameters, accept, context);
+    }
+
+    /**
+     * Create a Pet which contains more properties than what is defined.
+     *
+     * @param createParameters The createParameters parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -355,14 +510,31 @@ public final class Pets {
      * Create a Pet which contains more properties than what is defined.
      *
      * @param createParameters The createParameters parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<PetAPString> createAPStringAsync(PetAPString createParameters, Context context) {
+        return createAPStringWithResponseAsync(createParameters, context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Create a Pet which contains more properties than what is defined.
+     *
+     * @param createParameters The createParameters parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<PetAPString> createAPStringWithResponse(PetAPString createParameters) {
-        return createAPStringWithResponseAsync(createParameters).block();
+    public Response<PetAPString> createAPStringWithResponse(PetAPString createParameters, Context context) {
+        return createAPStringWithResponseAsync(createParameters, context).block();
     }
 
     /**
@@ -376,7 +548,7 @@ public final class Pets {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PetAPString createAPString(PetAPString createParameters) {
-        return createAPStringWithResponse(createParameters).getValue();
+        return createAPStringWithResponse(createParameters, Context.NONE).getValue();
     }
 
     /**
@@ -409,6 +581,33 @@ public final class Pets {
      * Create a Pet which contains more properties than what is defined.
      *
      * @param createParameters The createParameters parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<PetAPInProperties>> createAPInPropertiesWithResponseAsync(
+            PetAPInProperties createParameters, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (createParameters == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter createParameters is required and cannot be null."));
+        } else {
+            createParameters.validate();
+        }
+        final String accept = "application/json";
+        return service.createAPInProperties(this.client.getHost(), createParameters, accept, context);
+    }
+
+    /**
+     * Create a Pet which contains more properties than what is defined.
+     *
+     * @param createParameters The createParameters parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -423,14 +622,32 @@ public final class Pets {
      * Create a Pet which contains more properties than what is defined.
      *
      * @param createParameters The createParameters parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<PetAPInProperties> createAPInPropertiesAsync(PetAPInProperties createParameters, Context context) {
+        return createAPInPropertiesWithResponseAsync(createParameters, context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Create a Pet which contains more properties than what is defined.
+     *
+     * @param createParameters The createParameters parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<PetAPInProperties> createAPInPropertiesWithResponse(PetAPInProperties createParameters) {
-        return createAPInPropertiesWithResponseAsync(createParameters).block();
+    public Response<PetAPInProperties> createAPInPropertiesWithResponse(
+            PetAPInProperties createParameters, Context context) {
+        return createAPInPropertiesWithResponseAsync(createParameters, context).block();
     }
 
     /**
@@ -444,7 +661,7 @@ public final class Pets {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PetAPInProperties createAPInProperties(PetAPInProperties createParameters) {
-        return createAPInPropertiesWithResponse(createParameters).getValue();
+        return createAPInPropertiesWithResponse(createParameters, Context.NONE).getValue();
     }
 
     /**
@@ -480,6 +697,33 @@ public final class Pets {
      * Create a Pet which contains more properties than what is defined.
      *
      * @param createParameters The createParameters parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<PetAPInPropertiesWithAPString>> createAPInPropertiesWithAPStringWithResponseAsync(
+            PetAPInPropertiesWithAPString createParameters, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (createParameters == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter createParameters is required and cannot be null."));
+        } else {
+            createParameters.validate();
+        }
+        final String accept = "application/json";
+        return service.createAPInPropertiesWithAPString(this.client.getHost(), createParameters, accept, context);
+    }
+
+    /**
+     * Create a Pet which contains more properties than what is defined.
+     *
+     * @param createParameters The createParameters parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -496,6 +740,24 @@ public final class Pets {
      * Create a Pet which contains more properties than what is defined.
      *
      * @param createParameters The createParameters parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<PetAPInPropertiesWithAPString> createAPInPropertiesWithAPStringAsync(
+            PetAPInPropertiesWithAPString createParameters, Context context) {
+        return createAPInPropertiesWithAPStringWithResponseAsync(createParameters, context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Create a Pet which contains more properties than what is defined.
+     *
+     * @param createParameters The createParameters parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -503,8 +765,8 @@ public final class Pets {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<PetAPInPropertiesWithAPString> createAPInPropertiesWithAPStringWithResponse(
-            PetAPInPropertiesWithAPString createParameters) {
-        return createAPInPropertiesWithAPStringWithResponseAsync(createParameters).block();
+            PetAPInPropertiesWithAPString createParameters, Context context) {
+        return createAPInPropertiesWithAPStringWithResponseAsync(createParameters, context).block();
     }
 
     /**
@@ -519,6 +781,6 @@ public final class Pets {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PetAPInPropertiesWithAPString createAPInPropertiesWithAPString(
             PetAPInPropertiesWithAPString createParameters) {
-        return createAPInPropertiesWithAPStringWithResponse(createParameters).getValue();
+        return createAPInPropertiesWithAPStringWithResponse(createParameters, Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyarray/Arrays.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyarray/Arrays.java
@@ -554,6 +554,25 @@ public final class Arrays {
     /**
      * Get null array value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null array value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Integer>>> getNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get null array value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null array value on successful completion of {@link Mono}.
@@ -566,13 +585,29 @@ public final class Arrays {
     /**
      * Get null array value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null array value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Integer>> getNullAsync(Context context) {
+        return getNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get null array value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null array value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Integer>> getNullWithResponse() {
-        return getNullWithResponseAsync().block();
+    public Response<List<Integer>> getNullWithResponse(Context context) {
+        return getNullWithResponseAsync(context).block();
     }
 
     /**
@@ -584,7 +619,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Integer> getNull() {
-        return getNullWithResponse().getValue();
+        return getNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -607,6 +642,25 @@ public final class Arrays {
     /**
      * Get invalid array [1, 2, 3.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return invalid array [1, 2, 3 along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Integer>>> getInvalidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getInvalid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get invalid array [1, 2, 3.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return invalid array [1, 2, 3 on successful completion of {@link Mono}.
@@ -619,13 +673,29 @@ public final class Arrays {
     /**
      * Get invalid array [1, 2, 3.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return invalid array [1, 2, 3 on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Integer>> getInvalidAsync(Context context) {
+        return getInvalidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get invalid array [1, 2, 3.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return invalid array [1, 2, 3 along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Integer>> getInvalidWithResponse() {
-        return getInvalidWithResponseAsync().block();
+    public Response<List<Integer>> getInvalidWithResponse(Context context) {
+        return getInvalidWithResponseAsync(context).block();
     }
 
     /**
@@ -637,7 +707,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Integer> getInvalid() {
-        return getInvalidWithResponse().getValue();
+        return getInvalidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -660,6 +730,25 @@ public final class Arrays {
     /**
      * Get empty array value [].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return empty array value [] along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Integer>>> getEmptyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getEmpty(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get empty array value [].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return empty array value [] on successful completion of {@link Mono}.
@@ -672,13 +761,29 @@ public final class Arrays {
     /**
      * Get empty array value [].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return empty array value [] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Integer>> getEmptyAsync(Context context) {
+        return getEmptyWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get empty array value [].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return empty array value [] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Integer>> getEmptyWithResponse() {
-        return getEmptyWithResponseAsync().block();
+    public Response<List<Integer>> getEmptyWithResponse(Context context) {
+        return getEmptyWithResponseAsync(context).block();
     }
 
     /**
@@ -690,7 +795,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Integer> getEmpty() {
-        return getEmptyWithResponse().getValue();
+        return getEmptyWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -719,6 +824,29 @@ public final class Arrays {
      * Set array value empty [].
      *
      * @param arrayBody The empty array value [].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putEmptyWithResponseAsync(List<String> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putEmpty(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Set array value empty [].
+     *
+     * @param arrayBody The empty array value [].
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -733,14 +861,30 @@ public final class Arrays {
      * Set array value empty [].
      *
      * @param arrayBody The empty array value [].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putEmptyAsync(List<String> arrayBody, Context context) {
+        return putEmptyWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set array value empty [].
+     *
+     * @param arrayBody The empty array value [].
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putEmptyWithResponse(List<String> arrayBody) {
-        return putEmptyWithResponseAsync(arrayBody).block();
+    public Response<Void> putEmptyWithResponse(List<String> arrayBody, Context context) {
+        return putEmptyWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -753,7 +897,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putEmpty(List<String> arrayBody) {
-        putEmptyWithResponse(arrayBody);
+        putEmptyWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -777,6 +921,26 @@ public final class Arrays {
     /**
      * Get boolean array value [true, false, false, true].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return boolean array value [true, false, false, true] along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Boolean>>> getBooleanTfftWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getBooleanTfft(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get boolean array value [true, false, false, true].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return boolean array value [true, false, false, true] on successful completion of {@link Mono}.
@@ -789,13 +953,29 @@ public final class Arrays {
     /**
      * Get boolean array value [true, false, false, true].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return boolean array value [true, false, false, true] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Boolean>> getBooleanTfftAsync(Context context) {
+        return getBooleanTfftWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get boolean array value [true, false, false, true].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return boolean array value [true, false, false, true] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Boolean>> getBooleanTfftWithResponse() {
-        return getBooleanTfftWithResponseAsync().block();
+    public Response<List<Boolean>> getBooleanTfftWithResponse(Context context) {
+        return getBooleanTfftWithResponseAsync(context).block();
     }
 
     /**
@@ -807,7 +987,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Boolean> getBooleanTfft() {
-        return getBooleanTfftWithResponse().getValue();
+        return getBooleanTfftWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -837,6 +1017,29 @@ public final class Arrays {
      * Set array value empty [true, false, false, true].
      *
      * @param arrayBody The array value [true, false, false, true].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putBooleanTfftWithResponseAsync(List<Boolean> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putBooleanTfft(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Set array value empty [true, false, false, true].
+     *
+     * @param arrayBody The array value [true, false, false, true].
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -851,14 +1054,30 @@ public final class Arrays {
      * Set array value empty [true, false, false, true].
      *
      * @param arrayBody The array value [true, false, false, true].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putBooleanTfftAsync(List<Boolean> arrayBody, Context context) {
+        return putBooleanTfftWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set array value empty [true, false, false, true].
+     *
+     * @param arrayBody The array value [true, false, false, true].
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putBooleanTfftWithResponse(List<Boolean> arrayBody) {
-        return putBooleanTfftWithResponseAsync(arrayBody).block();
+    public Response<Void> putBooleanTfftWithResponse(List<Boolean> arrayBody, Context context) {
+        return putBooleanTfftWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -871,7 +1090,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putBooleanTfft(List<Boolean> arrayBody) {
-        putBooleanTfftWithResponse(arrayBody);
+        putBooleanTfftWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -895,6 +1114,26 @@ public final class Arrays {
     /**
      * Get boolean array value [true, null, false].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return boolean array value [true, null, false] along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Boolean>>> getBooleanInvalidNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getBooleanInvalidNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get boolean array value [true, null, false].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return boolean array value [true, null, false] on successful completion of {@link Mono}.
@@ -907,13 +1146,29 @@ public final class Arrays {
     /**
      * Get boolean array value [true, null, false].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return boolean array value [true, null, false] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Boolean>> getBooleanInvalidNullAsync(Context context) {
+        return getBooleanInvalidNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get boolean array value [true, null, false].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return boolean array value [true, null, false] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Boolean>> getBooleanInvalidNullWithResponse() {
-        return getBooleanInvalidNullWithResponseAsync().block();
+    public Response<List<Boolean>> getBooleanInvalidNullWithResponse(Context context) {
+        return getBooleanInvalidNullWithResponseAsync(context).block();
     }
 
     /**
@@ -925,7 +1180,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Boolean> getBooleanInvalidNull() {
-        return getBooleanInvalidNullWithResponse().getValue();
+        return getBooleanInvalidNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -949,6 +1204,26 @@ public final class Arrays {
     /**
      * Get boolean array value [true, 'boolean', false].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return boolean array value [true, 'boolean', false] along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Boolean>>> getBooleanInvalidStringWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getBooleanInvalidString(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get boolean array value [true, 'boolean', false].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return boolean array value [true, 'boolean', false] on successful completion of {@link Mono}.
@@ -961,13 +1236,29 @@ public final class Arrays {
     /**
      * Get boolean array value [true, 'boolean', false].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return boolean array value [true, 'boolean', false] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Boolean>> getBooleanInvalidStringAsync(Context context) {
+        return getBooleanInvalidStringWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get boolean array value [true, 'boolean', false].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return boolean array value [true, 'boolean', false] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Boolean>> getBooleanInvalidStringWithResponse() {
-        return getBooleanInvalidStringWithResponseAsync().block();
+    public Response<List<Boolean>> getBooleanInvalidStringWithResponse(Context context) {
+        return getBooleanInvalidStringWithResponseAsync(context).block();
     }
 
     /**
@@ -979,7 +1270,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Boolean> getBooleanInvalidString() {
-        return getBooleanInvalidStringWithResponse().getValue();
+        return getBooleanInvalidStringWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1002,6 +1293,25 @@ public final class Arrays {
     /**
      * Get integer array value [1, -1, 3, 300].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return integer array value [1, -1, 3, 300] along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Integer>>> getIntegerValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getIntegerValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get integer array value [1, -1, 3, 300].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return integer array value [1, -1, 3, 300] on successful completion of {@link Mono}.
@@ -1014,13 +1324,29 @@ public final class Arrays {
     /**
      * Get integer array value [1, -1, 3, 300].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return integer array value [1, -1, 3, 300] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Integer>> getIntegerValidAsync(Context context) {
+        return getIntegerValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get integer array value [1, -1, 3, 300].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return integer array value [1, -1, 3, 300] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Integer>> getIntegerValidWithResponse() {
-        return getIntegerValidWithResponseAsync().block();
+    public Response<List<Integer>> getIntegerValidWithResponse(Context context) {
+        return getIntegerValidWithResponseAsync(context).block();
     }
 
     /**
@@ -1032,7 +1358,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Integer> getIntegerValid() {
-        return getIntegerValidWithResponse().getValue();
+        return getIntegerValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1062,6 +1388,29 @@ public final class Arrays {
      * Set array value empty [1, -1, 3, 300].
      *
      * @param arrayBody The array value [1, -1, 3, 300].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putIntegerValidWithResponseAsync(List<Integer> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putIntegerValid(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Set array value empty [1, -1, 3, 300].
+     *
+     * @param arrayBody The array value [1, -1, 3, 300].
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1076,14 +1425,30 @@ public final class Arrays {
      * Set array value empty [1, -1, 3, 300].
      *
      * @param arrayBody The array value [1, -1, 3, 300].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putIntegerValidAsync(List<Integer> arrayBody, Context context) {
+        return putIntegerValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set array value empty [1, -1, 3, 300].
+     *
+     * @param arrayBody The array value [1, -1, 3, 300].
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putIntegerValidWithResponse(List<Integer> arrayBody) {
-        return putIntegerValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putIntegerValidWithResponse(List<Integer> arrayBody, Context context) {
+        return putIntegerValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -1096,7 +1461,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putIntegerValid(List<Integer> arrayBody) {
-        putIntegerValidWithResponse(arrayBody);
+        putIntegerValidWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -1119,6 +1484,25 @@ public final class Arrays {
     /**
      * Get integer array value [1, null, 0].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return integer array value [1, null, 0] along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Integer>>> getIntInvalidNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getIntInvalidNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get integer array value [1, null, 0].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return integer array value [1, null, 0] on successful completion of {@link Mono}.
@@ -1131,13 +1515,29 @@ public final class Arrays {
     /**
      * Get integer array value [1, null, 0].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return integer array value [1, null, 0] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Integer>> getIntInvalidNullAsync(Context context) {
+        return getIntInvalidNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get integer array value [1, null, 0].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return integer array value [1, null, 0] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Integer>> getIntInvalidNullWithResponse() {
-        return getIntInvalidNullWithResponseAsync().block();
+    public Response<List<Integer>> getIntInvalidNullWithResponse(Context context) {
+        return getIntInvalidNullWithResponseAsync(context).block();
     }
 
     /**
@@ -1149,7 +1549,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Integer> getIntInvalidNull() {
-        return getIntInvalidNullWithResponse().getValue();
+        return getIntInvalidNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1173,6 +1573,26 @@ public final class Arrays {
     /**
      * Get integer array value [1, 'integer', 0].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return integer array value [1, 'integer', 0] along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Integer>>> getIntInvalidStringWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getIntInvalidString(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get integer array value [1, 'integer', 0].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return integer array value [1, 'integer', 0] on successful completion of {@link Mono}.
@@ -1185,13 +1605,29 @@ public final class Arrays {
     /**
      * Get integer array value [1, 'integer', 0].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return integer array value [1, 'integer', 0] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Integer>> getIntInvalidStringAsync(Context context) {
+        return getIntInvalidStringWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get integer array value [1, 'integer', 0].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return integer array value [1, 'integer', 0] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Integer>> getIntInvalidStringWithResponse() {
-        return getIntInvalidStringWithResponseAsync().block();
+    public Response<List<Integer>> getIntInvalidStringWithResponse(Context context) {
+        return getIntInvalidStringWithResponseAsync(context).block();
     }
 
     /**
@@ -1203,7 +1639,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Integer> getIntInvalidString() {
-        return getIntInvalidStringWithResponse().getValue();
+        return getIntInvalidStringWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1226,6 +1662,25 @@ public final class Arrays {
     /**
      * Get integer array value [1, -1, 3, 300].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return integer array value [1, -1, 3, 300] along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Long>>> getLongValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getLongValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get integer array value [1, -1, 3, 300].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return integer array value [1, -1, 3, 300] on successful completion of {@link Mono}.
@@ -1238,13 +1693,29 @@ public final class Arrays {
     /**
      * Get integer array value [1, -1, 3, 300].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return integer array value [1, -1, 3, 300] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Long>> getLongValidAsync(Context context) {
+        return getLongValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get integer array value [1, -1, 3, 300].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return integer array value [1, -1, 3, 300] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Long>> getLongValidWithResponse() {
-        return getLongValidWithResponseAsync().block();
+    public Response<List<Long>> getLongValidWithResponse(Context context) {
+        return getLongValidWithResponseAsync(context).block();
     }
 
     /**
@@ -1256,7 +1727,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Long> getLongValid() {
-        return getLongValidWithResponse().getValue();
+        return getLongValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1285,6 +1756,29 @@ public final class Arrays {
      * Set array value empty [1, -1, 3, 300].
      *
      * @param arrayBody The array value [1, -1, 3, 300].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putLongValidWithResponseAsync(List<Long> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putLongValid(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Set array value empty [1, -1, 3, 300].
+     *
+     * @param arrayBody The array value [1, -1, 3, 300].
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1299,14 +1793,30 @@ public final class Arrays {
      * Set array value empty [1, -1, 3, 300].
      *
      * @param arrayBody The array value [1, -1, 3, 300].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putLongValidAsync(List<Long> arrayBody, Context context) {
+        return putLongValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set array value empty [1, -1, 3, 300].
+     *
+     * @param arrayBody The array value [1, -1, 3, 300].
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putLongValidWithResponse(List<Long> arrayBody) {
-        return putLongValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putLongValidWithResponse(List<Long> arrayBody, Context context) {
+        return putLongValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -1319,7 +1829,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putLongValid(List<Long> arrayBody) {
-        putLongValidWithResponse(arrayBody);
+        putLongValidWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -1342,6 +1852,25 @@ public final class Arrays {
     /**
      * Get long array value [1, null, 0].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return long array value [1, null, 0] along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Long>>> getLongInvalidNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getLongInvalidNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get long array value [1, null, 0].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return long array value [1, null, 0] on successful completion of {@link Mono}.
@@ -1354,13 +1883,29 @@ public final class Arrays {
     /**
      * Get long array value [1, null, 0].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return long array value [1, null, 0] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Long>> getLongInvalidNullAsync(Context context) {
+        return getLongInvalidNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get long array value [1, null, 0].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return long array value [1, null, 0] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Long>> getLongInvalidNullWithResponse() {
-        return getLongInvalidNullWithResponseAsync().block();
+    public Response<List<Long>> getLongInvalidNullWithResponse(Context context) {
+        return getLongInvalidNullWithResponseAsync(context).block();
     }
 
     /**
@@ -1372,7 +1917,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Long> getLongInvalidNull() {
-        return getLongInvalidNullWithResponse().getValue();
+        return getLongInvalidNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1395,6 +1940,25 @@ public final class Arrays {
     /**
      * Get long array value [1, 'integer', 0].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return long array value [1, 'integer', 0] along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Long>>> getLongInvalidStringWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getLongInvalidString(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get long array value [1, 'integer', 0].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return long array value [1, 'integer', 0] on successful completion of {@link Mono}.
@@ -1407,13 +1971,29 @@ public final class Arrays {
     /**
      * Get long array value [1, 'integer', 0].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return long array value [1, 'integer', 0] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Long>> getLongInvalidStringAsync(Context context) {
+        return getLongInvalidStringWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get long array value [1, 'integer', 0].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return long array value [1, 'integer', 0] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Long>> getLongInvalidStringWithResponse() {
-        return getLongInvalidStringWithResponseAsync().block();
+    public Response<List<Long>> getLongInvalidStringWithResponse(Context context) {
+        return getLongInvalidStringWithResponseAsync(context).block();
     }
 
     /**
@@ -1425,7 +2005,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Long> getLongInvalidString() {
-        return getLongInvalidStringWithResponse().getValue();
+        return getLongInvalidStringWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1449,6 +2029,26 @@ public final class Arrays {
     /**
      * Get float array value [0, -0.01, 1.2e20].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return float array value [0, -0.01, 1.2e20] along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Float>>> getFloatValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getFloatValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get float array value [0, -0.01, 1.2e20].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return float array value [0, -0.01, 1.2e20] on successful completion of {@link Mono}.
@@ -1461,13 +2061,29 @@ public final class Arrays {
     /**
      * Get float array value [0, -0.01, 1.2e20].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return float array value [0, -0.01, 1.2e20] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Float>> getFloatValidAsync(Context context) {
+        return getFloatValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get float array value [0, -0.01, 1.2e20].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return float array value [0, -0.01, 1.2e20] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Float>> getFloatValidWithResponse() {
-        return getFloatValidWithResponseAsync().block();
+    public Response<List<Float>> getFloatValidWithResponse(Context context) {
+        return getFloatValidWithResponseAsync(context).block();
     }
 
     /**
@@ -1479,7 +2095,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Float> getFloatValid() {
-        return getFloatValidWithResponse().getValue();
+        return getFloatValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1509,6 +2125,29 @@ public final class Arrays {
      * Set array value [0, -0.01, 1.2e20].
      *
      * @param arrayBody The array value [0, -0.01, 1.2e20].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putFloatValidWithResponseAsync(List<Float> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putFloatValid(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Set array value [0, -0.01, 1.2e20].
+     *
+     * @param arrayBody The array value [0, -0.01, 1.2e20].
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1523,14 +2162,30 @@ public final class Arrays {
      * Set array value [0, -0.01, 1.2e20].
      *
      * @param arrayBody The array value [0, -0.01, 1.2e20].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putFloatValidAsync(List<Float> arrayBody, Context context) {
+        return putFloatValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set array value [0, -0.01, 1.2e20].
+     *
+     * @param arrayBody The array value [0, -0.01, 1.2e20].
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putFloatValidWithResponse(List<Float> arrayBody) {
-        return putFloatValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putFloatValidWithResponse(List<Float> arrayBody, Context context) {
+        return putFloatValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -1543,7 +2198,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putFloatValid(List<Float> arrayBody) {
-        putFloatValidWithResponse(arrayBody);
+        putFloatValidWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -1567,6 +2222,26 @@ public final class Arrays {
     /**
      * Get float array value [0.0, null, -1.2e20].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return float array value [0.0, null, -1.2e20] along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Float>>> getFloatInvalidNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getFloatInvalidNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get float array value [0.0, null, -1.2e20].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return float array value [0.0, null, -1.2e20] on successful completion of {@link Mono}.
@@ -1579,13 +2254,29 @@ public final class Arrays {
     /**
      * Get float array value [0.0, null, -1.2e20].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return float array value [0.0, null, -1.2e20] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Float>> getFloatInvalidNullAsync(Context context) {
+        return getFloatInvalidNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get float array value [0.0, null, -1.2e20].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return float array value [0.0, null, -1.2e20] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Float>> getFloatInvalidNullWithResponse() {
-        return getFloatInvalidNullWithResponseAsync().block();
+    public Response<List<Float>> getFloatInvalidNullWithResponse(Context context) {
+        return getFloatInvalidNullWithResponseAsync(context).block();
     }
 
     /**
@@ -1597,7 +2288,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Float> getFloatInvalidNull() {
-        return getFloatInvalidNullWithResponse().getValue();
+        return getFloatInvalidNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1621,6 +2312,26 @@ public final class Arrays {
     /**
      * Get boolean array value [1.0, 'number', 0.0].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return boolean array value [1.0, 'number', 0.0] along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Float>>> getFloatInvalidStringWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getFloatInvalidString(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get boolean array value [1.0, 'number', 0.0].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return boolean array value [1.0, 'number', 0.0] on successful completion of {@link Mono}.
@@ -1633,13 +2344,29 @@ public final class Arrays {
     /**
      * Get boolean array value [1.0, 'number', 0.0].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return boolean array value [1.0, 'number', 0.0] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Float>> getFloatInvalidStringAsync(Context context) {
+        return getFloatInvalidStringWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get boolean array value [1.0, 'number', 0.0].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return boolean array value [1.0, 'number', 0.0] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Float>> getFloatInvalidStringWithResponse() {
-        return getFloatInvalidStringWithResponseAsync().block();
+    public Response<List<Float>> getFloatInvalidStringWithResponse(Context context) {
+        return getFloatInvalidStringWithResponseAsync(context).block();
     }
 
     /**
@@ -1651,7 +2378,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Float> getFloatInvalidString() {
-        return getFloatInvalidStringWithResponse().getValue();
+        return getFloatInvalidStringWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1675,6 +2402,26 @@ public final class Arrays {
     /**
      * Get float array value [0, -0.01, 1.2e20].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return float array value [0, -0.01, 1.2e20] along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Double>>> getDoubleValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDoubleValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get float array value [0, -0.01, 1.2e20].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return float array value [0, -0.01, 1.2e20] on successful completion of {@link Mono}.
@@ -1687,13 +2434,29 @@ public final class Arrays {
     /**
      * Get float array value [0, -0.01, 1.2e20].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return float array value [0, -0.01, 1.2e20] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Double>> getDoubleValidAsync(Context context) {
+        return getDoubleValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get float array value [0, -0.01, 1.2e20].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return float array value [0, -0.01, 1.2e20] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Double>> getDoubleValidWithResponse() {
-        return getDoubleValidWithResponseAsync().block();
+    public Response<List<Double>> getDoubleValidWithResponse(Context context) {
+        return getDoubleValidWithResponseAsync(context).block();
     }
 
     /**
@@ -1705,7 +2468,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Double> getDoubleValid() {
-        return getDoubleValidWithResponse().getValue();
+        return getDoubleValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1735,6 +2498,29 @@ public final class Arrays {
      * Set array value [0, -0.01, 1.2e20].
      *
      * @param arrayBody The array value [0, -0.01, 1.2e20].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putDoubleValidWithResponseAsync(List<Double> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putDoubleValid(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Set array value [0, -0.01, 1.2e20].
+     *
+     * @param arrayBody The array value [0, -0.01, 1.2e20].
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1749,14 +2535,30 @@ public final class Arrays {
      * Set array value [0, -0.01, 1.2e20].
      *
      * @param arrayBody The array value [0, -0.01, 1.2e20].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putDoubleValidAsync(List<Double> arrayBody, Context context) {
+        return putDoubleValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set array value [0, -0.01, 1.2e20].
+     *
+     * @param arrayBody The array value [0, -0.01, 1.2e20].
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDoubleValidWithResponse(List<Double> arrayBody) {
-        return putDoubleValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putDoubleValidWithResponse(List<Double> arrayBody, Context context) {
+        return putDoubleValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -1769,7 +2571,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDoubleValid(List<Double> arrayBody) {
-        putDoubleValidWithResponse(arrayBody);
+        putDoubleValidWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -1793,6 +2595,26 @@ public final class Arrays {
     /**
      * Get float array value [0.0, null, -1.2e20].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return float array value [0.0, null, -1.2e20] along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Double>>> getDoubleInvalidNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDoubleInvalidNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get float array value [0.0, null, -1.2e20].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return float array value [0.0, null, -1.2e20] on successful completion of {@link Mono}.
@@ -1805,13 +2627,29 @@ public final class Arrays {
     /**
      * Get float array value [0.0, null, -1.2e20].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return float array value [0.0, null, -1.2e20] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Double>> getDoubleInvalidNullAsync(Context context) {
+        return getDoubleInvalidNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get float array value [0.0, null, -1.2e20].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return float array value [0.0, null, -1.2e20] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Double>> getDoubleInvalidNullWithResponse() {
-        return getDoubleInvalidNullWithResponseAsync().block();
+    public Response<List<Double>> getDoubleInvalidNullWithResponse(Context context) {
+        return getDoubleInvalidNullWithResponseAsync(context).block();
     }
 
     /**
@@ -1823,7 +2661,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Double> getDoubleInvalidNull() {
-        return getDoubleInvalidNullWithResponse().getValue();
+        return getDoubleInvalidNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1847,6 +2685,26 @@ public final class Arrays {
     /**
      * Get boolean array value [1.0, 'number', 0.0].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return boolean array value [1.0, 'number', 0.0] along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Double>>> getDoubleInvalidStringWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDoubleInvalidString(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get boolean array value [1.0, 'number', 0.0].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return boolean array value [1.0, 'number', 0.0] on successful completion of {@link Mono}.
@@ -1859,13 +2717,29 @@ public final class Arrays {
     /**
      * Get boolean array value [1.0, 'number', 0.0].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return boolean array value [1.0, 'number', 0.0] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Double>> getDoubleInvalidStringAsync(Context context) {
+        return getDoubleInvalidStringWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get boolean array value [1.0, 'number', 0.0].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return boolean array value [1.0, 'number', 0.0] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Double>> getDoubleInvalidStringWithResponse() {
-        return getDoubleInvalidStringWithResponseAsync().block();
+    public Response<List<Double>> getDoubleInvalidStringWithResponse(Context context) {
+        return getDoubleInvalidStringWithResponseAsync(context).block();
     }
 
     /**
@@ -1877,7 +2751,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Double> getDoubleInvalidString() {
-        return getDoubleInvalidStringWithResponse().getValue();
+        return getDoubleInvalidStringWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1901,6 +2775,26 @@ public final class Arrays {
     /**
      * Get string array value ['foo1', 'foo2', 'foo3'].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return string array value ['foo1', 'foo2', 'foo3'] along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<String>>> getStringValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getStringValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get string array value ['foo1', 'foo2', 'foo3'].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string array value ['foo1', 'foo2', 'foo3'] on successful completion of {@link Mono}.
@@ -1913,13 +2807,29 @@ public final class Arrays {
     /**
      * Get string array value ['foo1', 'foo2', 'foo3'].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return string array value ['foo1', 'foo2', 'foo3'] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<String>> getStringValidAsync(Context context) {
+        return getStringValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get string array value ['foo1', 'foo2', 'foo3'].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string array value ['foo1', 'foo2', 'foo3'] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<String>> getStringValidWithResponse() {
-        return getStringValidWithResponseAsync().block();
+    public Response<List<String>> getStringValidWithResponse(Context context) {
+        return getStringValidWithResponseAsync(context).block();
     }
 
     /**
@@ -1931,7 +2841,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<String> getStringValid() {
-        return getStringValidWithResponse().getValue();
+        return getStringValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1961,6 +2871,29 @@ public final class Arrays {
      * Set array value ['foo1', 'foo2', 'foo3'].
      *
      * @param arrayBody The array value ['foo1', 'foo2', 'foo3'].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putStringValidWithResponseAsync(List<String> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putStringValid(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Set array value ['foo1', 'foo2', 'foo3'].
+     *
+     * @param arrayBody The array value ['foo1', 'foo2', 'foo3'].
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1975,14 +2908,30 @@ public final class Arrays {
      * Set array value ['foo1', 'foo2', 'foo3'].
      *
      * @param arrayBody The array value ['foo1', 'foo2', 'foo3'].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putStringValidAsync(List<String> arrayBody, Context context) {
+        return putStringValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set array value ['foo1', 'foo2', 'foo3'].
+     *
+     * @param arrayBody The array value ['foo1', 'foo2', 'foo3'].
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putStringValidWithResponse(List<String> arrayBody) {
-        return putStringValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putStringValidWithResponse(List<String> arrayBody, Context context) {
+        return putStringValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -1995,7 +2944,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putStringValid(List<String> arrayBody) {
-        putStringValidWithResponse(arrayBody);
+        putStringValidWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -2019,6 +2968,26 @@ public final class Arrays {
     /**
      * Get enum array value ['foo1', 'foo2', 'foo3'].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return enum array value ['foo1', 'foo2', 'foo3'] along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<FooEnum>>> getEnumValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getEnumValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get enum array value ['foo1', 'foo2', 'foo3'].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return enum array value ['foo1', 'foo2', 'foo3'] on successful completion of {@link Mono}.
@@ -2031,13 +3000,29 @@ public final class Arrays {
     /**
      * Get enum array value ['foo1', 'foo2', 'foo3'].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return enum array value ['foo1', 'foo2', 'foo3'] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<FooEnum>> getEnumValidAsync(Context context) {
+        return getEnumValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get enum array value ['foo1', 'foo2', 'foo3'].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return enum array value ['foo1', 'foo2', 'foo3'] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<FooEnum>> getEnumValidWithResponse() {
-        return getEnumValidWithResponseAsync().block();
+    public Response<List<FooEnum>> getEnumValidWithResponse(Context context) {
+        return getEnumValidWithResponseAsync(context).block();
     }
 
     /**
@@ -2049,7 +3034,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<FooEnum> getEnumValid() {
-        return getEnumValidWithResponse().getValue();
+        return getEnumValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2078,6 +3063,29 @@ public final class Arrays {
      * Set array value ['foo1', 'foo2', 'foo3'].
      *
      * @param arrayBody The array value ['foo1', 'foo2', 'foo3'].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putEnumValidWithResponseAsync(List<FooEnum> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putEnumValid(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Set array value ['foo1', 'foo2', 'foo3'].
+     *
+     * @param arrayBody The array value ['foo1', 'foo2', 'foo3'].
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -2092,14 +3100,30 @@ public final class Arrays {
      * Set array value ['foo1', 'foo2', 'foo3'].
      *
      * @param arrayBody The array value ['foo1', 'foo2', 'foo3'].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putEnumValidAsync(List<FooEnum> arrayBody, Context context) {
+        return putEnumValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set array value ['foo1', 'foo2', 'foo3'].
+     *
+     * @param arrayBody The array value ['foo1', 'foo2', 'foo3'].
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putEnumValidWithResponse(List<FooEnum> arrayBody) {
-        return putEnumValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putEnumValidWithResponse(List<FooEnum> arrayBody, Context context) {
+        return putEnumValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -2112,7 +3136,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putEnumValid(List<FooEnum> arrayBody) {
-        putEnumValidWithResponse(arrayBody);
+        putEnumValidWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -2136,6 +3160,26 @@ public final class Arrays {
     /**
      * Get enum array value ['foo1', 'foo2', 'foo3'].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return enum array value ['foo1', 'foo2', 'foo3'] along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Enum0>>> getStringEnumValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getStringEnumValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get enum array value ['foo1', 'foo2', 'foo3'].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return enum array value ['foo1', 'foo2', 'foo3'] on successful completion of {@link Mono}.
@@ -2148,13 +3192,29 @@ public final class Arrays {
     /**
      * Get enum array value ['foo1', 'foo2', 'foo3'].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return enum array value ['foo1', 'foo2', 'foo3'] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Enum0>> getStringEnumValidAsync(Context context) {
+        return getStringEnumValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get enum array value ['foo1', 'foo2', 'foo3'].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return enum array value ['foo1', 'foo2', 'foo3'] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Enum0>> getStringEnumValidWithResponse() {
-        return getStringEnumValidWithResponseAsync().block();
+    public Response<List<Enum0>> getStringEnumValidWithResponse(Context context) {
+        return getStringEnumValidWithResponseAsync(context).block();
     }
 
     /**
@@ -2166,7 +3226,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Enum0> getStringEnumValid() {
-        return getStringEnumValidWithResponse().getValue();
+        return getStringEnumValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2196,6 +3256,29 @@ public final class Arrays {
      * Set array value ['foo1', 'foo2', 'foo3'].
      *
      * @param arrayBody The array value ['foo1', 'foo2', 'foo3'].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putStringEnumValidWithResponseAsync(List<Enum1> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putStringEnumValid(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Set array value ['foo1', 'foo2', 'foo3'].
+     *
+     * @param arrayBody The array value ['foo1', 'foo2', 'foo3'].
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -2210,14 +3293,30 @@ public final class Arrays {
      * Set array value ['foo1', 'foo2', 'foo3'].
      *
      * @param arrayBody The array value ['foo1', 'foo2', 'foo3'].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putStringEnumValidAsync(List<Enum1> arrayBody, Context context) {
+        return putStringEnumValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set array value ['foo1', 'foo2', 'foo3'].
+     *
+     * @param arrayBody The array value ['foo1', 'foo2', 'foo3'].
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putStringEnumValidWithResponse(List<Enum1> arrayBody) {
-        return putStringEnumValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putStringEnumValidWithResponse(List<Enum1> arrayBody, Context context) {
+        return putStringEnumValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -2230,7 +3329,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putStringEnumValid(List<Enum1> arrayBody) {
-        putStringEnumValidWithResponse(arrayBody);
+        putStringEnumValidWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -2254,6 +3353,26 @@ public final class Arrays {
     /**
      * Get string array value ['foo', null, 'foo2'].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return string array value ['foo', null, 'foo2'] along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<String>>> getStringWithNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getStringWithNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get string array value ['foo', null, 'foo2'].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string array value ['foo', null, 'foo2'] on successful completion of {@link Mono}.
@@ -2266,13 +3385,29 @@ public final class Arrays {
     /**
      * Get string array value ['foo', null, 'foo2'].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return string array value ['foo', null, 'foo2'] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<String>> getStringWithNullAsync(Context context) {
+        return getStringWithNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get string array value ['foo', null, 'foo2'].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string array value ['foo', null, 'foo2'] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<String>> getStringWithNullWithResponse() {
-        return getStringWithNullWithResponseAsync().block();
+    public Response<List<String>> getStringWithNullWithResponse(Context context) {
+        return getStringWithNullWithResponseAsync(context).block();
     }
 
     /**
@@ -2284,7 +3419,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<String> getStringWithNull() {
-        return getStringWithNullWithResponse().getValue();
+        return getStringWithNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2308,6 +3443,26 @@ public final class Arrays {
     /**
      * Get string array value ['foo', 123, 'foo2'].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return string array value ['foo', 123, 'foo2'] along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<String>>> getStringWithInvalidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getStringWithInvalid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get string array value ['foo', 123, 'foo2'].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string array value ['foo', 123, 'foo2'] on successful completion of {@link Mono}.
@@ -2320,13 +3475,29 @@ public final class Arrays {
     /**
      * Get string array value ['foo', 123, 'foo2'].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return string array value ['foo', 123, 'foo2'] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<String>> getStringWithInvalidAsync(Context context) {
+        return getStringWithInvalidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get string array value ['foo', 123, 'foo2'].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string array value ['foo', 123, 'foo2'] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<String>> getStringWithInvalidWithResponse() {
-        return getStringWithInvalidWithResponseAsync().block();
+    public Response<List<String>> getStringWithInvalidWithResponse(Context context) {
+        return getStringWithInvalidWithResponseAsync(context).block();
     }
 
     /**
@@ -2338,7 +3509,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<String> getStringWithInvalid() {
-        return getStringWithInvalidWithResponse().getValue();
+        return getStringWithInvalidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2364,6 +3535,27 @@ public final class Arrays {
      * Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db',
      * 'f42f6aa1-a5bc-4ddf-907e-5f915de43205'].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db',
+     *     'f42f6aa1-a5bc-4ddf-907e-5f915de43205'] along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<UUID>>> getUuidValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getUuidValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db',
+     * 'f42f6aa1-a5bc-4ddf-907e-5f915de43205'].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db',
@@ -2378,14 +3570,32 @@ public final class Arrays {
      * Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db',
      * 'f42f6aa1-a5bc-4ddf-907e-5f915de43205'].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db',
+     *     'f42f6aa1-a5bc-4ddf-907e-5f915de43205'] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<UUID>> getUuidValidAsync(Context context) {
+        return getUuidValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db',
+     * 'f42f6aa1-a5bc-4ddf-907e-5f915de43205'].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db',
      *     'f42f6aa1-a5bc-4ddf-907e-5f915de43205'] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<UUID>> getUuidValidWithResponse() {
-        return getUuidValidWithResponseAsync().block();
+    public Response<List<UUID>> getUuidValidWithResponse(Context context) {
+        return getUuidValidWithResponseAsync(context).block();
     }
 
     /**
@@ -2399,7 +3609,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<UUID> getUuidValid() {
-        return getUuidValidWithResponse().getValue();
+        return getUuidValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2432,6 +3642,31 @@ public final class Arrays {
      *
      * @param arrayBody The array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db',
      *     'f42f6aa1-a5bc-4ddf-907e-5f915de43205'].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putUuidValidWithResponseAsync(List<UUID> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putUuidValid(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Set array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db',
+     * 'f42f6aa1-a5bc-4ddf-907e-5f915de43205'].
+     *
+     * @param arrayBody The array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db',
+     *     'f42f6aa1-a5bc-4ddf-907e-5f915de43205'].
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -2448,14 +3683,32 @@ public final class Arrays {
      *
      * @param arrayBody The array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db',
      *     'f42f6aa1-a5bc-4ddf-907e-5f915de43205'].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putUuidValidAsync(List<UUID> arrayBody, Context context) {
+        return putUuidValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db',
+     * 'f42f6aa1-a5bc-4ddf-907e-5f915de43205'].
+     *
+     * @param arrayBody The array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db',
+     *     'f42f6aa1-a5bc-4ddf-907e-5f915de43205'].
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putUuidValidWithResponse(List<UUID> arrayBody) {
-        return putUuidValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putUuidValidWithResponse(List<UUID> arrayBody, Context context) {
+        return putUuidValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -2470,7 +3723,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putUuidValid(List<UUID> arrayBody) {
-        putUuidValidWithResponse(arrayBody);
+        putUuidValidWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -2494,6 +3747,26 @@ public final class Arrays {
     /**
      * Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'foo'].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'foo'] along with {@link Response} on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<UUID>>> getUuidInvalidCharsWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getUuidInvalidChars(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'foo'].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'foo'] on successful completion of {@link
@@ -2507,13 +3780,30 @@ public final class Arrays {
     /**
      * Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'foo'].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'foo'] on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<UUID>> getUuidInvalidCharsAsync(Context context) {
+        return getUuidInvalidCharsWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'foo'].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'foo'] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<UUID>> getUuidInvalidCharsWithResponse() {
-        return getUuidInvalidCharsWithResponseAsync().block();
+    public Response<List<UUID>> getUuidInvalidCharsWithResponse(Context context) {
+        return getUuidInvalidCharsWithResponseAsync(context).block();
     }
 
     /**
@@ -2525,7 +3815,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<UUID> getUuidInvalidChars() {
-        return getUuidInvalidCharsWithResponse().getValue();
+        return getUuidInvalidCharsWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2549,6 +3839,26 @@ public final class Arrays {
     /**
      * Get integer array value ['2000-12-01', '1980-01-02', '1492-10-12'].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return integer array value ['2000-12-01', '1980-01-02', '1492-10-12'] along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<LocalDate>>> getDateValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDateValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get integer array value ['2000-12-01', '1980-01-02', '1492-10-12'].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return integer array value ['2000-12-01', '1980-01-02', '1492-10-12'] on successful completion of {@link Mono}.
@@ -2561,13 +3871,29 @@ public final class Arrays {
     /**
      * Get integer array value ['2000-12-01', '1980-01-02', '1492-10-12'].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return integer array value ['2000-12-01', '1980-01-02', '1492-10-12'] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<LocalDate>> getDateValidAsync(Context context) {
+        return getDateValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get integer array value ['2000-12-01', '1980-01-02', '1492-10-12'].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return integer array value ['2000-12-01', '1980-01-02', '1492-10-12'] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<LocalDate>> getDateValidWithResponse() {
-        return getDateValidWithResponseAsync().block();
+    public Response<List<LocalDate>> getDateValidWithResponse(Context context) {
+        return getDateValidWithResponseAsync(context).block();
     }
 
     /**
@@ -2579,7 +3905,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<LocalDate> getDateValid() {
-        return getDateValidWithResponse().getValue();
+        return getDateValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2608,6 +3934,29 @@ public final class Arrays {
      * Set array value ['2000-12-01', '1980-01-02', '1492-10-12'].
      *
      * @param arrayBody The array value ['2000-12-01', '1980-01-02', '1492-10-12'].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putDateValidWithResponseAsync(List<LocalDate> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putDateValid(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Set array value ['2000-12-01', '1980-01-02', '1492-10-12'].
+     *
+     * @param arrayBody The array value ['2000-12-01', '1980-01-02', '1492-10-12'].
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -2622,14 +3971,30 @@ public final class Arrays {
      * Set array value ['2000-12-01', '1980-01-02', '1492-10-12'].
      *
      * @param arrayBody The array value ['2000-12-01', '1980-01-02', '1492-10-12'].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putDateValidAsync(List<LocalDate> arrayBody, Context context) {
+        return putDateValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set array value ['2000-12-01', '1980-01-02', '1492-10-12'].
+     *
+     * @param arrayBody The array value ['2000-12-01', '1980-01-02', '1492-10-12'].
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDateValidWithResponse(List<LocalDate> arrayBody) {
-        return putDateValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putDateValidWithResponse(List<LocalDate> arrayBody, Context context) {
+        return putDateValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -2642,7 +4007,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDateValid(List<LocalDate> arrayBody) {
-        putDateValidWithResponse(arrayBody);
+        putDateValidWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -2666,6 +4031,26 @@ public final class Arrays {
     /**
      * Get date array value ['2012-01-01', null, '1776-07-04'].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return date array value ['2012-01-01', null, '1776-07-04'] along with {@link Response} on successful completion
+     *     of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<LocalDate>>> getDateInvalidNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDateInvalidNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get date array value ['2012-01-01', null, '1776-07-04'].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date array value ['2012-01-01', null, '1776-07-04'] on successful completion of {@link Mono}.
@@ -2678,13 +4063,29 @@ public final class Arrays {
     /**
      * Get date array value ['2012-01-01', null, '1776-07-04'].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return date array value ['2012-01-01', null, '1776-07-04'] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<LocalDate>> getDateInvalidNullAsync(Context context) {
+        return getDateInvalidNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get date array value ['2012-01-01', null, '1776-07-04'].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date array value ['2012-01-01', null, '1776-07-04'] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<LocalDate>> getDateInvalidNullWithResponse() {
-        return getDateInvalidNullWithResponseAsync().block();
+    public Response<List<LocalDate>> getDateInvalidNullWithResponse(Context context) {
+        return getDateInvalidNullWithResponseAsync(context).block();
     }
 
     /**
@@ -2696,7 +4097,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<LocalDate> getDateInvalidNull() {
-        return getDateInvalidNullWithResponse().getValue();
+        return getDateInvalidNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2720,6 +4121,26 @@ public final class Arrays {
     /**
      * Get date array value ['2011-03-22', 'date'].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return date array value ['2011-03-22', 'date'] along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<LocalDate>>> getDateInvalidCharsWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDateInvalidChars(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get date array value ['2011-03-22', 'date'].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date array value ['2011-03-22', 'date'] on successful completion of {@link Mono}.
@@ -2732,13 +4153,29 @@ public final class Arrays {
     /**
      * Get date array value ['2011-03-22', 'date'].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return date array value ['2011-03-22', 'date'] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<LocalDate>> getDateInvalidCharsAsync(Context context) {
+        return getDateInvalidCharsWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get date array value ['2011-03-22', 'date'].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date array value ['2011-03-22', 'date'] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<LocalDate>> getDateInvalidCharsWithResponse() {
-        return getDateInvalidCharsWithResponseAsync().block();
+    public Response<List<LocalDate>> getDateInvalidCharsWithResponse(Context context) {
+        return getDateInvalidCharsWithResponseAsync(context).block();
     }
 
     /**
@@ -2750,7 +4187,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<LocalDate> getDateInvalidChars() {
-        return getDateInvalidCharsWithResponse().getValue();
+        return getDateInvalidCharsWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2774,6 +4211,26 @@ public final class Arrays {
     /**
      * Get date-time array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00'].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return date-time array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00']
+     *     along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<OffsetDateTime>>> getDateTimeValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDateTimeValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get date-time array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00'].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date-time array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00']
@@ -2787,14 +4244,31 @@ public final class Arrays {
     /**
      * Get date-time array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00'].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return date-time array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00']
+     *     on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<OffsetDateTime>> getDateTimeValidAsync(Context context) {
+        return getDateTimeValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get date-time array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00'].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date-time array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00']
      *     along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<OffsetDateTime>> getDateTimeValidWithResponse() {
-        return getDateTimeValidWithResponseAsync().block();
+    public Response<List<OffsetDateTime>> getDateTimeValidWithResponse(Context context) {
+        return getDateTimeValidWithResponseAsync(context).block();
     }
 
     /**
@@ -2806,7 +4280,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<OffsetDateTime> getDateTimeValid() {
-        return getDateTimeValidWithResponse().getValue();
+        return getDateTimeValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2838,6 +4312,30 @@ public final class Arrays {
      *
      * @param arrayBody The array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00',
      *     '1492-10-12T10:15:01-08:00'].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putDateTimeValidWithResponseAsync(List<OffsetDateTime> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putDateTimeValid(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Set array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00'].
+     *
+     * @param arrayBody The array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00',
+     *     '1492-10-12T10:15:01-08:00'].
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -2853,14 +4351,31 @@ public final class Arrays {
      *
      * @param arrayBody The array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00',
      *     '1492-10-12T10:15:01-08:00'].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putDateTimeValidAsync(List<OffsetDateTime> arrayBody, Context context) {
+        return putDateTimeValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00'].
+     *
+     * @param arrayBody The array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00',
+     *     '1492-10-12T10:15:01-08:00'].
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDateTimeValidWithResponse(List<OffsetDateTime> arrayBody) {
-        return putDateTimeValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putDateTimeValidWithResponse(List<OffsetDateTime> arrayBody, Context context) {
+        return putDateTimeValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -2874,7 +4389,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDateTimeValid(List<OffsetDateTime> arrayBody) {
-        putDateTimeValidWithResponse(arrayBody);
+        putDateTimeValidWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -2898,6 +4413,26 @@ public final class Arrays {
     /**
      * Get date array value ['2000-12-01t00:00:01z', null].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return date array value ['2000-12-01t00:00:01z', null] along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<OffsetDateTime>>> getDateTimeInvalidNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDateTimeInvalidNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get date array value ['2000-12-01t00:00:01z', null].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date array value ['2000-12-01t00:00:01z', null] on successful completion of {@link Mono}.
@@ -2910,13 +4445,29 @@ public final class Arrays {
     /**
      * Get date array value ['2000-12-01t00:00:01z', null].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return date array value ['2000-12-01t00:00:01z', null] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<OffsetDateTime>> getDateTimeInvalidNullAsync(Context context) {
+        return getDateTimeInvalidNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get date array value ['2000-12-01t00:00:01z', null].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date array value ['2000-12-01t00:00:01z', null] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<OffsetDateTime>> getDateTimeInvalidNullWithResponse() {
-        return getDateTimeInvalidNullWithResponseAsync().block();
+    public Response<List<OffsetDateTime>> getDateTimeInvalidNullWithResponse(Context context) {
+        return getDateTimeInvalidNullWithResponseAsync(context).block();
     }
 
     /**
@@ -2928,7 +4479,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<OffsetDateTime> getDateTimeInvalidNull() {
-        return getDateTimeInvalidNullWithResponse().getValue();
+        return getDateTimeInvalidNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2952,6 +4503,26 @@ public final class Arrays {
     /**
      * Get date array value ['2000-12-01t00:00:01z', 'date-time'].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return date array value ['2000-12-01t00:00:01z', 'date-time'] along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<OffsetDateTime>>> getDateTimeInvalidCharsWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDateTimeInvalidChars(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get date array value ['2000-12-01t00:00:01z', 'date-time'].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date array value ['2000-12-01t00:00:01z', 'date-time'] on successful completion of {@link Mono}.
@@ -2964,13 +4535,29 @@ public final class Arrays {
     /**
      * Get date array value ['2000-12-01t00:00:01z', 'date-time'].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return date array value ['2000-12-01t00:00:01z', 'date-time'] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<OffsetDateTime>> getDateTimeInvalidCharsAsync(Context context) {
+        return getDateTimeInvalidCharsWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get date array value ['2000-12-01t00:00:01z', 'date-time'].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date array value ['2000-12-01t00:00:01z', 'date-time'] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<OffsetDateTime>> getDateTimeInvalidCharsWithResponse() {
-        return getDateTimeInvalidCharsWithResponseAsync().block();
+    public Response<List<OffsetDateTime>> getDateTimeInvalidCharsWithResponse(Context context) {
+        return getDateTimeInvalidCharsWithResponseAsync(context).block();
     }
 
     /**
@@ -2982,7 +4569,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<OffsetDateTime> getDateTimeInvalidChars() {
-        return getDateTimeInvalidCharsWithResponse().getValue();
+        return getDateTimeInvalidCharsWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -3008,6 +4595,27 @@ public final class Arrays {
      * Get date-time array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492
      * 10:15:01 GMT'].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return date-time array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct
+     *     1492 10:15:01 GMT'] along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<OffsetDateTime>>> getDateTimeRfc1123ValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDateTimeRfc1123Valid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get date-time array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492
+     * 10:15:01 GMT'].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date-time array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct
@@ -3022,14 +4630,32 @@ public final class Arrays {
      * Get date-time array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492
      * 10:15:01 GMT'].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return date-time array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct
+     *     1492 10:15:01 GMT'] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<OffsetDateTime>> getDateTimeRfc1123ValidAsync(Context context) {
+        return getDateTimeRfc1123ValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get date-time array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492
+     * 10:15:01 GMT'].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date-time array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct
      *     1492 10:15:01 GMT'] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<OffsetDateTime>> getDateTimeRfc1123ValidWithResponse() {
-        return getDateTimeRfc1123ValidWithResponseAsync().block();
+    public Response<List<OffsetDateTime>> getDateTimeRfc1123ValidWithResponse(Context context) {
+        return getDateTimeRfc1123ValidWithResponseAsync(context).block();
     }
 
     /**
@@ -3043,7 +4669,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<OffsetDateTime> getDateTimeRfc1123Valid() {
-        return getDateTimeRfc1123ValidWithResponse().getValue();
+        return getDateTimeRfc1123ValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -3079,6 +4705,34 @@ public final class Arrays {
      *
      * @param arrayBody The array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct
      *     1492 10:15:01 GMT'].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putDateTimeRfc1123ValidWithResponseAsync(
+            List<OffsetDateTime> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        List<DateTimeRfc1123> arrayBodyConverted =
+                arrayBody.stream().map(el -> new DateTimeRfc1123(el)).collect(java.util.stream.Collectors.toList());
+        return service.putDateTimeRfc1123Valid(this.client.getHost(), arrayBodyConverted, accept, context);
+    }
+
+    /**
+     * Set array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01
+     * GMT'].
+     *
+     * @param arrayBody The array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct
+     *     1492 10:15:01 GMT'].
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -3095,14 +4749,32 @@ public final class Arrays {
      *
      * @param arrayBody The array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct
      *     1492 10:15:01 GMT'].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putDateTimeRfc1123ValidAsync(List<OffsetDateTime> arrayBody, Context context) {
+        return putDateTimeRfc1123ValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01
+     * GMT'].
+     *
+     * @param arrayBody The array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct
+     *     1492 10:15:01 GMT'].
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDateTimeRfc1123ValidWithResponse(List<OffsetDateTime> arrayBody) {
-        return putDateTimeRfc1123ValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putDateTimeRfc1123ValidWithResponse(List<OffsetDateTime> arrayBody, Context context) {
+        return putDateTimeRfc1123ValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -3117,7 +4789,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDateTimeRfc1123Valid(List<OffsetDateTime> arrayBody) {
-        putDateTimeRfc1123ValidWithResponse(arrayBody);
+        putDateTimeRfc1123ValidWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -3141,6 +4813,26 @@ public final class Arrays {
     /**
      * Get duration array value ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return duration array value ['P123DT22H14M12.011S', 'P5DT1H0M0S'] along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Duration>>> getDurationValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDurationValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get duration array value ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return duration array value ['P123DT22H14M12.011S', 'P5DT1H0M0S'] on successful completion of {@link Mono}.
@@ -3153,13 +4845,29 @@ public final class Arrays {
     /**
      * Get duration array value ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return duration array value ['P123DT22H14M12.011S', 'P5DT1H0M0S'] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Duration>> getDurationValidAsync(Context context) {
+        return getDurationValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get duration array value ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return duration array value ['P123DT22H14M12.011S', 'P5DT1H0M0S'] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Duration>> getDurationValidWithResponse() {
-        return getDurationValidWithResponseAsync().block();
+    public Response<List<Duration>> getDurationValidWithResponse(Context context) {
+        return getDurationValidWithResponseAsync(context).block();
     }
 
     /**
@@ -3171,7 +4879,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Duration> getDurationValid() {
-        return getDurationValidWithResponse().getValue();
+        return getDurationValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -3201,6 +4909,29 @@ public final class Arrays {
      * Set array value ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
      *
      * @param arrayBody The array value ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putDurationValidWithResponseAsync(List<Duration> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putDurationValid(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Set array value ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
+     *
+     * @param arrayBody The array value ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -3215,14 +4946,30 @@ public final class Arrays {
      * Set array value ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
      *
      * @param arrayBody The array value ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putDurationValidAsync(List<Duration> arrayBody, Context context) {
+        return putDurationValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set array value ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
+     *
+     * @param arrayBody The array value ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDurationValidWithResponse(List<Duration> arrayBody) {
-        return putDurationValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putDurationValidWithResponse(List<Duration> arrayBody, Context context) {
+        return putDurationValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -3235,7 +4982,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDurationValid(List<Duration> arrayBody) {
-        putDurationValidWithResponse(arrayBody);
+        putDurationValidWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -3259,6 +5006,26 @@ public final class Arrays {
     /**
      * Get byte array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each item encoded in base64.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return byte array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each item encoded in base64
+     *     along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<byte[]>>> getByteValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getByteValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get byte array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each item encoded in base64.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return byte array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each item encoded in base64 on
@@ -3272,14 +5039,31 @@ public final class Arrays {
     /**
      * Get byte array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each item encoded in base64.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return byte array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each item encoded in base64 on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<byte[]>> getByteValidAsync(Context context) {
+        return getByteValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get byte array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each item encoded in base64.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return byte array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each item encoded in base64
      *     along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<byte[]>> getByteValidWithResponse() {
-        return getByteValidWithResponseAsync().block();
+    public Response<List<byte[]>> getByteValidWithResponse(Context context) {
+        return getByteValidWithResponseAsync(context).block();
     }
 
     /**
@@ -3291,7 +5075,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<byte[]> getByteValid() {
-        return getByteValidWithResponse().getValue();
+        return getByteValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -3322,6 +5106,30 @@ public final class Arrays {
      *
      * @param arrayBody The array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in
      *     base 64.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putByteValidWithResponseAsync(List<byte[]> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putByteValid(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Put the array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64.
+     *
+     * @param arrayBody The array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in
+     *     base 64.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -3337,14 +5145,31 @@ public final class Arrays {
      *
      * @param arrayBody The array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in
      *     base 64.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putByteValidAsync(List<byte[]> arrayBody, Context context) {
+        return putByteValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put the array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64.
+     *
+     * @param arrayBody The array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in
+     *     base 64.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putByteValidWithResponse(List<byte[]> arrayBody) {
-        return putByteValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putByteValidWithResponse(List<byte[]> arrayBody, Context context) {
+        return putByteValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -3358,7 +5183,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putByteValid(List<byte[]> arrayBody) {
-        putByteValidWithResponse(arrayBody);
+        putByteValidWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -3382,6 +5207,26 @@ public final class Arrays {
     /**
      * Get byte array value [hex(AB, AC, AD), null] with the first item base64 encoded.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return byte array value [hex(AB, AC, AD), null] with the first item base64 encoded along with {@link Response}
+     *     on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<byte[]>>> getByteInvalidNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getByteInvalidNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get byte array value [hex(AB, AC, AD), null] with the first item base64 encoded.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return byte array value [hex(AB, AC, AD), null] with the first item base64 encoded on successful completion of
@@ -3395,13 +5240,30 @@ public final class Arrays {
     /**
      * Get byte array value [hex(AB, AC, AD), null] with the first item base64 encoded.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return byte array value [hex(AB, AC, AD), null] with the first item base64 encoded on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<byte[]>> getByteInvalidNullAsync(Context context) {
+        return getByteInvalidNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get byte array value [hex(AB, AC, AD), null] with the first item base64 encoded.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return byte array value [hex(AB, AC, AD), null] with the first item base64 encoded along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<byte[]>> getByteInvalidNullWithResponse() {
-        return getByteInvalidNullWithResponseAsync().block();
+    public Response<List<byte[]>> getByteInvalidNullWithResponse(Context context) {
+        return getByteInvalidNullWithResponseAsync(context).block();
     }
 
     /**
@@ -3413,7 +5275,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<byte[]> getByteInvalidNull() {
-        return getByteInvalidNullWithResponse().getValue();
+        return getByteInvalidNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -3439,6 +5301,27 @@ public final class Arrays {
      * Get array value ['a string that gets encoded with base64url', 'test string' 'Lorem ipsum'] with the items
      * base64url encoded.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return array value ['a string that gets encoded with base64url', 'test string' 'Lorem ipsum'] with the items
+     *     base64url encoded along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<byte[]>>> getBase64UrlWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getBase64Url(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get array value ['a string that gets encoded with base64url', 'test string' 'Lorem ipsum'] with the items
+     * base64url encoded.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return array value ['a string that gets encoded with base64url', 'test string' 'Lorem ipsum'] with the items
@@ -3453,14 +5336,32 @@ public final class Arrays {
      * Get array value ['a string that gets encoded with base64url', 'test string' 'Lorem ipsum'] with the items
      * base64url encoded.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return array value ['a string that gets encoded with base64url', 'test string' 'Lorem ipsum'] with the items
+     *     base64url encoded on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<byte[]>> getBase64UrlAsync(Context context) {
+        return getBase64UrlWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get array value ['a string that gets encoded with base64url', 'test string' 'Lorem ipsum'] with the items
+     * base64url encoded.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return array value ['a string that gets encoded with base64url', 'test string' 'Lorem ipsum'] with the items
      *     base64url encoded along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<byte[]>> getBase64UrlWithResponse() {
-        return getBase64UrlWithResponseAsync().block();
+    public Response<List<byte[]>> getBase64UrlWithResponse(Context context) {
+        return getBase64UrlWithResponseAsync(context).block();
     }
 
     /**
@@ -3474,7 +5375,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<byte[]> getBase64Url() {
-        return getBase64UrlWithResponse().getValue();
+        return getBase64UrlWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -3497,6 +5398,25 @@ public final class Arrays {
     /**
      * Get array of complex type null value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return array of complex type null value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Product>>> getComplexNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getComplexNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get array of complex type null value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return array of complex type null value on successful completion of {@link Mono}.
@@ -3509,13 +5429,29 @@ public final class Arrays {
     /**
      * Get array of complex type null value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return array of complex type null value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Product>> getComplexNullAsync(Context context) {
+        return getComplexNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get array of complex type null value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return array of complex type null value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Product>> getComplexNullWithResponse() {
-        return getComplexNullWithResponseAsync().block();
+    public Response<List<Product>> getComplexNullWithResponse(Context context) {
+        return getComplexNullWithResponseAsync(context).block();
     }
 
     /**
@@ -3527,7 +5463,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Product> getComplexNull() {
-        return getComplexNullWithResponse().getValue();
+        return getComplexNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -3550,6 +5486,25 @@ public final class Arrays {
     /**
      * Get empty array of complex type [].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return empty array of complex type [] along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Product>>> getComplexEmptyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getComplexEmpty(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get empty array of complex type [].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return empty array of complex type [] on successful completion of {@link Mono}.
@@ -3562,13 +5517,29 @@ public final class Arrays {
     /**
      * Get empty array of complex type [].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return empty array of complex type [] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Product>> getComplexEmptyAsync(Context context) {
+        return getComplexEmptyWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get empty array of complex type [].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return empty array of complex type [] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Product>> getComplexEmptyWithResponse() {
-        return getComplexEmptyWithResponseAsync().block();
+    public Response<List<Product>> getComplexEmptyWithResponse(Context context) {
+        return getComplexEmptyWithResponseAsync(context).block();
     }
 
     /**
@@ -3580,7 +5551,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Product> getComplexEmpty() {
-        return getComplexEmptyWithResponse().getValue();
+        return getComplexEmptyWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -3604,6 +5575,26 @@ public final class Arrays {
     /**
      * Get array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}]
+     *     along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Product>>> getComplexItemNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getComplexItemNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}]
@@ -3617,14 +5608,31 @@ public final class Arrays {
     /**
      * Get array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}]
+     *     on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Product>> getComplexItemNullAsync(Context context) {
+        return getComplexItemNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}]
      *     along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Product>> getComplexItemNullWithResponse() {
-        return getComplexItemNullWithResponseAsync().block();
+    public Response<List<Product>> getComplexItemNullWithResponse(Context context) {
+        return getComplexItemNullWithResponseAsync(context).block();
     }
 
     /**
@@ -3636,7 +5644,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Product> getComplexItemNull() {
-        return getComplexItemNullWithResponse().getValue();
+        return getComplexItemNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -3660,6 +5668,26 @@ public final class Arrays {
     /**
      * Get array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}]
+     *     along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Product>>> getComplexItemEmptyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getComplexItemEmpty(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}]
@@ -3673,14 +5701,31 @@ public final class Arrays {
     /**
      * Get array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}]
+     *     on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Product>> getComplexItemEmptyAsync(Context context) {
+        return getComplexItemEmptyWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}]
      *     along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Product>> getComplexItemEmptyWithResponse() {
-        return getComplexItemEmptyWithResponseAsync().block();
+    public Response<List<Product>> getComplexItemEmptyWithResponse(Context context) {
+        return getComplexItemEmptyWithResponseAsync(context).block();
     }
 
     /**
@@ -3692,7 +5737,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Product> getComplexItemEmpty() {
-        return getComplexItemEmptyWithResponse().getValue();
+        return getComplexItemEmptyWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -3718,6 +5763,27 @@ public final class Arrays {
      * Get array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5,
      * 'string': '6'}].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5,
+     *     'string': '6'}] along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Product>>> getComplexValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getComplexValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5,
+     * 'string': '6'}].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5,
@@ -3732,14 +5798,32 @@ public final class Arrays {
      * Get array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5,
      * 'string': '6'}].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5,
+     *     'string': '6'}] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Product>> getComplexValidAsync(Context context) {
+        return getComplexValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5,
+     * 'string': '6'}].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5,
      *     'string': '6'}] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Product>> getComplexValidWithResponse() {
-        return getComplexValidWithResponseAsync().block();
+    public Response<List<Product>> getComplexValidWithResponse(Context context) {
+        return getComplexValidWithResponseAsync(context).block();
     }
 
     /**
@@ -3753,7 +5837,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Product> getComplexValid() {
-        return getComplexValidWithResponse().getValue();
+        return getComplexValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -3789,6 +5873,33 @@ public final class Arrays {
      *
      * @param arrayBody array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'},
      *     {'integer': 5, 'string': '6'}].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putComplexValidWithResponseAsync(List<Product> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        } else {
+            arrayBody.forEach(e -> e.validate());
+        }
+        final String accept = "application/json";
+        return service.putComplexValid(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Put an array of complex type with values [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'},
+     * {'integer': 5, 'string': '6'}].
+     *
+     * @param arrayBody array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'},
+     *     {'integer': 5, 'string': '6'}].
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -3805,14 +5916,32 @@ public final class Arrays {
      *
      * @param arrayBody array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'},
      *     {'integer': 5, 'string': '6'}].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putComplexValidAsync(List<Product> arrayBody, Context context) {
+        return putComplexValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put an array of complex type with values [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'},
+     * {'integer': 5, 'string': '6'}].
+     *
+     * @param arrayBody array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'},
+     *     {'integer': 5, 'string': '6'}].
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putComplexValidWithResponse(List<Product> arrayBody) {
-        return putComplexValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putComplexValidWithResponse(List<Product> arrayBody, Context context) {
+        return putComplexValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -3827,7 +5956,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putComplexValid(List<Product> arrayBody) {
-        putComplexValidWithResponse(arrayBody);
+        putComplexValidWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -3850,6 +5979,25 @@ public final class Arrays {
     /**
      * Get a null array.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a null array along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<List<String>>>> getArrayNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getArrayNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get a null array.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a null array on successful completion of {@link Mono}.
@@ -3862,13 +6010,29 @@ public final class Arrays {
     /**
      * Get a null array.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a null array on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<List<String>>> getArrayNullAsync(Context context) {
+        return getArrayNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get a null array.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a null array along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<List<String>>> getArrayNullWithResponse() {
-        return getArrayNullWithResponseAsync().block();
+    public Response<List<List<String>>> getArrayNullWithResponse(Context context) {
+        return getArrayNullWithResponseAsync(context).block();
     }
 
     /**
@@ -3880,7 +6044,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<List<String>> getArrayNull() {
-        return getArrayNullWithResponse().getValue();
+        return getArrayNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -3903,6 +6067,25 @@ public final class Arrays {
     /**
      * Get an empty array [].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an empty array [] along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<List<String>>>> getArrayEmptyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getArrayEmpty(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get an empty array [].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an empty array [] on successful completion of {@link Mono}.
@@ -3915,13 +6098,29 @@ public final class Arrays {
     /**
      * Get an empty array [].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an empty array [] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<List<String>>> getArrayEmptyAsync(Context context) {
+        return getArrayEmptyWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get an empty array [].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an empty array [] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<List<String>>> getArrayEmptyWithResponse() {
-        return getArrayEmptyWithResponseAsync().block();
+    public Response<List<List<String>>> getArrayEmptyWithResponse(Context context) {
+        return getArrayEmptyWithResponseAsync(context).block();
     }
 
     /**
@@ -3933,7 +6132,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<List<String>> getArrayEmpty() {
-        return getArrayEmptyWithResponse().getValue();
+        return getArrayEmptyWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -3957,6 +6156,26 @@ public final class Arrays {
     /**
      * Get an array of array of strings [['1', '2', '3'], null, ['7', '8', '9']].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of array of strings [['1', '2', '3'], null, ['7', '8', '9']] along with {@link Response} on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<List<String>>>> getArrayItemNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getArrayItemNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get an array of array of strings [['1', '2', '3'], null, ['7', '8', '9']].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an array of array of strings [['1', '2', '3'], null, ['7', '8', '9']] on successful completion of {@link
@@ -3970,13 +6189,30 @@ public final class Arrays {
     /**
      * Get an array of array of strings [['1', '2', '3'], null, ['7', '8', '9']].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of array of strings [['1', '2', '3'], null, ['7', '8', '9']] on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<List<String>>> getArrayItemNullAsync(Context context) {
+        return getArrayItemNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get an array of array of strings [['1', '2', '3'], null, ['7', '8', '9']].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an array of array of strings [['1', '2', '3'], null, ['7', '8', '9']] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<List<String>>> getArrayItemNullWithResponse() {
-        return getArrayItemNullWithResponseAsync().block();
+    public Response<List<List<String>>> getArrayItemNullWithResponse(Context context) {
+        return getArrayItemNullWithResponseAsync(context).block();
     }
 
     /**
@@ -3988,7 +6224,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<List<String>> getArrayItemNull() {
-        return getArrayItemNullWithResponse().getValue();
+        return getArrayItemNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -4012,6 +6248,26 @@ public final class Arrays {
     /**
      * Get an array of array of strings [['1', '2', '3'], [], ['7', '8', '9']].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of array of strings [['1', '2', '3'], [], ['7', '8', '9']] along with {@link Response} on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<List<String>>>> getArrayItemEmptyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getArrayItemEmpty(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get an array of array of strings [['1', '2', '3'], [], ['7', '8', '9']].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an array of array of strings [['1', '2', '3'], [], ['7', '8', '9']] on successful completion of {@link
@@ -4025,13 +6281,30 @@ public final class Arrays {
     /**
      * Get an array of array of strings [['1', '2', '3'], [], ['7', '8', '9']].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of array of strings [['1', '2', '3'], [], ['7', '8', '9']] on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<List<String>>> getArrayItemEmptyAsync(Context context) {
+        return getArrayItemEmptyWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get an array of array of strings [['1', '2', '3'], [], ['7', '8', '9']].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an array of array of strings [['1', '2', '3'], [], ['7', '8', '9']] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<List<String>>> getArrayItemEmptyWithResponse() {
-        return getArrayItemEmptyWithResponseAsync().block();
+    public Response<List<List<String>>> getArrayItemEmptyWithResponse(Context context) {
+        return getArrayItemEmptyWithResponseAsync(context).block();
     }
 
     /**
@@ -4043,7 +6316,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<List<String>> getArrayItemEmpty() {
-        return getArrayItemEmptyWithResponse().getValue();
+        return getArrayItemEmptyWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -4067,6 +6340,26 @@ public final class Arrays {
     /**
      * Get an array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']] along with {@link
+     *     Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<List<String>>>> getArrayValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getArrayValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get an array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']] on successful completion
@@ -4080,14 +6373,31 @@ public final class Arrays {
     /**
      * Get an array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']] on successful completion
+     *     of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<List<String>>> getArrayValidAsync(Context context) {
+        return getArrayValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get an array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']] along with {@link
      *     Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<List<String>>> getArrayValidWithResponse() {
-        return getArrayValidWithResponseAsync().block();
+    public Response<List<List<String>>> getArrayValidWithResponse(Context context) {
+        return getArrayValidWithResponseAsync(context).block();
     }
 
     /**
@@ -4099,7 +6409,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<List<String>> getArrayValid() {
-        return getArrayValidWithResponse().getValue();
+        return getArrayValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -4129,6 +6439,29 @@ public final class Arrays {
      * Put An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']].
      *
      * @param arrayBody An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putArrayValidWithResponseAsync(List<List<String>> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putArrayValid(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Put An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']].
+     *
+     * @param arrayBody An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']].
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -4143,14 +6476,30 @@ public final class Arrays {
      * Put An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']].
      *
      * @param arrayBody An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putArrayValidAsync(List<List<String>> arrayBody, Context context) {
+        return putArrayValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']].
+     *
+     * @param arrayBody An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']].
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putArrayValidWithResponse(List<List<String>> arrayBody) {
-        return putArrayValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putArrayValidWithResponse(List<List<String>> arrayBody, Context context) {
+        return putArrayValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -4163,7 +6512,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putArrayValid(List<List<String>> arrayBody) {
-        putArrayValidWithResponse(arrayBody);
+        putArrayValidWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -4187,6 +6536,26 @@ public final class Arrays {
     /**
      * Get an array of Dictionaries with value null.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of Dictionaries with value null along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Map<String, String>>>> getDictionaryNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDictionaryNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get an array of Dictionaries with value null.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an array of Dictionaries with value null on successful completion of {@link Mono}.
@@ -4199,13 +6568,29 @@ public final class Arrays {
     /**
      * Get an array of Dictionaries with value null.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of Dictionaries with value null on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Map<String, String>>> getDictionaryNullAsync(Context context) {
+        return getDictionaryNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get an array of Dictionaries with value null.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an array of Dictionaries with value null along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Map<String, String>>> getDictionaryNullWithResponse() {
-        return getDictionaryNullWithResponseAsync().block();
+    public Response<List<Map<String, String>>> getDictionaryNullWithResponse(Context context) {
+        return getDictionaryNullWithResponseAsync(context).block();
     }
 
     /**
@@ -4217,7 +6602,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Map<String, String>> getDictionaryNull() {
-        return getDictionaryNullWithResponse().getValue();
+        return getDictionaryNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -4241,6 +6626,26 @@ public final class Arrays {
     /**
      * Get an array of Dictionaries of type &lt;string, string&gt; with value [].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of Dictionaries of type &lt;string, string&gt; with value [] along with {@link Response} on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Map<String, String>>>> getDictionaryEmptyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDictionaryEmpty(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an array of Dictionaries of type &lt;string, string&gt; with value [] on successful completion of {@link
@@ -4254,13 +6659,30 @@ public final class Arrays {
     /**
      * Get an array of Dictionaries of type &lt;string, string&gt; with value [].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of Dictionaries of type &lt;string, string&gt; with value [] on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Map<String, String>>> getDictionaryEmptyAsync(Context context) {
+        return getDictionaryEmptyWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an array of Dictionaries of type &lt;string, string&gt; with value [] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Map<String, String>>> getDictionaryEmptyWithResponse() {
-        return getDictionaryEmptyWithResponseAsync().block();
+    public Response<List<Map<String, String>>> getDictionaryEmptyWithResponse(Context context) {
+        return getDictionaryEmptyWithResponseAsync(context).block();
     }
 
     /**
@@ -4272,7 +6694,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Map<String, String>> getDictionaryEmpty() {
-        return getDictionaryEmptyWithResponse().getValue();
+        return getDictionaryEmptyWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -4299,6 +6721,28 @@ public final class Arrays {
      * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'},
      * null, {'7': 'seven', '8': 'eight', '9': 'nine'}].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3':
+     *     'three'}, null, {'7': 'seven', '8': 'eight', '9': 'nine'}] along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Map<String, String>>>> getDictionaryItemNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDictionaryItemNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'},
+     * null, {'7': 'seven', '8': 'eight', '9': 'nine'}].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3':
@@ -4313,14 +6757,32 @@ public final class Arrays {
      * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'},
      * null, {'7': 'seven', '8': 'eight', '9': 'nine'}].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3':
+     *     'three'}, null, {'7': 'seven', '8': 'eight', '9': 'nine'}] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Map<String, String>>> getDictionaryItemNullAsync(Context context) {
+        return getDictionaryItemNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'},
+     * null, {'7': 'seven', '8': 'eight', '9': 'nine'}].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3':
      *     'three'}, null, {'7': 'seven', '8': 'eight', '9': 'nine'}] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Map<String, String>>> getDictionaryItemNullWithResponse() {
-        return getDictionaryItemNullWithResponseAsync().block();
+    public Response<List<Map<String, String>>> getDictionaryItemNullWithResponse(Context context) {
+        return getDictionaryItemNullWithResponseAsync(context).block();
     }
 
     /**
@@ -4334,7 +6796,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Map<String, String>> getDictionaryItemNull() {
-        return getDictionaryItemNullWithResponse().getValue();
+        return getDictionaryItemNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -4361,6 +6823,28 @@ public final class Arrays {
      * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'},
      * {}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3':
+     *     'three'}, {}, {'7': 'seven', '8': 'eight', '9': 'nine'}] along with {@link Response} on successful completion
+     *     of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Map<String, String>>>> getDictionaryItemEmptyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDictionaryItemEmpty(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'},
+     * {}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3':
@@ -4375,14 +6859,32 @@ public final class Arrays {
      * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'},
      * {}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3':
+     *     'three'}, {}, {'7': 'seven', '8': 'eight', '9': 'nine'}] on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Map<String, String>>> getDictionaryItemEmptyAsync(Context context) {
+        return getDictionaryItemEmptyWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'},
+     * {}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3':
      *     'three'}, {}, {'7': 'seven', '8': 'eight', '9': 'nine'}] along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Map<String, String>>> getDictionaryItemEmptyWithResponse() {
-        return getDictionaryItemEmptyWithResponseAsync().block();
+    public Response<List<Map<String, String>>> getDictionaryItemEmptyWithResponse(Context context) {
+        return getDictionaryItemEmptyWithResponseAsync(context).block();
     }
 
     /**
@@ -4396,7 +6898,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Map<String, String>> getDictionaryItemEmpty() {
-        return getDictionaryItemEmptyWithResponse().getValue();
+        return getDictionaryItemEmptyWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -4423,6 +6925,28 @@ public final class Arrays {
      * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'},
      * {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3':
+     *     'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}] along with
+     *     {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Map<String, String>>>> getDictionaryValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDictionaryValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'},
+     * {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3':
@@ -4438,6 +6962,25 @@ public final class Arrays {
      * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'},
      * {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3':
+     *     'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}] on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Map<String, String>>> getDictionaryValidAsync(Context context) {
+        return getDictionaryValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'},
+     * {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3':
@@ -4445,8 +6988,8 @@ public final class Arrays {
      *     {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Map<String, String>>> getDictionaryValidWithResponse() {
-        return getDictionaryValidWithResponseAsync().block();
+    public Response<List<Map<String, String>>> getDictionaryValidWithResponse(Context context) {
+        return getDictionaryValidWithResponseAsync(context).block();
     }
 
     /**
@@ -4460,7 +7003,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Map<String, String>> getDictionaryValid() {
-        return getDictionaryValidWithResponse().getValue();
+        return getDictionaryValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -4496,6 +7039,34 @@ public final class Arrays {
      *
      * @param arrayBody An array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two',
      *     '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3':
+     *     'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}] along with
+     *     {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putDictionaryValidWithResponseAsync(
+            List<Map<String, String>> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putDictionaryValid(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'},
+     * {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
+     *
+     * @param arrayBody An array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two',
+     *     '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -4514,6 +7085,26 @@ public final class Arrays {
      *
      * @param arrayBody An array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two',
      *     '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3':
+     *     'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}] on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putDictionaryValidAsync(List<Map<String, String>> arrayBody, Context context) {
+        return putDictionaryValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'},
+     * {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
+     *
+     * @param arrayBody An array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two',
+     *     '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -4522,8 +7113,8 @@ public final class Arrays {
      *     {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDictionaryValidWithResponse(List<Map<String, String>> arrayBody) {
-        return putDictionaryValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putDictionaryValidWithResponse(List<Map<String, String>> arrayBody, Context context) {
+        return putDictionaryValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -4538,6 +7129,6 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDictionaryValid(List<Map<String, String>> arrayBody) {
-        putDictionaryValidWithResponse(arrayBody);
+        putDictionaryValidWithResponse(arrayBody, Context.NONE);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/quirks/Bools.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/quirks/Bools.java
@@ -110,6 +110,25 @@ public final class Bools {
     /**
      * Get true Boolean value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return true Boolean value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Boolean>> getTrueWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getTrue(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get true Boolean value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return true Boolean value on successful completion of {@link Mono}.
@@ -122,13 +141,29 @@ public final class Bools {
     /**
      * Get true Boolean value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return true Boolean value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Boolean> getTrueAsync(Context context) {
+        return getTrueWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get true Boolean value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return true Boolean value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Boolean> getTrueWithResponse() {
-        return getTrueWithResponseAsync().block();
+    public Response<Boolean> getTrueWithResponse(Context context) {
+        return getTrueWithResponseAsync(context).block();
     }
 
     /**
@@ -140,7 +175,7 @@ public final class Bools {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean getTrue() {
-        return getTrueWithResponse().getValue();
+        return getTrueWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -166,6 +201,26 @@ public final class Bools {
      * Set Boolean value true.
      *
      * @param boolBody The boolBody parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putTrueWithResponseAsync(boolean boolBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putTrue(this.client.getHost(), boolBody, accept, context);
+    }
+
+    /**
+     * Set Boolean value true.
+     *
+     * @param boolBody The boolBody parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -180,14 +235,30 @@ public final class Bools {
      * Set Boolean value true.
      *
      * @param boolBody The boolBody parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putTrueAsync(boolean boolBody, Context context) {
+        return putTrueWithResponseAsync(boolBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set Boolean value true.
+     *
+     * @param boolBody The boolBody parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putTrueWithResponse(boolean boolBody) {
-        return putTrueWithResponseAsync(boolBody).block();
+    public Response<Void> putTrueWithResponse(boolean boolBody, Context context) {
+        return putTrueWithResponseAsync(boolBody, context).block();
     }
 
     /**
@@ -200,7 +271,7 @@ public final class Bools {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putTrue(boolean boolBody) {
-        putTrueWithResponse(boolBody);
+        putTrueWithResponse(boolBody, Context.NONE);
     }
 
     /**
@@ -223,6 +294,25 @@ public final class Bools {
     /**
      * Get false Boolean value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return false Boolean value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Boolean>> getFalseWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getFalse(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get false Boolean value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return false Boolean value on successful completion of {@link Mono}.
@@ -235,13 +325,29 @@ public final class Bools {
     /**
      * Get false Boolean value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return false Boolean value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Boolean> getFalseAsync(Context context) {
+        return getFalseWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get false Boolean value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return false Boolean value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Boolean> getFalseWithResponse() {
-        return getFalseWithResponseAsync().block();
+    public Response<Boolean> getFalseWithResponse(Context context) {
+        return getFalseWithResponseAsync(context).block();
     }
 
     /**
@@ -253,7 +359,7 @@ public final class Bools {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean getFalse() {
-        return getFalseWithResponse().getValue();
+        return getFalseWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -279,6 +385,26 @@ public final class Bools {
      * Set Boolean value false.
      *
      * @param boolBody The boolBody parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putFalseWithResponseAsync(boolean boolBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putFalse(this.client.getHost(), boolBody, accept, context);
+    }
+
+    /**
+     * Set Boolean value false.
+     *
+     * @param boolBody The boolBody parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -293,14 +419,30 @@ public final class Bools {
      * Set Boolean value false.
      *
      * @param boolBody The boolBody parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putFalseAsync(boolean boolBody, Context context) {
+        return putFalseWithResponseAsync(boolBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set Boolean value false.
+     *
+     * @param boolBody The boolBody parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putFalseWithResponse(boolean boolBody) {
-        return putFalseWithResponseAsync(boolBody).block();
+    public Response<Void> putFalseWithResponse(boolean boolBody, Context context) {
+        return putFalseWithResponseAsync(boolBody, context).block();
     }
 
     /**
@@ -313,7 +455,7 @@ public final class Bools {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putFalse(boolean boolBody) {
-        putFalseWithResponse(boolBody);
+        putFalseWithResponse(boolBody, Context.NONE);
     }
 
     /**
@@ -336,6 +478,25 @@ public final class Bools {
     /**
      * Get null Boolean value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null Boolean value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Boolean>> getNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get null Boolean value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null Boolean value on successful completion of {@link Mono}.
@@ -348,13 +509,29 @@ public final class Bools {
     /**
      * Get null Boolean value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null Boolean value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Boolean> getNullAsync(Context context) {
+        return getNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get null Boolean value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null Boolean value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Boolean> getNullWithResponse() {
-        return getNullWithResponseAsync().block();
+    public Response<Boolean> getNullWithResponse(Context context) {
+        return getNullWithResponseAsync(context).block();
     }
 
     /**
@@ -366,7 +543,7 @@ public final class Bools {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean getNull() {
-        return getNullWithResponse().getValue();
+        return getNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -389,6 +566,25 @@ public final class Bools {
     /**
      * Get invalid Boolean value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return invalid Boolean value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Boolean>> getInvalidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getInvalid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get invalid Boolean value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return invalid Boolean value on successful completion of {@link Mono}.
@@ -401,13 +597,29 @@ public final class Bools {
     /**
      * Get invalid Boolean value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return invalid Boolean value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Boolean> getInvalidAsync(Context context) {
+        return getInvalidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get invalid Boolean value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return invalid Boolean value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Boolean> getInvalidWithResponse() {
-        return getInvalidWithResponseAsync().block();
+    public Response<Boolean> getInvalidWithResponse(Context context) {
+        return getInvalidWithResponseAsync(context).block();
     }
 
     /**
@@ -419,6 +631,6 @@ public final class Bools {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean getInvalid() {
-        return getInvalidWithResponse().getValue();
+        return getInvalidWithResponse(Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodybyte/ByteOperations.java
+++ b/vanilla-tests/src/main/java/fixtures/bodybyte/ByteOperations.java
@@ -102,6 +102,25 @@ public final class ByteOperations {
     /**
      * Get null byte value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null byte value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<byte[]>> getNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get null byte value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null byte value on successful completion of {@link Mono}.
@@ -114,13 +133,29 @@ public final class ByteOperations {
     /**
      * Get null byte value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null byte value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<byte[]> getNullAsync(Context context) {
+        return getNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get null byte value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null byte value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<byte[]> getNullWithResponse() {
-        return getNullWithResponseAsync().block();
+    public Response<byte[]> getNullWithResponse(Context context) {
+        return getNullWithResponseAsync(context).block();
     }
 
     /**
@@ -132,7 +167,7 @@ public final class ByteOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public byte[] getNull() {
-        return getNullWithResponse().getValue();
+        return getNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -155,6 +190,25 @@ public final class ByteOperations {
     /**
      * Get empty byte value ''.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return empty byte value '' along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<byte[]>> getEmptyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getEmpty(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get empty byte value ''.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return empty byte value '' on successful completion of {@link Mono}.
@@ -167,13 +221,29 @@ public final class ByteOperations {
     /**
      * Get empty byte value ''.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return empty byte value '' on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<byte[]> getEmptyAsync(Context context) {
+        return getEmptyWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get empty byte value ''.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return empty byte value '' along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<byte[]> getEmptyWithResponse() {
-        return getEmptyWithResponseAsync().block();
+    public Response<byte[]> getEmptyWithResponse(Context context) {
+        return getEmptyWithResponseAsync(context).block();
     }
 
     /**
@@ -185,7 +255,7 @@ public final class ByteOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public byte[] getEmpty() {
-        return getEmptyWithResponse().getValue();
+        return getEmptyWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -209,6 +279,26 @@ public final class ByteOperations {
     /**
      * Get non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6) along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<byte[]>> getNonAsciiWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNonAscii(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6) on successful completion of {@link Mono}.
@@ -221,13 +311,29 @@ public final class ByteOperations {
     /**
      * Get non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6) on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<byte[]> getNonAsciiAsync(Context context) {
+        return getNonAsciiWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6) along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<byte[]> getNonAsciiWithResponse() {
-        return getNonAsciiWithResponseAsync().block();
+    public Response<byte[]> getNonAsciiWithResponse(Context context) {
+        return getNonAsciiWithResponseAsync(context).block();
     }
 
     /**
@@ -239,7 +345,7 @@ public final class ByteOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public byte[] getNonAscii() {
-        return getNonAsciiWithResponse().getValue();
+        return getNonAsciiWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -268,6 +374,29 @@ public final class ByteOperations {
      * Put non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
      *
      * @param byteBody Base64-encoded non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putNonAsciiWithResponseAsync(byte[] byteBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (byteBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter byteBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putNonAscii(this.client.getHost(), byteBody, accept, context);
+    }
+
+    /**
+     * Put non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
+     *
+     * @param byteBody Base64-encoded non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -282,14 +411,30 @@ public final class ByteOperations {
      * Put non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
      *
      * @param byteBody Base64-encoded non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putNonAsciiAsync(byte[] byteBody, Context context) {
+        return putNonAsciiWithResponseAsync(byteBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
+     *
+     * @param byteBody Base64-encoded non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putNonAsciiWithResponse(byte[] byteBody) {
-        return putNonAsciiWithResponseAsync(byteBody).block();
+    public Response<Void> putNonAsciiWithResponse(byte[] byteBody, Context context) {
+        return putNonAsciiWithResponseAsync(byteBody, context).block();
     }
 
     /**
@@ -302,7 +447,7 @@ public final class ByteOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putNonAscii(byte[] byteBody) {
-        putNonAsciiWithResponse(byteBody);
+        putNonAsciiWithResponse(byteBody, Context.NONE);
     }
 
     /**
@@ -325,6 +470,25 @@ public final class ByteOperations {
     /**
      * Get invalid byte value ':::SWAGGER::::'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return invalid byte value ':::SWAGGER::::' along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<byte[]>> getInvalidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getInvalid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get invalid byte value ':::SWAGGER::::'.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return invalid byte value ':::SWAGGER::::' on successful completion of {@link Mono}.
@@ -337,13 +501,29 @@ public final class ByteOperations {
     /**
      * Get invalid byte value ':::SWAGGER::::'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return invalid byte value ':::SWAGGER::::' on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<byte[]> getInvalidAsync(Context context) {
+        return getInvalidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get invalid byte value ':::SWAGGER::::'.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return invalid byte value ':::SWAGGER::::' along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<byte[]> getInvalidWithResponse() {
-        return getInvalidWithResponseAsync().block();
+    public Response<byte[]> getInvalidWithResponse(Context context) {
+        return getInvalidWithResponseAsync(context).block();
     }
 
     /**
@@ -355,6 +535,6 @@ public final class ByteOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public byte[] getInvalid() {
-        return getInvalidWithResponse().getValue();
+        return getInvalidWithResponse(Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/Arrays.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/Arrays.java
@@ -105,6 +105,25 @@ public final class Arrays {
     /**
      * Get complex types with array property.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with array property along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<ArrayWrapper>> getValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with array property.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with array property on successful completion of {@link Mono}.
@@ -117,13 +136,29 @@ public final class Arrays {
     /**
      * Get complex types with array property.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with array property on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<ArrayWrapper> getValidAsync(Context context) {
+        return getValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with array property.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with array property along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<ArrayWrapper> getValidWithResponse() {
-        return getValidWithResponseAsync().block();
+    public Response<ArrayWrapper> getValidWithResponse(Context context) {
+        return getValidWithResponseAsync(context).block();
     }
 
     /**
@@ -135,7 +170,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ArrayWrapper getValid() {
-        return getValidWithResponse().getValue();
+        return getValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -168,6 +203,32 @@ public final class Arrays {
      *
      * @param complexBody Please put an array with 4 items: "1, 2, 3, 4", "", null, "&amp;S#$(*Y", "The quick brown fox
      *     jumps over the lazy dog".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putValidWithResponseAsync(ArrayWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putValid(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with array property.
+     *
+     * @param complexBody Please put an array with 4 items: "1, 2, 3, 4", "", null, "&amp;S#$(*Y", "The quick brown fox
+     *     jumps over the lazy dog".
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -183,14 +244,31 @@ public final class Arrays {
      *
      * @param complexBody Please put an array with 4 items: "1, 2, 3, 4", "", null, "&amp;S#$(*Y", "The quick brown fox
      *     jumps over the lazy dog".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putValidAsync(ArrayWrapper complexBody, Context context) {
+        return putValidWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with array property.
+     *
+     * @param complexBody Please put an array with 4 items: "1, 2, 3, 4", "", null, "&amp;S#$(*Y", "The quick brown fox
+     *     jumps over the lazy dog".
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putValidWithResponse(ArrayWrapper complexBody) {
-        return putValidWithResponseAsync(complexBody).block();
+    public Response<Void> putValidWithResponse(ArrayWrapper complexBody, Context context) {
+        return putValidWithResponseAsync(complexBody, context).block();
     }
 
     /**
@@ -204,7 +282,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValid(ArrayWrapper complexBody) {
-        putValidWithResponse(complexBody);
+        putValidWithResponse(complexBody, Context.NONE);
     }
 
     /**
@@ -228,6 +306,26 @@ public final class Arrays {
     /**
      * Get complex types with array property which is empty.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with array property which is empty along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<ArrayWrapper>> getEmptyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getEmpty(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with array property which is empty.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with array property which is empty on successful completion of {@link Mono}.
@@ -240,13 +338,29 @@ public final class Arrays {
     /**
      * Get complex types with array property which is empty.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with array property which is empty on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<ArrayWrapper> getEmptyAsync(Context context) {
+        return getEmptyWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with array property which is empty.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with array property which is empty along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<ArrayWrapper> getEmptyWithResponse() {
-        return getEmptyWithResponseAsync().block();
+    public Response<ArrayWrapper> getEmptyWithResponse(Context context) {
+        return getEmptyWithResponseAsync(context).block();
     }
 
     /**
@@ -258,7 +372,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ArrayWrapper getEmpty() {
-        return getEmptyWithResponse().getValue();
+        return getEmptyWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -289,6 +403,31 @@ public final class Arrays {
      * Put complex types with array property which is empty.
      *
      * @param complexBody Please put an empty array.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putEmptyWithResponseAsync(ArrayWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putEmpty(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with array property which is empty.
+     *
+     * @param complexBody Please put an empty array.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -303,14 +442,30 @@ public final class Arrays {
      * Put complex types with array property which is empty.
      *
      * @param complexBody Please put an empty array.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putEmptyAsync(ArrayWrapper complexBody, Context context) {
+        return putEmptyWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with array property which is empty.
+     *
+     * @param complexBody Please put an empty array.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putEmptyWithResponse(ArrayWrapper complexBody) {
-        return putEmptyWithResponseAsync(complexBody).block();
+    public Response<Void> putEmptyWithResponse(ArrayWrapper complexBody, Context context) {
+        return putEmptyWithResponseAsync(complexBody, context).block();
     }
 
     /**
@@ -323,7 +478,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putEmpty(ArrayWrapper complexBody) {
-        putEmptyWithResponse(complexBody);
+        putEmptyWithResponse(complexBody, Context.NONE);
     }
 
     /**
@@ -347,6 +502,26 @@ public final class Arrays {
     /**
      * Get complex types with array property while server doesn't provide a response payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with array property while server doesn't provide a response payload along with {@link
+     *     Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<ArrayWrapper>> getNotProvidedWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNotProvided(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with array property while server doesn't provide a response payload.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with array property while server doesn't provide a response payload on successful
@@ -360,14 +535,31 @@ public final class Arrays {
     /**
      * Get complex types with array property while server doesn't provide a response payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with array property while server doesn't provide a response payload on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<ArrayWrapper> getNotProvidedAsync(Context context) {
+        return getNotProvidedWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with array property while server doesn't provide a response payload.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with array property while server doesn't provide a response payload along with {@link
      *     Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<ArrayWrapper> getNotProvidedWithResponse() {
-        return getNotProvidedWithResponseAsync().block();
+    public Response<ArrayWrapper> getNotProvidedWithResponse(Context context) {
+        return getNotProvidedWithResponseAsync(context).block();
     }
 
     /**
@@ -379,6 +571,6 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ArrayWrapper getNotProvided() {
-        return getNotProvidedWithResponse().getValue();
+        return getNotProvidedWithResponse(Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/Basics.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/Basics.java
@@ -111,6 +111,26 @@ public final class Basics {
     /**
      * Get complex type {id: 2, name: 'abc', color: 'YELLOW'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex type {id: 2, name: 'abc', color: 'YELLOW'} along with {@link Response} on successful completion
+     *     of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Basic>> getValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex type {id: 2, name: 'abc', color: 'YELLOW'}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex type {id: 2, name: 'abc', color: 'YELLOW'} on successful completion of {@link Mono}.
@@ -123,13 +143,29 @@ public final class Basics {
     /**
      * Get complex type {id: 2, name: 'abc', color: 'YELLOW'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex type {id: 2, name: 'abc', color: 'YELLOW'} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Basic> getValidAsync(Context context) {
+        return getValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex type {id: 2, name: 'abc', color: 'YELLOW'}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex type {id: 2, name: 'abc', color: 'YELLOW'} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Basic> getValidWithResponse() {
-        return getValidWithResponseAsync().block();
+    public Response<Basic> getValidWithResponse(Context context) {
+        return getValidWithResponseAsync(context).block();
     }
 
     /**
@@ -141,7 +177,7 @@ public final class Basics {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Basic getValid() {
-        return getValidWithResponse().getValue();
+        return getValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -175,6 +211,31 @@ public final class Basics {
      * Please put {id: 2, name: 'abc', color: 'Magenta'}.
      *
      * @param complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putValidWithResponseAsync(Basic complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putValid(this.client.getHost(), this.client.getApiVersion(), complexBody, accept, context);
+    }
+
+    /**
+     * Please put {id: 2, name: 'abc', color: 'Magenta'}.
+     *
+     * @param complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -189,14 +250,30 @@ public final class Basics {
      * Please put {id: 2, name: 'abc', color: 'Magenta'}.
      *
      * @param complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putValidAsync(Basic complexBody, Context context) {
+        return putValidWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Please put {id: 2, name: 'abc', color: 'Magenta'}.
+     *
+     * @param complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putValidWithResponse(Basic complexBody) {
-        return putValidWithResponseAsync(complexBody).block();
+    public Response<Void> putValidWithResponse(Basic complexBody, Context context) {
+        return putValidWithResponseAsync(complexBody, context).block();
     }
 
     /**
@@ -209,7 +286,7 @@ public final class Basics {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValid(Basic complexBody) {
-        putValidWithResponse(complexBody);
+        putValidWithResponse(complexBody, Context.NONE);
     }
 
     /**
@@ -233,6 +310,26 @@ public final class Basics {
     /**
      * Get a basic complex type that is invalid for the local strong type.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a basic complex type that is invalid for the local strong type along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Basic>> getInvalidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getInvalid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get a basic complex type that is invalid for the local strong type.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a basic complex type that is invalid for the local strong type on successful completion of {@link Mono}.
@@ -245,13 +342,29 @@ public final class Basics {
     /**
      * Get a basic complex type that is invalid for the local strong type.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a basic complex type that is invalid for the local strong type on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Basic> getInvalidAsync(Context context) {
+        return getInvalidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get a basic complex type that is invalid for the local strong type.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a basic complex type that is invalid for the local strong type along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Basic> getInvalidWithResponse() {
-        return getInvalidWithResponseAsync().block();
+    public Response<Basic> getInvalidWithResponse(Context context) {
+        return getInvalidWithResponseAsync(context).block();
     }
 
     /**
@@ -263,7 +376,7 @@ public final class Basics {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Basic getInvalid() {
-        return getInvalidWithResponse().getValue();
+        return getInvalidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -286,6 +399,25 @@ public final class Basics {
     /**
      * Get a basic complex type that is empty.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a basic complex type that is empty along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Basic>> getEmptyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getEmpty(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get a basic complex type that is empty.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a basic complex type that is empty on successful completion of {@link Mono}.
@@ -298,13 +430,29 @@ public final class Basics {
     /**
      * Get a basic complex type that is empty.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a basic complex type that is empty on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Basic> getEmptyAsync(Context context) {
+        return getEmptyWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get a basic complex type that is empty.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a basic complex type that is empty along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Basic> getEmptyWithResponse() {
-        return getEmptyWithResponseAsync().block();
+    public Response<Basic> getEmptyWithResponse(Context context) {
+        return getEmptyWithResponseAsync(context).block();
     }
 
     /**
@@ -316,7 +464,7 @@ public final class Basics {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Basic getEmpty() {
-        return getEmptyWithResponse().getValue();
+        return getEmptyWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -340,6 +488,26 @@ public final class Basics {
     /**
      * Get a basic complex type whose properties are null.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a basic complex type whose properties are null along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Basic>> getNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get a basic complex type whose properties are null.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a basic complex type whose properties are null on successful completion of {@link Mono}.
@@ -352,13 +520,29 @@ public final class Basics {
     /**
      * Get a basic complex type whose properties are null.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a basic complex type whose properties are null on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Basic> getNullAsync(Context context) {
+        return getNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get a basic complex type whose properties are null.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a basic complex type whose properties are null along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Basic> getNullWithResponse() {
-        return getNullWithResponseAsync().block();
+    public Response<Basic> getNullWithResponse(Context context) {
+        return getNullWithResponseAsync(context).block();
     }
 
     /**
@@ -370,7 +554,7 @@ public final class Basics {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Basic getNull() {
-        return getNullWithResponse().getValue();
+        return getNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -394,6 +578,26 @@ public final class Basics {
     /**
      * Get a basic complex type while the server doesn't provide a response payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a basic complex type while the server doesn't provide a response payload along with {@link Response} on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Basic>> getNotProvidedWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNotProvided(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get a basic complex type while the server doesn't provide a response payload.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a basic complex type while the server doesn't provide a response payload on successful completion of
@@ -407,13 +611,30 @@ public final class Basics {
     /**
      * Get a basic complex type while the server doesn't provide a response payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a basic complex type while the server doesn't provide a response payload on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Basic> getNotProvidedAsync(Context context) {
+        return getNotProvidedWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get a basic complex type while the server doesn't provide a response payload.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a basic complex type while the server doesn't provide a response payload along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Basic> getNotProvidedWithResponse() {
-        return getNotProvidedWithResponseAsync().block();
+    public Response<Basic> getNotProvidedWithResponse(Context context) {
+        return getNotProvidedWithResponseAsync(context).block();
     }
 
     /**
@@ -425,6 +646,6 @@ public final class Basics {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Basic getNotProvided() {
-        return getNotProvidedWithResponse().getValue();
+        return getNotProvidedWithResponse(Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/Dictionaries.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/Dictionaries.java
@@ -113,6 +113,26 @@ public final class Dictionaries {
     /**
      * Get complex types with dictionary property.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with dictionary property along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<DictionaryWrapper>> getValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with dictionary property.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with dictionary property on successful completion of {@link Mono}.
@@ -125,13 +145,29 @@ public final class Dictionaries {
     /**
      * Get complex types with dictionary property.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with dictionary property on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<DictionaryWrapper> getValidAsync(Context context) {
+        return getValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with dictionary property.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with dictionary property along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<DictionaryWrapper> getValidWithResponse() {
-        return getValidWithResponseAsync().block();
+    public Response<DictionaryWrapper> getValidWithResponse(Context context) {
+        return getValidWithResponseAsync(context).block();
     }
 
     /**
@@ -143,7 +179,7 @@ public final class Dictionaries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DictionaryWrapper getValid() {
-        return getValidWithResponse().getValue();
+        return getValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -176,6 +212,32 @@ public final class Dictionaries {
      *
      * @param complexBody Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint",
      *     "xls":"excel", "exe":"", "":null.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putValidWithResponseAsync(DictionaryWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putValid(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with dictionary property.
+     *
+     * @param complexBody Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint",
+     *     "xls":"excel", "exe":"", "":null.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -191,14 +253,31 @@ public final class Dictionaries {
      *
      * @param complexBody Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint",
      *     "xls":"excel", "exe":"", "":null.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putValidAsync(DictionaryWrapper complexBody, Context context) {
+        return putValidWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with dictionary property.
+     *
+     * @param complexBody Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint",
+     *     "xls":"excel", "exe":"", "":null.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putValidWithResponse(DictionaryWrapper complexBody) {
-        return putValidWithResponseAsync(complexBody).block();
+    public Response<Void> putValidWithResponse(DictionaryWrapper complexBody, Context context) {
+        return putValidWithResponseAsync(complexBody, context).block();
     }
 
     /**
@@ -212,7 +291,7 @@ public final class Dictionaries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValid(DictionaryWrapper complexBody) {
-        putValidWithResponse(complexBody);
+        putValidWithResponse(complexBody, Context.NONE);
     }
 
     /**
@@ -236,6 +315,26 @@ public final class Dictionaries {
     /**
      * Get complex types with dictionary property which is empty.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with dictionary property which is empty along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<DictionaryWrapper>> getEmptyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getEmpty(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with dictionary property which is empty.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with dictionary property which is empty on successful completion of {@link Mono}.
@@ -248,13 +347,29 @@ public final class Dictionaries {
     /**
      * Get complex types with dictionary property which is empty.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with dictionary property which is empty on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<DictionaryWrapper> getEmptyAsync(Context context) {
+        return getEmptyWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with dictionary property which is empty.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with dictionary property which is empty along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<DictionaryWrapper> getEmptyWithResponse() {
-        return getEmptyWithResponseAsync().block();
+    public Response<DictionaryWrapper> getEmptyWithResponse(Context context) {
+        return getEmptyWithResponseAsync(context).block();
     }
 
     /**
@@ -266,7 +381,7 @@ public final class Dictionaries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DictionaryWrapper getEmpty() {
-        return getEmptyWithResponse().getValue();
+        return getEmptyWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -297,6 +412,31 @@ public final class Dictionaries {
      * Put complex types with dictionary property which is empty.
      *
      * @param complexBody Please put an empty dictionary.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putEmptyWithResponseAsync(DictionaryWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putEmpty(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with dictionary property which is empty.
+     *
+     * @param complexBody Please put an empty dictionary.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -311,14 +451,30 @@ public final class Dictionaries {
      * Put complex types with dictionary property which is empty.
      *
      * @param complexBody Please put an empty dictionary.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putEmptyAsync(DictionaryWrapper complexBody, Context context) {
+        return putEmptyWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with dictionary property which is empty.
+     *
+     * @param complexBody Please put an empty dictionary.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putEmptyWithResponse(DictionaryWrapper complexBody) {
-        return putEmptyWithResponseAsync(complexBody).block();
+    public Response<Void> putEmptyWithResponse(DictionaryWrapper complexBody, Context context) {
+        return putEmptyWithResponseAsync(complexBody, context).block();
     }
 
     /**
@@ -331,7 +487,7 @@ public final class Dictionaries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putEmpty(DictionaryWrapper complexBody) {
-        putEmptyWithResponse(complexBody);
+        putEmptyWithResponse(complexBody, Context.NONE);
     }
 
     /**
@@ -355,6 +511,26 @@ public final class Dictionaries {
     /**
      * Get complex types with dictionary property which is null.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with dictionary property which is null along with {@link Response} on successful completion
+     *     of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<DictionaryWrapper>> getNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with dictionary property which is null.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with dictionary property which is null on successful completion of {@link Mono}.
@@ -367,13 +543,29 @@ public final class Dictionaries {
     /**
      * Get complex types with dictionary property which is null.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with dictionary property which is null on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<DictionaryWrapper> getNullAsync(Context context) {
+        return getNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with dictionary property which is null.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with dictionary property which is null along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<DictionaryWrapper> getNullWithResponse() {
-        return getNullWithResponseAsync().block();
+    public Response<DictionaryWrapper> getNullWithResponse(Context context) {
+        return getNullWithResponseAsync(context).block();
     }
 
     /**
@@ -385,7 +577,7 @@ public final class Dictionaries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DictionaryWrapper getNull() {
-        return getNullWithResponse().getValue();
+        return getNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -409,6 +601,26 @@ public final class Dictionaries {
     /**
      * Get complex types with dictionary property while server doesn't provide a response payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with dictionary property while server doesn't provide a response payload along with {@link
+     *     Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<DictionaryWrapper>> getNotProvidedWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNotProvided(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with dictionary property while server doesn't provide a response payload.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with dictionary property while server doesn't provide a response payload on successful
@@ -422,14 +634,31 @@ public final class Dictionaries {
     /**
      * Get complex types with dictionary property while server doesn't provide a response payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with dictionary property while server doesn't provide a response payload on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<DictionaryWrapper> getNotProvidedAsync(Context context) {
+        return getNotProvidedWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with dictionary property while server doesn't provide a response payload.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with dictionary property while server doesn't provide a response payload along with {@link
      *     Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<DictionaryWrapper> getNotProvidedWithResponse() {
-        return getNotProvidedWithResponseAsync().block();
+    public Response<DictionaryWrapper> getNotProvidedWithResponse(Context context) {
+        return getNotProvidedWithResponseAsync(context).block();
     }
 
     /**
@@ -441,6 +670,6 @@ public final class Dictionaries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DictionaryWrapper getNotProvided() {
-        return getNotProvidedWithResponse().getValue();
+        return getNotProvidedWithResponse(Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/Flattencomplexes.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/Flattencomplexes.java
@@ -75,6 +75,25 @@ public final class Flattencomplexes {
     /**
      * The getValid operation.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<MyBaseType>> getValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * The getValid operation.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body on successful completion of {@link Mono}.
@@ -87,13 +106,29 @@ public final class Flattencomplexes {
     /**
      * The getValid operation.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<MyBaseType> getValidAsync(Context context) {
+        return getValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * The getValid operation.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<MyBaseType> getValidWithResponse() {
-        return getValidWithResponseAsync().block();
+    public Response<MyBaseType> getValidWithResponse(Context context) {
+        return getValidWithResponseAsync(context).block();
     }
 
     /**
@@ -105,6 +140,6 @@ public final class Flattencomplexes {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyBaseType getValid() {
-        return getValidWithResponse().getValue();
+        return getValidWithResponse(Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/Inheritances.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/Inheritances.java
@@ -85,6 +85,25 @@ public final class Inheritances {
     /**
      * Get complex types that extend others.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that extend others along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Siamese>> getValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types that extend others.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types that extend others on successful completion of {@link Mono}.
@@ -97,13 +116,29 @@ public final class Inheritances {
     /**
      * Get complex types that extend others.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that extend others on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Siamese> getValidAsync(Context context) {
+        return getValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types that extend others.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types that extend others along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Siamese> getValidWithResponse() {
-        return getValidWithResponseAsync().block();
+    public Response<Siamese> getValidWithResponse(Context context) {
+        return getValidWithResponseAsync(context).block();
     }
 
     /**
@@ -115,7 +150,7 @@ public final class Inheritances {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Siamese getValid() {
-        return getValidWithResponse().getValue();
+        return getValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -150,6 +185,33 @@ public final class Inheritances {
      * @param complexBody Please put a siamese with id=2, name="Siameee", color=green, breed=persion, which hates 2
      *     dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1 and
      *     food="french fries".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putValidWithResponseAsync(Siamese complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putValid(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types that extend others.
+     *
+     * @param complexBody Please put a siamese with id=2, name="Siameee", color=green, breed=persion, which hates 2
+     *     dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1 and
+     *     food="french fries".
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -166,14 +228,32 @@ public final class Inheritances {
      * @param complexBody Please put a siamese with id=2, name="Siameee", color=green, breed=persion, which hates 2
      *     dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1 and
      *     food="french fries".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putValidAsync(Siamese complexBody, Context context) {
+        return putValidWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types that extend others.
+     *
+     * @param complexBody Please put a siamese with id=2, name="Siameee", color=green, breed=persion, which hates 2
+     *     dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1 and
+     *     food="french fries".
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putValidWithResponse(Siamese complexBody) {
-        return putValidWithResponseAsync(complexBody).block();
+    public Response<Void> putValidWithResponse(Siamese complexBody, Context context) {
+        return putValidWithResponseAsync(complexBody, context).block();
     }
 
     /**
@@ -188,6 +268,6 @@ public final class Inheritances {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValid(Siamese complexBody) {
-        putValidWithResponse(complexBody);
+        putValidWithResponse(complexBody, Context.NONE);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/Polymorphicrecursives.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/Polymorphicrecursives.java
@@ -87,6 +87,26 @@ public final class Polymorphicrecursives {
     /**
      * Get complex types that are polymorphic and have recursive references.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that are polymorphic and have recursive references along with {@link Response} on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Fish>> getValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types that are polymorphic and have recursive references.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types that are polymorphic and have recursive references on successful completion of {@link
@@ -100,13 +120,30 @@ public final class Polymorphicrecursives {
     /**
      * Get complex types that are polymorphic and have recursive references.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that are polymorphic and have recursive references on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Fish> getValidAsync(Context context) {
+        return getValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types that are polymorphic and have recursive references.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types that are polymorphic and have recursive references along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Fish> getValidWithResponse() {
-        return getValidWithResponseAsync().block();
+    public Response<Fish> getValidWithResponse(Context context) {
+        return getValidWithResponseAsync(context).block();
     }
 
     /**
@@ -118,7 +155,7 @@ public final class Polymorphicrecursives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Fish getValid() {
-        return getValidWithResponse().getValue();
+        return getValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -161,6 +198,37 @@ public final class Polymorphicrecursives {
      *     "length": 20, "age": 6 }, { "fishtype": "sawshark", "species": "dangerous", "length": 10, "age": 105 } ] }, {
      *     "fishtype": "sawshark", "species": "dangerous", "length": 10, "age": 105 } ] }, { "fishtype": "sawshark",
      *     "species": "dangerous", "length": 10, "age": 105 } ] }.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putValidWithResponseAsync(Fish complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putValid(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types that are polymorphic and have recursive references.
+     *
+     * @param complexBody Please put a salmon that looks like this: { "fishtype": "salmon", "species": "king", "length":
+     *     1, "age": 1, "location": "alaska", "iswild": true, "siblings": [ { "fishtype": "shark", "species":
+     *     "predator", "length": 20, "age": 6, "siblings": [ { "fishtype": "salmon", "species": "coho", "length": 2,
+     *     "age": 2, "location": "atlantic", "iswild": true, "siblings": [ { "fishtype": "shark", "species": "predator",
+     *     "length": 20, "age": 6 }, { "fishtype": "sawshark", "species": "dangerous", "length": 10, "age": 105 } ] }, {
+     *     "fishtype": "sawshark", "species": "dangerous", "length": 10, "age": 105 } ] }, { "fishtype": "sawshark",
+     *     "species": "dangerous", "length": 10, "age": 105 } ] }.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -181,14 +249,36 @@ public final class Polymorphicrecursives {
      *     "length": 20, "age": 6 }, { "fishtype": "sawshark", "species": "dangerous", "length": 10, "age": 105 } ] }, {
      *     "fishtype": "sawshark", "species": "dangerous", "length": 10, "age": 105 } ] }, { "fishtype": "sawshark",
      *     "species": "dangerous", "length": 10, "age": 105 } ] }.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putValidAsync(Fish complexBody, Context context) {
+        return putValidWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types that are polymorphic and have recursive references.
+     *
+     * @param complexBody Please put a salmon that looks like this: { "fishtype": "salmon", "species": "king", "length":
+     *     1, "age": 1, "location": "alaska", "iswild": true, "siblings": [ { "fishtype": "shark", "species":
+     *     "predator", "length": 20, "age": 6, "siblings": [ { "fishtype": "salmon", "species": "coho", "length": 2,
+     *     "age": 2, "location": "atlantic", "iswild": true, "siblings": [ { "fishtype": "shark", "species": "predator",
+     *     "length": 20, "age": 6 }, { "fishtype": "sawshark", "species": "dangerous", "length": 10, "age": 105 } ] }, {
+     *     "fishtype": "sawshark", "species": "dangerous", "length": 10, "age": 105 } ] }, { "fishtype": "sawshark",
+     *     "species": "dangerous", "length": 10, "age": 105 } ] }.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putValidWithResponse(Fish complexBody) {
-        return putValidWithResponseAsync(complexBody).block();
+    public Response<Void> putValidWithResponse(Fish complexBody, Context context) {
+        return putValidWithResponseAsync(complexBody, context).block();
     }
 
     /**
@@ -207,6 +297,6 @@ public final class Polymorphicrecursives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValid(Fish complexBody) {
-        putValidWithResponse(complexBody);
+        putValidWithResponse(complexBody, Context.NONE);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/Polymorphisms.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/Polymorphisms.java
@@ -139,6 +139,25 @@ public final class Polymorphisms {
     /**
      * Get complex types that are polymorphic.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that are polymorphic along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Fish>> getValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types that are polymorphic.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types that are polymorphic on successful completion of {@link Mono}.
@@ -151,13 +170,29 @@ public final class Polymorphisms {
     /**
      * Get complex types that are polymorphic.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that are polymorphic on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Fish> getValidAsync(Context context) {
+        return getValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types that are polymorphic.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types that are polymorphic along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Fish> getValidWithResponse() {
-        return getValidWithResponseAsync().block();
+    public Response<Fish> getValidWithResponse(Context context) {
+        return getValidWithResponseAsync(context).block();
     }
 
     /**
@@ -169,7 +204,7 @@ public final class Polymorphisms {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Fish getValid() {
-        return getValidWithResponse().getValue();
+        return getValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -210,6 +245,36 @@ public final class Polymorphisms {
      *     'birthday': '1900-01-05T01:00:00Z', 'length':10.0, 'picture': new Buffer([255, 255, 255, 255,
      *     254]).toString('base64'), 'species':'dangerous', }, { 'fishtype': 'goblin', 'age': 1, 'birthday':
      *     '2015-08-08T00:00:00Z', 'length': 30.0, 'species': 'scary', 'jawsize': 5 } ] };.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putValidWithResponseAsync(Fish complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putValid(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types that are polymorphic.
+     *
+     * @param complexBody Please put a salmon that looks like this: { 'fishtype':'Salmon', 'location':'alaska',
+     *     'iswild':true, 'species':'king', 'length':1.0, 'siblings':[ { 'fishtype':'Shark', 'age':6, 'birthday':
+     *     '2012-01-05T01:00:00Z', 'length':20.0, 'species':'predator', }, { 'fishtype':'Sawshark', 'age':105,
+     *     'birthday': '1900-01-05T01:00:00Z', 'length':10.0, 'picture': new Buffer([255, 255, 255, 255,
+     *     254]).toString('base64'), 'species':'dangerous', }, { 'fishtype': 'goblin', 'age': 1, 'birthday':
+     *     '2015-08-08T00:00:00Z', 'length': 30.0, 'species': 'scary', 'jawsize': 5 } ] };.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -229,14 +294,35 @@ public final class Polymorphisms {
      *     'birthday': '1900-01-05T01:00:00Z', 'length':10.0, 'picture': new Buffer([255, 255, 255, 255,
      *     254]).toString('base64'), 'species':'dangerous', }, { 'fishtype': 'goblin', 'age': 1, 'birthday':
      *     '2015-08-08T00:00:00Z', 'length': 30.0, 'species': 'scary', 'jawsize': 5 } ] };.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putValidAsync(Fish complexBody, Context context) {
+        return putValidWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types that are polymorphic.
+     *
+     * @param complexBody Please put a salmon that looks like this: { 'fishtype':'Salmon', 'location':'alaska',
+     *     'iswild':true, 'species':'king', 'length':1.0, 'siblings':[ { 'fishtype':'Shark', 'age':6, 'birthday':
+     *     '2012-01-05T01:00:00Z', 'length':20.0, 'species':'predator', }, { 'fishtype':'Sawshark', 'age':105,
+     *     'birthday': '1900-01-05T01:00:00Z', 'length':10.0, 'picture': new Buffer([255, 255, 255, 255,
+     *     254]).toString('base64'), 'species':'dangerous', }, { 'fishtype': 'goblin', 'age': 1, 'birthday':
+     *     '2015-08-08T00:00:00Z', 'length': 30.0, 'species': 'scary', 'jawsize': 5 } ] };.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putValidWithResponse(Fish complexBody) {
-        return putValidWithResponseAsync(complexBody).block();
+    public Response<Void> putValidWithResponse(Fish complexBody, Context context) {
+        return putValidWithResponseAsync(complexBody, context).block();
     }
 
     /**
@@ -254,7 +340,7 @@ public final class Polymorphisms {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValid(Fish complexBody) {
-        putValidWithResponse(complexBody);
+        putValidWithResponse(complexBody, Context.NONE);
     }
 
     /**
@@ -278,6 +364,26 @@ public final class Polymorphisms {
     /**
      * Get complex types that are polymorphic, JSON key contains a dot.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that are polymorphic, JSON key contains a dot along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<DotFish>> getDotSyntaxWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDotSyntax(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types that are polymorphic, JSON key contains a dot.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types that are polymorphic, JSON key contains a dot on successful completion of {@link Mono}.
@@ -290,13 +396,29 @@ public final class Polymorphisms {
     /**
      * Get complex types that are polymorphic, JSON key contains a dot.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that are polymorphic, JSON key contains a dot on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<DotFish> getDotSyntaxAsync(Context context) {
+        return getDotSyntaxWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types that are polymorphic, JSON key contains a dot.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types that are polymorphic, JSON key contains a dot along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<DotFish> getDotSyntaxWithResponse() {
-        return getDotSyntaxWithResponseAsync().block();
+    public Response<DotFish> getDotSyntaxWithResponse(Context context) {
+        return getDotSyntaxWithResponseAsync(context).block();
     }
 
     /**
@@ -308,7 +430,7 @@ public final class Polymorphisms {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DotFish getDotSyntax() {
-        return getDotSyntaxWithResponse().getValue();
+        return getDotSyntaxWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -335,6 +457,27 @@ public final class Polymorphisms {
      * Get complex object composing a polymorphic scalar property and array property with polymorphic element type, with
      * discriminator specified. Deserialization must NOT fail and use the discriminator type specified on the wire.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex object composing a polymorphic scalar property and array property with polymorphic element type,
+     *     with discriminator specified along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<DotFishMarket>> getComposedWithDiscriminatorWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getComposedWithDiscriminator(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex object composing a polymorphic scalar property and array property with polymorphic element type, with
+     * discriminator specified. Deserialization must NOT fail and use the discriminator type specified on the wire.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex object composing a polymorphic scalar property and array property with polymorphic element type,
@@ -349,14 +492,32 @@ public final class Polymorphisms {
      * Get complex object composing a polymorphic scalar property and array property with polymorphic element type, with
      * discriminator specified. Deserialization must NOT fail and use the discriminator type specified on the wire.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex object composing a polymorphic scalar property and array property with polymorphic element type,
+     *     with discriminator specified on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<DotFishMarket> getComposedWithDiscriminatorAsync(Context context) {
+        return getComposedWithDiscriminatorWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex object composing a polymorphic scalar property and array property with polymorphic element type, with
+     * discriminator specified. Deserialization must NOT fail and use the discriminator type specified on the wire.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex object composing a polymorphic scalar property and array property with polymorphic element type,
      *     with discriminator specified along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<DotFishMarket> getComposedWithDiscriminatorWithResponse() {
-        return getComposedWithDiscriminatorWithResponseAsync().block();
+    public Response<DotFishMarket> getComposedWithDiscriminatorWithResponse(Context context) {
+        return getComposedWithDiscriminatorWithResponseAsync(context).block();
     }
 
     /**
@@ -370,7 +531,7 @@ public final class Polymorphisms {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DotFishMarket getComposedWithDiscriminator() {
-        return getComposedWithDiscriminatorWithResponse().getValue();
+        return getComposedWithDiscriminatorWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -397,6 +558,27 @@ public final class Polymorphisms {
      * Get complex object composing a polymorphic scalar property and array property with polymorphic element type,
      * without discriminator specified on wire. Deserialization must NOT fail and use the explicit type of the property.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex object composing a polymorphic scalar property and array property with polymorphic element type,
+     *     without discriminator specified on wire along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<DotFishMarket>> getComposedWithoutDiscriminatorWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getComposedWithoutDiscriminator(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex object composing a polymorphic scalar property and array property with polymorphic element type,
+     * without discriminator specified on wire. Deserialization must NOT fail and use the explicit type of the property.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex object composing a polymorphic scalar property and array property with polymorphic element type,
@@ -411,14 +593,33 @@ public final class Polymorphisms {
      * Get complex object composing a polymorphic scalar property and array property with polymorphic element type,
      * without discriminator specified on wire. Deserialization must NOT fail and use the explicit type of the property.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex object composing a polymorphic scalar property and array property with polymorphic element type,
+     *     without discriminator specified on wire on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<DotFishMarket> getComposedWithoutDiscriminatorAsync(Context context) {
+        return getComposedWithoutDiscriminatorWithResponseAsync(context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex object composing a polymorphic scalar property and array property with polymorphic element type,
+     * without discriminator specified on wire. Deserialization must NOT fail and use the explicit type of the property.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex object composing a polymorphic scalar property and array property with polymorphic element type,
      *     without discriminator specified on wire along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<DotFishMarket> getComposedWithoutDiscriminatorWithResponse() {
-        return getComposedWithoutDiscriminatorWithResponseAsync().block();
+    public Response<DotFishMarket> getComposedWithoutDiscriminatorWithResponse(Context context) {
+        return getComposedWithoutDiscriminatorWithResponseAsync(context).block();
     }
 
     /**
@@ -432,7 +633,7 @@ public final class Polymorphisms {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DotFishMarket getComposedWithoutDiscriminator() {
-        return getComposedWithoutDiscriminatorWithResponse().getValue();
+        return getComposedWithoutDiscriminatorWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -456,6 +657,26 @@ public final class Polymorphisms {
     /**
      * Get complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties
+     *     along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Salmon>> getComplicatedWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getComplicated(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties
@@ -469,14 +690,31 @@ public final class Polymorphisms {
     /**
      * Get complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties
+     *     on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Salmon> getComplicatedAsync(Context context) {
+        return getComplicatedWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties
      *     along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Salmon> getComplicatedWithResponse() {
-        return getComplicatedWithResponseAsync().block();
+    public Response<Salmon> getComplicatedWithResponse(Context context) {
+        return getComplicatedWithResponseAsync(context).block();
     }
 
     /**
@@ -489,7 +727,7 @@ public final class Polymorphisms {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Salmon getComplicated() {
-        return getComplicatedWithResponse().getValue();
+        return getComplicatedWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -521,6 +759,31 @@ public final class Polymorphisms {
      * Put complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties.
      *
      * @param complexBody The complexBody parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putComplicatedWithResponseAsync(Salmon complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putComplicated(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties.
+     *
+     * @param complexBody The complexBody parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -535,14 +798,30 @@ public final class Polymorphisms {
      * Put complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties.
      *
      * @param complexBody The complexBody parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putComplicatedAsync(Salmon complexBody, Context context) {
+        return putComplicatedWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties.
+     *
+     * @param complexBody The complexBody parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putComplicatedWithResponse(Salmon complexBody) {
-        return putComplicatedWithResponseAsync(complexBody).block();
+    public Response<Void> putComplicatedWithResponse(Salmon complexBody, Context context) {
+        return putComplicatedWithResponseAsync(complexBody, context).block();
     }
 
     /**
@@ -555,7 +834,7 @@ public final class Polymorphisms {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putComplicated(Salmon complexBody) {
-        putComplicatedWithResponse(complexBody);
+        putComplicatedWithResponse(complexBody, Context.NONE);
     }
 
     /**
@@ -587,6 +866,31 @@ public final class Polymorphisms {
      * Put complex types that are polymorphic, omitting the discriminator.
      *
      * @param complexBody The complexBody parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Salmon>> putMissingDiscriminatorWithResponseAsync(Salmon complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putMissingDiscriminator(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types that are polymorphic, omitting the discriminator.
+     *
+     * @param complexBody The complexBody parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -601,14 +905,31 @@ public final class Polymorphisms {
      * Put complex types that are polymorphic, omitting the discriminator.
      *
      * @param complexBody The complexBody parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Salmon> putMissingDiscriminatorAsync(Salmon complexBody, Context context) {
+        return putMissingDiscriminatorWithResponseAsync(complexBody, context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Put complex types that are polymorphic, omitting the discriminator.
+     *
+     * @param complexBody The complexBody parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Salmon> putMissingDiscriminatorWithResponse(Salmon complexBody) {
-        return putMissingDiscriminatorWithResponseAsync(complexBody).block();
+    public Response<Salmon> putMissingDiscriminatorWithResponse(Salmon complexBody, Context context) {
+        return putMissingDiscriminatorWithResponseAsync(complexBody, context).block();
     }
 
     /**
@@ -622,7 +943,7 @@ public final class Polymorphisms {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Salmon putMissingDiscriminator(Salmon complexBody) {
-        return putMissingDiscriminatorWithResponse(complexBody).getValue();
+        return putMissingDiscriminatorWithResponse(complexBody, Context.NONE).getValue();
     }
 
     /**
@@ -664,6 +985,36 @@ public final class Polymorphisms {
      *     "2013-06-01T01:00:00Z", "location": "alaska", "picture": base64(FF FF FF FF FE), "siblings": [ { "fishtype":
      *     "shark", "species": "predator", "birthday": "2012-01-05T01:00:00Z", "length": 20, "age": 6 }, { "fishtype":
      *     "sawshark", "species": "dangerous", "picture": base64(FF FF FF FF FE), "length": 10, "age": 105 } ] }.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putValidMissingRequiredWithResponseAsync(Fish complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putValidMissingRequired(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request should not be
+     * allowed from the client.
+     *
+     * @param complexBody Please attempt put a sawshark that looks like this, the client should not allow this data to
+     *     be sent: { "fishtype": "sawshark", "species": "snaggle toothed", "length": 18.5, "age": 2, "birthday":
+     *     "2013-06-01T01:00:00Z", "location": "alaska", "picture": base64(FF FF FF FF FE), "siblings": [ { "fishtype":
+     *     "shark", "species": "predator", "birthday": "2012-01-05T01:00:00Z", "length": 20, "age": 6 }, { "fishtype":
+     *     "sawshark", "species": "dangerous", "picture": base64(FF FF FF FF FE), "length": 10, "age": 105 } ] }.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -683,14 +1034,35 @@ public final class Polymorphisms {
      *     "2013-06-01T01:00:00Z", "location": "alaska", "picture": base64(FF FF FF FF FE), "siblings": [ { "fishtype":
      *     "shark", "species": "predator", "birthday": "2012-01-05T01:00:00Z", "length": 20, "age": 6 }, { "fishtype":
      *     "sawshark", "species": "dangerous", "picture": base64(FF FF FF FF FE), "length": 10, "age": 105 } ] }.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putValidMissingRequiredAsync(Fish complexBody, Context context) {
+        return putValidMissingRequiredWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request should not be
+     * allowed from the client.
+     *
+     * @param complexBody Please attempt put a sawshark that looks like this, the client should not allow this data to
+     *     be sent: { "fishtype": "sawshark", "species": "snaggle toothed", "length": 18.5, "age": 2, "birthday":
+     *     "2013-06-01T01:00:00Z", "location": "alaska", "picture": base64(FF FF FF FF FE), "siblings": [ { "fishtype":
+     *     "shark", "species": "predator", "birthday": "2012-01-05T01:00:00Z", "length": 20, "age": 6 }, { "fishtype":
+     *     "sawshark", "species": "dangerous", "picture": base64(FF FF FF FF FE), "length": 10, "age": 105 } ] }.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putValidMissingRequiredWithResponse(Fish complexBody) {
-        return putValidMissingRequiredWithResponseAsync(complexBody).block();
+    public Response<Void> putValidMissingRequiredWithResponse(Fish complexBody, Context context) {
+        return putValidMissingRequiredWithResponseAsync(complexBody, context).block();
     }
 
     /**
@@ -708,6 +1080,6 @@ public final class Polymorphisms {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValidMissingRequired(Fish complexBody) {
-        putValidMissingRequiredWithResponse(complexBody);
+        putValidMissingRequiredWithResponse(complexBody, Context.NONE);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/Primitives.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/Primitives.java
@@ -246,6 +246,26 @@ public final class Primitives {
     /**
      * Get complex types with integer properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with integer properties along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<IntWrapper>> getIntWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getInt(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with integer properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with integer properties on successful completion of {@link Mono}.
@@ -258,13 +278,29 @@ public final class Primitives {
     /**
      * Get complex types with integer properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with integer properties on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<IntWrapper> getIntAsync(Context context) {
+        return getIntWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with integer properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with integer properties along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<IntWrapper> getIntWithResponse() {
-        return getIntWithResponseAsync().block();
+    public Response<IntWrapper> getIntWithResponse(Context context) {
+        return getIntWithResponseAsync(context).block();
     }
 
     /**
@@ -276,7 +312,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public IntWrapper getInt() {
-        return getIntWithResponse().getValue();
+        return getIntWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -307,6 +343,31 @@ public final class Primitives {
      * Put complex types with integer properties.
      *
      * @param complexBody Please put -1 and 2.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putIntWithResponseAsync(IntWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putInt(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with integer properties.
+     *
+     * @param complexBody Please put -1 and 2.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -321,14 +382,30 @@ public final class Primitives {
      * Put complex types with integer properties.
      *
      * @param complexBody Please put -1 and 2.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putIntAsync(IntWrapper complexBody, Context context) {
+        return putIntWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with integer properties.
+     *
+     * @param complexBody Please put -1 and 2.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putIntWithResponse(IntWrapper complexBody) {
-        return putIntWithResponseAsync(complexBody).block();
+    public Response<Void> putIntWithResponse(IntWrapper complexBody, Context context) {
+        return putIntWithResponseAsync(complexBody, context).block();
     }
 
     /**
@@ -341,7 +418,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putInt(IntWrapper complexBody) {
-        putIntWithResponse(complexBody);
+        putIntWithResponse(complexBody, Context.NONE);
     }
 
     /**
@@ -364,6 +441,25 @@ public final class Primitives {
     /**
      * Get complex types with long properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with long properties along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<LongWrapper>> getLongWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getLong(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with long properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with long properties on successful completion of {@link Mono}.
@@ -376,13 +472,29 @@ public final class Primitives {
     /**
      * Get complex types with long properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with long properties on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<LongWrapper> getLongAsync(Context context) {
+        return getLongWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with long properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with long properties along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<LongWrapper> getLongWithResponse() {
-        return getLongWithResponseAsync().block();
+    public Response<LongWrapper> getLongWithResponse(Context context) {
+        return getLongWithResponseAsync(context).block();
     }
 
     /**
@@ -394,7 +506,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public LongWrapper getLong() {
-        return getLongWithResponse().getValue();
+        return getLongWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -425,6 +537,31 @@ public final class Primitives {
      * Put complex types with long properties.
      *
      * @param complexBody Please put 1099511627775 and -999511627788.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putLongWithResponseAsync(LongWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putLong(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with long properties.
+     *
+     * @param complexBody Please put 1099511627775 and -999511627788.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -439,14 +576,30 @@ public final class Primitives {
      * Put complex types with long properties.
      *
      * @param complexBody Please put 1099511627775 and -999511627788.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putLongAsync(LongWrapper complexBody, Context context) {
+        return putLongWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with long properties.
+     *
+     * @param complexBody Please put 1099511627775 and -999511627788.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putLongWithResponse(LongWrapper complexBody) {
-        return putLongWithResponseAsync(complexBody).block();
+    public Response<Void> putLongWithResponse(LongWrapper complexBody, Context context) {
+        return putLongWithResponseAsync(complexBody, context).block();
     }
 
     /**
@@ -459,7 +612,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putLong(LongWrapper complexBody) {
-        putLongWithResponse(complexBody);
+        putLongWithResponse(complexBody, Context.NONE);
     }
 
     /**
@@ -482,6 +635,25 @@ public final class Primitives {
     /**
      * Get complex types with float properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with float properties along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<FloatWrapper>> getFloatWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getFloat(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with float properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with float properties on successful completion of {@link Mono}.
@@ -494,13 +666,29 @@ public final class Primitives {
     /**
      * Get complex types with float properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with float properties on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<FloatWrapper> getFloatAsync(Context context) {
+        return getFloatWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with float properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with float properties along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<FloatWrapper> getFloatWithResponse() {
-        return getFloatWithResponseAsync().block();
+    public Response<FloatWrapper> getFloatWithResponse(Context context) {
+        return getFloatWithResponseAsync(context).block();
     }
 
     /**
@@ -512,7 +700,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public FloatWrapper getFloat() {
-        return getFloatWithResponse().getValue();
+        return getFloatWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -543,6 +731,31 @@ public final class Primitives {
      * Put complex types with float properties.
      *
      * @param complexBody Please put 1.05 and -0.003.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putFloatWithResponseAsync(FloatWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putFloat(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with float properties.
+     *
+     * @param complexBody Please put 1.05 and -0.003.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -557,14 +770,30 @@ public final class Primitives {
      * Put complex types with float properties.
      *
      * @param complexBody Please put 1.05 and -0.003.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putFloatAsync(FloatWrapper complexBody, Context context) {
+        return putFloatWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with float properties.
+     *
+     * @param complexBody Please put 1.05 and -0.003.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putFloatWithResponse(FloatWrapper complexBody) {
-        return putFloatWithResponseAsync(complexBody).block();
+    public Response<Void> putFloatWithResponse(FloatWrapper complexBody, Context context) {
+        return putFloatWithResponseAsync(complexBody, context).block();
     }
 
     /**
@@ -577,7 +806,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putFloat(FloatWrapper complexBody) {
-        putFloatWithResponse(complexBody);
+        putFloatWithResponse(complexBody, Context.NONE);
     }
 
     /**
@@ -601,6 +830,26 @@ public final class Primitives {
     /**
      * Get complex types with double properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with double properties along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<DoubleWrapper>> getDoubleWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDouble(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with double properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with double properties on successful completion of {@link Mono}.
@@ -613,13 +862,29 @@ public final class Primitives {
     /**
      * Get complex types with double properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with double properties on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<DoubleWrapper> getDoubleAsync(Context context) {
+        return getDoubleWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with double properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with double properties along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<DoubleWrapper> getDoubleWithResponse() {
-        return getDoubleWithResponseAsync().block();
+    public Response<DoubleWrapper> getDoubleWithResponse(Context context) {
+        return getDoubleWithResponseAsync(context).block();
     }
 
     /**
@@ -631,7 +896,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DoubleWrapper getDouble() {
-        return getDoubleWithResponse().getValue();
+        return getDoubleWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -662,6 +927,31 @@ public final class Primitives {
      * Put complex types with double properties.
      *
      * @param complexBody Please put 3e-100 and -0.000000000000000000000000000000000000000000000000000000005.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putDoubleWithResponseAsync(DoubleWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putDouble(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with double properties.
+     *
+     * @param complexBody Please put 3e-100 and -0.000000000000000000000000000000000000000000000000000000005.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -676,14 +966,30 @@ public final class Primitives {
      * Put complex types with double properties.
      *
      * @param complexBody Please put 3e-100 and -0.000000000000000000000000000000000000000000000000000000005.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putDoubleAsync(DoubleWrapper complexBody, Context context) {
+        return putDoubleWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with double properties.
+     *
+     * @param complexBody Please put 3e-100 and -0.000000000000000000000000000000000000000000000000000000005.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDoubleWithResponse(DoubleWrapper complexBody) {
-        return putDoubleWithResponseAsync(complexBody).block();
+    public Response<Void> putDoubleWithResponse(DoubleWrapper complexBody, Context context) {
+        return putDoubleWithResponseAsync(complexBody, context).block();
     }
 
     /**
@@ -696,7 +1002,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDouble(DoubleWrapper complexBody) {
-        putDoubleWithResponse(complexBody);
+        putDoubleWithResponse(complexBody, Context.NONE);
     }
 
     /**
@@ -719,6 +1025,25 @@ public final class Primitives {
     /**
      * Get complex types with bool properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with bool properties along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BooleanWrapper>> getBoolWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getBool(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with bool properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with bool properties on successful completion of {@link Mono}.
@@ -731,13 +1056,29 @@ public final class Primitives {
     /**
      * Get complex types with bool properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with bool properties on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<BooleanWrapper> getBoolAsync(Context context) {
+        return getBoolWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with bool properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with bool properties along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BooleanWrapper> getBoolWithResponse() {
-        return getBoolWithResponseAsync().block();
+    public Response<BooleanWrapper> getBoolWithResponse(Context context) {
+        return getBoolWithResponseAsync(context).block();
     }
 
     /**
@@ -749,7 +1090,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public BooleanWrapper getBool() {
-        return getBoolWithResponse().getValue();
+        return getBoolWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -780,6 +1121,31 @@ public final class Primitives {
      * Put complex types with bool properties.
      *
      * @param complexBody Please put true and false.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putBoolWithResponseAsync(BooleanWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putBool(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with bool properties.
+     *
+     * @param complexBody Please put true and false.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -794,14 +1160,30 @@ public final class Primitives {
      * Put complex types with bool properties.
      *
      * @param complexBody Please put true and false.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putBoolAsync(BooleanWrapper complexBody, Context context) {
+        return putBoolWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with bool properties.
+     *
+     * @param complexBody Please put true and false.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putBoolWithResponse(BooleanWrapper complexBody) {
-        return putBoolWithResponseAsync(complexBody).block();
+    public Response<Void> putBoolWithResponse(BooleanWrapper complexBody, Context context) {
+        return putBoolWithResponseAsync(complexBody, context).block();
     }
 
     /**
@@ -814,7 +1196,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putBool(BooleanWrapper complexBody) {
-        putBoolWithResponse(complexBody);
+        putBoolWithResponse(complexBody, Context.NONE);
     }
 
     /**
@@ -838,6 +1220,26 @@ public final class Primitives {
     /**
      * Get complex types with string properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with string properties along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<StringWrapper>> getStringWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getString(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with string properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with string properties on successful completion of {@link Mono}.
@@ -850,13 +1252,29 @@ public final class Primitives {
     /**
      * Get complex types with string properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with string properties on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<StringWrapper> getStringAsync(Context context) {
+        return getStringWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with string properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with string properties along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<StringWrapper> getStringWithResponse() {
-        return getStringWithResponseAsync().block();
+    public Response<StringWrapper> getStringWithResponse(Context context) {
+        return getStringWithResponseAsync(context).block();
     }
 
     /**
@@ -868,7 +1286,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public StringWrapper getString() {
-        return getStringWithResponse().getValue();
+        return getStringWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -899,6 +1317,31 @@ public final class Primitives {
      * Put complex types with string properties.
      *
      * @param complexBody Please put 'goodrequest', '', and null.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putStringWithResponseAsync(StringWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putString(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with string properties.
+     *
+     * @param complexBody Please put 'goodrequest', '', and null.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -913,14 +1356,30 @@ public final class Primitives {
      * Put complex types with string properties.
      *
      * @param complexBody Please put 'goodrequest', '', and null.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putStringAsync(StringWrapper complexBody, Context context) {
+        return putStringWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with string properties.
+     *
+     * @param complexBody Please put 'goodrequest', '', and null.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putStringWithResponse(StringWrapper complexBody) {
-        return putStringWithResponseAsync(complexBody).block();
+    public Response<Void> putStringWithResponse(StringWrapper complexBody, Context context) {
+        return putStringWithResponseAsync(complexBody, context).block();
     }
 
     /**
@@ -933,7 +1392,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putString(StringWrapper complexBody) {
-        putStringWithResponse(complexBody);
+        putStringWithResponse(complexBody, Context.NONE);
     }
 
     /**
@@ -956,6 +1415,25 @@ public final class Primitives {
     /**
      * Get complex types with date properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with date properties along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<DateWrapper>> getDateWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDate(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with date properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with date properties on successful completion of {@link Mono}.
@@ -968,13 +1446,29 @@ public final class Primitives {
     /**
      * Get complex types with date properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with date properties on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<DateWrapper> getDateAsync(Context context) {
+        return getDateWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with date properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with date properties along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<DateWrapper> getDateWithResponse() {
-        return getDateWithResponseAsync().block();
+    public Response<DateWrapper> getDateWithResponse(Context context) {
+        return getDateWithResponseAsync(context).block();
     }
 
     /**
@@ -986,7 +1480,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DateWrapper getDate() {
-        return getDateWithResponse().getValue();
+        return getDateWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1017,6 +1511,31 @@ public final class Primitives {
      * Put complex types with date properties.
      *
      * @param complexBody Please put '0001-01-01' and '2016-02-29'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putDateWithResponseAsync(DateWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putDate(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with date properties.
+     *
+     * @param complexBody Please put '0001-01-01' and '2016-02-29'.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1031,14 +1550,30 @@ public final class Primitives {
      * Put complex types with date properties.
      *
      * @param complexBody Please put '0001-01-01' and '2016-02-29'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putDateAsync(DateWrapper complexBody, Context context) {
+        return putDateWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with date properties.
+     *
+     * @param complexBody Please put '0001-01-01' and '2016-02-29'.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDateWithResponse(DateWrapper complexBody) {
-        return putDateWithResponseAsync(complexBody).block();
+    public Response<Void> putDateWithResponse(DateWrapper complexBody, Context context) {
+        return putDateWithResponseAsync(complexBody, context).block();
     }
 
     /**
@@ -1051,7 +1586,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDate(DateWrapper complexBody) {
-        putDateWithResponse(complexBody);
+        putDateWithResponse(complexBody, Context.NONE);
     }
 
     /**
@@ -1075,6 +1610,26 @@ public final class Primitives {
     /**
      * Get complex types with datetime properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with datetime properties along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<DatetimeWrapper>> getDateTimeWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDateTime(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with datetime properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with datetime properties on successful completion of {@link Mono}.
@@ -1087,13 +1642,29 @@ public final class Primitives {
     /**
      * Get complex types with datetime properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with datetime properties on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<DatetimeWrapper> getDateTimeAsync(Context context) {
+        return getDateTimeWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with datetime properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with datetime properties along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<DatetimeWrapper> getDateTimeWithResponse() {
-        return getDateTimeWithResponseAsync().block();
+    public Response<DatetimeWrapper> getDateTimeWithResponse(Context context) {
+        return getDateTimeWithResponseAsync(context).block();
     }
 
     /**
@@ -1105,7 +1676,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DatetimeWrapper getDateTime() {
-        return getDateTimeWithResponse().getValue();
+        return getDateTimeWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1137,6 +1708,31 @@ public final class Primitives {
      * Put complex types with datetime properties.
      *
      * @param complexBody Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putDateTimeWithResponseAsync(DatetimeWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putDateTime(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with datetime properties.
+     *
+     * @param complexBody Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1151,14 +1747,30 @@ public final class Primitives {
      * Put complex types with datetime properties.
      *
      * @param complexBody Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putDateTimeAsync(DatetimeWrapper complexBody, Context context) {
+        return putDateTimeWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with datetime properties.
+     *
+     * @param complexBody Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDateTimeWithResponse(DatetimeWrapper complexBody) {
-        return putDateTimeWithResponseAsync(complexBody).block();
+    public Response<Void> putDateTimeWithResponse(DatetimeWrapper complexBody, Context context) {
+        return putDateTimeWithResponseAsync(complexBody, context).block();
     }
 
     /**
@@ -1171,7 +1783,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDateTime(DatetimeWrapper complexBody) {
-        putDateTimeWithResponse(complexBody);
+        putDateTimeWithResponse(complexBody, Context.NONE);
     }
 
     /**
@@ -1195,6 +1807,26 @@ public final class Primitives {
     /**
      * Get complex types with datetimeRfc1123 properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with datetimeRfc1123 properties along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Datetimerfc1123Wrapper>> getDateTimeRfc1123WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDateTimeRfc1123(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with datetimeRfc1123 properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with datetimeRfc1123 properties on successful completion of {@link Mono}.
@@ -1207,13 +1839,29 @@ public final class Primitives {
     /**
      * Get complex types with datetimeRfc1123 properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with datetimeRfc1123 properties on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Datetimerfc1123Wrapper> getDateTimeRfc1123Async(Context context) {
+        return getDateTimeRfc1123WithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with datetimeRfc1123 properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with datetimeRfc1123 properties along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Datetimerfc1123Wrapper> getDateTimeRfc1123WithResponse() {
-        return getDateTimeRfc1123WithResponseAsync().block();
+    public Response<Datetimerfc1123Wrapper> getDateTimeRfc1123WithResponse(Context context) {
+        return getDateTimeRfc1123WithResponseAsync(context).block();
     }
 
     /**
@@ -1225,7 +1873,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Datetimerfc1123Wrapper getDateTimeRfc1123() {
-        return getDateTimeRfc1123WithResponse().getValue();
+        return getDateTimeRfc1123WithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1257,6 +1905,32 @@ public final class Primitives {
      * Put complex types with datetimeRfc1123 properties.
      *
      * @param complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00 GMT'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putDateTimeRfc1123WithResponseAsync(
+            Datetimerfc1123Wrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putDateTimeRfc1123(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with datetimeRfc1123 properties.
+     *
+     * @param complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00 GMT'.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1271,14 +1945,30 @@ public final class Primitives {
      * Put complex types with datetimeRfc1123 properties.
      *
      * @param complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00 GMT'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putDateTimeRfc1123Async(Datetimerfc1123Wrapper complexBody, Context context) {
+        return putDateTimeRfc1123WithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with datetimeRfc1123 properties.
+     *
+     * @param complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00 GMT'.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDateTimeRfc1123WithResponse(Datetimerfc1123Wrapper complexBody) {
-        return putDateTimeRfc1123WithResponseAsync(complexBody).block();
+    public Response<Void> putDateTimeRfc1123WithResponse(Datetimerfc1123Wrapper complexBody, Context context) {
+        return putDateTimeRfc1123WithResponseAsync(complexBody, context).block();
     }
 
     /**
@@ -1291,7 +1981,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDateTimeRfc1123(Datetimerfc1123Wrapper complexBody) {
-        putDateTimeRfc1123WithResponse(complexBody);
+        putDateTimeRfc1123WithResponse(complexBody, Context.NONE);
     }
 
     /**
@@ -1315,6 +2005,26 @@ public final class Primitives {
     /**
      * Get complex types with duration properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with duration properties along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<DurationWrapper>> getDurationWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDuration(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with duration properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with duration properties on successful completion of {@link Mono}.
@@ -1327,13 +2037,29 @@ public final class Primitives {
     /**
      * Get complex types with duration properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with duration properties on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<DurationWrapper> getDurationAsync(Context context) {
+        return getDurationWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with duration properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with duration properties along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<DurationWrapper> getDurationWithResponse() {
-        return getDurationWithResponseAsync().block();
+    public Response<DurationWrapper> getDurationWithResponse(Context context) {
+        return getDurationWithResponseAsync(context).block();
     }
 
     /**
@@ -1345,7 +2071,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DurationWrapper getDuration() {
-        return getDurationWithResponse().getValue();
+        return getDurationWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1377,6 +2103,31 @@ public final class Primitives {
      * Put complex types with duration properties.
      *
      * @param complexBody Please put 'P123DT22H14M12.011S'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putDurationWithResponseAsync(DurationWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putDuration(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with duration properties.
+     *
+     * @param complexBody Please put 'P123DT22H14M12.011S'.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1391,14 +2142,30 @@ public final class Primitives {
      * Put complex types with duration properties.
      *
      * @param complexBody Please put 'P123DT22H14M12.011S'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putDurationAsync(DurationWrapper complexBody, Context context) {
+        return putDurationWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with duration properties.
+     *
+     * @param complexBody Please put 'P123DT22H14M12.011S'.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDurationWithResponse(DurationWrapper complexBody) {
-        return putDurationWithResponseAsync(complexBody).block();
+    public Response<Void> putDurationWithResponse(DurationWrapper complexBody, Context context) {
+        return putDurationWithResponseAsync(complexBody, context).block();
     }
 
     /**
@@ -1411,7 +2178,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDuration(DurationWrapper complexBody) {
-        putDurationWithResponse(complexBody);
+        putDurationWithResponse(complexBody, Context.NONE);
     }
 
     /**
@@ -1434,6 +2201,25 @@ public final class Primitives {
     /**
      * Get complex types with byte properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with byte properties along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<ByteWrapper>> getByteWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getByte(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with byte properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with byte properties on successful completion of {@link Mono}.
@@ -1446,13 +2232,29 @@ public final class Primitives {
     /**
      * Get complex types with byte properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with byte properties on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<ByteWrapper> getByteAsync(Context context) {
+        return getByteWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with byte properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with byte properties along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<ByteWrapper> getByteWithResponse() {
-        return getByteWithResponseAsync().block();
+    public Response<ByteWrapper> getByteWithResponse(Context context) {
+        return getByteWithResponseAsync(context).block();
     }
 
     /**
@@ -1464,7 +2266,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ByteWrapper getByte() {
-        return getByteWithResponse().getValue();
+        return getByteWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1495,6 +2297,31 @@ public final class Primitives {
      * Put complex types with byte properties.
      *
      * @param complexBody Please put non-ascii byte string hex(FF FE FD FC 00 FA F9 F8 F7 F6).
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putByteWithResponseAsync(ByteWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putByte(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with byte properties.
+     *
+     * @param complexBody Please put non-ascii byte string hex(FF FE FD FC 00 FA F9 F8 F7 F6).
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1509,14 +2336,30 @@ public final class Primitives {
      * Put complex types with byte properties.
      *
      * @param complexBody Please put non-ascii byte string hex(FF FE FD FC 00 FA F9 F8 F7 F6).
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putByteAsync(ByteWrapper complexBody, Context context) {
+        return putByteWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with byte properties.
+     *
+     * @param complexBody Please put non-ascii byte string hex(FF FE FD FC 00 FA F9 F8 F7 F6).
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putByteWithResponse(ByteWrapper complexBody) {
-        return putByteWithResponseAsync(complexBody).block();
+    public Response<Void> putByteWithResponse(ByteWrapper complexBody, Context context) {
+        return putByteWithResponseAsync(complexBody, context).block();
     }
 
     /**
@@ -1529,6 +2372,6 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putByte(ByteWrapper complexBody) {
-        putByteWithResponse(complexBody);
+        putByteWithResponse(complexBody, Context.NONE);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/Readonlyproperties.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/Readonlyproperties.java
@@ -87,6 +87,26 @@ public final class Readonlyproperties {
     /**
      * Get complex types that have readonly properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that have readonly properties along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<ReadonlyObj>> getValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types that have readonly properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types that have readonly properties on successful completion of {@link Mono}.
@@ -99,13 +119,29 @@ public final class Readonlyproperties {
     /**
      * Get complex types that have readonly properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that have readonly properties on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<ReadonlyObj> getValidAsync(Context context) {
+        return getValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types that have readonly properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types that have readonly properties along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<ReadonlyObj> getValidWithResponse() {
-        return getValidWithResponseAsync().block();
+    public Response<ReadonlyObj> getValidWithResponse(Context context) {
+        return getValidWithResponseAsync(context).block();
     }
 
     /**
@@ -117,7 +153,7 @@ public final class Readonlyproperties {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ReadonlyObj getValid() {
-        return getValidWithResponse().getValue();
+        return getValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -148,6 +184,31 @@ public final class Readonlyproperties {
      * Put complex types that have readonly properties.
      *
      * @param complexBody The complexBody parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putValidWithResponseAsync(ReadonlyObj complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putValid(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types that have readonly properties.
+     *
+     * @param complexBody The complexBody parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -162,14 +223,30 @@ public final class Readonlyproperties {
      * Put complex types that have readonly properties.
      *
      * @param complexBody The complexBody parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putValidAsync(ReadonlyObj complexBody, Context context) {
+        return putValidWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types that have readonly properties.
+     *
+     * @param complexBody The complexBody parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putValidWithResponse(ReadonlyObj complexBody) {
-        return putValidWithResponseAsync(complexBody).block();
+    public Response<Void> putValidWithResponse(ReadonlyObj complexBody, Context context) {
+        return putValidWithResponseAsync(complexBody, context).block();
     }
 
     /**
@@ -182,6 +259,6 @@ public final class Readonlyproperties {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValid(ReadonlyObj complexBody) {
-        putValidWithResponse(complexBody);
+        putValidWithResponse(complexBody, Context.NONE);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodydate/DateOperations.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydate/DateOperations.java
@@ -124,6 +124,25 @@ public final class DateOperations {
     /**
      * Get null date value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null date value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<LocalDate>> getNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get null date value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null date value on successful completion of {@link Mono}.
@@ -136,13 +155,29 @@ public final class DateOperations {
     /**
      * Get null date value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null date value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<LocalDate> getNullAsync(Context context) {
+        return getNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get null date value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null date value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<LocalDate> getNullWithResponse() {
-        return getNullWithResponseAsync().block();
+    public Response<LocalDate> getNullWithResponse(Context context) {
+        return getNullWithResponseAsync(context).block();
     }
 
     /**
@@ -154,7 +189,7 @@ public final class DateOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public LocalDate getNull() {
-        return getNullWithResponse().getValue();
+        return getNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -177,6 +212,25 @@ public final class DateOperations {
     /**
      * Get invalid date value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return invalid date value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<LocalDate>> getInvalidDateWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getInvalidDate(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get invalid date value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return invalid date value on successful completion of {@link Mono}.
@@ -189,13 +243,29 @@ public final class DateOperations {
     /**
      * Get invalid date value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return invalid date value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<LocalDate> getInvalidDateAsync(Context context) {
+        return getInvalidDateWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get invalid date value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return invalid date value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<LocalDate> getInvalidDateWithResponse() {
-        return getInvalidDateWithResponseAsync().block();
+    public Response<LocalDate> getInvalidDateWithResponse(Context context) {
+        return getInvalidDateWithResponseAsync(context).block();
     }
 
     /**
@@ -207,7 +277,7 @@ public final class DateOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public LocalDate getInvalidDate() {
-        return getInvalidDateWithResponse().getValue();
+        return getInvalidDateWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -230,6 +300,25 @@ public final class DateOperations {
     /**
      * Get overflow date value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return overflow date value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<LocalDate>> getOverflowDateWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getOverflowDate(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get overflow date value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return overflow date value on successful completion of {@link Mono}.
@@ -242,13 +331,29 @@ public final class DateOperations {
     /**
      * Get overflow date value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return overflow date value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<LocalDate> getOverflowDateAsync(Context context) {
+        return getOverflowDateWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get overflow date value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return overflow date value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<LocalDate> getOverflowDateWithResponse() {
-        return getOverflowDateWithResponseAsync().block();
+    public Response<LocalDate> getOverflowDateWithResponse(Context context) {
+        return getOverflowDateWithResponseAsync(context).block();
     }
 
     /**
@@ -260,7 +365,7 @@ public final class DateOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public LocalDate getOverflowDate() {
-        return getOverflowDateWithResponse().getValue();
+        return getOverflowDateWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -283,6 +388,25 @@ public final class DateOperations {
     /**
      * Get underflow date value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return underflow date value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<LocalDate>> getUnderflowDateWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getUnderflowDate(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get underflow date value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return underflow date value on successful completion of {@link Mono}.
@@ -295,13 +419,29 @@ public final class DateOperations {
     /**
      * Get underflow date value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return underflow date value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<LocalDate> getUnderflowDateAsync(Context context) {
+        return getUnderflowDateWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get underflow date value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return underflow date value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<LocalDate> getUnderflowDateWithResponse() {
-        return getUnderflowDateWithResponseAsync().block();
+    public Response<LocalDate> getUnderflowDateWithResponse(Context context) {
+        return getUnderflowDateWithResponseAsync(context).block();
     }
 
     /**
@@ -313,7 +453,7 @@ public final class DateOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public LocalDate getUnderflowDate() {
-        return getUnderflowDateWithResponse().getValue();
+        return getUnderflowDateWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -342,6 +482,29 @@ public final class DateOperations {
      * Put max date value 9999-12-31.
      *
      * @param dateBody date body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putMaxDateWithResponseAsync(LocalDate dateBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (dateBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter dateBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putMaxDate(this.client.getHost(), dateBody, accept, context);
+    }
+
+    /**
+     * Put max date value 9999-12-31.
+     *
+     * @param dateBody date body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -356,14 +519,30 @@ public final class DateOperations {
      * Put max date value 9999-12-31.
      *
      * @param dateBody date body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putMaxDateAsync(LocalDate dateBody, Context context) {
+        return putMaxDateWithResponseAsync(dateBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put max date value 9999-12-31.
+     *
+     * @param dateBody date body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putMaxDateWithResponse(LocalDate dateBody) {
-        return putMaxDateWithResponseAsync(dateBody).block();
+    public Response<Void> putMaxDateWithResponse(LocalDate dateBody, Context context) {
+        return putMaxDateWithResponseAsync(dateBody, context).block();
     }
 
     /**
@@ -376,7 +555,7 @@ public final class DateOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putMaxDate(LocalDate dateBody) {
-        putMaxDateWithResponse(dateBody);
+        putMaxDateWithResponse(dateBody, Context.NONE);
     }
 
     /**
@@ -399,6 +578,25 @@ public final class DateOperations {
     /**
      * Get max date value 9999-12-31.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return max date value 9999-12-31 along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<LocalDate>> getMaxDateWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getMaxDate(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get max date value 9999-12-31.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return max date value 9999-12-31 on successful completion of {@link Mono}.
@@ -411,13 +609,29 @@ public final class DateOperations {
     /**
      * Get max date value 9999-12-31.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return max date value 9999-12-31 on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<LocalDate> getMaxDateAsync(Context context) {
+        return getMaxDateWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get max date value 9999-12-31.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return max date value 9999-12-31 along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<LocalDate> getMaxDateWithResponse() {
-        return getMaxDateWithResponseAsync().block();
+    public Response<LocalDate> getMaxDateWithResponse(Context context) {
+        return getMaxDateWithResponseAsync(context).block();
     }
 
     /**
@@ -429,7 +643,7 @@ public final class DateOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public LocalDate getMaxDate() {
-        return getMaxDateWithResponse().getValue();
+        return getMaxDateWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -458,6 +672,29 @@ public final class DateOperations {
      * Put min date value 0000-01-01.
      *
      * @param dateBody date body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putMinDateWithResponseAsync(LocalDate dateBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (dateBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter dateBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putMinDate(this.client.getHost(), dateBody, accept, context);
+    }
+
+    /**
+     * Put min date value 0000-01-01.
+     *
+     * @param dateBody date body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -472,14 +709,30 @@ public final class DateOperations {
      * Put min date value 0000-01-01.
      *
      * @param dateBody date body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putMinDateAsync(LocalDate dateBody, Context context) {
+        return putMinDateWithResponseAsync(dateBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put min date value 0000-01-01.
+     *
+     * @param dateBody date body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putMinDateWithResponse(LocalDate dateBody) {
-        return putMinDateWithResponseAsync(dateBody).block();
+    public Response<Void> putMinDateWithResponse(LocalDate dateBody, Context context) {
+        return putMinDateWithResponseAsync(dateBody, context).block();
     }
 
     /**
@@ -492,7 +745,7 @@ public final class DateOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putMinDate(LocalDate dateBody) {
-        putMinDateWithResponse(dateBody);
+        putMinDateWithResponse(dateBody, Context.NONE);
     }
 
     /**
@@ -515,6 +768,25 @@ public final class DateOperations {
     /**
      * Get min date value 0000-01-01.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return min date value 0000-01-01 along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<LocalDate>> getMinDateWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getMinDate(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get min date value 0000-01-01.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return min date value 0000-01-01 on successful completion of {@link Mono}.
@@ -527,13 +799,29 @@ public final class DateOperations {
     /**
      * Get min date value 0000-01-01.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return min date value 0000-01-01 on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<LocalDate> getMinDateAsync(Context context) {
+        return getMinDateWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get min date value 0000-01-01.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return min date value 0000-01-01 along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<LocalDate> getMinDateWithResponse() {
-        return getMinDateWithResponseAsync().block();
+    public Response<LocalDate> getMinDateWithResponse(Context context) {
+        return getMinDateWithResponseAsync(context).block();
     }
 
     /**
@@ -545,6 +833,6 @@ public final class DateOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public LocalDate getMinDate() {
-        return getMinDateWithResponse().getValue();
+        return getMinDateWithResponse(Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodydatetime/DatetimeOperations.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydatetime/DatetimeOperations.java
@@ -240,6 +240,25 @@ public final class DatetimeOperations {
     /**
      * Get null datetime value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null datetime value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<OffsetDateTime>> getNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get null datetime value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null datetime value on successful completion of {@link Mono}.
@@ -252,13 +271,29 @@ public final class DatetimeOperations {
     /**
      * Get null datetime value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null datetime value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<OffsetDateTime> getNullAsync(Context context) {
+        return getNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get null datetime value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null datetime value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OffsetDateTime> getNullWithResponse() {
-        return getNullWithResponseAsync().block();
+    public Response<OffsetDateTime> getNullWithResponse(Context context) {
+        return getNullWithResponseAsync(context).block();
     }
 
     /**
@@ -270,7 +305,7 @@ public final class DatetimeOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getNull() {
-        return getNullWithResponse().getValue();
+        return getNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -293,6 +328,25 @@ public final class DatetimeOperations {
     /**
      * Get invalid datetime value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return invalid datetime value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<OffsetDateTime>> getInvalidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getInvalid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get invalid datetime value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return invalid datetime value on successful completion of {@link Mono}.
@@ -305,13 +359,29 @@ public final class DatetimeOperations {
     /**
      * Get invalid datetime value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return invalid datetime value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<OffsetDateTime> getInvalidAsync(Context context) {
+        return getInvalidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get invalid datetime value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return invalid datetime value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OffsetDateTime> getInvalidWithResponse() {
-        return getInvalidWithResponseAsync().block();
+    public Response<OffsetDateTime> getInvalidWithResponse(Context context) {
+        return getInvalidWithResponseAsync(context).block();
     }
 
     /**
@@ -323,7 +393,7 @@ public final class DatetimeOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getInvalid() {
-        return getInvalidWithResponse().getValue();
+        return getInvalidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -346,6 +416,25 @@ public final class DatetimeOperations {
     /**
      * Get overflow datetime value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return overflow datetime value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<OffsetDateTime>> getOverflowWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getOverflow(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get overflow datetime value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return overflow datetime value on successful completion of {@link Mono}.
@@ -358,13 +447,29 @@ public final class DatetimeOperations {
     /**
      * Get overflow datetime value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return overflow datetime value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<OffsetDateTime> getOverflowAsync(Context context) {
+        return getOverflowWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get overflow datetime value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return overflow datetime value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OffsetDateTime> getOverflowWithResponse() {
-        return getOverflowWithResponseAsync().block();
+    public Response<OffsetDateTime> getOverflowWithResponse(Context context) {
+        return getOverflowWithResponseAsync(context).block();
     }
 
     /**
@@ -376,7 +481,7 @@ public final class DatetimeOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getOverflow() {
-        return getOverflowWithResponse().getValue();
+        return getOverflowWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -399,6 +504,25 @@ public final class DatetimeOperations {
     /**
      * Get underflow datetime value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return underflow datetime value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<OffsetDateTime>> getUnderflowWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getUnderflow(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get underflow datetime value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return underflow datetime value on successful completion of {@link Mono}.
@@ -411,13 +535,29 @@ public final class DatetimeOperations {
     /**
      * Get underflow datetime value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return underflow datetime value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<OffsetDateTime> getUnderflowAsync(Context context) {
+        return getUnderflowWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get underflow datetime value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return underflow datetime value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OffsetDateTime> getUnderflowWithResponse() {
-        return getUnderflowWithResponseAsync().block();
+    public Response<OffsetDateTime> getUnderflowWithResponse(Context context) {
+        return getUnderflowWithResponseAsync(context).block();
     }
 
     /**
@@ -429,7 +569,7 @@ public final class DatetimeOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getUnderflow() {
-        return getUnderflowWithResponse().getValue();
+        return getUnderflowWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -459,6 +599,29 @@ public final class DatetimeOperations {
      * Put max datetime value 9999-12-31T23:59:59.999Z.
      *
      * @param datetimeBody datetime body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putUtcMaxDateTimeWithResponseAsync(OffsetDateTime datetimeBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (datetimeBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter datetimeBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putUtcMaxDateTime(this.client.getHost(), datetimeBody, accept, context);
+    }
+
+    /**
+     * Put max datetime value 9999-12-31T23:59:59.999Z.
+     *
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -473,14 +636,30 @@ public final class DatetimeOperations {
      * Put max datetime value 9999-12-31T23:59:59.999Z.
      *
      * @param datetimeBody datetime body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putUtcMaxDateTimeAsync(OffsetDateTime datetimeBody, Context context) {
+        return putUtcMaxDateTimeWithResponseAsync(datetimeBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put max datetime value 9999-12-31T23:59:59.999Z.
+     *
+     * @param datetimeBody datetime body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putUtcMaxDateTimeWithResponse(OffsetDateTime datetimeBody) {
-        return putUtcMaxDateTimeWithResponseAsync(datetimeBody).block();
+    public Response<Void> putUtcMaxDateTimeWithResponse(OffsetDateTime datetimeBody, Context context) {
+        return putUtcMaxDateTimeWithResponseAsync(datetimeBody, context).block();
     }
 
     /**
@@ -493,7 +672,7 @@ public final class DatetimeOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putUtcMaxDateTime(OffsetDateTime datetimeBody) {
-        putUtcMaxDateTimeWithResponse(datetimeBody);
+        putUtcMaxDateTimeWithResponse(datetimeBody, Context.NONE);
     }
 
     /**
@@ -527,6 +706,32 @@ public final class DatetimeOperations {
      * <p>This is against the recommendation that asks for 3 digits, but allow to test what happens in that scenario.
      *
      * @param datetimeBody datetime body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putUtcMaxDateTime7DigitsWithResponseAsync(
+            OffsetDateTime datetimeBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (datetimeBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter datetimeBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putUtcMaxDateTime7Digits(this.client.getHost(), datetimeBody, accept, context);
+    }
+
+    /**
+     * Put max datetime value 9999-12-31T23:59:59.9999999Z
+     *
+     * <p>This is against the recommendation that asks for 3 digits, but allow to test what happens in that scenario.
+     *
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -543,14 +748,32 @@ public final class DatetimeOperations {
      * <p>This is against the recommendation that asks for 3 digits, but allow to test what happens in that scenario.
      *
      * @param datetimeBody datetime body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putUtcMaxDateTime7DigitsAsync(OffsetDateTime datetimeBody, Context context) {
+        return putUtcMaxDateTime7DigitsWithResponseAsync(datetimeBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put max datetime value 9999-12-31T23:59:59.9999999Z
+     *
+     * <p>This is against the recommendation that asks for 3 digits, but allow to test what happens in that scenario.
+     *
+     * @param datetimeBody datetime body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putUtcMaxDateTime7DigitsWithResponse(OffsetDateTime datetimeBody) {
-        return putUtcMaxDateTime7DigitsWithResponseAsync(datetimeBody).block();
+    public Response<Void> putUtcMaxDateTime7DigitsWithResponse(OffsetDateTime datetimeBody, Context context) {
+        return putUtcMaxDateTime7DigitsWithResponseAsync(datetimeBody, context).block();
     }
 
     /**
@@ -565,7 +788,7 @@ public final class DatetimeOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putUtcMaxDateTime7Digits(OffsetDateTime datetimeBody) {
-        putUtcMaxDateTime7DigitsWithResponse(datetimeBody);
+        putUtcMaxDateTime7DigitsWithResponse(datetimeBody, Context.NONE);
     }
 
     /**
@@ -590,6 +813,26 @@ public final class DatetimeOperations {
     /**
      * Get max datetime value 9999-12-31t23:59:59.999z.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return max datetime value 9999-12-31t23:59:59.999z along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<OffsetDateTime>> getUtcLowercaseMaxDateTimeWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getUtcLowercaseMaxDateTime(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get max datetime value 9999-12-31t23:59:59.999z.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return max datetime value 9999-12-31t23:59:59.999z on successful completion of {@link Mono}.
@@ -602,13 +845,29 @@ public final class DatetimeOperations {
     /**
      * Get max datetime value 9999-12-31t23:59:59.999z.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return max datetime value 9999-12-31t23:59:59.999z on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<OffsetDateTime> getUtcLowercaseMaxDateTimeAsync(Context context) {
+        return getUtcLowercaseMaxDateTimeWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get max datetime value 9999-12-31t23:59:59.999z.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return max datetime value 9999-12-31t23:59:59.999z along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OffsetDateTime> getUtcLowercaseMaxDateTimeWithResponse() {
-        return getUtcLowercaseMaxDateTimeWithResponseAsync().block();
+    public Response<OffsetDateTime> getUtcLowercaseMaxDateTimeWithResponse(Context context) {
+        return getUtcLowercaseMaxDateTimeWithResponseAsync(context).block();
     }
 
     /**
@@ -620,7 +879,7 @@ public final class DatetimeOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getUtcLowercaseMaxDateTime() {
-        return getUtcLowercaseMaxDateTimeWithResponse().getValue();
+        return getUtcLowercaseMaxDateTimeWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -645,6 +904,26 @@ public final class DatetimeOperations {
     /**
      * Get max datetime value 9999-12-31T23:59:59.999Z.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return max datetime value 9999-12-31T23:59:59.999Z along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<OffsetDateTime>> getUtcUppercaseMaxDateTimeWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getUtcUppercaseMaxDateTime(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get max datetime value 9999-12-31T23:59:59.999Z.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return max datetime value 9999-12-31T23:59:59.999Z on successful completion of {@link Mono}.
@@ -657,13 +936,29 @@ public final class DatetimeOperations {
     /**
      * Get max datetime value 9999-12-31T23:59:59.999Z.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return max datetime value 9999-12-31T23:59:59.999Z on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<OffsetDateTime> getUtcUppercaseMaxDateTimeAsync(Context context) {
+        return getUtcUppercaseMaxDateTimeWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get max datetime value 9999-12-31T23:59:59.999Z.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return max datetime value 9999-12-31T23:59:59.999Z along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OffsetDateTime> getUtcUppercaseMaxDateTimeWithResponse() {
-        return getUtcUppercaseMaxDateTimeWithResponseAsync().block();
+    public Response<OffsetDateTime> getUtcUppercaseMaxDateTimeWithResponse(Context context) {
+        return getUtcUppercaseMaxDateTimeWithResponseAsync(context).block();
     }
 
     /**
@@ -675,7 +970,7 @@ public final class DatetimeOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getUtcUppercaseMaxDateTime() {
-        return getUtcUppercaseMaxDateTimeWithResponse().getValue();
+        return getUtcUppercaseMaxDateTimeWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -703,6 +998,27 @@ public final class DatetimeOperations {
      *
      * <p>This is against the recommendation that asks for 3 digits, but allow to test what happens in that scenario.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<OffsetDateTime>> getUtcUppercaseMaxDateTime7DigitsWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getUtcUppercaseMaxDateTime7Digits(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get max datetime value 9999-12-31T23:59:59.9999999Z
+     *
+     * <p>This is against the recommendation that asks for 3 digits, but allow to test what happens in that scenario.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body on successful completion of {@link Mono}.
@@ -717,13 +1033,32 @@ public final class DatetimeOperations {
      *
      * <p>This is against the recommendation that asks for 3 digits, but allow to test what happens in that scenario.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<OffsetDateTime> getUtcUppercaseMaxDateTime7DigitsAsync(Context context) {
+        return getUtcUppercaseMaxDateTime7DigitsWithResponseAsync(context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get max datetime value 9999-12-31T23:59:59.9999999Z
+     *
+     * <p>This is against the recommendation that asks for 3 digits, but allow to test what happens in that scenario.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OffsetDateTime> getUtcUppercaseMaxDateTime7DigitsWithResponse() {
-        return getUtcUppercaseMaxDateTime7DigitsWithResponseAsync().block();
+    public Response<OffsetDateTime> getUtcUppercaseMaxDateTime7DigitsWithResponse(Context context) {
+        return getUtcUppercaseMaxDateTime7DigitsWithResponseAsync(context).block();
     }
 
     /**
@@ -737,7 +1072,7 @@ public final class DatetimeOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getUtcUppercaseMaxDateTime7Digits() {
-        return getUtcUppercaseMaxDateTime7DigitsWithResponse().getValue();
+        return getUtcUppercaseMaxDateTime7DigitsWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -769,6 +1104,30 @@ public final class DatetimeOperations {
      * Put max datetime value with positive numoffset 9999-12-31t23:59:59.999+14:00.
      *
      * @param datetimeBody datetime body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putLocalPositiveOffsetMaxDateTimeWithResponseAsync(
+            OffsetDateTime datetimeBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (datetimeBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter datetimeBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putLocalPositiveOffsetMaxDateTime(this.client.getHost(), datetimeBody, accept, context);
+    }
+
+    /**
+     * Put max datetime value with positive numoffset 9999-12-31t23:59:59.999+14:00.
+     *
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -783,14 +1142,31 @@ public final class DatetimeOperations {
      * Put max datetime value with positive numoffset 9999-12-31t23:59:59.999+14:00.
      *
      * @param datetimeBody datetime body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putLocalPositiveOffsetMaxDateTimeAsync(OffsetDateTime datetimeBody, Context context) {
+        return putLocalPositiveOffsetMaxDateTimeWithResponseAsync(datetimeBody, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put max datetime value with positive numoffset 9999-12-31t23:59:59.999+14:00.
+     *
+     * @param datetimeBody datetime body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putLocalPositiveOffsetMaxDateTimeWithResponse(OffsetDateTime datetimeBody) {
-        return putLocalPositiveOffsetMaxDateTimeWithResponseAsync(datetimeBody).block();
+    public Response<Void> putLocalPositiveOffsetMaxDateTimeWithResponse(OffsetDateTime datetimeBody, Context context) {
+        return putLocalPositiveOffsetMaxDateTimeWithResponseAsync(datetimeBody, context).block();
     }
 
     /**
@@ -803,7 +1179,7 @@ public final class DatetimeOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putLocalPositiveOffsetMaxDateTime(OffsetDateTime datetimeBody) {
-        putLocalPositiveOffsetMaxDateTimeWithResponse(datetimeBody);
+        putLocalPositiveOffsetMaxDateTimeWithResponse(datetimeBody, Context.NONE);
     }
 
     /**
@@ -828,6 +1204,26 @@ public final class DatetimeOperations {
     /**
      * Get max datetime value with positive num offset 9999-12-31t23:59:59.999+14:00.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return max datetime value with positive num offset 9999-12-31t23:59:59.999+14:00 along with {@link Response} on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<OffsetDateTime>> getLocalPositiveOffsetLowercaseMaxDateTimeWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getLocalPositiveOffsetLowercaseMaxDateTime(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get max datetime value with positive num offset 9999-12-31t23:59:59.999+14:00.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return max datetime value with positive num offset 9999-12-31t23:59:59.999+14:00 on successful completion of
@@ -842,13 +1238,31 @@ public final class DatetimeOperations {
     /**
      * Get max datetime value with positive num offset 9999-12-31t23:59:59.999+14:00.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return max datetime value with positive num offset 9999-12-31t23:59:59.999+14:00 on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<OffsetDateTime> getLocalPositiveOffsetLowercaseMaxDateTimeAsync(Context context) {
+        return getLocalPositiveOffsetLowercaseMaxDateTimeWithResponseAsync(context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get max datetime value with positive num offset 9999-12-31t23:59:59.999+14:00.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return max datetime value with positive num offset 9999-12-31t23:59:59.999+14:00 along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OffsetDateTime> getLocalPositiveOffsetLowercaseMaxDateTimeWithResponse() {
-        return getLocalPositiveOffsetLowercaseMaxDateTimeWithResponseAsync().block();
+    public Response<OffsetDateTime> getLocalPositiveOffsetLowercaseMaxDateTimeWithResponse(Context context) {
+        return getLocalPositiveOffsetLowercaseMaxDateTimeWithResponseAsync(context).block();
     }
 
     /**
@@ -860,7 +1274,7 @@ public final class DatetimeOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getLocalPositiveOffsetLowercaseMaxDateTime() {
-        return getLocalPositiveOffsetLowercaseMaxDateTimeWithResponse().getValue();
+        return getLocalPositiveOffsetLowercaseMaxDateTimeWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -885,6 +1299,26 @@ public final class DatetimeOperations {
     /**
      * Get max datetime value with positive num offset 9999-12-31T23:59:59.999+14:00.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return max datetime value with positive num offset 9999-12-31T23:59:59.999+14:00 along with {@link Response} on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<OffsetDateTime>> getLocalPositiveOffsetUppercaseMaxDateTimeWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getLocalPositiveOffsetUppercaseMaxDateTime(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get max datetime value with positive num offset 9999-12-31T23:59:59.999+14:00.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return max datetime value with positive num offset 9999-12-31T23:59:59.999+14:00 on successful completion of
@@ -899,13 +1333,31 @@ public final class DatetimeOperations {
     /**
      * Get max datetime value with positive num offset 9999-12-31T23:59:59.999+14:00.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return max datetime value with positive num offset 9999-12-31T23:59:59.999+14:00 on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<OffsetDateTime> getLocalPositiveOffsetUppercaseMaxDateTimeAsync(Context context) {
+        return getLocalPositiveOffsetUppercaseMaxDateTimeWithResponseAsync(context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get max datetime value with positive num offset 9999-12-31T23:59:59.999+14:00.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return max datetime value with positive num offset 9999-12-31T23:59:59.999+14:00 along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OffsetDateTime> getLocalPositiveOffsetUppercaseMaxDateTimeWithResponse() {
-        return getLocalPositiveOffsetUppercaseMaxDateTimeWithResponseAsync().block();
+    public Response<OffsetDateTime> getLocalPositiveOffsetUppercaseMaxDateTimeWithResponse(Context context) {
+        return getLocalPositiveOffsetUppercaseMaxDateTimeWithResponseAsync(context).block();
     }
 
     /**
@@ -917,7 +1369,7 @@ public final class DatetimeOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getLocalPositiveOffsetUppercaseMaxDateTime() {
-        return getLocalPositiveOffsetUppercaseMaxDateTimeWithResponse().getValue();
+        return getLocalPositiveOffsetUppercaseMaxDateTimeWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -949,6 +1401,30 @@ public final class DatetimeOperations {
      * Put max datetime value with positive numoffset 9999-12-31t23:59:59.999-14:00.
      *
      * @param datetimeBody datetime body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putLocalNegativeOffsetMaxDateTimeWithResponseAsync(
+            OffsetDateTime datetimeBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (datetimeBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter datetimeBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putLocalNegativeOffsetMaxDateTime(this.client.getHost(), datetimeBody, accept, context);
+    }
+
+    /**
+     * Put max datetime value with positive numoffset 9999-12-31t23:59:59.999-14:00.
+     *
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -963,14 +1439,31 @@ public final class DatetimeOperations {
      * Put max datetime value with positive numoffset 9999-12-31t23:59:59.999-14:00.
      *
      * @param datetimeBody datetime body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putLocalNegativeOffsetMaxDateTimeAsync(OffsetDateTime datetimeBody, Context context) {
+        return putLocalNegativeOffsetMaxDateTimeWithResponseAsync(datetimeBody, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put max datetime value with positive numoffset 9999-12-31t23:59:59.999-14:00.
+     *
+     * @param datetimeBody datetime body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putLocalNegativeOffsetMaxDateTimeWithResponse(OffsetDateTime datetimeBody) {
-        return putLocalNegativeOffsetMaxDateTimeWithResponseAsync(datetimeBody).block();
+    public Response<Void> putLocalNegativeOffsetMaxDateTimeWithResponse(OffsetDateTime datetimeBody, Context context) {
+        return putLocalNegativeOffsetMaxDateTimeWithResponseAsync(datetimeBody, context).block();
     }
 
     /**
@@ -983,7 +1476,7 @@ public final class DatetimeOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putLocalNegativeOffsetMaxDateTime(OffsetDateTime datetimeBody) {
-        putLocalNegativeOffsetMaxDateTimeWithResponse(datetimeBody);
+        putLocalNegativeOffsetMaxDateTimeWithResponse(datetimeBody, Context.NONE);
     }
 
     /**
@@ -1008,6 +1501,26 @@ public final class DatetimeOperations {
     /**
      * Get max datetime value with positive num offset 9999-12-31T23:59:59.999-14:00.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return max datetime value with positive num offset 9999-12-31T23:59:59.999-14:00 along with {@link Response} on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<OffsetDateTime>> getLocalNegativeOffsetUppercaseMaxDateTimeWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getLocalNegativeOffsetUppercaseMaxDateTime(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get max datetime value with positive num offset 9999-12-31T23:59:59.999-14:00.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return max datetime value with positive num offset 9999-12-31T23:59:59.999-14:00 on successful completion of
@@ -1022,13 +1535,31 @@ public final class DatetimeOperations {
     /**
      * Get max datetime value with positive num offset 9999-12-31T23:59:59.999-14:00.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return max datetime value with positive num offset 9999-12-31T23:59:59.999-14:00 on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<OffsetDateTime> getLocalNegativeOffsetUppercaseMaxDateTimeAsync(Context context) {
+        return getLocalNegativeOffsetUppercaseMaxDateTimeWithResponseAsync(context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get max datetime value with positive num offset 9999-12-31T23:59:59.999-14:00.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return max datetime value with positive num offset 9999-12-31T23:59:59.999-14:00 along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OffsetDateTime> getLocalNegativeOffsetUppercaseMaxDateTimeWithResponse() {
-        return getLocalNegativeOffsetUppercaseMaxDateTimeWithResponseAsync().block();
+    public Response<OffsetDateTime> getLocalNegativeOffsetUppercaseMaxDateTimeWithResponse(Context context) {
+        return getLocalNegativeOffsetUppercaseMaxDateTimeWithResponseAsync(context).block();
     }
 
     /**
@@ -1040,7 +1571,7 @@ public final class DatetimeOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getLocalNegativeOffsetUppercaseMaxDateTime() {
-        return getLocalNegativeOffsetUppercaseMaxDateTimeWithResponse().getValue();
+        return getLocalNegativeOffsetUppercaseMaxDateTimeWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1065,6 +1596,26 @@ public final class DatetimeOperations {
     /**
      * Get max datetime value with positive num offset 9999-12-31t23:59:59.999-14:00.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return max datetime value with positive num offset 9999-12-31t23:59:59.999-14:00 along with {@link Response} on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<OffsetDateTime>> getLocalNegativeOffsetLowercaseMaxDateTimeWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getLocalNegativeOffsetLowercaseMaxDateTime(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get max datetime value with positive num offset 9999-12-31t23:59:59.999-14:00.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return max datetime value with positive num offset 9999-12-31t23:59:59.999-14:00 on successful completion of
@@ -1079,13 +1630,31 @@ public final class DatetimeOperations {
     /**
      * Get max datetime value with positive num offset 9999-12-31t23:59:59.999-14:00.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return max datetime value with positive num offset 9999-12-31t23:59:59.999-14:00 on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<OffsetDateTime> getLocalNegativeOffsetLowercaseMaxDateTimeAsync(Context context) {
+        return getLocalNegativeOffsetLowercaseMaxDateTimeWithResponseAsync(context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get max datetime value with positive num offset 9999-12-31t23:59:59.999-14:00.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return max datetime value with positive num offset 9999-12-31t23:59:59.999-14:00 along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OffsetDateTime> getLocalNegativeOffsetLowercaseMaxDateTimeWithResponse() {
-        return getLocalNegativeOffsetLowercaseMaxDateTimeWithResponseAsync().block();
+    public Response<OffsetDateTime> getLocalNegativeOffsetLowercaseMaxDateTimeWithResponse(Context context) {
+        return getLocalNegativeOffsetLowercaseMaxDateTimeWithResponseAsync(context).block();
     }
 
     /**
@@ -1097,7 +1666,7 @@ public final class DatetimeOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getLocalNegativeOffsetLowercaseMaxDateTime() {
-        return getLocalNegativeOffsetLowercaseMaxDateTimeWithResponse().getValue();
+        return getLocalNegativeOffsetLowercaseMaxDateTimeWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1127,6 +1696,29 @@ public final class DatetimeOperations {
      * Put min datetime value 0001-01-01T00:00:00Z.
      *
      * @param datetimeBody datetime body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putUtcMinDateTimeWithResponseAsync(OffsetDateTime datetimeBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (datetimeBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter datetimeBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putUtcMinDateTime(this.client.getHost(), datetimeBody, accept, context);
+    }
+
+    /**
+     * Put min datetime value 0001-01-01T00:00:00Z.
+     *
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1141,14 +1733,30 @@ public final class DatetimeOperations {
      * Put min datetime value 0001-01-01T00:00:00Z.
      *
      * @param datetimeBody datetime body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putUtcMinDateTimeAsync(OffsetDateTime datetimeBody, Context context) {
+        return putUtcMinDateTimeWithResponseAsync(datetimeBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put min datetime value 0001-01-01T00:00:00Z.
+     *
+     * @param datetimeBody datetime body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putUtcMinDateTimeWithResponse(OffsetDateTime datetimeBody) {
-        return putUtcMinDateTimeWithResponseAsync(datetimeBody).block();
+    public Response<Void> putUtcMinDateTimeWithResponse(OffsetDateTime datetimeBody, Context context) {
+        return putUtcMinDateTimeWithResponseAsync(datetimeBody, context).block();
     }
 
     /**
@@ -1161,7 +1769,7 @@ public final class DatetimeOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putUtcMinDateTime(OffsetDateTime datetimeBody) {
-        putUtcMinDateTimeWithResponse(datetimeBody);
+        putUtcMinDateTimeWithResponse(datetimeBody, Context.NONE);
     }
 
     /**
@@ -1185,6 +1793,26 @@ public final class DatetimeOperations {
     /**
      * Get min datetime value 0001-01-01T00:00:00Z.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return min datetime value 0001-01-01T00:00:00Z along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<OffsetDateTime>> getUtcMinDateTimeWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getUtcMinDateTime(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get min datetime value 0001-01-01T00:00:00Z.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return min datetime value 0001-01-01T00:00:00Z on successful completion of {@link Mono}.
@@ -1197,13 +1825,29 @@ public final class DatetimeOperations {
     /**
      * Get min datetime value 0001-01-01T00:00:00Z.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return min datetime value 0001-01-01T00:00:00Z on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<OffsetDateTime> getUtcMinDateTimeAsync(Context context) {
+        return getUtcMinDateTimeWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get min datetime value 0001-01-01T00:00:00Z.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return min datetime value 0001-01-01T00:00:00Z along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OffsetDateTime> getUtcMinDateTimeWithResponse() {
-        return getUtcMinDateTimeWithResponseAsync().block();
+    public Response<OffsetDateTime> getUtcMinDateTimeWithResponse(Context context) {
+        return getUtcMinDateTimeWithResponseAsync(context).block();
     }
 
     /**
@@ -1215,7 +1859,7 @@ public final class DatetimeOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getUtcMinDateTime() {
-        return getUtcMinDateTimeWithResponse().getValue();
+        return getUtcMinDateTimeWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1247,6 +1891,30 @@ public final class DatetimeOperations {
      * Put min datetime value 0001-01-01T00:00:00+14:00.
      *
      * @param datetimeBody datetime body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putLocalPositiveOffsetMinDateTimeWithResponseAsync(
+            OffsetDateTime datetimeBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (datetimeBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter datetimeBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putLocalPositiveOffsetMinDateTime(this.client.getHost(), datetimeBody, accept, context);
+    }
+
+    /**
+     * Put min datetime value 0001-01-01T00:00:00+14:00.
+     *
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1261,14 +1929,31 @@ public final class DatetimeOperations {
      * Put min datetime value 0001-01-01T00:00:00+14:00.
      *
      * @param datetimeBody datetime body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putLocalPositiveOffsetMinDateTimeAsync(OffsetDateTime datetimeBody, Context context) {
+        return putLocalPositiveOffsetMinDateTimeWithResponseAsync(datetimeBody, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put min datetime value 0001-01-01T00:00:00+14:00.
+     *
+     * @param datetimeBody datetime body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putLocalPositiveOffsetMinDateTimeWithResponse(OffsetDateTime datetimeBody) {
-        return putLocalPositiveOffsetMinDateTimeWithResponseAsync(datetimeBody).block();
+    public Response<Void> putLocalPositiveOffsetMinDateTimeWithResponse(OffsetDateTime datetimeBody, Context context) {
+        return putLocalPositiveOffsetMinDateTimeWithResponseAsync(datetimeBody, context).block();
     }
 
     /**
@@ -1281,7 +1966,7 @@ public final class DatetimeOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putLocalPositiveOffsetMinDateTime(OffsetDateTime datetimeBody) {
-        putLocalPositiveOffsetMinDateTimeWithResponse(datetimeBody);
+        putLocalPositiveOffsetMinDateTimeWithResponse(datetimeBody, Context.NONE);
     }
 
     /**
@@ -1306,6 +1991,26 @@ public final class DatetimeOperations {
     /**
      * Get min datetime value 0001-01-01T00:00:00+14:00.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return min datetime value 0001-01-01T00:00:00+14:00 along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<OffsetDateTime>> getLocalPositiveOffsetMinDateTimeWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getLocalPositiveOffsetMinDateTime(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get min datetime value 0001-01-01T00:00:00+14:00.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return min datetime value 0001-01-01T00:00:00+14:00 on successful completion of {@link Mono}.
@@ -1318,13 +2023,30 @@ public final class DatetimeOperations {
     /**
      * Get min datetime value 0001-01-01T00:00:00+14:00.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return min datetime value 0001-01-01T00:00:00+14:00 on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<OffsetDateTime> getLocalPositiveOffsetMinDateTimeAsync(Context context) {
+        return getLocalPositiveOffsetMinDateTimeWithResponseAsync(context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get min datetime value 0001-01-01T00:00:00+14:00.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return min datetime value 0001-01-01T00:00:00+14:00 along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OffsetDateTime> getLocalPositiveOffsetMinDateTimeWithResponse() {
-        return getLocalPositiveOffsetMinDateTimeWithResponseAsync().block();
+    public Response<OffsetDateTime> getLocalPositiveOffsetMinDateTimeWithResponse(Context context) {
+        return getLocalPositiveOffsetMinDateTimeWithResponseAsync(context).block();
     }
 
     /**
@@ -1336,7 +2058,7 @@ public final class DatetimeOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getLocalPositiveOffsetMinDateTime() {
-        return getLocalPositiveOffsetMinDateTimeWithResponse().getValue();
+        return getLocalPositiveOffsetMinDateTimeWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1368,6 +2090,30 @@ public final class DatetimeOperations {
      * Put min datetime value 0001-01-01T00:00:00-14:00.
      *
      * @param datetimeBody datetime body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putLocalNegativeOffsetMinDateTimeWithResponseAsync(
+            OffsetDateTime datetimeBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (datetimeBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter datetimeBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putLocalNegativeOffsetMinDateTime(this.client.getHost(), datetimeBody, accept, context);
+    }
+
+    /**
+     * Put min datetime value 0001-01-01T00:00:00-14:00.
+     *
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1382,14 +2128,31 @@ public final class DatetimeOperations {
      * Put min datetime value 0001-01-01T00:00:00-14:00.
      *
      * @param datetimeBody datetime body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putLocalNegativeOffsetMinDateTimeAsync(OffsetDateTime datetimeBody, Context context) {
+        return putLocalNegativeOffsetMinDateTimeWithResponseAsync(datetimeBody, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put min datetime value 0001-01-01T00:00:00-14:00.
+     *
+     * @param datetimeBody datetime body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putLocalNegativeOffsetMinDateTimeWithResponse(OffsetDateTime datetimeBody) {
-        return putLocalNegativeOffsetMinDateTimeWithResponseAsync(datetimeBody).block();
+    public Response<Void> putLocalNegativeOffsetMinDateTimeWithResponse(OffsetDateTime datetimeBody, Context context) {
+        return putLocalNegativeOffsetMinDateTimeWithResponseAsync(datetimeBody, context).block();
     }
 
     /**
@@ -1402,7 +2165,7 @@ public final class DatetimeOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putLocalNegativeOffsetMinDateTime(OffsetDateTime datetimeBody) {
-        putLocalNegativeOffsetMinDateTimeWithResponse(datetimeBody);
+        putLocalNegativeOffsetMinDateTimeWithResponse(datetimeBody, Context.NONE);
     }
 
     /**
@@ -1427,6 +2190,26 @@ public final class DatetimeOperations {
     /**
      * Get min datetime value 0001-01-01T00:00:00-14:00.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return min datetime value 0001-01-01T00:00:00-14:00 along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<OffsetDateTime>> getLocalNegativeOffsetMinDateTimeWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getLocalNegativeOffsetMinDateTime(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get min datetime value 0001-01-01T00:00:00-14:00.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return min datetime value 0001-01-01T00:00:00-14:00 on successful completion of {@link Mono}.
@@ -1439,13 +2222,30 @@ public final class DatetimeOperations {
     /**
      * Get min datetime value 0001-01-01T00:00:00-14:00.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return min datetime value 0001-01-01T00:00:00-14:00 on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<OffsetDateTime> getLocalNegativeOffsetMinDateTimeAsync(Context context) {
+        return getLocalNegativeOffsetMinDateTimeWithResponseAsync(context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get min datetime value 0001-01-01T00:00:00-14:00.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return min datetime value 0001-01-01T00:00:00-14:00 along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OffsetDateTime> getLocalNegativeOffsetMinDateTimeWithResponse() {
-        return getLocalNegativeOffsetMinDateTimeWithResponseAsync().block();
+    public Response<OffsetDateTime> getLocalNegativeOffsetMinDateTimeWithResponse(Context context) {
+        return getLocalNegativeOffsetMinDateTimeWithResponseAsync(context).block();
     }
 
     /**
@@ -1457,7 +2257,7 @@ public final class DatetimeOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getLocalNegativeOffsetMinDateTime() {
-        return getLocalNegativeOffsetMinDateTimeWithResponse().getValue();
+        return getLocalNegativeOffsetMinDateTimeWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1482,6 +2282,26 @@ public final class DatetimeOperations {
     /**
      * Get min datetime value 0001-01-01T00:00:00.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return min datetime value 0001-01-01T00:00:00 along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<OffsetDateTime>> getLocalNoOffsetMinDateTimeWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getLocalNoOffsetMinDateTime(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get min datetime value 0001-01-01T00:00:00.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return min datetime value 0001-01-01T00:00:00 on successful completion of {@link Mono}.
@@ -1494,13 +2314,29 @@ public final class DatetimeOperations {
     /**
      * Get min datetime value 0001-01-01T00:00:00.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return min datetime value 0001-01-01T00:00:00 on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<OffsetDateTime> getLocalNoOffsetMinDateTimeAsync(Context context) {
+        return getLocalNoOffsetMinDateTimeWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get min datetime value 0001-01-01T00:00:00.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return min datetime value 0001-01-01T00:00:00 along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OffsetDateTime> getLocalNoOffsetMinDateTimeWithResponse() {
-        return getLocalNoOffsetMinDateTimeWithResponseAsync().block();
+    public Response<OffsetDateTime> getLocalNoOffsetMinDateTimeWithResponse(Context context) {
+        return getLocalNoOffsetMinDateTimeWithResponseAsync(context).block();
     }
 
     /**
@@ -1512,6 +2348,6 @@ public final class DatetimeOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getLocalNoOffsetMinDateTime() {
-        return getLocalNoOffsetMinDateTimeWithResponse().getValue();
+        return getLocalNoOffsetMinDateTimeWithResponse(Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodydatetimerfc1123/Datetimerfc1123s.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydatetimerfc1123/Datetimerfc1123s.java
@@ -140,6 +140,25 @@ public final class Datetimerfc1123s {
     /**
      * Get null datetime value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null datetime value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<OffsetDateTime>> getNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get null datetime value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null datetime value on successful completion of {@link Mono}.
@@ -152,13 +171,29 @@ public final class Datetimerfc1123s {
     /**
      * Get null datetime value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null datetime value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<OffsetDateTime> getNullAsync(Context context) {
+        return getNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get null datetime value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null datetime value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OffsetDateTime> getNullWithResponse() {
-        return getNullWithResponseAsync().block();
+    public Response<OffsetDateTime> getNullWithResponse(Context context) {
+        return getNullWithResponseAsync(context).block();
     }
 
     /**
@@ -170,7 +205,7 @@ public final class Datetimerfc1123s {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getNull() {
-        return getNullWithResponse().getValue();
+        return getNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -193,6 +228,25 @@ public final class Datetimerfc1123s {
     /**
      * Get invalid datetime value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return invalid datetime value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<OffsetDateTime>> getInvalidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getInvalid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get invalid datetime value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return invalid datetime value on successful completion of {@link Mono}.
@@ -205,13 +259,29 @@ public final class Datetimerfc1123s {
     /**
      * Get invalid datetime value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return invalid datetime value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<OffsetDateTime> getInvalidAsync(Context context) {
+        return getInvalidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get invalid datetime value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return invalid datetime value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OffsetDateTime> getInvalidWithResponse() {
-        return getInvalidWithResponseAsync().block();
+    public Response<OffsetDateTime> getInvalidWithResponse(Context context) {
+        return getInvalidWithResponseAsync(context).block();
     }
 
     /**
@@ -223,7 +293,7 @@ public final class Datetimerfc1123s {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getInvalid() {
-        return getInvalidWithResponse().getValue();
+        return getInvalidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -246,6 +316,25 @@ public final class Datetimerfc1123s {
     /**
      * Get overflow datetime value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return overflow datetime value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<OffsetDateTime>> getOverflowWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getOverflow(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get overflow datetime value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return overflow datetime value on successful completion of {@link Mono}.
@@ -258,13 +347,29 @@ public final class Datetimerfc1123s {
     /**
      * Get overflow datetime value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return overflow datetime value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<OffsetDateTime> getOverflowAsync(Context context) {
+        return getOverflowWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get overflow datetime value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return overflow datetime value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OffsetDateTime> getOverflowWithResponse() {
-        return getOverflowWithResponseAsync().block();
+    public Response<OffsetDateTime> getOverflowWithResponse(Context context) {
+        return getOverflowWithResponseAsync(context).block();
     }
 
     /**
@@ -276,7 +381,7 @@ public final class Datetimerfc1123s {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getOverflow() {
-        return getOverflowWithResponse().getValue();
+        return getOverflowWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -299,6 +404,25 @@ public final class Datetimerfc1123s {
     /**
      * Get underflow datetime value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return underflow datetime value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<OffsetDateTime>> getUnderflowWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getUnderflow(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get underflow datetime value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return underflow datetime value on successful completion of {@link Mono}.
@@ -311,13 +435,29 @@ public final class Datetimerfc1123s {
     /**
      * Get underflow datetime value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return underflow datetime value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<OffsetDateTime> getUnderflowAsync(Context context) {
+        return getUnderflowWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get underflow datetime value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return underflow datetime value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OffsetDateTime> getUnderflowWithResponse() {
-        return getUnderflowWithResponseAsync().block();
+    public Response<OffsetDateTime> getUnderflowWithResponse(Context context) {
+        return getUnderflowWithResponseAsync(context).block();
     }
 
     /**
@@ -329,7 +469,7 @@ public final class Datetimerfc1123s {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getUnderflow() {
-        return getUnderflowWithResponse().getValue();
+        return getUnderflowWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -360,6 +500,30 @@ public final class Datetimerfc1123s {
      * Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT.
      *
      * @param datetimeBody datetime body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putUtcMaxDateTimeWithResponseAsync(OffsetDateTime datetimeBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (datetimeBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter datetimeBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        DateTimeRfc1123 datetimeBodyConverted = new DateTimeRfc1123(datetimeBody);
+        return service.putUtcMaxDateTime(this.client.getHost(), datetimeBodyConverted, accept, context);
+    }
+
+    /**
+     * Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT.
+     *
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -374,14 +538,30 @@ public final class Datetimerfc1123s {
      * Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT.
      *
      * @param datetimeBody datetime body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putUtcMaxDateTimeAsync(OffsetDateTime datetimeBody, Context context) {
+        return putUtcMaxDateTimeWithResponseAsync(datetimeBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT.
+     *
+     * @param datetimeBody datetime body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putUtcMaxDateTimeWithResponse(OffsetDateTime datetimeBody) {
-        return putUtcMaxDateTimeWithResponseAsync(datetimeBody).block();
+    public Response<Void> putUtcMaxDateTimeWithResponse(OffsetDateTime datetimeBody, Context context) {
+        return putUtcMaxDateTimeWithResponseAsync(datetimeBody, context).block();
     }
 
     /**
@@ -394,7 +574,7 @@ public final class Datetimerfc1123s {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putUtcMaxDateTime(OffsetDateTime datetimeBody) {
-        putUtcMaxDateTimeWithResponse(datetimeBody);
+        putUtcMaxDateTimeWithResponse(datetimeBody, Context.NONE);
     }
 
     /**
@@ -419,6 +599,26 @@ public final class Datetimerfc1123s {
     /**
      * Get max datetime value fri, 31 dec 9999 23:59:59 gmt.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return max datetime value fri, 31 dec 9999 23:59:59 gmt along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<OffsetDateTime>> getUtcLowercaseMaxDateTimeWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getUtcLowercaseMaxDateTime(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get max datetime value fri, 31 dec 9999 23:59:59 gmt.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return max datetime value fri, 31 dec 9999 23:59:59 gmt on successful completion of {@link Mono}.
@@ -431,13 +631,29 @@ public final class Datetimerfc1123s {
     /**
      * Get max datetime value fri, 31 dec 9999 23:59:59 gmt.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return max datetime value fri, 31 dec 9999 23:59:59 gmt on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<OffsetDateTime> getUtcLowercaseMaxDateTimeAsync(Context context) {
+        return getUtcLowercaseMaxDateTimeWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get max datetime value fri, 31 dec 9999 23:59:59 gmt.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return max datetime value fri, 31 dec 9999 23:59:59 gmt along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OffsetDateTime> getUtcLowercaseMaxDateTimeWithResponse() {
-        return getUtcLowercaseMaxDateTimeWithResponseAsync().block();
+    public Response<OffsetDateTime> getUtcLowercaseMaxDateTimeWithResponse(Context context) {
+        return getUtcLowercaseMaxDateTimeWithResponseAsync(context).block();
     }
 
     /**
@@ -449,7 +665,7 @@ public final class Datetimerfc1123s {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getUtcLowercaseMaxDateTime() {
-        return getUtcLowercaseMaxDateTimeWithResponse().getValue();
+        return getUtcLowercaseMaxDateTimeWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -474,6 +690,26 @@ public final class Datetimerfc1123s {
     /**
      * Get max datetime value FRI, 31 DEC 9999 23:59:59 GMT.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return max datetime value FRI, 31 DEC 9999 23:59:59 GMT along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<OffsetDateTime>> getUtcUppercaseMaxDateTimeWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getUtcUppercaseMaxDateTime(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get max datetime value FRI, 31 DEC 9999 23:59:59 GMT.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return max datetime value FRI, 31 DEC 9999 23:59:59 GMT on successful completion of {@link Mono}.
@@ -486,13 +722,29 @@ public final class Datetimerfc1123s {
     /**
      * Get max datetime value FRI, 31 DEC 9999 23:59:59 GMT.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return max datetime value FRI, 31 DEC 9999 23:59:59 GMT on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<OffsetDateTime> getUtcUppercaseMaxDateTimeAsync(Context context) {
+        return getUtcUppercaseMaxDateTimeWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get max datetime value FRI, 31 DEC 9999 23:59:59 GMT.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return max datetime value FRI, 31 DEC 9999 23:59:59 GMT along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OffsetDateTime> getUtcUppercaseMaxDateTimeWithResponse() {
-        return getUtcUppercaseMaxDateTimeWithResponseAsync().block();
+    public Response<OffsetDateTime> getUtcUppercaseMaxDateTimeWithResponse(Context context) {
+        return getUtcUppercaseMaxDateTimeWithResponseAsync(context).block();
     }
 
     /**
@@ -504,7 +756,7 @@ public final class Datetimerfc1123s {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getUtcUppercaseMaxDateTime() {
-        return getUtcUppercaseMaxDateTimeWithResponse().getValue();
+        return getUtcUppercaseMaxDateTimeWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -535,6 +787,30 @@ public final class Datetimerfc1123s {
      * Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
      *
      * @param datetimeBody datetime body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putUtcMinDateTimeWithResponseAsync(OffsetDateTime datetimeBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (datetimeBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter datetimeBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        DateTimeRfc1123 datetimeBodyConverted = new DateTimeRfc1123(datetimeBody);
+        return service.putUtcMinDateTime(this.client.getHost(), datetimeBodyConverted, accept, context);
+    }
+
+    /**
+     * Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
+     *
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -549,14 +825,30 @@ public final class Datetimerfc1123s {
      * Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
      *
      * @param datetimeBody datetime body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putUtcMinDateTimeAsync(OffsetDateTime datetimeBody, Context context) {
+        return putUtcMinDateTimeWithResponseAsync(datetimeBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
+     *
+     * @param datetimeBody datetime body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putUtcMinDateTimeWithResponse(OffsetDateTime datetimeBody) {
-        return putUtcMinDateTimeWithResponseAsync(datetimeBody).block();
+    public Response<Void> putUtcMinDateTimeWithResponse(OffsetDateTime datetimeBody, Context context) {
+        return putUtcMinDateTimeWithResponseAsync(datetimeBody, context).block();
     }
 
     /**
@@ -569,7 +861,7 @@ public final class Datetimerfc1123s {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putUtcMinDateTime(OffsetDateTime datetimeBody) {
-        putUtcMinDateTimeWithResponse(datetimeBody);
+        putUtcMinDateTimeWithResponse(datetimeBody, Context.NONE);
     }
 
     /**
@@ -593,6 +885,26 @@ public final class Datetimerfc1123s {
     /**
      * Get min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return min datetime value Mon, 1 Jan 0001 00:00:00 GMT along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<OffsetDateTime>> getUtcMinDateTimeWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getUtcMinDateTime(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return min datetime value Mon, 1 Jan 0001 00:00:00 GMT on successful completion of {@link Mono}.
@@ -605,13 +917,29 @@ public final class Datetimerfc1123s {
     /**
      * Get min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return min datetime value Mon, 1 Jan 0001 00:00:00 GMT on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<OffsetDateTime> getUtcMinDateTimeAsync(Context context) {
+        return getUtcMinDateTimeWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return min datetime value Mon, 1 Jan 0001 00:00:00 GMT along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OffsetDateTime> getUtcMinDateTimeWithResponse() {
-        return getUtcMinDateTimeWithResponseAsync().block();
+    public Response<OffsetDateTime> getUtcMinDateTimeWithResponse(Context context) {
+        return getUtcMinDateTimeWithResponseAsync(context).block();
     }
 
     /**
@@ -623,6 +951,6 @@ public final class Datetimerfc1123s {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getUtcMinDateTime() {
-        return getUtcMinDateTimeWithResponse().getValue();
+        return getUtcMinDateTimeWithResponse(Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceClient.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceClient.java
@@ -9,6 +9,7 @@ import com.azure.core.annotation.ReturnType;
 import com.azure.core.annotation.ServiceClient;
 import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.http.rest.Response;
+import com.azure.core.util.Context;
 import fixtures.bodydictionary.implementation.DictionariesImpl;
 import fixtures.bodydictionary.models.ErrorException;
 import fixtures.bodydictionary.models.Widget;
@@ -36,14 +37,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get null dictionary value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null dictionary value along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Integer>> getNullWithResponse() {
-        return this.serviceClient.getNullWithResponse();
+    public Response<Map<String, Integer>> getNullWithResponse(Context context) {
+        return this.serviceClient.getNullWithResponse(context);
     }
 
     /**
@@ -62,14 +65,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get empty dictionary value {}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return empty dictionary value {} along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Integer>> getEmptyWithResponse() {
-        return this.serviceClient.getEmptyWithResponse();
+    public Response<Map<String, Integer>> getEmptyWithResponse(Context context) {
+        return this.serviceClient.getEmptyWithResponse(context);
     }
 
     /**
@@ -89,6 +94,7 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      * Set dictionary value empty {}.
      *
      * @param arrayBody The empty dictionary value {}.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -96,8 +102,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putEmptyWithResponse(Map<String, String> arrayBody) {
-        return this.serviceClient.putEmptyWithResponse(arrayBody);
+    public Response<Void> putEmptyWithResponse(Map<String, String> arrayBody, Context context) {
+        return this.serviceClient.putEmptyWithResponse(arrayBody, context);
     }
 
     /**
@@ -117,14 +123,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get Dictionary with null value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return dictionary with null value along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, String>> getNullValueWithResponse() {
-        return this.serviceClient.getNullValueWithResponse();
+    public Response<Map<String, String>> getNullValueWithResponse(Context context) {
+        return this.serviceClient.getNullValueWithResponse(context);
     }
 
     /**
@@ -143,14 +151,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get Dictionary with null key.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return dictionary with null key along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, String>> getNullKeyWithResponse() {
-        return this.serviceClient.getNullKeyWithResponse();
+    public Response<Map<String, String>> getNullKeyWithResponse(Context context) {
+        return this.serviceClient.getNullKeyWithResponse(context);
     }
 
     /**
@@ -169,14 +179,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get Dictionary with key as empty string.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return dictionary with key as empty string along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, String>> getEmptyStringKeyWithResponse() {
-        return this.serviceClient.getEmptyStringKeyWithResponse();
+    public Response<Map<String, String>> getEmptyStringKeyWithResponse(Context context) {
+        return this.serviceClient.getEmptyStringKeyWithResponse(context);
     }
 
     /**
@@ -195,14 +207,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get invalid Dictionary value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return invalid Dictionary value along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, String>> getInvalidWithResponse() {
-        return this.serviceClient.getInvalidWithResponse();
+    public Response<Map<String, String>> getInvalidWithResponse(Context context) {
+        return this.serviceClient.getInvalidWithResponse(context);
     }
 
     /**
@@ -221,14 +235,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get boolean dictionary value {"0": true, "1": false, "2": false, "3": true }.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return boolean dictionary value {"0": true, "1": false, "2": false, "3": true } along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Boolean>> getBooleanTfftWithResponse() {
-        return this.serviceClient.getBooleanTfftWithResponse();
+    public Response<Map<String, Boolean>> getBooleanTfftWithResponse(Context context) {
+        return this.serviceClient.getBooleanTfftWithResponse(context);
     }
 
     /**
@@ -248,6 +264,7 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      * Set dictionary value empty {"0": true, "1": false, "2": false, "3": true }.
      *
      * @param arrayBody The dictionary value {"0": true, "1": false, "2": false, "3": true }.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -255,8 +272,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putBooleanTfftWithResponse(Map<String, Boolean> arrayBody) {
-        return this.serviceClient.putBooleanTfftWithResponse(arrayBody);
+    public Response<Void> putBooleanTfftWithResponse(Map<String, Boolean> arrayBody, Context context) {
+        return this.serviceClient.putBooleanTfftWithResponse(arrayBody, context);
     }
 
     /**
@@ -276,14 +293,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get boolean dictionary value {"0": true, "1": null, "2": false }.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return boolean dictionary value {"0": true, "1": null, "2": false } along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Boolean>> getBooleanInvalidNullWithResponse() {
-        return this.serviceClient.getBooleanInvalidNullWithResponse();
+    public Response<Map<String, Boolean>> getBooleanInvalidNullWithResponse(Context context) {
+        return this.serviceClient.getBooleanInvalidNullWithResponse(context);
     }
 
     /**
@@ -302,14 +321,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get boolean dictionary value '{"0": true, "1": "boolean", "2": false}'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return boolean dictionary value '{"0": true, "1": "boolean", "2": false}' along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Boolean>> getBooleanInvalidStringWithResponse() {
-        return this.serviceClient.getBooleanInvalidStringWithResponse();
+    public Response<Map<String, Boolean>> getBooleanInvalidStringWithResponse(Context context) {
+        return this.serviceClient.getBooleanInvalidStringWithResponse(context);
     }
 
     /**
@@ -328,14 +349,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300} along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Integer>> getIntegerValidWithResponse() {
-        return this.serviceClient.getIntegerValidWithResponse();
+    public Response<Map<String, Integer>> getIntegerValidWithResponse(Context context) {
+        return this.serviceClient.getIntegerValidWithResponse(context);
     }
 
     /**
@@ -355,6 +378,7 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
      *
      * @param arrayBody The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -362,8 +386,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putIntegerValidWithResponse(Map<String, Integer> arrayBody) {
-        return this.serviceClient.putIntegerValidWithResponse(arrayBody);
+    public Response<Void> putIntegerValidWithResponse(Map<String, Integer> arrayBody, Context context) {
+        return this.serviceClient.putIntegerValidWithResponse(arrayBody, context);
     }
 
     /**
@@ -383,14 +407,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get integer dictionary value {"0": 1, "1": null, "2": 0}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return integer dictionary value {"0": 1, "1": null, "2": 0} along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Integer>> getIntInvalidNullWithResponse() {
-        return this.serviceClient.getIntInvalidNullWithResponse();
+    public Response<Map<String, Integer>> getIntInvalidNullWithResponse(Context context) {
+        return this.serviceClient.getIntInvalidNullWithResponse(context);
     }
 
     /**
@@ -409,14 +435,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get integer dictionary value {"0": 1, "1": "integer", "2": 0}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return integer dictionary value {"0": 1, "1": "integer", "2": 0} along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Integer>> getIntInvalidStringWithResponse() {
-        return this.serviceClient.getIntInvalidStringWithResponse();
+    public Response<Map<String, Integer>> getIntInvalidStringWithResponse(Context context) {
+        return this.serviceClient.getIntInvalidStringWithResponse(context);
     }
 
     /**
@@ -435,14 +463,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300} along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Long>> getLongValidWithResponse() {
-        return this.serviceClient.getLongValidWithResponse();
+    public Response<Map<String, Long>> getLongValidWithResponse(Context context) {
+        return this.serviceClient.getLongValidWithResponse(context);
     }
 
     /**
@@ -462,6 +492,7 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
      *
      * @param arrayBody The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -469,8 +500,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putLongValidWithResponse(Map<String, Long> arrayBody) {
-        return this.serviceClient.putLongValidWithResponse(arrayBody);
+    public Response<Void> putLongValidWithResponse(Map<String, Long> arrayBody, Context context) {
+        return this.serviceClient.putLongValidWithResponse(arrayBody, context);
     }
 
     /**
@@ -490,14 +521,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get long dictionary value {"0": 1, "1": null, "2": 0}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return long dictionary value {"0": 1, "1": null, "2": 0} along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Long>> getLongInvalidNullWithResponse() {
-        return this.serviceClient.getLongInvalidNullWithResponse();
+    public Response<Map<String, Long>> getLongInvalidNullWithResponse(Context context) {
+        return this.serviceClient.getLongInvalidNullWithResponse(context);
     }
 
     /**
@@ -516,14 +549,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get long dictionary value {"0": 1, "1": "integer", "2": 0}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return long dictionary value {"0": 1, "1": "integer", "2": 0} along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Long>> getLongInvalidStringWithResponse() {
-        return this.serviceClient.getLongInvalidStringWithResponse();
+    public Response<Map<String, Long>> getLongInvalidStringWithResponse(Context context) {
+        return this.serviceClient.getLongInvalidStringWithResponse(context);
     }
 
     /**
@@ -542,14 +577,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20} along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Float>> getFloatValidWithResponse() {
-        return this.serviceClient.getFloatValidWithResponse();
+    public Response<Map<String, Float>> getFloatValidWithResponse(Context context) {
+        return this.serviceClient.getFloatValidWithResponse(context);
     }
 
     /**
@@ -569,6 +606,7 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      *
      * @param arrayBody The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -576,8 +614,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putFloatValidWithResponse(Map<String, Float> arrayBody) {
-        return this.serviceClient.putFloatValidWithResponse(arrayBody);
+    public Response<Void> putFloatValidWithResponse(Map<String, Float> arrayBody, Context context) {
+        return this.serviceClient.putFloatValidWithResponse(arrayBody, context);
     }
 
     /**
@@ -597,14 +635,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return float dictionary value {"0": 0.0, "1": null, "2": 1.2e20} along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Float>> getFloatInvalidNullWithResponse() {
-        return this.serviceClient.getFloatInvalidNullWithResponse();
+    public Response<Map<String, Float>> getFloatInvalidNullWithResponse(Context context) {
+        return this.serviceClient.getFloatInvalidNullWithResponse(context);
     }
 
     /**
@@ -623,14 +663,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0} along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Float>> getFloatInvalidStringWithResponse() {
-        return this.serviceClient.getFloatInvalidStringWithResponse();
+    public Response<Map<String, Float>> getFloatInvalidStringWithResponse(Context context) {
+        return this.serviceClient.getFloatInvalidStringWithResponse(context);
     }
 
     /**
@@ -649,14 +691,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20} along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Double>> getDoubleValidWithResponse() {
-        return this.serviceClient.getDoubleValidWithResponse();
+    public Response<Map<String, Double>> getDoubleValidWithResponse(Context context) {
+        return this.serviceClient.getDoubleValidWithResponse(context);
     }
 
     /**
@@ -676,6 +720,7 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      *
      * @param arrayBody The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -683,8 +728,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDoubleValidWithResponse(Map<String, Double> arrayBody) {
-        return this.serviceClient.putDoubleValidWithResponse(arrayBody);
+    public Response<Void> putDoubleValidWithResponse(Map<String, Double> arrayBody, Context context) {
+        return this.serviceClient.putDoubleValidWithResponse(arrayBody, context);
     }
 
     /**
@@ -704,14 +749,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return float dictionary value {"0": 0.0, "1": null, "2": 1.2e20} along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Double>> getDoubleInvalidNullWithResponse() {
-        return this.serviceClient.getDoubleInvalidNullWithResponse();
+    public Response<Map<String, Double>> getDoubleInvalidNullWithResponse(Context context) {
+        return this.serviceClient.getDoubleInvalidNullWithResponse(context);
     }
 
     /**
@@ -730,14 +777,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0} along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Double>> getDoubleInvalidStringWithResponse() {
-        return this.serviceClient.getDoubleInvalidStringWithResponse();
+    public Response<Map<String, Double>> getDoubleInvalidStringWithResponse(Context context) {
+        return this.serviceClient.getDoubleInvalidStringWithResponse(context);
     }
 
     /**
@@ -756,14 +805,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"} along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, String>> getStringValidWithResponse() {
-        return this.serviceClient.getStringValidWithResponse();
+    public Response<Map<String, String>> getStringValidWithResponse(Context context) {
+        return this.serviceClient.getStringValidWithResponse(context);
     }
 
     /**
@@ -783,6 +834,7 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      * Set dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
      *
      * @param arrayBody The dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -790,8 +842,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putStringValidWithResponse(Map<String, String> arrayBody) {
-        return this.serviceClient.putStringValidWithResponse(arrayBody);
+    public Response<Void> putStringValidWithResponse(Map<String, String> arrayBody, Context context) {
+        return this.serviceClient.putStringValidWithResponse(arrayBody, context);
     }
 
     /**
@@ -811,14 +863,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get string dictionary value {"0": "foo", "1": null, "2": "foo2"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string dictionary value {"0": "foo", "1": null, "2": "foo2"} along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, String>> getStringWithNullWithResponse() {
-        return this.serviceClient.getStringWithNullWithResponse();
+    public Response<Map<String, String>> getStringWithNullWithResponse(Context context) {
+        return this.serviceClient.getStringWithNullWithResponse(context);
     }
 
     /**
@@ -837,14 +891,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get string dictionary value {"0": "foo", "1": 123, "2": "foo2"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string dictionary value {"0": "foo", "1": 123, "2": "foo2"} along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, String>> getStringWithInvalidWithResponse() {
-        return this.serviceClient.getStringWithInvalidWithResponse();
+    public Response<Map<String, String>> getStringWithInvalidWithResponse(Context context) {
+        return this.serviceClient.getStringWithInvalidWithResponse(context);
     }
 
     /**
@@ -863,6 +919,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get integer dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return integer dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"} along with {@link
@@ -870,8 +928,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, LocalDate>> getDateValidWithResponse() {
-        return this.serviceClient.getDateValidWithResponse();
+    public Response<Map<String, LocalDate>> getDateValidWithResponse(Context context) {
+        return this.serviceClient.getDateValidWithResponse(context);
     }
 
     /**
@@ -891,6 +949,7 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      * Set dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
      *
      * @param arrayBody The dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -898,8 +957,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDateValidWithResponse(Map<String, LocalDate> arrayBody) {
-        return this.serviceClient.putDateValidWithResponse(arrayBody);
+    public Response<Void> putDateValidWithResponse(Map<String, LocalDate> arrayBody, Context context) {
+        return this.serviceClient.putDateValidWithResponse(arrayBody, context);
     }
 
     /**
@@ -919,14 +978,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"} along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, LocalDate>> getDateInvalidNullWithResponse() {
-        return this.serviceClient.getDateInvalidNullWithResponse();
+    public Response<Map<String, LocalDate>> getDateInvalidNullWithResponse(Context context) {
+        return this.serviceClient.getDateInvalidNullWithResponse(context);
     }
 
     /**
@@ -945,14 +1006,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get date dictionary value {"0": "2011-03-22", "1": "date"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date dictionary value {"0": "2011-03-22", "1": "date"} along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, LocalDate>> getDateInvalidCharsWithResponse() {
-        return this.serviceClient.getDateInvalidCharsWithResponse();
+    public Response<Map<String, LocalDate>> getDateInvalidCharsWithResponse(Context context) {
+        return this.serviceClient.getDateInvalidCharsWithResponse(context);
     }
 
     /**
@@ -972,6 +1035,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      * Get date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2":
      * "1492-10-12T10:15:01-08:00"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2":
@@ -979,8 +1044,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, OffsetDateTime>> getDateTimeValidWithResponse() {
-        return this.serviceClient.getDateTimeValidWithResponse();
+    public Response<Map<String, OffsetDateTime>> getDateTimeValidWithResponse(Context context) {
+        return this.serviceClient.getDateTimeValidWithResponse(context);
     }
 
     /**
@@ -1004,6 +1069,7 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      *
      * @param arrayBody The dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2":
      *     "1492-10-12T10:15:01-08:00"}.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1011,8 +1077,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDateTimeValidWithResponse(Map<String, OffsetDateTime> arrayBody) {
-        return this.serviceClient.putDateTimeValidWithResponse(arrayBody);
+    public Response<Void> putDateTimeValidWithResponse(Map<String, OffsetDateTime> arrayBody, Context context) {
+        return this.serviceClient.putDateTimeValidWithResponse(arrayBody, context);
     }
 
     /**
@@ -1034,14 +1100,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": null}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date dictionary value {"0": "2000-12-01t00:00:01z", "1": null} along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, OffsetDateTime>> getDateTimeInvalidNullWithResponse() {
-        return this.serviceClient.getDateTimeInvalidNullWithResponse();
+    public Response<Map<String, OffsetDateTime>> getDateTimeInvalidNullWithResponse(Context context) {
+        return this.serviceClient.getDateTimeInvalidNullWithResponse(context);
     }
 
     /**
@@ -1060,14 +1128,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"} along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, OffsetDateTime>> getDateTimeInvalidCharsWithResponse() {
-        return this.serviceClient.getDateTimeInvalidCharsWithResponse();
+    public Response<Map<String, OffsetDateTime>> getDateTimeInvalidCharsWithResponse(Context context) {
+        return this.serviceClient.getDateTimeInvalidCharsWithResponse(context);
     }
 
     /**
@@ -1087,6 +1157,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      * Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35
      * GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35
@@ -1094,8 +1166,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, OffsetDateTime>> getDateTimeRfc1123ValidWithResponse() {
-        return this.serviceClient.getDateTimeRfc1123ValidWithResponse();
+    public Response<Map<String, OffsetDateTime>> getDateTimeRfc1123ValidWithResponse(Context context) {
+        return this.serviceClient.getDateTimeRfc1123ValidWithResponse(context);
     }
 
     /**
@@ -1119,6 +1191,7 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      *
      * @param arrayBody The dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35
      *     GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1126,8 +1199,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDateTimeRfc1123ValidWithResponse(Map<String, OffsetDateTime> arrayBody) {
-        return this.serviceClient.putDateTimeRfc1123ValidWithResponse(arrayBody);
+    public Response<Void> putDateTimeRfc1123ValidWithResponse(Map<String, OffsetDateTime> arrayBody, Context context) {
+        return this.serviceClient.putDateTimeRfc1123ValidWithResponse(arrayBody, context);
     }
 
     /**
@@ -1149,14 +1222,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"} along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Duration>> getDurationValidWithResponse() {
-        return this.serviceClient.getDurationValidWithResponse();
+    public Response<Map<String, Duration>> getDurationValidWithResponse(Context context) {
+        return this.serviceClient.getDurationValidWithResponse(context);
     }
 
     /**
@@ -1176,6 +1251,7 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      * Set dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
      *
      * @param arrayBody The dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1183,8 +1259,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDurationValidWithResponse(Map<String, Duration> arrayBody) {
-        return this.serviceClient.putDurationValidWithResponse(arrayBody);
+    public Response<Void> putDurationValidWithResponse(Map<String, Duration> arrayBody, Context context) {
+        return this.serviceClient.putDurationValidWithResponse(arrayBody, context);
     }
 
     /**
@@ -1205,6 +1281,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      * Get byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item
      * encoded in base64.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item
@@ -1212,8 +1290,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, byte[]>> getByteValidWithResponse() {
-        return this.serviceClient.getByteValidWithResponse();
+    public Response<Map<String, byte[]>> getByteValidWithResponse(Context context) {
+        return this.serviceClient.getByteValidWithResponse(context);
     }
 
     /**
@@ -1237,6 +1315,7 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      *
      * @param arrayBody The dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with
      *     each elementencoded in base 64.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1244,8 +1323,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putByteValidWithResponse(Map<String, byte[]> arrayBody) {
-        return this.serviceClient.putByteValidWithResponse(arrayBody);
+    public Response<Void> putByteValidWithResponse(Map<String, byte[]> arrayBody, Context context) {
+        return this.serviceClient.putByteValidWithResponse(arrayBody, context);
     }
 
     /**
@@ -1267,6 +1346,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded along with
@@ -1274,8 +1355,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, byte[]>> getByteInvalidNullWithResponse() {
-        return this.serviceClient.getByteInvalidNullWithResponse();
+    public Response<Map<String, byte[]>> getByteInvalidNullWithResponse(Context context) {
+        return this.serviceClient.getByteInvalidNullWithResponse(context);
     }
 
     /**
@@ -1295,6 +1376,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      * Get base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem
      * ipsum"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2":
@@ -1302,8 +1385,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, byte[]>> getBase64UrlWithResponse() {
-        return this.serviceClient.getBase64UrlWithResponse();
+    public Response<Map<String, byte[]>> getBase64UrlWithResponse(Context context) {
+        return this.serviceClient.getBase64UrlWithResponse(context);
     }
 
     /**
@@ -1324,14 +1407,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get dictionary of complex type null value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return dictionary of complex type null value along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Widget>> getComplexNullWithResponse() {
-        return this.serviceClient.getComplexNullWithResponse();
+    public Response<Map<String, Widget>> getComplexNullWithResponse(Context context) {
+        return this.serviceClient.getComplexNullWithResponse(context);
     }
 
     /**
@@ -1350,14 +1435,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get empty dictionary of complex type {}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return empty dictionary of complex type {} along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Widget>> getComplexEmptyWithResponse() {
-        return this.serviceClient.getComplexEmptyWithResponse();
+    public Response<Map<String, Widget>> getComplexEmptyWithResponse(Context context) {
+        return this.serviceClient.getComplexEmptyWithResponse(context);
     }
 
     /**
@@ -1377,6 +1464,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      * Get dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null, "2": {"integer": 5,
      * "string": "6"}}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null, "2":
@@ -1384,8 +1473,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Widget>> getComplexItemNullWithResponse() {
-        return this.serviceClient.getComplexItemNullWithResponse();
+    public Response<Map<String, Widget>> getComplexItemNullWithResponse(Context context) {
+        return this.serviceClient.getComplexItemNullWithResponse(context);
     }
 
     /**
@@ -1407,6 +1496,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      * Get dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer": 5,
      * "string": "6"}}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer":
@@ -1414,8 +1505,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Widget>> getComplexItemEmptyWithResponse() {
-        return this.serviceClient.getComplexItemEmptyWithResponse();
+    public Response<Map<String, Widget>> getComplexItemEmptyWithResponse(Context context) {
+        return this.serviceClient.getComplexItemEmptyWithResponse(context);
     }
 
     /**
@@ -1437,6 +1528,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      * Get dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2":
      * {"integer": 5, "string": "6"}}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"},
@@ -1444,8 +1537,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Widget>> getComplexValidWithResponse() {
-        return this.serviceClient.getComplexValidWithResponse();
+    public Response<Map<String, Widget>> getComplexValidWithResponse(Context context) {
+        return this.serviceClient.getComplexValidWithResponse(context);
     }
 
     /**
@@ -1469,6 +1562,7 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      *
      * @param arrayBody Dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3,
      *     "string": "4"}, "2": {"integer": 5, "string": "6"}}.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1476,8 +1570,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putComplexValidWithResponse(Map<String, Widget> arrayBody) {
-        return this.serviceClient.putComplexValidWithResponse(arrayBody);
+    public Response<Void> putComplexValidWithResponse(Map<String, Widget> arrayBody, Context context) {
+        return this.serviceClient.putComplexValidWithResponse(arrayBody, context);
     }
 
     /**
@@ -1499,14 +1593,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get a null array.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a null array along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, List<String>>> getArrayNullWithResponse() {
-        return this.serviceClient.getArrayNullWithResponse();
+    public Response<Map<String, List<String>>> getArrayNullWithResponse(Context context) {
+        return this.serviceClient.getArrayNullWithResponse(context);
     }
 
     /**
@@ -1525,14 +1621,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get an empty dictionary {}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an empty dictionary {} along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, List<String>>> getArrayEmptyWithResponse() {
-        return this.serviceClient.getArrayEmptyWithResponse();
+    public Response<Map<String, List<String>>> getArrayEmptyWithResponse(Context context) {
+        return this.serviceClient.getArrayEmptyWithResponse(context);
     }
 
     /**
@@ -1551,6 +1649,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]} along with
@@ -1558,8 +1658,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, List<String>>> getArrayItemNullWithResponse() {
-        return this.serviceClient.getArrayItemNullWithResponse();
+    public Response<Map<String, List<String>>> getArrayItemNullWithResponse(Context context) {
+        return this.serviceClient.getArrayItemNullWithResponse(context);
     }
 
     /**
@@ -1578,6 +1678,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]} along with {@link
@@ -1585,8 +1687,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, List<String>>> getArrayItemEmptyWithResponse() {
-        return this.serviceClient.getArrayItemEmptyWithResponse();
+    public Response<Map<String, List<String>>> getArrayItemEmptyWithResponse(Context context) {
+        return this.serviceClient.getArrayItemEmptyWithResponse(context);
     }
 
     /**
@@ -1605,6 +1707,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]} along
@@ -1612,8 +1716,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, List<String>>> getArrayValidWithResponse() {
-        return this.serviceClient.getArrayValidWithResponse();
+    public Response<Map<String, List<String>>> getArrayValidWithResponse(Context context) {
+        return this.serviceClient.getArrayValidWithResponse(context);
     }
 
     /**
@@ -1633,6 +1737,7 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      * Put An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
      *
      * @param arrayBody An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1640,8 +1745,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putArrayValidWithResponse(Map<String, List<String>> arrayBody) {
-        return this.serviceClient.putArrayValidWithResponse(arrayBody);
+    public Response<Void> putArrayValidWithResponse(Map<String, List<String>> arrayBody, Context context) {
+        return this.serviceClient.putArrayValidWithResponse(arrayBody, context);
     }
 
     /**
@@ -1661,14 +1766,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get an dictionaries of dictionaries with value null.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an dictionaries of dictionaries with value null along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Map<String, String>>> getDictionaryNullWithResponse() {
-        return this.serviceClient.getDictionaryNullWithResponse();
+    public Response<Map<String, Map<String, String>>> getDictionaryNullWithResponse(Context context) {
+        return this.serviceClient.getDictionaryNullWithResponse(context);
     }
 
     /**
@@ -1687,14 +1794,16 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     /**
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an dictionaries of dictionaries of type &lt;string, string&gt; with value {} along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Map<String, String>>> getDictionaryEmptyWithResponse() {
-        return this.serviceClient.getDictionaryEmptyWithResponse();
+    public Response<Map<String, Map<String, String>>> getDictionaryEmptyWithResponse(Context context) {
+        return this.serviceClient.getDictionaryEmptyWithResponse(context);
     }
 
     /**
@@ -1714,6 +1823,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3":
      * "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two",
@@ -1721,8 +1832,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Map<String, String>>> getDictionaryItemNullWithResponse() {
-        return this.serviceClient.getDictionaryItemNullWithResponse();
+    public Response<Map<String, Map<String, String>>> getDictionaryItemNullWithResponse(Context context) {
+        return this.serviceClient.getDictionaryItemNullWithResponse(context);
     }
 
     /**
@@ -1744,6 +1855,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3":
      * "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two",
@@ -1751,8 +1864,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Map<String, String>>> getDictionaryItemEmptyWithResponse() {
-        return this.serviceClient.getDictionaryItemEmptyWithResponse();
+    public Response<Map<String, Map<String, String>>> getDictionaryItemEmptyWithResponse(Context context) {
+        return this.serviceClient.getDictionaryItemEmptyWithResponse(context);
     }
 
     /**
@@ -1774,6 +1887,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3":
      * "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two",
@@ -1782,8 +1897,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Map<String, String>>> getDictionaryValidWithResponse() {
-        return this.serviceClient.getDictionaryValidWithResponse();
+    public Response<Map<String, Map<String, String>>> getDictionaryValidWithResponse(Context context) {
+        return this.serviceClient.getDictionaryValidWithResponse(context);
     }
 
     /**
@@ -1808,6 +1923,7 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      * @param arrayBody An dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one",
      *     "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight",
      *     "9": "nine"}}.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1817,8 +1933,8 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDictionaryValidWithResponse(Map<String, Map<String, String>> arrayBody) {
-        return this.serviceClient.putDictionaryValidWithResponse(arrayBody);
+    public Response<Void> putDictionaryValidWithResponse(Map<String, Map<String, String>> arrayBody, Context context) {
+        return this.serviceClient.putDictionaryValidWithResponse(arrayBody, context);
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/bodydictionary/implementation/DictionariesImpl.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydictionary/implementation/DictionariesImpl.java
@@ -518,6 +518,25 @@ public final class DictionariesImpl {
     /**
      * Get null dictionary value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null dictionary value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Integer>>> getNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get null dictionary value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null dictionary value on successful completion of {@link Mono}.
@@ -530,13 +549,29 @@ public final class DictionariesImpl {
     /**
      * Get null dictionary value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null dictionary value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Integer>> getNullAsync(Context context) {
+        return getNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get null dictionary value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null dictionary value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Integer>> getNullWithResponse() {
-        return getNullWithResponseAsync().block();
+    public Response<Map<String, Integer>> getNullWithResponse(Context context) {
+        return getNullWithResponseAsync(context).block();
     }
 
     /**
@@ -548,7 +583,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Integer> getNull() {
-        return getNullWithResponse().getValue();
+        return getNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -571,6 +606,25 @@ public final class DictionariesImpl {
     /**
      * Get empty dictionary value {}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return empty dictionary value {} along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Integer>>> getEmptyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getEmpty(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get empty dictionary value {}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return empty dictionary value {} on successful completion of {@link Mono}.
@@ -583,13 +637,29 @@ public final class DictionariesImpl {
     /**
      * Get empty dictionary value {}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return empty dictionary value {} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Integer>> getEmptyAsync(Context context) {
+        return getEmptyWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get empty dictionary value {}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return empty dictionary value {} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Integer>> getEmptyWithResponse() {
-        return getEmptyWithResponseAsync().block();
+    public Response<Map<String, Integer>> getEmptyWithResponse(Context context) {
+        return getEmptyWithResponseAsync(context).block();
     }
 
     /**
@@ -601,7 +671,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Integer> getEmpty() {
-        return getEmptyWithResponse().getValue();
+        return getEmptyWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -630,6 +700,29 @@ public final class DictionariesImpl {
      * Set dictionary value empty {}.
      *
      * @param arrayBody The empty dictionary value {}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putEmptyWithResponseAsync(Map<String, String> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putEmpty(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Set dictionary value empty {}.
+     *
+     * @param arrayBody The empty dictionary value {}.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -644,14 +737,30 @@ public final class DictionariesImpl {
      * Set dictionary value empty {}.
      *
      * @param arrayBody The empty dictionary value {}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putEmptyAsync(Map<String, String> arrayBody, Context context) {
+        return putEmptyWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set dictionary value empty {}.
+     *
+     * @param arrayBody The empty dictionary value {}.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putEmptyWithResponse(Map<String, String> arrayBody) {
-        return putEmptyWithResponseAsync(arrayBody).block();
+    public Response<Void> putEmptyWithResponse(Map<String, String> arrayBody, Context context) {
+        return putEmptyWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -664,7 +773,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putEmpty(Map<String, String> arrayBody) {
-        putEmptyWithResponse(arrayBody);
+        putEmptyWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -687,6 +796,25 @@ public final class DictionariesImpl {
     /**
      * Get Dictionary with null value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return dictionary with null value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, String>>> getNullValueWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNullValue(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get Dictionary with null value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return dictionary with null value on successful completion of {@link Mono}.
@@ -699,13 +827,29 @@ public final class DictionariesImpl {
     /**
      * Get Dictionary with null value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return dictionary with null value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, String>> getNullValueAsync(Context context) {
+        return getNullValueWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get Dictionary with null value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return dictionary with null value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, String>> getNullValueWithResponse() {
-        return getNullValueWithResponseAsync().block();
+    public Response<Map<String, String>> getNullValueWithResponse(Context context) {
+        return getNullValueWithResponseAsync(context).block();
     }
 
     /**
@@ -717,7 +861,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, String> getNullValue() {
-        return getNullValueWithResponse().getValue();
+        return getNullValueWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -740,6 +884,25 @@ public final class DictionariesImpl {
     /**
      * Get Dictionary with null key.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return dictionary with null key along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, String>>> getNullKeyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNullKey(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get Dictionary with null key.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return dictionary with null key on successful completion of {@link Mono}.
@@ -752,13 +915,29 @@ public final class DictionariesImpl {
     /**
      * Get Dictionary with null key.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return dictionary with null key on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, String>> getNullKeyAsync(Context context) {
+        return getNullKeyWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get Dictionary with null key.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return dictionary with null key along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, String>> getNullKeyWithResponse() {
-        return getNullKeyWithResponseAsync().block();
+    public Response<Map<String, String>> getNullKeyWithResponse(Context context) {
+        return getNullKeyWithResponseAsync(context).block();
     }
 
     /**
@@ -770,7 +949,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, String> getNullKey() {
-        return getNullKeyWithResponse().getValue();
+        return getNullKeyWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -793,6 +972,25 @@ public final class DictionariesImpl {
     /**
      * Get Dictionary with key as empty string.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return dictionary with key as empty string along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, String>>> getEmptyStringKeyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getEmptyStringKey(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get Dictionary with key as empty string.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return dictionary with key as empty string on successful completion of {@link Mono}.
@@ -805,13 +1003,29 @@ public final class DictionariesImpl {
     /**
      * Get Dictionary with key as empty string.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return dictionary with key as empty string on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, String>> getEmptyStringKeyAsync(Context context) {
+        return getEmptyStringKeyWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get Dictionary with key as empty string.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return dictionary with key as empty string along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, String>> getEmptyStringKeyWithResponse() {
-        return getEmptyStringKeyWithResponseAsync().block();
+    public Response<Map<String, String>> getEmptyStringKeyWithResponse(Context context) {
+        return getEmptyStringKeyWithResponseAsync(context).block();
     }
 
     /**
@@ -823,7 +1037,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, String> getEmptyStringKey() {
-        return getEmptyStringKeyWithResponse().getValue();
+        return getEmptyStringKeyWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -846,6 +1060,25 @@ public final class DictionariesImpl {
     /**
      * Get invalid Dictionary value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return invalid Dictionary value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, String>>> getInvalidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getInvalid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get invalid Dictionary value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return invalid Dictionary value on successful completion of {@link Mono}.
@@ -858,13 +1091,29 @@ public final class DictionariesImpl {
     /**
      * Get invalid Dictionary value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return invalid Dictionary value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, String>> getInvalidAsync(Context context) {
+        return getInvalidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get invalid Dictionary value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return invalid Dictionary value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, String>> getInvalidWithResponse() {
-        return getInvalidWithResponseAsync().block();
+    public Response<Map<String, String>> getInvalidWithResponse(Context context) {
+        return getInvalidWithResponseAsync(context).block();
     }
 
     /**
@@ -876,7 +1125,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, String> getInvalid() {
-        return getInvalidWithResponse().getValue();
+        return getInvalidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -900,6 +1149,26 @@ public final class DictionariesImpl {
     /**
      * Get boolean dictionary value {"0": true, "1": false, "2": false, "3": true }.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return boolean dictionary value {"0": true, "1": false, "2": false, "3": true } along with {@link Response} on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Boolean>>> getBooleanTfftWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getBooleanTfft(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get boolean dictionary value {"0": true, "1": false, "2": false, "3": true }.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return boolean dictionary value {"0": true, "1": false, "2": false, "3": true } on successful completion of
@@ -913,13 +1182,30 @@ public final class DictionariesImpl {
     /**
      * Get boolean dictionary value {"0": true, "1": false, "2": false, "3": true }.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return boolean dictionary value {"0": true, "1": false, "2": false, "3": true } on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Boolean>> getBooleanTfftAsync(Context context) {
+        return getBooleanTfftWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get boolean dictionary value {"0": true, "1": false, "2": false, "3": true }.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return boolean dictionary value {"0": true, "1": false, "2": false, "3": true } along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Boolean>> getBooleanTfftWithResponse() {
-        return getBooleanTfftWithResponseAsync().block();
+    public Response<Map<String, Boolean>> getBooleanTfftWithResponse(Context context) {
+        return getBooleanTfftWithResponseAsync(context).block();
     }
 
     /**
@@ -931,7 +1217,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Boolean> getBooleanTfft() {
-        return getBooleanTfftWithResponse().getValue();
+        return getBooleanTfftWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -961,6 +1247,29 @@ public final class DictionariesImpl {
      * Set dictionary value empty {"0": true, "1": false, "2": false, "3": true }.
      *
      * @param arrayBody The dictionary value {"0": true, "1": false, "2": false, "3": true }.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putBooleanTfftWithResponseAsync(Map<String, Boolean> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putBooleanTfft(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Set dictionary value empty {"0": true, "1": false, "2": false, "3": true }.
+     *
+     * @param arrayBody The dictionary value {"0": true, "1": false, "2": false, "3": true }.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -975,14 +1284,30 @@ public final class DictionariesImpl {
      * Set dictionary value empty {"0": true, "1": false, "2": false, "3": true }.
      *
      * @param arrayBody The dictionary value {"0": true, "1": false, "2": false, "3": true }.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putBooleanTfftAsync(Map<String, Boolean> arrayBody, Context context) {
+        return putBooleanTfftWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set dictionary value empty {"0": true, "1": false, "2": false, "3": true }.
+     *
+     * @param arrayBody The dictionary value {"0": true, "1": false, "2": false, "3": true }.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putBooleanTfftWithResponse(Map<String, Boolean> arrayBody) {
-        return putBooleanTfftWithResponseAsync(arrayBody).block();
+    public Response<Void> putBooleanTfftWithResponse(Map<String, Boolean> arrayBody, Context context) {
+        return putBooleanTfftWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -995,7 +1320,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putBooleanTfft(Map<String, Boolean> arrayBody) {
-        putBooleanTfftWithResponse(arrayBody);
+        putBooleanTfftWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -1019,6 +1344,26 @@ public final class DictionariesImpl {
     /**
      * Get boolean dictionary value {"0": true, "1": null, "2": false }.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return boolean dictionary value {"0": true, "1": null, "2": false } along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Boolean>>> getBooleanInvalidNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getBooleanInvalidNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get boolean dictionary value {"0": true, "1": null, "2": false }.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return boolean dictionary value {"0": true, "1": null, "2": false } on successful completion of {@link Mono}.
@@ -1031,13 +1376,29 @@ public final class DictionariesImpl {
     /**
      * Get boolean dictionary value {"0": true, "1": null, "2": false }.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return boolean dictionary value {"0": true, "1": null, "2": false } on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Boolean>> getBooleanInvalidNullAsync(Context context) {
+        return getBooleanInvalidNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get boolean dictionary value {"0": true, "1": null, "2": false }.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return boolean dictionary value {"0": true, "1": null, "2": false } along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Boolean>> getBooleanInvalidNullWithResponse() {
-        return getBooleanInvalidNullWithResponseAsync().block();
+    public Response<Map<String, Boolean>> getBooleanInvalidNullWithResponse(Context context) {
+        return getBooleanInvalidNullWithResponseAsync(context).block();
     }
 
     /**
@@ -1049,7 +1410,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Boolean> getBooleanInvalidNull() {
-        return getBooleanInvalidNullWithResponse().getValue();
+        return getBooleanInvalidNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1073,6 +1434,26 @@ public final class DictionariesImpl {
     /**
      * Get boolean dictionary value '{"0": true, "1": "boolean", "2": false}'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return boolean dictionary value '{"0": true, "1": "boolean", "2": false}' along with {@link Response} on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Boolean>>> getBooleanInvalidStringWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getBooleanInvalidString(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get boolean dictionary value '{"0": true, "1": "boolean", "2": false}'.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return boolean dictionary value '{"0": true, "1": "boolean", "2": false}' on successful completion of {@link
@@ -1086,13 +1467,30 @@ public final class DictionariesImpl {
     /**
      * Get boolean dictionary value '{"0": true, "1": "boolean", "2": false}'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return boolean dictionary value '{"0": true, "1": "boolean", "2": false}' on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Boolean>> getBooleanInvalidStringAsync(Context context) {
+        return getBooleanInvalidStringWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get boolean dictionary value '{"0": true, "1": "boolean", "2": false}'.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return boolean dictionary value '{"0": true, "1": "boolean", "2": false}' along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Boolean>> getBooleanInvalidStringWithResponse() {
-        return getBooleanInvalidStringWithResponseAsync().block();
+    public Response<Map<String, Boolean>> getBooleanInvalidStringWithResponse(Context context) {
+        return getBooleanInvalidStringWithResponseAsync(context).block();
     }
 
     /**
@@ -1104,7 +1502,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Boolean> getBooleanInvalidString() {
-        return getBooleanInvalidStringWithResponse().getValue();
+        return getBooleanInvalidStringWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1128,6 +1526,26 @@ public final class DictionariesImpl {
     /**
      * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300} along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Integer>>> getIntegerValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getIntegerValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300} on successful completion of {@link Mono}.
@@ -1140,13 +1558,29 @@ public final class DictionariesImpl {
     /**
      * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Integer>> getIntegerValidAsync(Context context) {
+        return getIntegerValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Integer>> getIntegerValidWithResponse() {
-        return getIntegerValidWithResponseAsync().block();
+    public Response<Map<String, Integer>> getIntegerValidWithResponse(Context context) {
+        return getIntegerValidWithResponseAsync(context).block();
     }
 
     /**
@@ -1158,7 +1592,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Integer> getIntegerValid() {
-        return getIntegerValidWithResponse().getValue();
+        return getIntegerValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1188,6 +1622,29 @@ public final class DictionariesImpl {
      * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
      *
      * @param arrayBody The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putIntegerValidWithResponseAsync(Map<String, Integer> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putIntegerValid(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
+     *
+     * @param arrayBody The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1202,14 +1659,30 @@ public final class DictionariesImpl {
      * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
      *
      * @param arrayBody The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putIntegerValidAsync(Map<String, Integer> arrayBody, Context context) {
+        return putIntegerValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
+     *
+     * @param arrayBody The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putIntegerValidWithResponse(Map<String, Integer> arrayBody) {
-        return putIntegerValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putIntegerValidWithResponse(Map<String, Integer> arrayBody, Context context) {
+        return putIntegerValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -1222,7 +1695,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putIntegerValid(Map<String, Integer> arrayBody) {
-        putIntegerValidWithResponse(arrayBody);
+        putIntegerValidWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -1246,6 +1719,26 @@ public final class DictionariesImpl {
     /**
      * Get integer dictionary value {"0": 1, "1": null, "2": 0}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return integer dictionary value {"0": 1, "1": null, "2": 0} along with {@link Response} on successful completion
+     *     of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Integer>>> getIntInvalidNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getIntInvalidNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get integer dictionary value {"0": 1, "1": null, "2": 0}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return integer dictionary value {"0": 1, "1": null, "2": 0} on successful completion of {@link Mono}.
@@ -1258,13 +1751,29 @@ public final class DictionariesImpl {
     /**
      * Get integer dictionary value {"0": 1, "1": null, "2": 0}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return integer dictionary value {"0": 1, "1": null, "2": 0} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Integer>> getIntInvalidNullAsync(Context context) {
+        return getIntInvalidNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get integer dictionary value {"0": 1, "1": null, "2": 0}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return integer dictionary value {"0": 1, "1": null, "2": 0} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Integer>> getIntInvalidNullWithResponse() {
-        return getIntInvalidNullWithResponseAsync().block();
+    public Response<Map<String, Integer>> getIntInvalidNullWithResponse(Context context) {
+        return getIntInvalidNullWithResponseAsync(context).block();
     }
 
     /**
@@ -1276,7 +1785,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Integer> getIntInvalidNull() {
-        return getIntInvalidNullWithResponse().getValue();
+        return getIntInvalidNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1300,6 +1809,26 @@ public final class DictionariesImpl {
     /**
      * Get integer dictionary value {"0": 1, "1": "integer", "2": 0}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return integer dictionary value {"0": 1, "1": "integer", "2": 0} along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Integer>>> getIntInvalidStringWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getIntInvalidString(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get integer dictionary value {"0": 1, "1": "integer", "2": 0}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return integer dictionary value {"0": 1, "1": "integer", "2": 0} on successful completion of {@link Mono}.
@@ -1312,13 +1841,29 @@ public final class DictionariesImpl {
     /**
      * Get integer dictionary value {"0": 1, "1": "integer", "2": 0}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return integer dictionary value {"0": 1, "1": "integer", "2": 0} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Integer>> getIntInvalidStringAsync(Context context) {
+        return getIntInvalidStringWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get integer dictionary value {"0": 1, "1": "integer", "2": 0}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return integer dictionary value {"0": 1, "1": "integer", "2": 0} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Integer>> getIntInvalidStringWithResponse() {
-        return getIntInvalidStringWithResponseAsync().block();
+    public Response<Map<String, Integer>> getIntInvalidStringWithResponse(Context context) {
+        return getIntInvalidStringWithResponseAsync(context).block();
     }
 
     /**
@@ -1330,7 +1875,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Integer> getIntInvalidString() {
-        return getIntInvalidStringWithResponse().getValue();
+        return getIntInvalidStringWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1354,6 +1899,26 @@ public final class DictionariesImpl {
     /**
      * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300} along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Long>>> getLongValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getLongValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300} on successful completion of {@link Mono}.
@@ -1366,13 +1931,29 @@ public final class DictionariesImpl {
     /**
      * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Long>> getLongValidAsync(Context context) {
+        return getLongValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Long>> getLongValidWithResponse() {
-        return getLongValidWithResponseAsync().block();
+    public Response<Map<String, Long>> getLongValidWithResponse(Context context) {
+        return getLongValidWithResponseAsync(context).block();
     }
 
     /**
@@ -1384,7 +1965,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Long> getLongValid() {
-        return getLongValidWithResponse().getValue();
+        return getLongValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1413,6 +1994,29 @@ public final class DictionariesImpl {
      * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
      *
      * @param arrayBody The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putLongValidWithResponseAsync(Map<String, Long> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putLongValid(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
+     *
+     * @param arrayBody The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1427,14 +2031,30 @@ public final class DictionariesImpl {
      * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
      *
      * @param arrayBody The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putLongValidAsync(Map<String, Long> arrayBody, Context context) {
+        return putLongValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
+     *
+     * @param arrayBody The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putLongValidWithResponse(Map<String, Long> arrayBody) {
-        return putLongValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putLongValidWithResponse(Map<String, Long> arrayBody, Context context) {
+        return putLongValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -1447,7 +2067,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putLongValid(Map<String, Long> arrayBody) {
-        putLongValidWithResponse(arrayBody);
+        putLongValidWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -1471,6 +2091,26 @@ public final class DictionariesImpl {
     /**
      * Get long dictionary value {"0": 1, "1": null, "2": 0}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return long dictionary value {"0": 1, "1": null, "2": 0} along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Long>>> getLongInvalidNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getLongInvalidNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get long dictionary value {"0": 1, "1": null, "2": 0}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return long dictionary value {"0": 1, "1": null, "2": 0} on successful completion of {@link Mono}.
@@ -1483,13 +2123,29 @@ public final class DictionariesImpl {
     /**
      * Get long dictionary value {"0": 1, "1": null, "2": 0}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return long dictionary value {"0": 1, "1": null, "2": 0} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Long>> getLongInvalidNullAsync(Context context) {
+        return getLongInvalidNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get long dictionary value {"0": 1, "1": null, "2": 0}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return long dictionary value {"0": 1, "1": null, "2": 0} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Long>> getLongInvalidNullWithResponse() {
-        return getLongInvalidNullWithResponseAsync().block();
+    public Response<Map<String, Long>> getLongInvalidNullWithResponse(Context context) {
+        return getLongInvalidNullWithResponseAsync(context).block();
     }
 
     /**
@@ -1501,7 +2157,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Long> getLongInvalidNull() {
-        return getLongInvalidNullWithResponse().getValue();
+        return getLongInvalidNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1525,6 +2181,26 @@ public final class DictionariesImpl {
     /**
      * Get long dictionary value {"0": 1, "1": "integer", "2": 0}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return long dictionary value {"0": 1, "1": "integer", "2": 0} along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Long>>> getLongInvalidStringWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getLongInvalidString(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get long dictionary value {"0": 1, "1": "integer", "2": 0}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return long dictionary value {"0": 1, "1": "integer", "2": 0} on successful completion of {@link Mono}.
@@ -1537,13 +2213,29 @@ public final class DictionariesImpl {
     /**
      * Get long dictionary value {"0": 1, "1": "integer", "2": 0}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return long dictionary value {"0": 1, "1": "integer", "2": 0} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Long>> getLongInvalidStringAsync(Context context) {
+        return getLongInvalidStringWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get long dictionary value {"0": 1, "1": "integer", "2": 0}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return long dictionary value {"0": 1, "1": "integer", "2": 0} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Long>> getLongInvalidStringWithResponse() {
-        return getLongInvalidStringWithResponseAsync().block();
+    public Response<Map<String, Long>> getLongInvalidStringWithResponse(Context context) {
+        return getLongInvalidStringWithResponseAsync(context).block();
     }
 
     /**
@@ -1555,7 +2247,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Long> getLongInvalidString() {
-        return getLongInvalidStringWithResponse().getValue();
+        return getLongInvalidStringWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1579,6 +2271,26 @@ public final class DictionariesImpl {
     /**
      * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20} along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Float>>> getFloatValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getFloatValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20} on successful completion of {@link Mono}.
@@ -1591,13 +2303,29 @@ public final class DictionariesImpl {
     /**
      * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Float>> getFloatValidAsync(Context context) {
+        return getFloatValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Float>> getFloatValidWithResponse() {
-        return getFloatValidWithResponseAsync().block();
+    public Response<Map<String, Float>> getFloatValidWithResponse(Context context) {
+        return getFloatValidWithResponseAsync(context).block();
     }
 
     /**
@@ -1609,7 +2337,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Float> getFloatValid() {
-        return getFloatValidWithResponse().getValue();
+        return getFloatValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1639,6 +2367,29 @@ public final class DictionariesImpl {
      * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      *
      * @param arrayBody The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putFloatValidWithResponseAsync(Map<String, Float> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putFloatValid(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     *
+     * @param arrayBody The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1653,14 +2404,30 @@ public final class DictionariesImpl {
      * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      *
      * @param arrayBody The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putFloatValidAsync(Map<String, Float> arrayBody, Context context) {
+        return putFloatValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     *
+     * @param arrayBody The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putFloatValidWithResponse(Map<String, Float> arrayBody) {
-        return putFloatValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putFloatValidWithResponse(Map<String, Float> arrayBody, Context context) {
+        return putFloatValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -1673,7 +2440,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putFloatValid(Map<String, Float> arrayBody) {
-        putFloatValidWithResponse(arrayBody);
+        putFloatValidWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -1697,6 +2464,26 @@ public final class DictionariesImpl {
     /**
      * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return float dictionary value {"0": 0.0, "1": null, "2": 1.2e20} along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Float>>> getFloatInvalidNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getFloatInvalidNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return float dictionary value {"0": 0.0, "1": null, "2": 1.2e20} on successful completion of {@link Mono}.
@@ -1709,13 +2496,29 @@ public final class DictionariesImpl {
     /**
      * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return float dictionary value {"0": 0.0, "1": null, "2": 1.2e20} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Float>> getFloatInvalidNullAsync(Context context) {
+        return getFloatInvalidNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return float dictionary value {"0": 0.0, "1": null, "2": 1.2e20} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Float>> getFloatInvalidNullWithResponse() {
-        return getFloatInvalidNullWithResponseAsync().block();
+    public Response<Map<String, Float>> getFloatInvalidNullWithResponse(Context context) {
+        return getFloatInvalidNullWithResponseAsync(context).block();
     }
 
     /**
@@ -1727,7 +2530,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Float> getFloatInvalidNull() {
-        return getFloatInvalidNullWithResponse().getValue();
+        return getFloatInvalidNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1751,6 +2554,26 @@ public final class DictionariesImpl {
     /**
      * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0} along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Float>>> getFloatInvalidStringWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getFloatInvalidString(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0} on successful completion of {@link Mono}.
@@ -1763,13 +2586,29 @@ public final class DictionariesImpl {
     /**
      * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Float>> getFloatInvalidStringAsync(Context context) {
+        return getFloatInvalidStringWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Float>> getFloatInvalidStringWithResponse() {
-        return getFloatInvalidStringWithResponseAsync().block();
+    public Response<Map<String, Float>> getFloatInvalidStringWithResponse(Context context) {
+        return getFloatInvalidStringWithResponseAsync(context).block();
     }
 
     /**
@@ -1781,7 +2620,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Float> getFloatInvalidString() {
-        return getFloatInvalidStringWithResponse().getValue();
+        return getFloatInvalidStringWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1805,6 +2644,26 @@ public final class DictionariesImpl {
     /**
      * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20} along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Double>>> getDoubleValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDoubleValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20} on successful completion of {@link Mono}.
@@ -1817,13 +2676,29 @@ public final class DictionariesImpl {
     /**
      * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Double>> getDoubleValidAsync(Context context) {
+        return getDoubleValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Double>> getDoubleValidWithResponse() {
-        return getDoubleValidWithResponseAsync().block();
+    public Response<Map<String, Double>> getDoubleValidWithResponse(Context context) {
+        return getDoubleValidWithResponseAsync(context).block();
     }
 
     /**
@@ -1835,7 +2710,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Double> getDoubleValid() {
-        return getDoubleValidWithResponse().getValue();
+        return getDoubleValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1865,6 +2740,29 @@ public final class DictionariesImpl {
      * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      *
      * @param arrayBody The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putDoubleValidWithResponseAsync(Map<String, Double> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putDoubleValid(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     *
+     * @param arrayBody The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1879,14 +2777,30 @@ public final class DictionariesImpl {
      * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      *
      * @param arrayBody The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putDoubleValidAsync(Map<String, Double> arrayBody, Context context) {
+        return putDoubleValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     *
+     * @param arrayBody The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDoubleValidWithResponse(Map<String, Double> arrayBody) {
-        return putDoubleValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putDoubleValidWithResponse(Map<String, Double> arrayBody, Context context) {
+        return putDoubleValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -1899,7 +2813,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDoubleValid(Map<String, Double> arrayBody) {
-        putDoubleValidWithResponse(arrayBody);
+        putDoubleValidWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -1923,6 +2837,26 @@ public final class DictionariesImpl {
     /**
      * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return float dictionary value {"0": 0.0, "1": null, "2": 1.2e20} along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Double>>> getDoubleInvalidNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDoubleInvalidNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return float dictionary value {"0": 0.0, "1": null, "2": 1.2e20} on successful completion of {@link Mono}.
@@ -1935,13 +2869,29 @@ public final class DictionariesImpl {
     /**
      * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return float dictionary value {"0": 0.0, "1": null, "2": 1.2e20} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Double>> getDoubleInvalidNullAsync(Context context) {
+        return getDoubleInvalidNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return float dictionary value {"0": 0.0, "1": null, "2": 1.2e20} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Double>> getDoubleInvalidNullWithResponse() {
-        return getDoubleInvalidNullWithResponseAsync().block();
+    public Response<Map<String, Double>> getDoubleInvalidNullWithResponse(Context context) {
+        return getDoubleInvalidNullWithResponseAsync(context).block();
     }
 
     /**
@@ -1953,7 +2903,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Double> getDoubleInvalidNull() {
-        return getDoubleInvalidNullWithResponse().getValue();
+        return getDoubleInvalidNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1977,6 +2927,26 @@ public final class DictionariesImpl {
     /**
      * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0} along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Double>>> getDoubleInvalidStringWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDoubleInvalidString(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0} on successful completion of {@link Mono}.
@@ -1989,13 +2959,29 @@ public final class DictionariesImpl {
     /**
      * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Double>> getDoubleInvalidStringAsync(Context context) {
+        return getDoubleInvalidStringWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Double>> getDoubleInvalidStringWithResponse() {
-        return getDoubleInvalidStringWithResponseAsync().block();
+    public Response<Map<String, Double>> getDoubleInvalidStringWithResponse(Context context) {
+        return getDoubleInvalidStringWithResponseAsync(context).block();
     }
 
     /**
@@ -2007,7 +2993,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Double> getDoubleInvalidString() {
-        return getDoubleInvalidStringWithResponse().getValue();
+        return getDoubleInvalidStringWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2031,6 +3017,26 @@ public final class DictionariesImpl {
     /**
      * Get string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"} along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, String>>> getStringValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getStringValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"} on successful completion of {@link Mono}.
@@ -2043,13 +3049,29 @@ public final class DictionariesImpl {
     /**
      * Get string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, String>> getStringValidAsync(Context context) {
+        return getStringValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, String>> getStringValidWithResponse() {
-        return getStringValidWithResponseAsync().block();
+    public Response<Map<String, String>> getStringValidWithResponse(Context context) {
+        return getStringValidWithResponseAsync(context).block();
     }
 
     /**
@@ -2061,7 +3083,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, String> getStringValid() {
-        return getStringValidWithResponse().getValue();
+        return getStringValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2091,6 +3113,29 @@ public final class DictionariesImpl {
      * Set dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
      *
      * @param arrayBody The dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putStringValidWithResponseAsync(Map<String, String> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putStringValid(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Set dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
+     *
+     * @param arrayBody The dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -2105,14 +3150,30 @@ public final class DictionariesImpl {
      * Set dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
      *
      * @param arrayBody The dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putStringValidAsync(Map<String, String> arrayBody, Context context) {
+        return putStringValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
+     *
+     * @param arrayBody The dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putStringValidWithResponse(Map<String, String> arrayBody) {
-        return putStringValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putStringValidWithResponse(Map<String, String> arrayBody, Context context) {
+        return putStringValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -2125,7 +3186,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putStringValid(Map<String, String> arrayBody) {
-        putStringValidWithResponse(arrayBody);
+        putStringValidWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -2149,6 +3210,26 @@ public final class DictionariesImpl {
     /**
      * Get string dictionary value {"0": "foo", "1": null, "2": "foo2"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return string dictionary value {"0": "foo", "1": null, "2": "foo2"} along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, String>>> getStringWithNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getStringWithNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get string dictionary value {"0": "foo", "1": null, "2": "foo2"}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string dictionary value {"0": "foo", "1": null, "2": "foo2"} on successful completion of {@link Mono}.
@@ -2161,13 +3242,29 @@ public final class DictionariesImpl {
     /**
      * Get string dictionary value {"0": "foo", "1": null, "2": "foo2"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return string dictionary value {"0": "foo", "1": null, "2": "foo2"} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, String>> getStringWithNullAsync(Context context) {
+        return getStringWithNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get string dictionary value {"0": "foo", "1": null, "2": "foo2"}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string dictionary value {"0": "foo", "1": null, "2": "foo2"} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, String>> getStringWithNullWithResponse() {
-        return getStringWithNullWithResponseAsync().block();
+    public Response<Map<String, String>> getStringWithNullWithResponse(Context context) {
+        return getStringWithNullWithResponseAsync(context).block();
     }
 
     /**
@@ -2179,7 +3276,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, String> getStringWithNull() {
-        return getStringWithNullWithResponse().getValue();
+        return getStringWithNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2203,6 +3300,26 @@ public final class DictionariesImpl {
     /**
      * Get string dictionary value {"0": "foo", "1": 123, "2": "foo2"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return string dictionary value {"0": "foo", "1": 123, "2": "foo2"} along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, String>>> getStringWithInvalidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getStringWithInvalid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get string dictionary value {"0": "foo", "1": 123, "2": "foo2"}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string dictionary value {"0": "foo", "1": 123, "2": "foo2"} on successful completion of {@link Mono}.
@@ -2215,13 +3332,29 @@ public final class DictionariesImpl {
     /**
      * Get string dictionary value {"0": "foo", "1": 123, "2": "foo2"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return string dictionary value {"0": "foo", "1": 123, "2": "foo2"} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, String>> getStringWithInvalidAsync(Context context) {
+        return getStringWithInvalidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get string dictionary value {"0": "foo", "1": 123, "2": "foo2"}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string dictionary value {"0": "foo", "1": 123, "2": "foo2"} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, String>> getStringWithInvalidWithResponse() {
-        return getStringWithInvalidWithResponseAsync().block();
+    public Response<Map<String, String>> getStringWithInvalidWithResponse(Context context) {
+        return getStringWithInvalidWithResponseAsync(context).block();
     }
 
     /**
@@ -2233,7 +3366,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, String> getStringWithInvalid() {
-        return getStringWithInvalidWithResponse().getValue();
+        return getStringWithInvalidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2257,6 +3390,26 @@ public final class DictionariesImpl {
     /**
      * Get integer dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return integer dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"} along with {@link
+     *     Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, LocalDate>>> getDateValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDateValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get integer dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return integer dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"} on successful
@@ -2270,14 +3423,31 @@ public final class DictionariesImpl {
     /**
      * Get integer dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return integer dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, LocalDate>> getDateValidAsync(Context context) {
+        return getDateValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get integer dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return integer dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"} along with {@link
      *     Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, LocalDate>> getDateValidWithResponse() {
-        return getDateValidWithResponseAsync().block();
+    public Response<Map<String, LocalDate>> getDateValidWithResponse(Context context) {
+        return getDateValidWithResponseAsync(context).block();
     }
 
     /**
@@ -2289,7 +3459,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, LocalDate> getDateValid() {
-        return getDateValidWithResponse().getValue();
+        return getDateValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2318,6 +3488,29 @@ public final class DictionariesImpl {
      * Set dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
      *
      * @param arrayBody The dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putDateValidWithResponseAsync(Map<String, LocalDate> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putDateValid(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Set dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
+     *
+     * @param arrayBody The dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -2332,14 +3525,30 @@ public final class DictionariesImpl {
      * Set dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
      *
      * @param arrayBody The dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putDateValidAsync(Map<String, LocalDate> arrayBody, Context context) {
+        return putDateValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
+     *
+     * @param arrayBody The dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDateValidWithResponse(Map<String, LocalDate> arrayBody) {
-        return putDateValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putDateValidWithResponse(Map<String, LocalDate> arrayBody, Context context) {
+        return putDateValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -2352,7 +3561,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDateValid(Map<String, LocalDate> arrayBody) {
-        putDateValidWithResponse(arrayBody);
+        putDateValidWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -2376,6 +3585,26 @@ public final class DictionariesImpl {
     /**
      * Get date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"} along with {@link Response} on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, LocalDate>>> getDateInvalidNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDateInvalidNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"} on successful completion of
@@ -2389,13 +3618,30 @@ public final class DictionariesImpl {
     /**
      * Get date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, LocalDate>> getDateInvalidNullAsync(Context context) {
+        return getDateInvalidNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, LocalDate>> getDateInvalidNullWithResponse() {
-        return getDateInvalidNullWithResponseAsync().block();
+    public Response<Map<String, LocalDate>> getDateInvalidNullWithResponse(Context context) {
+        return getDateInvalidNullWithResponseAsync(context).block();
     }
 
     /**
@@ -2407,7 +3653,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, LocalDate> getDateInvalidNull() {
-        return getDateInvalidNullWithResponse().getValue();
+        return getDateInvalidNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2431,6 +3677,26 @@ public final class DictionariesImpl {
     /**
      * Get date dictionary value {"0": "2011-03-22", "1": "date"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return date dictionary value {"0": "2011-03-22", "1": "date"} along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, LocalDate>>> getDateInvalidCharsWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDateInvalidChars(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get date dictionary value {"0": "2011-03-22", "1": "date"}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date dictionary value {"0": "2011-03-22", "1": "date"} on successful completion of {@link Mono}.
@@ -2443,13 +3709,29 @@ public final class DictionariesImpl {
     /**
      * Get date dictionary value {"0": "2011-03-22", "1": "date"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return date dictionary value {"0": "2011-03-22", "1": "date"} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, LocalDate>> getDateInvalidCharsAsync(Context context) {
+        return getDateInvalidCharsWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get date dictionary value {"0": "2011-03-22", "1": "date"}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date dictionary value {"0": "2011-03-22", "1": "date"} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, LocalDate>> getDateInvalidCharsWithResponse() {
-        return getDateInvalidCharsWithResponseAsync().block();
+    public Response<Map<String, LocalDate>> getDateInvalidCharsWithResponse(Context context) {
+        return getDateInvalidCharsWithResponseAsync(context).block();
     }
 
     /**
@@ -2461,7 +3743,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, LocalDate> getDateInvalidChars() {
-        return getDateInvalidCharsWithResponse().getValue();
+        return getDateInvalidCharsWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2487,6 +3769,27 @@ public final class DictionariesImpl {
      * Get date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2":
      * "1492-10-12T10:15:01-08:00"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2":
+     *     "1492-10-12T10:15:01-08:00"} along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, OffsetDateTime>>> getDateTimeValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDateTimeValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2":
+     * "1492-10-12T10:15:01-08:00"}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2":
@@ -2501,14 +3804,32 @@ public final class DictionariesImpl {
      * Get date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2":
      * "1492-10-12T10:15:01-08:00"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2":
+     *     "1492-10-12T10:15:01-08:00"} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, OffsetDateTime>> getDateTimeValidAsync(Context context) {
+        return getDateTimeValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2":
+     * "1492-10-12T10:15:01-08:00"}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2":
      *     "1492-10-12T10:15:01-08:00"} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, OffsetDateTime>> getDateTimeValidWithResponse() {
-        return getDateTimeValidWithResponseAsync().block();
+    public Response<Map<String, OffsetDateTime>> getDateTimeValidWithResponse(Context context) {
+        return getDateTimeValidWithResponseAsync(context).block();
     }
 
     /**
@@ -2522,7 +3843,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, OffsetDateTime> getDateTimeValid() {
-        return getDateTimeValidWithResponse().getValue();
+        return getDateTimeValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2556,6 +3877,32 @@ public final class DictionariesImpl {
      *
      * @param arrayBody The dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2":
      *     "1492-10-12T10:15:01-08:00"}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putDateTimeValidWithResponseAsync(
+            Map<String, OffsetDateTime> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putDateTimeValid(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Set dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2":
+     * "1492-10-12T10:15:01-08:00"}.
+     *
+     * @param arrayBody The dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2":
+     *     "1492-10-12T10:15:01-08:00"}.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -2572,14 +3919,32 @@ public final class DictionariesImpl {
      *
      * @param arrayBody The dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2":
      *     "1492-10-12T10:15:01-08:00"}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putDateTimeValidAsync(Map<String, OffsetDateTime> arrayBody, Context context) {
+        return putDateTimeValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2":
+     * "1492-10-12T10:15:01-08:00"}.
+     *
+     * @param arrayBody The dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2":
+     *     "1492-10-12T10:15:01-08:00"}.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDateTimeValidWithResponse(Map<String, OffsetDateTime> arrayBody) {
-        return putDateTimeValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putDateTimeValidWithResponse(Map<String, OffsetDateTime> arrayBody, Context context) {
+        return putDateTimeValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -2594,7 +3959,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDateTimeValid(Map<String, OffsetDateTime> arrayBody) {
-        putDateTimeValidWithResponse(arrayBody);
+        putDateTimeValidWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -2618,6 +3983,26 @@ public final class DictionariesImpl {
     /**
      * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": null}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return date dictionary value {"0": "2000-12-01t00:00:01z", "1": null} along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, OffsetDateTime>>> getDateTimeInvalidNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDateTimeInvalidNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": null}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date dictionary value {"0": "2000-12-01t00:00:01z", "1": null} on successful completion of {@link Mono}.
@@ -2630,13 +4015,29 @@ public final class DictionariesImpl {
     /**
      * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": null}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return date dictionary value {"0": "2000-12-01t00:00:01z", "1": null} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, OffsetDateTime>> getDateTimeInvalidNullAsync(Context context) {
+        return getDateTimeInvalidNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": null}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date dictionary value {"0": "2000-12-01t00:00:01z", "1": null} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, OffsetDateTime>> getDateTimeInvalidNullWithResponse() {
-        return getDateTimeInvalidNullWithResponseAsync().block();
+    public Response<Map<String, OffsetDateTime>> getDateTimeInvalidNullWithResponse(Context context) {
+        return getDateTimeInvalidNullWithResponseAsync(context).block();
     }
 
     /**
@@ -2648,7 +4049,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, OffsetDateTime> getDateTimeInvalidNull() {
-        return getDateTimeInvalidNullWithResponse().getValue();
+        return getDateTimeInvalidNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2672,6 +4073,26 @@ public final class DictionariesImpl {
     /**
      * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"} along with {@link Response} on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, OffsetDateTime>>> getDateTimeInvalidCharsWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDateTimeInvalidChars(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"} on successful completion of {@link
@@ -2685,13 +4106,30 @@ public final class DictionariesImpl {
     /**
      * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, OffsetDateTime>> getDateTimeInvalidCharsAsync(Context context) {
+        return getDateTimeInvalidCharsWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, OffsetDateTime>> getDateTimeInvalidCharsWithResponse() {
-        return getDateTimeInvalidCharsWithResponseAsync().block();
+    public Response<Map<String, OffsetDateTime>> getDateTimeInvalidCharsWithResponse(Context context) {
+        return getDateTimeInvalidCharsWithResponseAsync(context).block();
     }
 
     /**
@@ -2703,7 +4141,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, OffsetDateTime> getDateTimeInvalidChars() {
-        return getDateTimeInvalidCharsWithResponse().getValue();
+        return getDateTimeInvalidCharsWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2730,6 +4168,28 @@ public final class DictionariesImpl {
      * Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35
      * GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35
+     *     GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"} along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, OffsetDateTime>>> getDateTimeRfc1123ValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDateTimeRfc1123Valid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35
+     * GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35
@@ -2744,14 +4204,32 @@ public final class DictionariesImpl {
      * Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35
      * GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35
+     *     GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, OffsetDateTime>> getDateTimeRfc1123ValidAsync(Context context) {
+        return getDateTimeRfc1123ValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35
+     * GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35
      *     GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, OffsetDateTime>> getDateTimeRfc1123ValidWithResponse() {
-        return getDateTimeRfc1123ValidWithResponseAsync().block();
+    public Response<Map<String, OffsetDateTime>> getDateTimeRfc1123ValidWithResponse(Context context) {
+        return getDateTimeRfc1123ValidWithResponseAsync(context).block();
     }
 
     /**
@@ -2765,7 +4243,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, OffsetDateTime> getDateTimeRfc1123Valid() {
-        return getDateTimeRfc1123ValidWithResponse().getValue();
+        return getDateTimeRfc1123ValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2804,6 +4282,37 @@ public final class DictionariesImpl {
      *
      * @param arrayBody The dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35
      *     GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putDateTimeRfc1123ValidWithResponseAsync(
+            Map<String, OffsetDateTime> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        Map<String, DateTimeRfc1123> arrayBodyConverted =
+                arrayBody.entrySet().stream()
+                        .collect(
+                                java.util.stream.Collectors.toMap(
+                                        Map.Entry::getKey, el -> new DateTimeRfc1123(el.getValue())));
+        return service.putDateTimeRfc1123Valid(this.client.getHost(), arrayBodyConverted, accept, context);
+    }
+
+    /**
+     * Set dictionary value empty {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2":
+     * "Wed, 12 Oct 1492 10:15:01 GMT"}.
+     *
+     * @param arrayBody The dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35
+     *     GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -2820,14 +4329,32 @@ public final class DictionariesImpl {
      *
      * @param arrayBody The dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35
      *     GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putDateTimeRfc1123ValidAsync(Map<String, OffsetDateTime> arrayBody, Context context) {
+        return putDateTimeRfc1123ValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set dictionary value empty {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2":
+     * "Wed, 12 Oct 1492 10:15:01 GMT"}.
+     *
+     * @param arrayBody The dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35
+     *     GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDateTimeRfc1123ValidWithResponse(Map<String, OffsetDateTime> arrayBody) {
-        return putDateTimeRfc1123ValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putDateTimeRfc1123ValidWithResponse(Map<String, OffsetDateTime> arrayBody, Context context) {
+        return putDateTimeRfc1123ValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -2842,7 +4369,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDateTimeRfc1123Valid(Map<String, OffsetDateTime> arrayBody) {
-        putDateTimeRfc1123ValidWithResponse(arrayBody);
+        putDateTimeRfc1123ValidWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -2866,6 +4393,26 @@ public final class DictionariesImpl {
     /**
      * Get duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"} along with {@link Response} on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Duration>>> getDurationValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDurationValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"} on successful completion of
@@ -2879,13 +4426,30 @@ public final class DictionariesImpl {
     /**
      * Get duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Duration>> getDurationValidAsync(Context context) {
+        return getDurationValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Duration>> getDurationValidWithResponse() {
-        return getDurationValidWithResponseAsync().block();
+    public Response<Map<String, Duration>> getDurationValidWithResponse(Context context) {
+        return getDurationValidWithResponseAsync(context).block();
     }
 
     /**
@@ -2897,7 +4461,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Duration> getDurationValid() {
-        return getDurationValidWithResponse().getValue();
+        return getDurationValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2927,6 +4491,29 @@ public final class DictionariesImpl {
      * Set dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
      *
      * @param arrayBody The dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putDurationValidWithResponseAsync(Map<String, Duration> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putDurationValid(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Set dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
+     *
+     * @param arrayBody The dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -2941,14 +4528,30 @@ public final class DictionariesImpl {
      * Set dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
      *
      * @param arrayBody The dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putDurationValidAsync(Map<String, Duration> arrayBody, Context context) {
+        return putDurationValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
+     *
+     * @param arrayBody The dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDurationValidWithResponse(Map<String, Duration> arrayBody) {
-        return putDurationValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putDurationValidWithResponse(Map<String, Duration> arrayBody, Context context) {
+        return putDurationValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -2961,7 +4564,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDurationValid(Map<String, Duration> arrayBody) {
-        putDurationValidWithResponse(arrayBody);
+        putDurationValidWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -2987,6 +4590,27 @@ public final class DictionariesImpl {
      * Get byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item
      * encoded in base64.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item
+     *     encoded in base64 along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, byte[]>>> getByteValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getByteValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item
+     * encoded in base64.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item
@@ -3001,14 +4625,32 @@ public final class DictionariesImpl {
      * Get byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item
      * encoded in base64.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item
+     *     encoded in base64 on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, byte[]>> getByteValidAsync(Context context) {
+        return getByteValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item
+     * encoded in base64.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item
      *     encoded in base64 along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, byte[]>> getByteValidWithResponse() {
-        return getByteValidWithResponseAsync().block();
+    public Response<Map<String, byte[]>> getByteValidWithResponse(Context context) {
+        return getByteValidWithResponseAsync(context).block();
     }
 
     /**
@@ -3022,7 +4664,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, byte[]> getByteValid() {
-        return getByteValidWithResponse().getValue();
+        return getByteValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -3055,6 +4697,31 @@ public final class DictionariesImpl {
      *
      * @param arrayBody The dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with
      *     each elementencoded in base 64.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putByteValidWithResponseAsync(Map<String, byte[]> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putByteValid(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Put the dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each
+     * elementencoded in base 64.
+     *
+     * @param arrayBody The dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with
+     *     each elementencoded in base 64.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -3071,14 +4738,32 @@ public final class DictionariesImpl {
      *
      * @param arrayBody The dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with
      *     each elementencoded in base 64.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putByteValidAsync(Map<String, byte[]> arrayBody, Context context) {
+        return putByteValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put the dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each
+     * elementencoded in base 64.
+     *
+     * @param arrayBody The dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with
+     *     each elementencoded in base 64.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putByteValidWithResponse(Map<String, byte[]> arrayBody) {
-        return putByteValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putByteValidWithResponse(Map<String, byte[]> arrayBody, Context context) {
+        return putByteValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -3093,7 +4778,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putByteValid(Map<String, byte[]> arrayBody) {
-        putByteValidWithResponse(arrayBody);
+        putByteValidWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -3117,6 +4802,26 @@ public final class DictionariesImpl {
     /**
      * Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded along with
+     *     {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, byte[]>>> getByteInvalidNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getByteInvalidNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded on successful
@@ -3130,14 +4835,31 @@ public final class DictionariesImpl {
     /**
      * Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, byte[]>> getByteInvalidNullAsync(Context context) {
+        return getByteInvalidNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded along with
      *     {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, byte[]>> getByteInvalidNullWithResponse() {
-        return getByteInvalidNullWithResponseAsync().block();
+    public Response<Map<String, byte[]>> getByteInvalidNullWithResponse(Context context) {
+        return getByteInvalidNullWithResponseAsync(context).block();
     }
 
     /**
@@ -3149,7 +4871,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, byte[]> getByteInvalidNull() {
-        return getByteInvalidNullWithResponse().getValue();
+        return getByteInvalidNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -3175,6 +4897,27 @@ public final class DictionariesImpl {
      * Get base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem
      * ipsum"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2":
+     *     "Lorem ipsum"} along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, byte[]>>> getBase64UrlWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getBase64Url(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem
+     * ipsum"}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2":
@@ -3189,14 +4932,32 @@ public final class DictionariesImpl {
      * Get base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem
      * ipsum"}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2":
+     *     "Lorem ipsum"} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, byte[]>> getBase64UrlAsync(Context context) {
+        return getBase64UrlWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem
+     * ipsum"}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2":
      *     "Lorem ipsum"} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, byte[]>> getBase64UrlWithResponse() {
-        return getBase64UrlWithResponseAsync().block();
+    public Response<Map<String, byte[]>> getBase64UrlWithResponse(Context context) {
+        return getBase64UrlWithResponseAsync(context).block();
     }
 
     /**
@@ -3210,7 +4971,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, byte[]> getBase64Url() {
-        return getBase64UrlWithResponse().getValue();
+        return getBase64UrlWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -3234,6 +4995,26 @@ public final class DictionariesImpl {
     /**
      * Get dictionary of complex type null value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return dictionary of complex type null value along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Widget>>> getComplexNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getComplexNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get dictionary of complex type null value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return dictionary of complex type null value on successful completion of {@link Mono}.
@@ -3246,13 +5027,29 @@ public final class DictionariesImpl {
     /**
      * Get dictionary of complex type null value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return dictionary of complex type null value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Widget>> getComplexNullAsync(Context context) {
+        return getComplexNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get dictionary of complex type null value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return dictionary of complex type null value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Widget>> getComplexNullWithResponse() {
-        return getComplexNullWithResponseAsync().block();
+    public Response<Map<String, Widget>> getComplexNullWithResponse(Context context) {
+        return getComplexNullWithResponseAsync(context).block();
     }
 
     /**
@@ -3264,7 +5061,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Widget> getComplexNull() {
-        return getComplexNullWithResponse().getValue();
+        return getComplexNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -3287,6 +5084,25 @@ public final class DictionariesImpl {
     /**
      * Get empty dictionary of complex type {}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return empty dictionary of complex type {} along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Widget>>> getComplexEmptyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getComplexEmpty(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get empty dictionary of complex type {}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return empty dictionary of complex type {} on successful completion of {@link Mono}.
@@ -3299,13 +5115,29 @@ public final class DictionariesImpl {
     /**
      * Get empty dictionary of complex type {}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return empty dictionary of complex type {} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Widget>> getComplexEmptyAsync(Context context) {
+        return getComplexEmptyWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get empty dictionary of complex type {}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return empty dictionary of complex type {} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Widget>> getComplexEmptyWithResponse() {
-        return getComplexEmptyWithResponseAsync().block();
+    public Response<Map<String, Widget>> getComplexEmptyWithResponse(Context context) {
+        return getComplexEmptyWithResponseAsync(context).block();
     }
 
     /**
@@ -3317,7 +5149,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Widget> getComplexEmpty() {
-        return getComplexEmptyWithResponse().getValue();
+        return getComplexEmptyWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -3343,6 +5175,27 @@ public final class DictionariesImpl {
      * Get dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null, "2": {"integer": 5,
      * "string": "6"}}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null, "2":
+     *     {"integer": 5, "string": "6"}} along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Widget>>> getComplexItemNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getComplexItemNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null, "2": {"integer": 5,
+     * "string": "6"}}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null, "2":
@@ -3357,14 +5210,32 @@ public final class DictionariesImpl {
      * Get dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null, "2": {"integer": 5,
      * "string": "6"}}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null, "2":
+     *     {"integer": 5, "string": "6"}} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Widget>> getComplexItemNullAsync(Context context) {
+        return getComplexItemNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null, "2": {"integer": 5,
+     * "string": "6"}}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null, "2":
      *     {"integer": 5, "string": "6"}} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Widget>> getComplexItemNullWithResponse() {
-        return getComplexItemNullWithResponseAsync().block();
+    public Response<Map<String, Widget>> getComplexItemNullWithResponse(Context context) {
+        return getComplexItemNullWithResponseAsync(context).block();
     }
 
     /**
@@ -3378,7 +5249,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Widget> getComplexItemNull() {
-        return getComplexItemNullWithResponse().getValue();
+        return getComplexItemNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -3404,6 +5275,27 @@ public final class DictionariesImpl {
      * Get dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer": 5,
      * "string": "6"}}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer":
+     *     5, "string": "6"}} along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Widget>>> getComplexItemEmptyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getComplexItemEmpty(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer": 5,
+     * "string": "6"}}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer":
@@ -3418,14 +5310,32 @@ public final class DictionariesImpl {
      * Get dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer": 5,
      * "string": "6"}}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer":
+     *     5, "string": "6"}} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Widget>> getComplexItemEmptyAsync(Context context) {
+        return getComplexItemEmptyWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer": 5,
+     * "string": "6"}}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer":
      *     5, "string": "6"}} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Widget>> getComplexItemEmptyWithResponse() {
-        return getComplexItemEmptyWithResponseAsync().block();
+    public Response<Map<String, Widget>> getComplexItemEmptyWithResponse(Context context) {
+        return getComplexItemEmptyWithResponseAsync(context).block();
     }
 
     /**
@@ -3439,7 +5349,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Widget> getComplexItemEmpty() {
-        return getComplexItemEmptyWithResponse().getValue();
+        return getComplexItemEmptyWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -3465,6 +5375,27 @@ public final class DictionariesImpl {
      * Get dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2":
      * {"integer": 5, "string": "6"}}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"},
+     *     "2": {"integer": 5, "string": "6"}} along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Widget>>> getComplexValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getComplexValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2":
+     * {"integer": 5, "string": "6"}}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"},
@@ -3479,14 +5410,32 @@ public final class DictionariesImpl {
      * Get dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2":
      * {"integer": 5, "string": "6"}}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"},
+     *     "2": {"integer": 5, "string": "6"}} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Widget>> getComplexValidAsync(Context context) {
+        return getComplexValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2":
+     * {"integer": 5, "string": "6"}}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"},
      *     "2": {"integer": 5, "string": "6"}} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Widget>> getComplexValidWithResponse() {
-        return getComplexValidWithResponseAsync().block();
+    public Response<Map<String, Widget>> getComplexValidWithResponse(Context context) {
+        return getComplexValidWithResponseAsync(context).block();
     }
 
     /**
@@ -3500,7 +5449,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Widget> getComplexValid() {
-        return getComplexValidWithResponse().getValue();
+        return getComplexValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -3543,6 +5492,40 @@ public final class DictionariesImpl {
      *
      * @param arrayBody Dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3,
      *     "string": "4"}, "2": {"integer": 5, "string": "6"}}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putComplexValidWithResponseAsync(Map<String, Widget> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        } else {
+            arrayBody
+                    .values()
+                    .forEach(
+                            e -> {
+                                if (e != null) {
+                                    e.validate();
+                                }
+                            });
+        }
+        final String accept = "application/json";
+        return service.putComplexValid(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Put an dictionary of complex type with values {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string":
+     * "4"}, "2": {"integer": 5, "string": "6"}}.
+     *
+     * @param arrayBody Dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3,
+     *     "string": "4"}, "2": {"integer": 5, "string": "6"}}.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -3559,14 +5542,32 @@ public final class DictionariesImpl {
      *
      * @param arrayBody Dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3,
      *     "string": "4"}, "2": {"integer": 5, "string": "6"}}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putComplexValidAsync(Map<String, Widget> arrayBody, Context context) {
+        return putComplexValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put an dictionary of complex type with values {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string":
+     * "4"}, "2": {"integer": 5, "string": "6"}}.
+     *
+     * @param arrayBody Dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3,
+     *     "string": "4"}, "2": {"integer": 5, "string": "6"}}.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putComplexValidWithResponse(Map<String, Widget> arrayBody) {
-        return putComplexValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putComplexValidWithResponse(Map<String, Widget> arrayBody, Context context) {
+        return putComplexValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -3581,7 +5582,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putComplexValid(Map<String, Widget> arrayBody) {
-        putComplexValidWithResponse(arrayBody);
+        putComplexValidWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -3604,6 +5605,25 @@ public final class DictionariesImpl {
     /**
      * Get a null array.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a null array along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, List<String>>>> getArrayNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getArrayNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get a null array.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a null array on successful completion of {@link Mono}.
@@ -3616,13 +5636,29 @@ public final class DictionariesImpl {
     /**
      * Get a null array.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a null array on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, List<String>>> getArrayNullAsync(Context context) {
+        return getArrayNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get a null array.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a null array along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, List<String>>> getArrayNullWithResponse() {
-        return getArrayNullWithResponseAsync().block();
+    public Response<Map<String, List<String>>> getArrayNullWithResponse(Context context) {
+        return getArrayNullWithResponseAsync(context).block();
     }
 
     /**
@@ -3634,7 +5670,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, List<String>> getArrayNull() {
-        return getArrayNullWithResponse().getValue();
+        return getArrayNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -3657,6 +5693,25 @@ public final class DictionariesImpl {
     /**
      * Get an empty dictionary {}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an empty dictionary {} along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, List<String>>>> getArrayEmptyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getArrayEmpty(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get an empty dictionary {}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an empty dictionary {} on successful completion of {@link Mono}.
@@ -3669,13 +5724,29 @@ public final class DictionariesImpl {
     /**
      * Get an empty dictionary {}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an empty dictionary {} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, List<String>>> getArrayEmptyAsync(Context context) {
+        return getArrayEmptyWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get an empty dictionary {}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an empty dictionary {} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, List<String>>> getArrayEmptyWithResponse() {
-        return getArrayEmptyWithResponseAsync().block();
+    public Response<Map<String, List<String>>> getArrayEmptyWithResponse(Context context) {
+        return getArrayEmptyWithResponseAsync(context).block();
     }
 
     /**
@@ -3687,7 +5758,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, List<String>> getArrayEmpty() {
-        return getArrayEmptyWithResponse().getValue();
+        return getArrayEmptyWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -3711,6 +5782,26 @@ public final class DictionariesImpl {
     /**
      * Get an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]} along with
+     *     {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, List<String>>>> getArrayItemNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getArrayItemNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]} on successful
@@ -3724,14 +5815,31 @@ public final class DictionariesImpl {
     /**
      * Get an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, List<String>>> getArrayItemNullAsync(Context context) {
+        return getArrayItemNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]} along with
      *     {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, List<String>>> getArrayItemNullWithResponse() {
-        return getArrayItemNullWithResponseAsync().block();
+    public Response<Map<String, List<String>>> getArrayItemNullWithResponse(Context context) {
+        return getArrayItemNullWithResponseAsync(context).block();
     }
 
     /**
@@ -3743,7 +5851,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, List<String>> getArrayItemNull() {
-        return getArrayItemNullWithResponse().getValue();
+        return getArrayItemNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -3767,6 +5875,26 @@ public final class DictionariesImpl {
     /**
      * Get an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]} along with {@link
+     *     Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, List<String>>>> getArrayItemEmptyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getArrayItemEmpty(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]} on successful
@@ -3780,14 +5908,31 @@ public final class DictionariesImpl {
     /**
      * Get an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, List<String>>> getArrayItemEmptyAsync(Context context) {
+        return getArrayItemEmptyWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]} along with {@link
      *     Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, List<String>>> getArrayItemEmptyWithResponse() {
-        return getArrayItemEmptyWithResponseAsync().block();
+    public Response<Map<String, List<String>>> getArrayItemEmptyWithResponse(Context context) {
+        return getArrayItemEmptyWithResponseAsync(context).block();
     }
 
     /**
@@ -3799,7 +5944,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, List<String>> getArrayItemEmpty() {
-        return getArrayItemEmptyWithResponse().getValue();
+        return getArrayItemEmptyWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -3823,6 +5968,26 @@ public final class DictionariesImpl {
     /**
      * Get an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]} along
+     *     with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, List<String>>>> getArrayValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getArrayValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]} on
@@ -3836,14 +6001,31 @@ public final class DictionariesImpl {
     /**
      * Get an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]} on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, List<String>>> getArrayValidAsync(Context context) {
+        return getArrayValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]} along
      *     with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, List<String>>> getArrayValidWithResponse() {
-        return getArrayValidWithResponseAsync().block();
+    public Response<Map<String, List<String>>> getArrayValidWithResponse(Context context) {
+        return getArrayValidWithResponseAsync(context).block();
     }
 
     /**
@@ -3855,7 +6037,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, List<String>> getArrayValid() {
-        return getArrayValidWithResponse().getValue();
+        return getArrayValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -3885,6 +6067,29 @@ public final class DictionariesImpl {
      * Put An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
      *
      * @param arrayBody An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putArrayValidWithResponseAsync(Map<String, List<String>> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putArrayValid(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Put An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
+     *
+     * @param arrayBody An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -3899,14 +6104,30 @@ public final class DictionariesImpl {
      * Put An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
      *
      * @param arrayBody An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putArrayValidAsync(Map<String, List<String>> arrayBody, Context context) {
+        return putArrayValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
+     *
+     * @param arrayBody An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putArrayValidWithResponse(Map<String, List<String>> arrayBody) {
-        return putArrayValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putArrayValidWithResponse(Map<String, List<String>> arrayBody, Context context) {
+        return putArrayValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -3919,7 +6140,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putArrayValid(Map<String, List<String>> arrayBody) {
-        putArrayValidWithResponse(arrayBody);
+        putArrayValidWithResponse(arrayBody, Context.NONE);
     }
 
     /**
@@ -3943,6 +6164,26 @@ public final class DictionariesImpl {
     /**
      * Get an dictionaries of dictionaries with value null.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an dictionaries of dictionaries with value null along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Map<String, String>>>> getDictionaryNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDictionaryNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get an dictionaries of dictionaries with value null.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an dictionaries of dictionaries with value null on successful completion of {@link Mono}.
@@ -3955,13 +6196,29 @@ public final class DictionariesImpl {
     /**
      * Get an dictionaries of dictionaries with value null.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an dictionaries of dictionaries with value null on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Map<String, String>>> getDictionaryNullAsync(Context context) {
+        return getDictionaryNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get an dictionaries of dictionaries with value null.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an dictionaries of dictionaries with value null along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Map<String, String>>> getDictionaryNullWithResponse() {
-        return getDictionaryNullWithResponseAsync().block();
+    public Response<Map<String, Map<String, String>>> getDictionaryNullWithResponse(Context context) {
+        return getDictionaryNullWithResponseAsync(context).block();
     }
 
     /**
@@ -3973,7 +6230,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Map<String, String>> getDictionaryNull() {
-        return getDictionaryNullWithResponse().getValue();
+        return getDictionaryNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -3997,6 +6254,26 @@ public final class DictionariesImpl {
     /**
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an dictionaries of dictionaries of type &lt;string, string&gt; with value {} along with {@link Response}
+     *     on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Map<String, String>>>> getDictionaryEmptyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDictionaryEmpty(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an dictionaries of dictionaries of type &lt;string, string&gt; with value {} on successful completion of
@@ -4010,13 +6287,30 @@ public final class DictionariesImpl {
     /**
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an dictionaries of dictionaries of type &lt;string, string&gt; with value {} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Map<String, String>>> getDictionaryEmptyAsync(Context context) {
+        return getDictionaryEmptyWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an dictionaries of dictionaries of type &lt;string, string&gt; with value {} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Map<String, String>>> getDictionaryEmptyWithResponse() {
-        return getDictionaryEmptyWithResponseAsync().block();
+    public Response<Map<String, Map<String, String>>> getDictionaryEmptyWithResponse(Context context) {
+        return getDictionaryEmptyWithResponseAsync(context).block();
     }
 
     /**
@@ -4028,7 +6322,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Map<String, String>> getDictionaryEmpty() {
-        return getDictionaryEmptyWithResponse().getValue();
+        return getDictionaryEmptyWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -4055,6 +6349,28 @@ public final class DictionariesImpl {
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3":
      * "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two",
+     *     "3": "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}} along with {@link Response} on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Map<String, String>>>> getDictionaryItemNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDictionaryItemNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3":
+     * "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two",
@@ -4070,14 +6386,33 @@ public final class DictionariesImpl {
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3":
      * "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two",
+     *     "3": "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Map<String, String>>> getDictionaryItemNullAsync(Context context) {
+        return getDictionaryItemNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3":
+     * "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two",
      *     "3": "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Map<String, String>>> getDictionaryItemNullWithResponse() {
-        return getDictionaryItemNullWithResponseAsync().block();
+    public Response<Map<String, Map<String, String>>> getDictionaryItemNullWithResponse(Context context) {
+        return getDictionaryItemNullWithResponseAsync(context).block();
     }
 
     /**
@@ -4091,7 +6426,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Map<String, String>> getDictionaryItemNull() {
-        return getDictionaryItemNullWithResponse().getValue();
+        return getDictionaryItemNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -4118,6 +6453,28 @@ public final class DictionariesImpl {
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3":
      * "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two",
+     *     "3": "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}} along with {@link Response} on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Map<String, String>>>> getDictionaryItemEmptyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDictionaryItemEmpty(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3":
+     * "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two",
@@ -4133,14 +6490,33 @@ public final class DictionariesImpl {
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3":
      * "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two",
+     *     "3": "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Map<String, String>>> getDictionaryItemEmptyAsync(Context context) {
+        return getDictionaryItemEmptyWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3":
+     * "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two",
      *     "3": "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}} along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Map<String, String>>> getDictionaryItemEmptyWithResponse() {
-        return getDictionaryItemEmptyWithResponseAsync().block();
+    public Response<Map<String, Map<String, String>>> getDictionaryItemEmptyWithResponse(Context context) {
+        return getDictionaryItemEmptyWithResponseAsync(context).block();
     }
 
     /**
@@ -4154,7 +6530,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Map<String, String>> getDictionaryItemEmpty() {
-        return getDictionaryItemEmptyWithResponse().getValue();
+        return getDictionaryItemEmptyWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -4181,6 +6557,28 @@ public final class DictionariesImpl {
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3":
      * "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two",
+     *     "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
+     *     along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Map<String, String>>>> getDictionaryValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDictionaryValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3":
+     * "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two",
@@ -4196,6 +6594,25 @@ public final class DictionariesImpl {
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3":
      * "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two",
+     *     "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
+     *     on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Map<String, String>>> getDictionaryValidAsync(Context context) {
+        return getDictionaryValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3":
+     * "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two",
@@ -4203,8 +6620,8 @@ public final class DictionariesImpl {
      *     along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Map<String, String>>> getDictionaryValidWithResponse() {
-        return getDictionaryValidWithResponseAsync().block();
+    public Response<Map<String, Map<String, String>>> getDictionaryValidWithResponse(Context context) {
+        return getDictionaryValidWithResponseAsync(context).block();
     }
 
     /**
@@ -4218,7 +6635,7 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Map<String, String>> getDictionaryValid() {
-        return getDictionaryValidWithResponse().getValue();
+        return getDictionaryValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -4256,6 +6673,35 @@ public final class DictionariesImpl {
      * @param arrayBody An dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one",
      *     "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight",
      *     "9": "nine"}}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two",
+     *     "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
+     *     along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putDictionaryValidWithResponseAsync(
+            Map<String, Map<String, String>> arrayBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putDictionaryValid(this.client.getHost(), arrayBody, accept, context);
+    }
+
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3":
+     * "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     *
+     * @param arrayBody An dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one",
+     *     "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight",
+     *     "9": "nine"}}.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -4275,6 +6721,27 @@ public final class DictionariesImpl {
      * @param arrayBody An dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one",
      *     "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight",
      *     "9": "nine"}}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two",
+     *     "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
+     *     on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putDictionaryValidAsync(Map<String, Map<String, String>> arrayBody, Context context) {
+        return putDictionaryValidWithResponseAsync(arrayBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3":
+     * "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     *
+     * @param arrayBody An dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one",
+     *     "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight",
+     *     "9": "nine"}}.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -4283,8 +6750,8 @@ public final class DictionariesImpl {
      *     along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDictionaryValidWithResponse(Map<String, Map<String, String>> arrayBody) {
-        return putDictionaryValidWithResponseAsync(arrayBody).block();
+    public Response<Void> putDictionaryValidWithResponse(Map<String, Map<String, String>> arrayBody, Context context) {
+        return putDictionaryValidWithResponseAsync(arrayBody, context).block();
     }
 
     /**
@@ -4300,6 +6767,6 @@ public final class DictionariesImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDictionaryValid(Map<String, Map<String, String>> arrayBody) {
-        putDictionaryValidWithResponse(arrayBody);
+        putDictionaryValidWithResponse(arrayBody, Context.NONE);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyduration/DurationOperations.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyduration/DurationOperations.java
@@ -98,6 +98,25 @@ public final class DurationOperations {
     /**
      * Get null duration value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null duration value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Duration>> getNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get null duration value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null duration value on successful completion of {@link Mono}.
@@ -110,13 +129,29 @@ public final class DurationOperations {
     /**
      * Get null duration value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null duration value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Duration> getNullAsync(Context context) {
+        return getNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get null duration value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null duration value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Duration> getNullWithResponse() {
-        return getNullWithResponseAsync().block();
+    public Response<Duration> getNullWithResponse(Context context) {
+        return getNullWithResponseAsync(context).block();
     }
 
     /**
@@ -128,7 +163,7 @@ public final class DurationOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Duration getNull() {
-        return getNullWithResponse().getValue();
+        return getNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -158,6 +193,29 @@ public final class DurationOperations {
      * Put a positive duration value.
      *
      * @param durationBody duration body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putPositiveDurationWithResponseAsync(Duration durationBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (durationBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter durationBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putPositiveDuration(this.client.getHost(), durationBody, accept, context);
+    }
+
+    /**
+     * Put a positive duration value.
+     *
+     * @param durationBody duration body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -172,14 +230,30 @@ public final class DurationOperations {
      * Put a positive duration value.
      *
      * @param durationBody duration body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putPositiveDurationAsync(Duration durationBody, Context context) {
+        return putPositiveDurationWithResponseAsync(durationBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put a positive duration value.
+     *
+     * @param durationBody duration body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putPositiveDurationWithResponse(Duration durationBody) {
-        return putPositiveDurationWithResponseAsync(durationBody).block();
+    public Response<Void> putPositiveDurationWithResponse(Duration durationBody, Context context) {
+        return putPositiveDurationWithResponseAsync(durationBody, context).block();
     }
 
     /**
@@ -192,7 +266,7 @@ public final class DurationOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putPositiveDuration(Duration durationBody) {
-        putPositiveDurationWithResponse(durationBody);
+        putPositiveDurationWithResponse(durationBody, Context.NONE);
     }
 
     /**
@@ -215,6 +289,25 @@ public final class DurationOperations {
     /**
      * Get a positive duration value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a positive duration value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Duration>> getPositiveDurationWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getPositiveDuration(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get a positive duration value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a positive duration value on successful completion of {@link Mono}.
@@ -227,13 +320,29 @@ public final class DurationOperations {
     /**
      * Get a positive duration value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a positive duration value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Duration> getPositiveDurationAsync(Context context) {
+        return getPositiveDurationWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get a positive duration value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a positive duration value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Duration> getPositiveDurationWithResponse() {
-        return getPositiveDurationWithResponseAsync().block();
+    public Response<Duration> getPositiveDurationWithResponse(Context context) {
+        return getPositiveDurationWithResponseAsync(context).block();
     }
 
     /**
@@ -245,7 +354,7 @@ public final class DurationOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Duration getPositiveDuration() {
-        return getPositiveDurationWithResponse().getValue();
+        return getPositiveDurationWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -268,6 +377,25 @@ public final class DurationOperations {
     /**
      * Get an invalid duration value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an invalid duration value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Duration>> getInvalidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getInvalid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get an invalid duration value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an invalid duration value on successful completion of {@link Mono}.
@@ -280,13 +408,29 @@ public final class DurationOperations {
     /**
      * Get an invalid duration value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an invalid duration value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Duration> getInvalidAsync(Context context) {
+        return getInvalidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get an invalid duration value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an invalid duration value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Duration> getInvalidWithResponse() {
-        return getInvalidWithResponseAsync().block();
+    public Response<Duration> getInvalidWithResponse(Context context) {
+        return getInvalidWithResponseAsync(context).block();
     }
 
     /**
@@ -298,6 +442,6 @@ public final class DurationOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Duration getInvalid() {
-        return getInvalidWithResponse().getValue();
+        return getInvalidWithResponse(Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyformdataurlencoded/Formdataurlencodeds.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyformdataurlencoded/Formdataurlencodeds.java
@@ -118,6 +118,37 @@ public final class Formdataurlencodeds {
      * @param petAge How many years is it old?.
      * @param name Updated name of the pet.
      * @param status Updated status of the pet.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> updatePetWithFormWithResponseAsync(
+            int petId, PetType petType, PetFood petFood, int petAge, String name, String status, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (petType == null) {
+            return Mono.error(new IllegalArgumentException("Parameter petType is required and cannot be null."));
+        }
+        if (petFood == null) {
+            return Mono.error(new IllegalArgumentException("Parameter petFood is required and cannot be null."));
+        }
+        return service.updatePetWithForm(this.client.getHost(), petId, petType, petFood, petAge, name, status, context);
+    }
+
+    /**
+     * Updates a pet in the store with form data.
+     *
+     * @param petId ID of pet that needs to be updated.
+     * @param petType Can take a value of dog, or cat, or fish.
+     * @param petFood Can take a value of meat, or fish, or plant.
+     * @param petAge How many years is it old?.
+     * @param name Updated name of the pet.
+     * @param status Updated status of the pet.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -159,6 +190,29 @@ public final class Formdataurlencodeds {
      * @param petAge How many years is it old?.
      * @param name Updated name of the pet.
      * @param status Updated status of the pet.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> updatePetWithFormAsync(
+            int petId, PetType petType, PetFood petFood, int petAge, String name, String status, Context context) {
+        return updatePetWithFormWithResponseAsync(petId, petType, petFood, petAge, name, status, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Updates a pet in the store with form data.
+     *
+     * @param petId ID of pet that needs to be updated.
+     * @param petType Can take a value of dog, or cat, or fish.
+     * @param petFood Can take a value of meat, or fish, or plant.
+     * @param petAge How many years is it old?.
+     * @param name Updated name of the pet.
+     * @param status Updated status of the pet.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -166,8 +220,8 @@ public final class Formdataurlencodeds {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> updatePetWithFormWithResponse(
-            int petId, PetType petType, PetFood petFood, int petAge, String name, String status) {
-        return updatePetWithFormWithResponseAsync(petId, petType, petFood, petAge, name, status).block();
+            int petId, PetType petType, PetFood petFood, int petAge, String name, String status, Context context) {
+        return updatePetWithFormWithResponseAsync(petId, petType, petFood, petAge, name, status, context).block();
     }
 
     /**
@@ -185,7 +239,7 @@ public final class Formdataurlencodeds {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void updatePetWithForm(int petId, PetType petType, PetFood petFood, int petAge, String name, String status) {
-        updatePetWithFormWithResponse(petId, petType, petFood, petAge, name, status);
+        updatePetWithFormWithResponse(petId, petType, petFood, petAge, name, status, Context.NONE);
     }
 
     /**
@@ -203,7 +257,7 @@ public final class Formdataurlencodeds {
     public void updatePetWithForm(int petId, PetType petType, PetFood petFood, int petAge) {
         final String name = null;
         final String status = null;
-        updatePetWithFormWithResponse(petId, petType, petFood, petAge, name, status);
+        updatePetWithFormWithResponse(petId, petType, petFood, petAge, name, status, Context.NONE);
     }
 
     /**
@@ -242,6 +296,35 @@ public final class Formdataurlencodeds {
      *
      * @param serviceParam Indicates the name of your Azure container registry.
      * @param accessToken AAD access token, mandatory when grant_type is access_token_refresh_token or access_token.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> partialConstantBodyWithResponseAsync(
+            String serviceParam, String accessToken, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (serviceParam == null) {
+            return Mono.error(new IllegalArgumentException("Parameter serviceParam is required and cannot be null."));
+        }
+        if (accessToken == null) {
+            return Mono.error(new IllegalArgumentException("Parameter accessToken is required and cannot be null."));
+        }
+        final String grantType = "access_token";
+        return service.partialConstantBody(this.client.getHost(), grantType, serviceParam, accessToken, context);
+    }
+
+    /**
+     * Test a partially constant formdata body. Pass in { grant_type: 'access_token', access_token: 'foo', service:
+     * 'bar' } to pass the test.
+     *
+     * @param serviceParam Indicates the name of your Azure container registry.
+     * @param accessToken AAD access token, mandatory when grant_type is access_token_refresh_token or access_token.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -258,14 +341,33 @@ public final class Formdataurlencodeds {
      *
      * @param serviceParam Indicates the name of your Azure container registry.
      * @param accessToken AAD access token, mandatory when grant_type is access_token_refresh_token or access_token.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> partialConstantBodyAsync(String serviceParam, String accessToken, Context context) {
+        return partialConstantBodyWithResponseAsync(serviceParam, accessToken, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test a partially constant formdata body. Pass in { grant_type: 'access_token', access_token: 'foo', service:
+     * 'bar' } to pass the test.
+     *
+     * @param serviceParam Indicates the name of your Azure container registry.
+     * @param accessToken AAD access token, mandatory when grant_type is access_token_refresh_token or access_token.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> partialConstantBodyWithResponse(String serviceParam, String accessToken) {
-        return partialConstantBodyWithResponseAsync(serviceParam, accessToken).block();
+    public Response<Void> partialConstantBodyWithResponse(String serviceParam, String accessToken, Context context) {
+        return partialConstantBodyWithResponseAsync(serviceParam, accessToken, context).block();
     }
 
     /**
@@ -280,6 +382,6 @@ public final class Formdataurlencodeds {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void partialConstantBody(String serviceParam, String accessToken) {
-        partialConstantBodyWithResponse(serviceParam, accessToken);
+        partialConstantBodyWithResponse(serviceParam, accessToken, Context.NONE);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyinteger/Ints.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyinteger/Ints.java
@@ -172,6 +172,25 @@ public final class Ints {
     /**
      * Get null Int value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null Int value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Integer>> getNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get null Int value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null Int value on successful completion of {@link Mono}.
@@ -184,13 +203,29 @@ public final class Ints {
     /**
      * Get null Int value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null Int value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Integer> getNullAsync(Context context) {
+        return getNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get null Int value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null Int value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Integer> getNullWithResponse() {
-        return getNullWithResponseAsync().block();
+    public Response<Integer> getNullWithResponse(Context context) {
+        return getNullWithResponseAsync(context).block();
     }
 
     /**
@@ -202,7 +237,7 @@ public final class Ints {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public int getNull() {
-        return getNullWithResponse().getValue();
+        return getNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -225,6 +260,25 @@ public final class Ints {
     /**
      * Get invalid Int value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return invalid Int value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Integer>> getInvalidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getInvalid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get invalid Int value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return invalid Int value on successful completion of {@link Mono}.
@@ -237,13 +291,29 @@ public final class Ints {
     /**
      * Get invalid Int value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return invalid Int value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Integer> getInvalidAsync(Context context) {
+        return getInvalidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get invalid Int value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return invalid Int value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Integer> getInvalidWithResponse() {
-        return getInvalidWithResponseAsync().block();
+    public Response<Integer> getInvalidWithResponse(Context context) {
+        return getInvalidWithResponseAsync(context).block();
     }
 
     /**
@@ -255,7 +325,7 @@ public final class Ints {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public int getInvalid() {
-        return getInvalidWithResponse().getValue();
+        return getInvalidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -278,6 +348,25 @@ public final class Ints {
     /**
      * Get overflow Int32 value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return overflow Int32 value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Integer>> getOverflowInt32WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getOverflowInt32(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get overflow Int32 value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return overflow Int32 value on successful completion of {@link Mono}.
@@ -290,13 +379,29 @@ public final class Ints {
     /**
      * Get overflow Int32 value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return overflow Int32 value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Integer> getOverflowInt32Async(Context context) {
+        return getOverflowInt32WithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get overflow Int32 value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return overflow Int32 value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Integer> getOverflowInt32WithResponse() {
-        return getOverflowInt32WithResponseAsync().block();
+    public Response<Integer> getOverflowInt32WithResponse(Context context) {
+        return getOverflowInt32WithResponseAsync(context).block();
     }
 
     /**
@@ -308,7 +413,7 @@ public final class Ints {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public int getOverflowInt32() {
-        return getOverflowInt32WithResponse().getValue();
+        return getOverflowInt32WithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -331,6 +436,25 @@ public final class Ints {
     /**
      * Get underflow Int32 value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return underflow Int32 value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Integer>> getUnderflowInt32WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getUnderflowInt32(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get underflow Int32 value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return underflow Int32 value on successful completion of {@link Mono}.
@@ -343,13 +467,29 @@ public final class Ints {
     /**
      * Get underflow Int32 value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return underflow Int32 value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Integer> getUnderflowInt32Async(Context context) {
+        return getUnderflowInt32WithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get underflow Int32 value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return underflow Int32 value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Integer> getUnderflowInt32WithResponse() {
-        return getUnderflowInt32WithResponseAsync().block();
+    public Response<Integer> getUnderflowInt32WithResponse(Context context) {
+        return getUnderflowInt32WithResponseAsync(context).block();
     }
 
     /**
@@ -361,7 +501,7 @@ public final class Ints {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public int getUnderflowInt32() {
-        return getUnderflowInt32WithResponse().getValue();
+        return getUnderflowInt32WithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -384,6 +524,25 @@ public final class Ints {
     /**
      * Get overflow Int64 value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return overflow Int64 value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Long>> getOverflowInt64WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getOverflowInt64(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get overflow Int64 value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return overflow Int64 value on successful completion of {@link Mono}.
@@ -396,13 +555,29 @@ public final class Ints {
     /**
      * Get overflow Int64 value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return overflow Int64 value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Long> getOverflowInt64Async(Context context) {
+        return getOverflowInt64WithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get overflow Int64 value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return overflow Int64 value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Long> getOverflowInt64WithResponse() {
-        return getOverflowInt64WithResponseAsync().block();
+    public Response<Long> getOverflowInt64WithResponse(Context context) {
+        return getOverflowInt64WithResponseAsync(context).block();
     }
 
     /**
@@ -414,7 +589,7 @@ public final class Ints {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public long getOverflowInt64() {
-        return getOverflowInt64WithResponse().getValue();
+        return getOverflowInt64WithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -437,6 +612,25 @@ public final class Ints {
     /**
      * Get underflow Int64 value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return underflow Int64 value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Long>> getUnderflowInt64WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getUnderflowInt64(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get underflow Int64 value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return underflow Int64 value on successful completion of {@link Mono}.
@@ -449,13 +643,29 @@ public final class Ints {
     /**
      * Get underflow Int64 value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return underflow Int64 value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Long> getUnderflowInt64Async(Context context) {
+        return getUnderflowInt64WithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get underflow Int64 value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return underflow Int64 value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Long> getUnderflowInt64WithResponse() {
-        return getUnderflowInt64WithResponseAsync().block();
+    public Response<Long> getUnderflowInt64WithResponse(Context context) {
+        return getUnderflowInt64WithResponseAsync(context).block();
     }
 
     /**
@@ -467,7 +677,7 @@ public final class Ints {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public long getUnderflowInt64() {
-        return getUnderflowInt64WithResponse().getValue();
+        return getUnderflowInt64WithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -493,6 +703,26 @@ public final class Ints {
      * Put max int32 value.
      *
      * @param intBody int body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putMax32WithResponseAsync(int intBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putMax32(this.client.getHost(), intBody, accept, context);
+    }
+
+    /**
+     * Put max int32 value.
+     *
+     * @param intBody int body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -507,14 +737,30 @@ public final class Ints {
      * Put max int32 value.
      *
      * @param intBody int body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putMax32Async(int intBody, Context context) {
+        return putMax32WithResponseAsync(intBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put max int32 value.
+     *
+     * @param intBody int body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putMax32WithResponse(int intBody) {
-        return putMax32WithResponseAsync(intBody).block();
+    public Response<Void> putMax32WithResponse(int intBody, Context context) {
+        return putMax32WithResponseAsync(intBody, context).block();
     }
 
     /**
@@ -527,7 +773,7 @@ public final class Ints {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putMax32(int intBody) {
-        putMax32WithResponse(intBody);
+        putMax32WithResponse(intBody, Context.NONE);
     }
 
     /**
@@ -553,6 +799,26 @@ public final class Ints {
      * Put max int64 value.
      *
      * @param intBody int body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putMax64WithResponseAsync(long intBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putMax64(this.client.getHost(), intBody, accept, context);
+    }
+
+    /**
+     * Put max int64 value.
+     *
+     * @param intBody int body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -567,14 +833,30 @@ public final class Ints {
      * Put max int64 value.
      *
      * @param intBody int body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putMax64Async(long intBody, Context context) {
+        return putMax64WithResponseAsync(intBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put max int64 value.
+     *
+     * @param intBody int body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putMax64WithResponse(long intBody) {
-        return putMax64WithResponseAsync(intBody).block();
+    public Response<Void> putMax64WithResponse(long intBody, Context context) {
+        return putMax64WithResponseAsync(intBody, context).block();
     }
 
     /**
@@ -587,7 +869,7 @@ public final class Ints {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putMax64(long intBody) {
-        putMax64WithResponse(intBody);
+        putMax64WithResponse(intBody, Context.NONE);
     }
 
     /**
@@ -613,6 +895,26 @@ public final class Ints {
      * Put min int32 value.
      *
      * @param intBody int body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putMin32WithResponseAsync(int intBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putMin32(this.client.getHost(), intBody, accept, context);
+    }
+
+    /**
+     * Put min int32 value.
+     *
+     * @param intBody int body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -627,14 +929,30 @@ public final class Ints {
      * Put min int32 value.
      *
      * @param intBody int body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putMin32Async(int intBody, Context context) {
+        return putMin32WithResponseAsync(intBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put min int32 value.
+     *
+     * @param intBody int body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putMin32WithResponse(int intBody) {
-        return putMin32WithResponseAsync(intBody).block();
+    public Response<Void> putMin32WithResponse(int intBody, Context context) {
+        return putMin32WithResponseAsync(intBody, context).block();
     }
 
     /**
@@ -647,7 +965,7 @@ public final class Ints {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putMin32(int intBody) {
-        putMin32WithResponse(intBody);
+        putMin32WithResponse(intBody, Context.NONE);
     }
 
     /**
@@ -673,6 +991,26 @@ public final class Ints {
      * Put min int64 value.
      *
      * @param intBody int body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putMin64WithResponseAsync(long intBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putMin64(this.client.getHost(), intBody, accept, context);
+    }
+
+    /**
+     * Put min int64 value.
+     *
+     * @param intBody int body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -687,14 +1025,30 @@ public final class Ints {
      * Put min int64 value.
      *
      * @param intBody int body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putMin64Async(long intBody, Context context) {
+        return putMin64WithResponseAsync(intBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put min int64 value.
+     *
+     * @param intBody int body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putMin64WithResponse(long intBody) {
-        return putMin64WithResponseAsync(intBody).block();
+    public Response<Void> putMin64WithResponse(long intBody, Context context) {
+        return putMin64WithResponseAsync(intBody, context).block();
     }
 
     /**
@@ -707,7 +1061,7 @@ public final class Ints {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putMin64(long intBody) {
-        putMin64WithResponse(intBody);
+        putMin64WithResponse(intBody, Context.NONE);
     }
 
     /**
@@ -730,6 +1084,25 @@ public final class Ints {
     /**
      * Get datetime encoded as Unix time value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return datetime encoded as Unix time value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<OffsetDateTime>> getUnixTimeWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getUnixTime(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get datetime encoded as Unix time value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return datetime encoded as Unix time value on successful completion of {@link Mono}.
@@ -742,13 +1115,29 @@ public final class Ints {
     /**
      * Get datetime encoded as Unix time value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return datetime encoded as Unix time value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<OffsetDateTime> getUnixTimeAsync(Context context) {
+        return getUnixTimeWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get datetime encoded as Unix time value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return datetime encoded as Unix time value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OffsetDateTime> getUnixTimeWithResponse() {
-        return getUnixTimeWithResponseAsync().block();
+    public Response<OffsetDateTime> getUnixTimeWithResponse(Context context) {
+        return getUnixTimeWithResponseAsync(context).block();
     }
 
     /**
@@ -760,7 +1149,7 @@ public final class Ints {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getUnixTime() {
-        return getUnixTimeWithResponse().getValue();
+        return getUnixTimeWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -791,6 +1180,30 @@ public final class Ints {
      * Put datetime encoded as Unix time.
      *
      * @param intBody int body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putUnixTimeDateWithResponseAsync(OffsetDateTime intBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (intBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter intBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        long intBodyConverted = intBody.toEpochSecond();
+        return service.putUnixTimeDate(this.client.getHost(), intBodyConverted, accept, context);
+    }
+
+    /**
+     * Put datetime encoded as Unix time.
+     *
+     * @param intBody int body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -805,14 +1218,30 @@ public final class Ints {
      * Put datetime encoded as Unix time.
      *
      * @param intBody int body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putUnixTimeDateAsync(OffsetDateTime intBody, Context context) {
+        return putUnixTimeDateWithResponseAsync(intBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put datetime encoded as Unix time.
+     *
+     * @param intBody int body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putUnixTimeDateWithResponse(OffsetDateTime intBody) {
-        return putUnixTimeDateWithResponseAsync(intBody).block();
+    public Response<Void> putUnixTimeDateWithResponse(OffsetDateTime intBody, Context context) {
+        return putUnixTimeDateWithResponseAsync(intBody, context).block();
     }
 
     /**
@@ -825,7 +1254,7 @@ public final class Ints {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putUnixTimeDate(OffsetDateTime intBody) {
-        putUnixTimeDateWithResponse(intBody);
+        putUnixTimeDateWithResponse(intBody, Context.NONE);
     }
 
     /**
@@ -848,6 +1277,25 @@ public final class Ints {
     /**
      * Get invalid Unix time value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return invalid Unix time value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<OffsetDateTime>> getInvalidUnixTimeWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getInvalidUnixTime(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get invalid Unix time value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return invalid Unix time value on successful completion of {@link Mono}.
@@ -860,13 +1308,29 @@ public final class Ints {
     /**
      * Get invalid Unix time value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return invalid Unix time value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<OffsetDateTime> getInvalidUnixTimeAsync(Context context) {
+        return getInvalidUnixTimeWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get invalid Unix time value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return invalid Unix time value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OffsetDateTime> getInvalidUnixTimeWithResponse() {
-        return getInvalidUnixTimeWithResponseAsync().block();
+    public Response<OffsetDateTime> getInvalidUnixTimeWithResponse(Context context) {
+        return getInvalidUnixTimeWithResponseAsync(context).block();
     }
 
     /**
@@ -878,7 +1342,7 @@ public final class Ints {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getInvalidUnixTime() {
-        return getInvalidUnixTimeWithResponse().getValue();
+        return getInvalidUnixTimeWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -901,6 +1365,25 @@ public final class Ints {
     /**
      * Get null Unix time value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null Unix time value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<OffsetDateTime>> getNullUnixTimeWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNullUnixTime(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get null Unix time value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null Unix time value on successful completion of {@link Mono}.
@@ -913,13 +1396,29 @@ public final class Ints {
     /**
      * Get null Unix time value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null Unix time value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<OffsetDateTime> getNullUnixTimeAsync(Context context) {
+        return getNullUnixTimeWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get null Unix time value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null Unix time value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OffsetDateTime> getNullUnixTimeWithResponse() {
-        return getNullUnixTimeWithResponseAsync().block();
+    public Response<OffsetDateTime> getNullUnixTimeWithResponse(Context context) {
+        return getNullUnixTimeWithResponseAsync(context).block();
     }
 
     /**
@@ -931,6 +1430,6 @@ public final class Ints {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getNullUnixTime() {
-        return getNullUnixTimeWithResponse().getValue();
+        return getNullUnixTimeWithResponse(Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodynumber/Numbers.java
+++ b/vanilla-tests/src/main/java/fixtures/bodynumber/Numbers.java
@@ -243,6 +243,25 @@ public final class Numbers {
     /**
      * Get null Number value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null Number value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Float>> getNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get null Number value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null Number value on successful completion of {@link Mono}.
@@ -255,13 +274,29 @@ public final class Numbers {
     /**
      * Get null Number value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null Number value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Float> getNullAsync(Context context) {
+        return getNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get null Number value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null Number value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Float> getNullWithResponse() {
-        return getNullWithResponseAsync().block();
+    public Response<Float> getNullWithResponse(Context context) {
+        return getNullWithResponseAsync(context).block();
     }
 
     /**
@@ -273,7 +308,7 @@ public final class Numbers {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public float getNull() {
-        return getNullWithResponse().getValue();
+        return getNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -296,6 +331,25 @@ public final class Numbers {
     /**
      * Get invalid float Number value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return invalid float Number value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Float>> getInvalidFloatWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getInvalidFloat(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get invalid float Number value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return invalid float Number value on successful completion of {@link Mono}.
@@ -308,13 +362,29 @@ public final class Numbers {
     /**
      * Get invalid float Number value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return invalid float Number value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Float> getInvalidFloatAsync(Context context) {
+        return getInvalidFloatWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get invalid float Number value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return invalid float Number value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Float> getInvalidFloatWithResponse() {
-        return getInvalidFloatWithResponseAsync().block();
+    public Response<Float> getInvalidFloatWithResponse(Context context) {
+        return getInvalidFloatWithResponseAsync(context).block();
     }
 
     /**
@@ -326,7 +396,7 @@ public final class Numbers {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public float getInvalidFloat() {
-        return getInvalidFloatWithResponse().getValue();
+        return getInvalidFloatWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -349,6 +419,25 @@ public final class Numbers {
     /**
      * Get invalid double Number value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return invalid double Number value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Double>> getInvalidDoubleWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getInvalidDouble(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get invalid double Number value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return invalid double Number value on successful completion of {@link Mono}.
@@ -361,13 +450,29 @@ public final class Numbers {
     /**
      * Get invalid double Number value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return invalid double Number value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Double> getInvalidDoubleAsync(Context context) {
+        return getInvalidDoubleWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get invalid double Number value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return invalid double Number value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Double> getInvalidDoubleWithResponse() {
-        return getInvalidDoubleWithResponseAsync().block();
+    public Response<Double> getInvalidDoubleWithResponse(Context context) {
+        return getInvalidDoubleWithResponseAsync(context).block();
     }
 
     /**
@@ -379,7 +484,7 @@ public final class Numbers {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public double getInvalidDouble() {
-        return getInvalidDoubleWithResponse().getValue();
+        return getInvalidDoubleWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -402,6 +507,25 @@ public final class Numbers {
     /**
      * Get invalid decimal Number value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return invalid decimal Number value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BigDecimal>> getInvalidDecimalWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getInvalidDecimal(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get invalid decimal Number value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return invalid decimal Number value on successful completion of {@link Mono}.
@@ -414,13 +538,29 @@ public final class Numbers {
     /**
      * Get invalid decimal Number value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return invalid decimal Number value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<BigDecimal> getInvalidDecimalAsync(Context context) {
+        return getInvalidDecimalWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get invalid decimal Number value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return invalid decimal Number value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BigDecimal> getInvalidDecimalWithResponse() {
-        return getInvalidDecimalWithResponseAsync().block();
+    public Response<BigDecimal> getInvalidDecimalWithResponse(Context context) {
+        return getInvalidDecimalWithResponseAsync(context).block();
     }
 
     /**
@@ -432,7 +572,7 @@ public final class Numbers {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public BigDecimal getInvalidDecimal() {
-        return getInvalidDecimalWithResponse().getValue();
+        return getInvalidDecimalWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -458,6 +598,26 @@ public final class Numbers {
      * Put big float value 3.402823e+20.
      *
      * @param numberBody number body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putBigFloatWithResponseAsync(float numberBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putBigFloat(this.client.getHost(), numberBody, accept, context);
+    }
+
+    /**
+     * Put big float value 3.402823e+20.
+     *
+     * @param numberBody number body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -472,14 +632,30 @@ public final class Numbers {
      * Put big float value 3.402823e+20.
      *
      * @param numberBody number body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putBigFloatAsync(float numberBody, Context context) {
+        return putBigFloatWithResponseAsync(numberBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put big float value 3.402823e+20.
+     *
+     * @param numberBody number body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putBigFloatWithResponse(float numberBody) {
-        return putBigFloatWithResponseAsync(numberBody).block();
+    public Response<Void> putBigFloatWithResponse(float numberBody, Context context) {
+        return putBigFloatWithResponseAsync(numberBody, context).block();
     }
 
     /**
@@ -492,7 +668,7 @@ public final class Numbers {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putBigFloat(float numberBody) {
-        putBigFloatWithResponse(numberBody);
+        putBigFloatWithResponse(numberBody, Context.NONE);
     }
 
     /**
@@ -515,6 +691,25 @@ public final class Numbers {
     /**
      * Get big float value 3.402823e+20.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return big float value 3.402823e+20 along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Float>> getBigFloatWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getBigFloat(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get big float value 3.402823e+20.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return big float value 3.402823e+20 on successful completion of {@link Mono}.
@@ -527,13 +722,29 @@ public final class Numbers {
     /**
      * Get big float value 3.402823e+20.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return big float value 3.402823e+20 on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Float> getBigFloatAsync(Context context) {
+        return getBigFloatWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get big float value 3.402823e+20.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return big float value 3.402823e+20 along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Float> getBigFloatWithResponse() {
-        return getBigFloatWithResponseAsync().block();
+    public Response<Float> getBigFloatWithResponse(Context context) {
+        return getBigFloatWithResponseAsync(context).block();
     }
 
     /**
@@ -545,7 +756,7 @@ public final class Numbers {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public float getBigFloat() {
-        return getBigFloatWithResponse().getValue();
+        return getBigFloatWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -572,6 +783,26 @@ public final class Numbers {
      * Put big double value 2.5976931e+101.
      *
      * @param numberBody number body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putBigDoubleWithResponseAsync(double numberBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putBigDouble(this.client.getHost(), numberBody, accept, context);
+    }
+
+    /**
+     * Put big double value 2.5976931e+101.
+     *
+     * @param numberBody number body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -586,14 +817,30 @@ public final class Numbers {
      * Put big double value 2.5976931e+101.
      *
      * @param numberBody number body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putBigDoubleAsync(double numberBody, Context context) {
+        return putBigDoubleWithResponseAsync(numberBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put big double value 2.5976931e+101.
+     *
+     * @param numberBody number body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putBigDoubleWithResponse(double numberBody) {
-        return putBigDoubleWithResponseAsync(numberBody).block();
+    public Response<Void> putBigDoubleWithResponse(double numberBody, Context context) {
+        return putBigDoubleWithResponseAsync(numberBody, context).block();
     }
 
     /**
@@ -606,7 +853,7 @@ public final class Numbers {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putBigDouble(double numberBody) {
-        putBigDoubleWithResponse(numberBody);
+        putBigDoubleWithResponse(numberBody, Context.NONE);
     }
 
     /**
@@ -629,6 +876,25 @@ public final class Numbers {
     /**
      * Get big double value 2.5976931e+101.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return big double value 2.5976931e+101 along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Double>> getBigDoubleWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getBigDouble(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get big double value 2.5976931e+101.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return big double value 2.5976931e+101 on successful completion of {@link Mono}.
@@ -641,13 +907,29 @@ public final class Numbers {
     /**
      * Get big double value 2.5976931e+101.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return big double value 2.5976931e+101 on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Double> getBigDoubleAsync(Context context) {
+        return getBigDoubleWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get big double value 2.5976931e+101.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return big double value 2.5976931e+101 along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Double> getBigDoubleWithResponse() {
-        return getBigDoubleWithResponseAsync().block();
+    public Response<Double> getBigDoubleWithResponse(Context context) {
+        return getBigDoubleWithResponseAsync(context).block();
     }
 
     /**
@@ -659,7 +941,7 @@ public final class Numbers {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public double getBigDouble() {
-        return getBigDoubleWithResponse().getValue();
+        return getBigDoubleWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -684,6 +966,26 @@ public final class Numbers {
     /**
      * Put big double value 99999999.99.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putBigDoublePositiveDecimalWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final double numberBody = 9.999999999E7;
+        final String accept = "application/json";
+        return service.putBigDoublePositiveDecimal(this.client.getHost(), numberBody, accept, context);
+    }
+
+    /**
+     * Put big double value 99999999.99.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -696,13 +998,29 @@ public final class Numbers {
     /**
      * Put big double value 99999999.99.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putBigDoublePositiveDecimalAsync(Context context) {
+        return putBigDoublePositiveDecimalWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put big double value 99999999.99.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putBigDoublePositiveDecimalWithResponse() {
-        return putBigDoublePositiveDecimalWithResponseAsync().block();
+    public Response<Void> putBigDoublePositiveDecimalWithResponse(Context context) {
+        return putBigDoublePositiveDecimalWithResponseAsync(context).block();
     }
 
     /**
@@ -713,7 +1031,7 @@ public final class Numbers {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putBigDoublePositiveDecimal() {
-        putBigDoublePositiveDecimalWithResponse();
+        putBigDoublePositiveDecimalWithResponse(Context.NONE);
     }
 
     /**
@@ -737,6 +1055,25 @@ public final class Numbers {
     /**
      * Get big double value 99999999.99.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return big double value 99999999.99 along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Double>> getBigDoublePositiveDecimalWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getBigDoublePositiveDecimal(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get big double value 99999999.99.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return big double value 99999999.99 on successful completion of {@link Mono}.
@@ -749,13 +1086,29 @@ public final class Numbers {
     /**
      * Get big double value 99999999.99.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return big double value 99999999.99 on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Double> getBigDoublePositiveDecimalAsync(Context context) {
+        return getBigDoublePositiveDecimalWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get big double value 99999999.99.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return big double value 99999999.99 along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Double> getBigDoublePositiveDecimalWithResponse() {
-        return getBigDoublePositiveDecimalWithResponseAsync().block();
+    public Response<Double> getBigDoublePositiveDecimalWithResponse(Context context) {
+        return getBigDoublePositiveDecimalWithResponseAsync(context).block();
     }
 
     /**
@@ -767,7 +1120,7 @@ public final class Numbers {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public double getBigDoublePositiveDecimal() {
-        return getBigDoublePositiveDecimalWithResponse().getValue();
+        return getBigDoublePositiveDecimalWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -792,6 +1145,26 @@ public final class Numbers {
     /**
      * Put big double value -99999999.99.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putBigDoubleNegativeDecimalWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final double numberBody = -9.999999999E7;
+        final String accept = "application/json";
+        return service.putBigDoubleNegativeDecimal(this.client.getHost(), numberBody, accept, context);
+    }
+
+    /**
+     * Put big double value -99999999.99.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -804,13 +1177,29 @@ public final class Numbers {
     /**
      * Put big double value -99999999.99.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putBigDoubleNegativeDecimalAsync(Context context) {
+        return putBigDoubleNegativeDecimalWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put big double value -99999999.99.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putBigDoubleNegativeDecimalWithResponse() {
-        return putBigDoubleNegativeDecimalWithResponseAsync().block();
+    public Response<Void> putBigDoubleNegativeDecimalWithResponse(Context context) {
+        return putBigDoubleNegativeDecimalWithResponseAsync(context).block();
     }
 
     /**
@@ -821,7 +1210,7 @@ public final class Numbers {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putBigDoubleNegativeDecimal() {
-        putBigDoubleNegativeDecimalWithResponse();
+        putBigDoubleNegativeDecimalWithResponse(Context.NONE);
     }
 
     /**
@@ -845,6 +1234,25 @@ public final class Numbers {
     /**
      * Get big double value -99999999.99.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return big double value -99999999.99 along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Double>> getBigDoubleNegativeDecimalWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getBigDoubleNegativeDecimal(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get big double value -99999999.99.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return big double value -99999999.99 on successful completion of {@link Mono}.
@@ -857,13 +1265,29 @@ public final class Numbers {
     /**
      * Get big double value -99999999.99.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return big double value -99999999.99 on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Double> getBigDoubleNegativeDecimalAsync(Context context) {
+        return getBigDoubleNegativeDecimalWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get big double value -99999999.99.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return big double value -99999999.99 along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Double> getBigDoubleNegativeDecimalWithResponse() {
-        return getBigDoubleNegativeDecimalWithResponseAsync().block();
+    public Response<Double> getBigDoubleNegativeDecimalWithResponse(Context context) {
+        return getBigDoubleNegativeDecimalWithResponseAsync(context).block();
     }
 
     /**
@@ -875,7 +1299,7 @@ public final class Numbers {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public double getBigDoubleNegativeDecimal() {
-        return getBigDoubleNegativeDecimalWithResponse().getValue();
+        return getBigDoubleNegativeDecimalWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -905,6 +1329,29 @@ public final class Numbers {
      * Put big decimal value 2.5976931e+101.
      *
      * @param numberBody number body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putBigDecimalWithResponseAsync(BigDecimal numberBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (numberBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter numberBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putBigDecimal(this.client.getHost(), numberBody, accept, context);
+    }
+
+    /**
+     * Put big decimal value 2.5976931e+101.
+     *
+     * @param numberBody number body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -919,14 +1366,30 @@ public final class Numbers {
      * Put big decimal value 2.5976931e+101.
      *
      * @param numberBody number body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putBigDecimalAsync(BigDecimal numberBody, Context context) {
+        return putBigDecimalWithResponseAsync(numberBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put big decimal value 2.5976931e+101.
+     *
+     * @param numberBody number body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putBigDecimalWithResponse(BigDecimal numberBody) {
-        return putBigDecimalWithResponseAsync(numberBody).block();
+    public Response<Void> putBigDecimalWithResponse(BigDecimal numberBody, Context context) {
+        return putBigDecimalWithResponseAsync(numberBody, context).block();
     }
 
     /**
@@ -939,7 +1402,7 @@ public final class Numbers {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putBigDecimal(BigDecimal numberBody) {
-        putBigDecimalWithResponse(numberBody);
+        putBigDecimalWithResponse(numberBody, Context.NONE);
     }
 
     /**
@@ -962,6 +1425,25 @@ public final class Numbers {
     /**
      * Get big decimal value 2.5976931e+101.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return big decimal value 2.5976931e+101 along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BigDecimal>> getBigDecimalWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getBigDecimal(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get big decimal value 2.5976931e+101.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return big decimal value 2.5976931e+101 on successful completion of {@link Mono}.
@@ -974,13 +1456,29 @@ public final class Numbers {
     /**
      * Get big decimal value 2.5976931e+101.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return big decimal value 2.5976931e+101 on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<BigDecimal> getBigDecimalAsync(Context context) {
+        return getBigDecimalWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get big decimal value 2.5976931e+101.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return big decimal value 2.5976931e+101 along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BigDecimal> getBigDecimalWithResponse() {
-        return getBigDecimalWithResponseAsync().block();
+    public Response<BigDecimal> getBigDecimalWithResponse(Context context) {
+        return getBigDecimalWithResponseAsync(context).block();
     }
 
     /**
@@ -992,7 +1490,7 @@ public final class Numbers {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public BigDecimal getBigDecimal() {
-        return getBigDecimalWithResponse().getValue();
+        return getBigDecimalWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1017,6 +1515,26 @@ public final class Numbers {
     /**
      * Put big decimal value 99999999.99.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putBigDecimalPositiveDecimalWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final BigDecimal numberBody = new BigDecimal("9.999999999E7");
+        final String accept = "application/json";
+        return service.putBigDecimalPositiveDecimal(this.client.getHost(), numberBody, accept, context);
+    }
+
+    /**
+     * Put big decimal value 99999999.99.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1029,13 +1547,29 @@ public final class Numbers {
     /**
      * Put big decimal value 99999999.99.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putBigDecimalPositiveDecimalAsync(Context context) {
+        return putBigDecimalPositiveDecimalWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put big decimal value 99999999.99.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putBigDecimalPositiveDecimalWithResponse() {
-        return putBigDecimalPositiveDecimalWithResponseAsync().block();
+    public Response<Void> putBigDecimalPositiveDecimalWithResponse(Context context) {
+        return putBigDecimalPositiveDecimalWithResponseAsync(context).block();
     }
 
     /**
@@ -1046,7 +1580,7 @@ public final class Numbers {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putBigDecimalPositiveDecimal() {
-        putBigDecimalPositiveDecimalWithResponse();
+        putBigDecimalPositiveDecimalWithResponse(Context.NONE);
     }
 
     /**
@@ -1070,6 +1604,25 @@ public final class Numbers {
     /**
      * Get big decimal value 99999999.99.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return big decimal value 99999999.99 along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BigDecimal>> getBigDecimalPositiveDecimalWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getBigDecimalPositiveDecimal(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get big decimal value 99999999.99.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return big decimal value 99999999.99 on successful completion of {@link Mono}.
@@ -1082,13 +1635,29 @@ public final class Numbers {
     /**
      * Get big decimal value 99999999.99.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return big decimal value 99999999.99 on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<BigDecimal> getBigDecimalPositiveDecimalAsync(Context context) {
+        return getBigDecimalPositiveDecimalWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get big decimal value 99999999.99.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return big decimal value 99999999.99 along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BigDecimal> getBigDecimalPositiveDecimalWithResponse() {
-        return getBigDecimalPositiveDecimalWithResponseAsync().block();
+    public Response<BigDecimal> getBigDecimalPositiveDecimalWithResponse(Context context) {
+        return getBigDecimalPositiveDecimalWithResponseAsync(context).block();
     }
 
     /**
@@ -1100,7 +1669,7 @@ public final class Numbers {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public BigDecimal getBigDecimalPositiveDecimal() {
-        return getBigDecimalPositiveDecimalWithResponse().getValue();
+        return getBigDecimalPositiveDecimalWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1125,6 +1694,26 @@ public final class Numbers {
     /**
      * Put big decimal value -99999999.99.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putBigDecimalNegativeDecimalWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final BigDecimal numberBody = new BigDecimal("-9.999999999E7");
+        final String accept = "application/json";
+        return service.putBigDecimalNegativeDecimal(this.client.getHost(), numberBody, accept, context);
+    }
+
+    /**
+     * Put big decimal value -99999999.99.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1137,13 +1726,29 @@ public final class Numbers {
     /**
      * Put big decimal value -99999999.99.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putBigDecimalNegativeDecimalAsync(Context context) {
+        return putBigDecimalNegativeDecimalWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put big decimal value -99999999.99.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putBigDecimalNegativeDecimalWithResponse() {
-        return putBigDecimalNegativeDecimalWithResponseAsync().block();
+    public Response<Void> putBigDecimalNegativeDecimalWithResponse(Context context) {
+        return putBigDecimalNegativeDecimalWithResponseAsync(context).block();
     }
 
     /**
@@ -1154,7 +1759,7 @@ public final class Numbers {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putBigDecimalNegativeDecimal() {
-        putBigDecimalNegativeDecimalWithResponse();
+        putBigDecimalNegativeDecimalWithResponse(Context.NONE);
     }
 
     /**
@@ -1178,6 +1783,25 @@ public final class Numbers {
     /**
      * Get big decimal value -99999999.99.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return big decimal value -99999999.99 along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BigDecimal>> getBigDecimalNegativeDecimalWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getBigDecimalNegativeDecimal(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get big decimal value -99999999.99.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return big decimal value -99999999.99 on successful completion of {@link Mono}.
@@ -1190,13 +1814,29 @@ public final class Numbers {
     /**
      * Get big decimal value -99999999.99.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return big decimal value -99999999.99 on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<BigDecimal> getBigDecimalNegativeDecimalAsync(Context context) {
+        return getBigDecimalNegativeDecimalWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get big decimal value -99999999.99.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return big decimal value -99999999.99 along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BigDecimal> getBigDecimalNegativeDecimalWithResponse() {
-        return getBigDecimalNegativeDecimalWithResponseAsync().block();
+    public Response<BigDecimal> getBigDecimalNegativeDecimalWithResponse(Context context) {
+        return getBigDecimalNegativeDecimalWithResponseAsync(context).block();
     }
 
     /**
@@ -1208,7 +1848,7 @@ public final class Numbers {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public BigDecimal getBigDecimalNegativeDecimal() {
-        return getBigDecimalNegativeDecimalWithResponse().getValue();
+        return getBigDecimalNegativeDecimalWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1235,6 +1875,26 @@ public final class Numbers {
      * Put small float value 3.402823e-20.
      *
      * @param numberBody number body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putSmallFloatWithResponseAsync(float numberBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putSmallFloat(this.client.getHost(), numberBody, accept, context);
+    }
+
+    /**
+     * Put small float value 3.402823e-20.
+     *
+     * @param numberBody number body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1249,14 +1909,30 @@ public final class Numbers {
      * Put small float value 3.402823e-20.
      *
      * @param numberBody number body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putSmallFloatAsync(float numberBody, Context context) {
+        return putSmallFloatWithResponseAsync(numberBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put small float value 3.402823e-20.
+     *
+     * @param numberBody number body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putSmallFloatWithResponse(float numberBody) {
-        return putSmallFloatWithResponseAsync(numberBody).block();
+    public Response<Void> putSmallFloatWithResponse(float numberBody, Context context) {
+        return putSmallFloatWithResponseAsync(numberBody, context).block();
     }
 
     /**
@@ -1269,7 +1945,7 @@ public final class Numbers {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putSmallFloat(float numberBody) {
-        putSmallFloatWithResponse(numberBody);
+        putSmallFloatWithResponse(numberBody, Context.NONE);
     }
 
     /**
@@ -1292,6 +1968,25 @@ public final class Numbers {
     /**
      * Get big double value 3.402823e-20.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return big double value 3.402823e-20 along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Double>> getSmallFloatWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getSmallFloat(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get big double value 3.402823e-20.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return big double value 3.402823e-20 on successful completion of {@link Mono}.
@@ -1304,13 +1999,29 @@ public final class Numbers {
     /**
      * Get big double value 3.402823e-20.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return big double value 3.402823e-20 on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Double> getSmallFloatAsync(Context context) {
+        return getSmallFloatWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get big double value 3.402823e-20.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return big double value 3.402823e-20 along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Double> getSmallFloatWithResponse() {
-        return getSmallFloatWithResponseAsync().block();
+    public Response<Double> getSmallFloatWithResponse(Context context) {
+        return getSmallFloatWithResponseAsync(context).block();
     }
 
     /**
@@ -1322,7 +2033,7 @@ public final class Numbers {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public double getSmallFloat() {
-        return getSmallFloatWithResponse().getValue();
+        return getSmallFloatWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1349,6 +2060,26 @@ public final class Numbers {
      * Put small double value 2.5976931e-101.
      *
      * @param numberBody number body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putSmallDoubleWithResponseAsync(double numberBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putSmallDouble(this.client.getHost(), numberBody, accept, context);
+    }
+
+    /**
+     * Put small double value 2.5976931e-101.
+     *
+     * @param numberBody number body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1363,14 +2094,30 @@ public final class Numbers {
      * Put small double value 2.5976931e-101.
      *
      * @param numberBody number body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putSmallDoubleAsync(double numberBody, Context context) {
+        return putSmallDoubleWithResponseAsync(numberBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put small double value 2.5976931e-101.
+     *
+     * @param numberBody number body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putSmallDoubleWithResponse(double numberBody) {
-        return putSmallDoubleWithResponseAsync(numberBody).block();
+    public Response<Void> putSmallDoubleWithResponse(double numberBody, Context context) {
+        return putSmallDoubleWithResponseAsync(numberBody, context).block();
     }
 
     /**
@@ -1383,7 +2130,7 @@ public final class Numbers {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putSmallDouble(double numberBody) {
-        putSmallDoubleWithResponse(numberBody);
+        putSmallDoubleWithResponse(numberBody, Context.NONE);
     }
 
     /**
@@ -1406,6 +2153,25 @@ public final class Numbers {
     /**
      * Get big double value 2.5976931e-101.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return big double value 2.5976931e-101 along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Double>> getSmallDoubleWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getSmallDouble(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get big double value 2.5976931e-101.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return big double value 2.5976931e-101 on successful completion of {@link Mono}.
@@ -1418,13 +2184,29 @@ public final class Numbers {
     /**
      * Get big double value 2.5976931e-101.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return big double value 2.5976931e-101 on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Double> getSmallDoubleAsync(Context context) {
+        return getSmallDoubleWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get big double value 2.5976931e-101.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return big double value 2.5976931e-101 along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Double> getSmallDoubleWithResponse() {
-        return getSmallDoubleWithResponseAsync().block();
+    public Response<Double> getSmallDoubleWithResponse(Context context) {
+        return getSmallDoubleWithResponseAsync(context).block();
     }
 
     /**
@@ -1436,7 +2218,7 @@ public final class Numbers {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public double getSmallDouble() {
-        return getSmallDoubleWithResponse().getValue();
+        return getSmallDoubleWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1466,6 +2248,29 @@ public final class Numbers {
      * Put small decimal value 2.5976931e-101.
      *
      * @param numberBody number body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putSmallDecimalWithResponseAsync(BigDecimal numberBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (numberBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter numberBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putSmallDecimal(this.client.getHost(), numberBody, accept, context);
+    }
+
+    /**
+     * Put small decimal value 2.5976931e-101.
+     *
+     * @param numberBody number body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1480,14 +2285,30 @@ public final class Numbers {
      * Put small decimal value 2.5976931e-101.
      *
      * @param numberBody number body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putSmallDecimalAsync(BigDecimal numberBody, Context context) {
+        return putSmallDecimalWithResponseAsync(numberBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put small decimal value 2.5976931e-101.
+     *
+     * @param numberBody number body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putSmallDecimalWithResponse(BigDecimal numberBody) {
-        return putSmallDecimalWithResponseAsync(numberBody).block();
+    public Response<Void> putSmallDecimalWithResponse(BigDecimal numberBody, Context context) {
+        return putSmallDecimalWithResponseAsync(numberBody, context).block();
     }
 
     /**
@@ -1500,7 +2321,7 @@ public final class Numbers {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putSmallDecimal(BigDecimal numberBody) {
-        putSmallDecimalWithResponse(numberBody);
+        putSmallDecimalWithResponse(numberBody, Context.NONE);
     }
 
     /**
@@ -1523,6 +2344,25 @@ public final class Numbers {
     /**
      * Get small decimal value 2.5976931e-101.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return small decimal value 2.5976931e-101 along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BigDecimal>> getSmallDecimalWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getSmallDecimal(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get small decimal value 2.5976931e-101.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return small decimal value 2.5976931e-101 on successful completion of {@link Mono}.
@@ -1535,13 +2375,29 @@ public final class Numbers {
     /**
      * Get small decimal value 2.5976931e-101.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return small decimal value 2.5976931e-101 on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<BigDecimal> getSmallDecimalAsync(Context context) {
+        return getSmallDecimalWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get small decimal value 2.5976931e-101.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return small decimal value 2.5976931e-101 along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BigDecimal> getSmallDecimalWithResponse() {
-        return getSmallDecimalWithResponseAsync().block();
+    public Response<BigDecimal> getSmallDecimalWithResponse(Context context) {
+        return getSmallDecimalWithResponseAsync(context).block();
     }
 
     /**
@@ -1553,6 +2409,6 @@ public final class Numbers {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public BigDecimal getSmallDecimal() {
-        return getSmallDecimalWithResponse().getValue();
+        return getSmallDecimalWithResponse(Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodystring/Enums.java
+++ b/vanilla-tests/src/main/java/fixtures/bodystring/Enums.java
@@ -7,6 +7,7 @@ package fixtures.bodystring;
 import com.azure.core.annotation.ReturnType;
 import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.http.rest.Response;
+import com.azure.core.util.Context;
 import fixtures.bodystring.models.Colors;
 import fixtures.bodystring.models.RefColorConstant;
 import reactor.core.publisher.Mono;
@@ -27,6 +28,19 @@ public interface Enums {
     /**
      * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color' along with {@link
+     *     Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Response<Colors>> getNotExpandableWithResponseAsync(Context context);
+
+    /**
+     * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color' on successful
@@ -38,13 +52,28 @@ public interface Enums {
     /**
      * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color' on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Colors> getNotExpandableAsync(Context context);
+
+    /**
+     * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color' along with {@link
      *     Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    Response<Colors> getNotExpandableWithResponse();
+    Response<Colors> getNotExpandableWithResponse(Context context);
 
     /**
      * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
@@ -72,6 +101,19 @@ public interface Enums {
      * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
      * @param stringBody string body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Response<Void>> putNotExpandableWithResponseAsync(Colors stringBody, Context context);
+
+    /**
+     * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @param stringBody string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -84,13 +126,27 @@ public interface Enums {
      * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
      * @param stringBody string body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Void> putNotExpandableAsync(Colors stringBody, Context context);
+
+    /**
+     * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @param stringBody string body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    Response<Void> putNotExpandableWithResponse(Colors stringBody);
+    Response<Void> putNotExpandableWithResponse(Colors stringBody, Context context);
 
     /**
      * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
@@ -117,6 +173,19 @@ public interface Enums {
     /**
      * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color' along with {@link
+     *     Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Response<Colors>> getReferencedWithResponseAsync(Context context);
+
+    /**
+     * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color' on successful
@@ -128,13 +197,28 @@ public interface Enums {
     /**
      * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color' on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Colors> getReferencedAsync(Context context);
+
+    /**
+     * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color' along with {@link
      *     Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    Response<Colors> getReferencedWithResponse();
+    Response<Colors> getReferencedWithResponse(Context context);
 
     /**
      * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
@@ -162,6 +246,19 @@ public interface Enums {
      * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
      * @param enumStringBody enum string body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Response<Void>> putReferencedWithResponseAsync(Colors enumStringBody, Context context);
+
+    /**
+     * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @param enumStringBody enum string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -174,13 +271,27 @@ public interface Enums {
      * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
      * @param enumStringBody enum string body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Void> putReferencedAsync(Colors enumStringBody, Context context);
+
+    /**
+     * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @param enumStringBody enum string body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    Response<Void> putReferencedWithResponse(Colors enumStringBody);
+    Response<Void> putReferencedWithResponse(Colors enumStringBody, Context context);
 
     /**
      * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
@@ -207,6 +318,19 @@ public interface Enums {
     /**
      * Get value 'green-color' from the constant.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return value 'green-color' from the constant along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Response<RefColorConstant>> getReferencedConstantWithResponseAsync(Context context);
+
+    /**
+     * Get value 'green-color' from the constant.
+     *
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return value 'green-color' from the constant on successful completion of {@link Mono}.
@@ -217,12 +341,26 @@ public interface Enums {
     /**
      * Get value 'green-color' from the constant.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return value 'green-color' from the constant on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<RefColorConstant> getReferencedConstantAsync(Context context);
+
+    /**
+     * Get value 'green-color' from the constant.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return value 'green-color' from the constant along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    Response<RefColorConstant> getReferencedConstantWithResponse();
+    Response<RefColorConstant> getReferencedConstantWithResponse(Context context);
 
     /**
      * Get value 'green-color' from the constant.
@@ -250,6 +388,19 @@ public interface Enums {
      * Sends value 'green-color' from a constant.
      *
      * @param enumStringBody enum string body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Response<Void>> putReferencedConstantWithResponseAsync(RefColorConstant enumStringBody, Context context);
+
+    /**
+     * Sends value 'green-color' from a constant.
+     *
+     * @param enumStringBody enum string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -262,13 +413,27 @@ public interface Enums {
      * Sends value 'green-color' from a constant.
      *
      * @param enumStringBody enum string body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Void> putReferencedConstantAsync(RefColorConstant enumStringBody, Context context);
+
+    /**
+     * Sends value 'green-color' from a constant.
+     *
+     * @param enumStringBody enum string body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    Response<Void> putReferencedConstantWithResponse(RefColorConstant enumStringBody);
+    Response<Void> putReferencedConstantWithResponse(RefColorConstant enumStringBody, Context context);
 
     /**
      * Sends value 'green-color' from a constant.

--- a/vanilla-tests/src/main/java/fixtures/bodystring/StringOperations.java
+++ b/vanilla-tests/src/main/java/fixtures/bodystring/StringOperations.java
@@ -7,6 +7,7 @@ package fixtures.bodystring;
 import com.azure.core.annotation.ReturnType;
 import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.http.rest.Response;
+import com.azure.core.util.Context;
 import reactor.core.publisher.Mono;
 
 /** An instance of this class provides access to all the operations defined in StringOperations. */
@@ -24,6 +25,18 @@ public interface StringOperations {
     /**
      * Get null string value value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null string value value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Response<String>> getNullWithResponseAsync(Context context);
+
+    /**
+     * Get null string value value.
+     *
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null string value value on successful completion of {@link Mono}.
@@ -34,12 +47,26 @@ public interface StringOperations {
     /**
      * Get null string value value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null string value value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<String> getNullAsync(Context context);
+
+    /**
+     * Get null string value value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null string value value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    Response<String> getNullWithResponse();
+    Response<String> getNullWithResponse(Context context);
 
     /**
      * Get null string value value.
@@ -67,6 +94,19 @@ public interface StringOperations {
      * Set string value null.
      *
      * @param stringBody string body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Response<Void>> putNullWithResponseAsync(String stringBody, Context context);
+
+    /**
+     * Set string value null.
+     *
+     * @param stringBody string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -89,13 +129,27 @@ public interface StringOperations {
      * Set string value null.
      *
      * @param stringBody string body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Void> putNullAsync(String stringBody, Context context);
+
+    /**
+     * Set string value null.
+     *
+     * @param stringBody string body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    Response<Void> putNullWithResponse(String stringBody);
+    Response<Void> putNullWithResponse(String stringBody, Context context);
 
     /**
      * Set string value null.
@@ -130,6 +184,18 @@ public interface StringOperations {
     /**
      * Get empty string value value ''.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return empty string value value '' along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Response<String>> getEmptyWithResponseAsync(Context context);
+
+    /**
+     * Get empty string value value ''.
+     *
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return empty string value value '' on successful completion of {@link Mono}.
@@ -140,12 +206,26 @@ public interface StringOperations {
     /**
      * Get empty string value value ''.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return empty string value value '' on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<String> getEmptyAsync(Context context);
+
+    /**
+     * Get empty string value value ''.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return empty string value value '' along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    Response<String> getEmptyWithResponse();
+    Response<String> getEmptyWithResponse(Context context);
 
     /**
      * Get empty string value value ''.
@@ -170,6 +250,18 @@ public interface StringOperations {
     /**
      * Set string value empty ''.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Response<Void>> putEmptyWithResponseAsync(Context context);
+
+    /**
+     * Set string value empty ''.
+     *
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -180,12 +272,26 @@ public interface StringOperations {
     /**
      * Set string value empty ''.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Void> putEmptyAsync(Context context);
+
+    /**
+     * Set string value empty ''.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    Response<Void> putEmptyWithResponse();
+    Response<Void> putEmptyWithResponse(Context context);
 
     /**
      * Set string value empty ''.
@@ -210,6 +316,19 @@ public interface StringOperations {
     /**
      * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€' along with
+     *     {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Response<String>> getMbcsWithResponseAsync(Context context);
+
+    /**
+     * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
+     *
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€' on successful
@@ -221,13 +340,28 @@ public interface StringOperations {
     /**
      * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€' on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<String> getMbcsAsync(Context context);
+
+    /**
+     * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€' along with
      *     {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    Response<String> getMbcsWithResponse();
+    Response<String> getMbcsWithResponse(Context context);
 
     /**
      * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
@@ -252,6 +386,18 @@ public interface StringOperations {
     /**
      * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Response<Void>> putMbcsWithResponseAsync(Context context);
+
+    /**
+     * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
+     *
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -262,12 +408,26 @@ public interface StringOperations {
     /**
      * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Void> putMbcsAsync(Context context);
+
+    /**
+     * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    Response<Void> putMbcsWithResponse();
+    Response<Void> putMbcsWithResponse(Context context);
 
     /**
      * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
@@ -295,6 +455,21 @@ public interface StringOperations {
      * Get string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
      * all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time
+     *     for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;' along with {@link
+     *     Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Response<String>> getWhitespaceWithResponseAsync(Context context);
+
+    /**
+     * Get string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
+     * all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     *
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time
@@ -308,6 +483,23 @@ public interface StringOperations {
      * Get string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
      * all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time
+     *     for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;' on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<String> getWhitespaceAsync(Context context);
+
+    /**
+     * Get string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
+     * all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time
@@ -315,7 +507,7 @@ public interface StringOperations {
      *     Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    Response<String> getWhitespaceWithResponse();
+    Response<String> getWhitespaceWithResponse(Context context);
 
     /**
      * Get string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
@@ -344,6 +536,19 @@ public interface StringOperations {
      * Set String value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
      * all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Response<Void>> putWhitespaceWithResponseAsync(Context context);
+
+    /**
+     * Set String value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
+     * all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     *
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -355,12 +560,27 @@ public interface StringOperations {
      * Set String value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
      * all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Void> putWhitespaceAsync(Context context);
+
+    /**
+     * Set String value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
+     * all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    Response<Void> putWhitespaceWithResponse();
+    Response<Void> putWhitespaceWithResponse(Context context);
 
     /**
      * Set String value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
@@ -386,6 +606,19 @@ public interface StringOperations {
     /**
      * Get String value when no string value is sent in response payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return string value when no string value is sent in response payload along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Response<String>> getNotProvidedWithResponseAsync(Context context);
+
+    /**
+     * Get String value when no string value is sent in response payload.
+     *
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string value when no string value is sent in response payload on successful completion of {@link Mono}.
@@ -396,12 +629,26 @@ public interface StringOperations {
     /**
      * Get String value when no string value is sent in response payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return string value when no string value is sent in response payload on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<String> getNotProvidedAsync(Context context);
+
+    /**
+     * Get String value when no string value is sent in response payload.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string value when no string value is sent in response payload along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    Response<String> getNotProvidedWithResponse();
+    Response<String> getNotProvidedWithResponse(Context context);
 
     /**
      * Get String value when no string value is sent in response payload.
@@ -426,6 +673,18 @@ public interface StringOperations {
     /**
      * Get value that is base64 encoded.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return value that is base64 encoded along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Response<byte[]>> getBase64EncodedWithResponseAsync(Context context);
+
+    /**
+     * Get value that is base64 encoded.
+     *
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return value that is base64 encoded on successful completion of {@link Mono}.
@@ -436,12 +695,26 @@ public interface StringOperations {
     /**
      * Get value that is base64 encoded.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return value that is base64 encoded on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<byte[]> getBase64EncodedAsync(Context context);
+
+    /**
+     * Get value that is base64 encoded.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return value that is base64 encoded along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    Response<byte[]> getBase64EncodedWithResponse();
+    Response<byte[]> getBase64EncodedWithResponse(Context context);
 
     /**
      * Get value that is base64 encoded.
@@ -466,6 +739,18 @@ public interface StringOperations {
     /**
      * Get value that is base64url encoded.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return value that is base64url encoded along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Response<byte[]>> getBase64UrlEncodedWithResponseAsync(Context context);
+
+    /**
+     * Get value that is base64url encoded.
+     *
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return value that is base64url encoded on successful completion of {@link Mono}.
@@ -476,12 +761,26 @@ public interface StringOperations {
     /**
      * Get value that is base64url encoded.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return value that is base64url encoded on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<byte[]> getBase64UrlEncodedAsync(Context context);
+
+    /**
+     * Get value that is base64url encoded.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return value that is base64url encoded along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    Response<byte[]> getBase64UrlEncodedWithResponse();
+    Response<byte[]> getBase64UrlEncodedWithResponse(Context context);
 
     /**
      * Get value that is base64url encoded.
@@ -509,6 +808,19 @@ public interface StringOperations {
      * Put value that is base64url encoded.
      *
      * @param stringBody string body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Response<Void>> putBase64UrlEncodedWithResponseAsync(byte[] stringBody, Context context);
+
+    /**
+     * Put value that is base64url encoded.
+     *
+     * @param stringBody string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -521,13 +833,27 @@ public interface StringOperations {
      * Put value that is base64url encoded.
      *
      * @param stringBody string body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Void> putBase64UrlEncodedAsync(byte[] stringBody, Context context);
+
+    /**
+     * Put value that is base64url encoded.
+     *
+     * @param stringBody string body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    Response<Void> putBase64UrlEncodedWithResponse(byte[] stringBody);
+    Response<Void> putBase64UrlEncodedWithResponse(byte[] stringBody, Context context);
 
     /**
      * Put value that is base64url encoded.
@@ -554,6 +880,19 @@ public interface StringOperations {
     /**
      * Get null value that is expected to be base64url encoded.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null value that is expected to be base64url encoded along with {@link Response} on successful completion
+     *     of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<Response<byte[]>> getNullBase64UrlEncodedWithResponseAsync(Context context);
+
+    /**
+     * Get null value that is expected to be base64url encoded.
+     *
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null value that is expected to be base64url encoded on successful completion of {@link Mono}.
@@ -564,12 +903,26 @@ public interface StringOperations {
     /**
      * Get null value that is expected to be base64url encoded.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null value that is expected to be base64url encoded on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    Mono<byte[]> getNullBase64UrlEncodedAsync(Context context);
+
+    /**
+     * Get null value that is expected to be base64url encoded.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null value that is expected to be base64url encoded along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    Response<byte[]> getNullBase64UrlEncodedWithResponse();
+    Response<byte[]> getNullBase64UrlEncodedWithResponse(Context context);
 
     /**
      * Get null value that is expected to be base64url encoded.

--- a/vanilla-tests/src/main/java/fixtures/bodystring/implementation/EnumsImpl.java
+++ b/vanilla-tests/src/main/java/fixtures/bodystring/implementation/EnumsImpl.java
@@ -117,6 +117,26 @@ public final class EnumsImpl implements Enums {
     /**
      * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color' along with {@link
+     *     Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Colors>> getNotExpandableWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNotExpandable(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color' on successful
@@ -130,14 +150,31 @@ public final class EnumsImpl implements Enums {
     /**
      * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color' on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Colors> getNotExpandableAsync(Context context) {
+        return getNotExpandableWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color' along with {@link
      *     Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Colors> getNotExpandableWithResponse() {
-        return getNotExpandableWithResponseAsync().block();
+    public Response<Colors> getNotExpandableWithResponse(Context context) {
+        return getNotExpandableWithResponseAsync(context).block();
     }
 
     /**
@@ -149,7 +186,7 @@ public final class EnumsImpl implements Enums {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Colors getNotExpandable() {
-        return getNotExpandableWithResponse().getValue();
+        return getNotExpandableWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -179,6 +216,29 @@ public final class EnumsImpl implements Enums {
      * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
      * @param stringBody string body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putNotExpandableWithResponseAsync(Colors stringBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (stringBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter stringBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putNotExpandable(this.client.getHost(), stringBody, accept, context);
+    }
+
+    /**
+     * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @param stringBody string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -193,14 +253,30 @@ public final class EnumsImpl implements Enums {
      * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
      * @param stringBody string body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putNotExpandableAsync(Colors stringBody, Context context) {
+        return putNotExpandableWithResponseAsync(stringBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @param stringBody string body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putNotExpandableWithResponse(Colors stringBody) {
-        return putNotExpandableWithResponseAsync(stringBody).block();
+    public Response<Void> putNotExpandableWithResponse(Colors stringBody, Context context) {
+        return putNotExpandableWithResponseAsync(stringBody, context).block();
     }
 
     /**
@@ -213,7 +289,7 @@ public final class EnumsImpl implements Enums {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putNotExpandable(Colors stringBody) {
-        putNotExpandableWithResponse(stringBody);
+        putNotExpandableWithResponse(stringBody, Context.NONE);
     }
 
     /**
@@ -237,6 +313,26 @@ public final class EnumsImpl implements Enums {
     /**
      * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color' along with {@link
+     *     Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Colors>> getReferencedWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getReferenced(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color' on successful
@@ -250,14 +346,31 @@ public final class EnumsImpl implements Enums {
     /**
      * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color' on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Colors> getReferencedAsync(Context context) {
+        return getReferencedWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color' along with {@link
      *     Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Colors> getReferencedWithResponse() {
-        return getReferencedWithResponseAsync().block();
+    public Response<Colors> getReferencedWithResponse(Context context) {
+        return getReferencedWithResponseAsync(context).block();
     }
 
     /**
@@ -269,7 +382,7 @@ public final class EnumsImpl implements Enums {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Colors getReferenced() {
-        return getReferencedWithResponse().getValue();
+        return getReferencedWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -299,6 +412,29 @@ public final class EnumsImpl implements Enums {
      * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
      * @param enumStringBody enum string body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putReferencedWithResponseAsync(Colors enumStringBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (enumStringBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter enumStringBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putReferenced(this.client.getHost(), enumStringBody, accept, context);
+    }
+
+    /**
+     * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @param enumStringBody enum string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -313,14 +449,30 @@ public final class EnumsImpl implements Enums {
      * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
      * @param enumStringBody enum string body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putReferencedAsync(Colors enumStringBody, Context context) {
+        return putReferencedWithResponseAsync(enumStringBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @param enumStringBody enum string body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putReferencedWithResponse(Colors enumStringBody) {
-        return putReferencedWithResponseAsync(enumStringBody).block();
+    public Response<Void> putReferencedWithResponse(Colors enumStringBody, Context context) {
+        return putReferencedWithResponseAsync(enumStringBody, context).block();
     }
 
     /**
@@ -333,7 +485,7 @@ public final class EnumsImpl implements Enums {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putReferenced(Colors enumStringBody) {
-        putReferencedWithResponse(enumStringBody);
+        putReferencedWithResponse(enumStringBody, Context.NONE);
     }
 
     /**
@@ -357,6 +509,26 @@ public final class EnumsImpl implements Enums {
     /**
      * Get value 'green-color' from the constant.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return value 'green-color' from the constant along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<RefColorConstant>> getReferencedConstantWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getReferencedConstant(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get value 'green-color' from the constant.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return value 'green-color' from the constant on successful completion of {@link Mono}.
@@ -369,13 +541,29 @@ public final class EnumsImpl implements Enums {
     /**
      * Get value 'green-color' from the constant.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return value 'green-color' from the constant on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<RefColorConstant> getReferencedConstantAsync(Context context) {
+        return getReferencedConstantWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get value 'green-color' from the constant.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return value 'green-color' from the constant along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<RefColorConstant> getReferencedConstantWithResponse() {
-        return getReferencedConstantWithResponseAsync().block();
+    public Response<RefColorConstant> getReferencedConstantWithResponse(Context context) {
+        return getReferencedConstantWithResponseAsync(context).block();
     }
 
     /**
@@ -387,7 +575,7 @@ public final class EnumsImpl implements Enums {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public RefColorConstant getReferencedConstant() {
-        return getReferencedConstantWithResponse().getValue();
+        return getReferencedConstantWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -419,6 +607,32 @@ public final class EnumsImpl implements Enums {
      * Sends value 'green-color' from a constant.
      *
      * @param enumStringBody enum string body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putReferencedConstantWithResponseAsync(
+            RefColorConstant enumStringBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (enumStringBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter enumStringBody is required and cannot be null."));
+        } else {
+            enumStringBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putReferencedConstant(this.client.getHost(), enumStringBody, accept, context);
+    }
+
+    /**
+     * Sends value 'green-color' from a constant.
+     *
+     * @param enumStringBody enum string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -433,14 +647,30 @@ public final class EnumsImpl implements Enums {
      * Sends value 'green-color' from a constant.
      *
      * @param enumStringBody enum string body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putReferencedConstantAsync(RefColorConstant enumStringBody, Context context) {
+        return putReferencedConstantWithResponseAsync(enumStringBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Sends value 'green-color' from a constant.
+     *
+     * @param enumStringBody enum string body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putReferencedConstantWithResponse(RefColorConstant enumStringBody) {
-        return putReferencedConstantWithResponseAsync(enumStringBody).block();
+    public Response<Void> putReferencedConstantWithResponse(RefColorConstant enumStringBody, Context context) {
+        return putReferencedConstantWithResponseAsync(enumStringBody, context).block();
     }
 
     /**
@@ -453,6 +683,6 @@ public final class EnumsImpl implements Enums {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putReferencedConstant(RefColorConstant enumStringBody) {
-        putReferencedConstantWithResponse(enumStringBody);
+        putReferencedConstantWithResponse(enumStringBody, Context.NONE);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodystring/implementation/StringOperationsImpl.java
+++ b/vanilla-tests/src/main/java/fixtures/bodystring/implementation/StringOperationsImpl.java
@@ -168,6 +168,25 @@ public final class StringOperationsImpl implements StringOperations {
     /**
      * Get null string value value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null string value value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> getNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get null string value value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null string value value on successful completion of {@link Mono}.
@@ -180,13 +199,29 @@ public final class StringOperationsImpl implements StringOperations {
     /**
      * Get null string value value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null string value value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> getNullAsync(Context context) {
+        return getNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get null string value value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null string value value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> getNullWithResponse() {
-        return getNullWithResponseAsync().block();
+    public Response<String> getNullWithResponse(Context context) {
+        return getNullWithResponseAsync(context).block();
     }
 
     /**
@@ -198,7 +233,7 @@ public final class StringOperationsImpl implements StringOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String getNull() {
-        return getNullWithResponse().getValue();
+        return getNullWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -218,6 +253,26 @@ public final class StringOperationsImpl implements StringOperations {
         }
         final String accept = "application/json";
         return FluxUtil.withContext(context -> service.putNull(this.client.getHost(), stringBody, accept, context));
+    }
+
+    /**
+     * Set string value null.
+     *
+     * @param stringBody string body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putNullWithResponseAsync(String stringBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putNull(this.client.getHost(), stringBody, accept, context);
     }
 
     /**
@@ -251,14 +306,30 @@ public final class StringOperationsImpl implements StringOperations {
      * Set string value null.
      *
      * @param stringBody string body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putNullAsync(String stringBody, Context context) {
+        return putNullWithResponseAsync(stringBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set string value null.
+     *
+     * @param stringBody string body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putNullWithResponse(String stringBody) {
-        return putNullWithResponseAsync(stringBody).block();
+    public Response<Void> putNullWithResponse(String stringBody, Context context) {
+        return putNullWithResponseAsync(stringBody, context).block();
     }
 
     /**
@@ -271,7 +342,7 @@ public final class StringOperationsImpl implements StringOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putNull(String stringBody) {
-        putNullWithResponse(stringBody);
+        putNullWithResponse(stringBody, Context.NONE);
     }
 
     /**
@@ -283,7 +354,7 @@ public final class StringOperationsImpl implements StringOperations {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putNull() {
         final String stringBody = null;
-        putNullWithResponse(stringBody);
+        putNullWithResponse(stringBody, Context.NONE);
     }
 
     /**
@@ -306,6 +377,25 @@ public final class StringOperationsImpl implements StringOperations {
     /**
      * Get empty string value value ''.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return empty string value value '' along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> getEmptyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getEmpty(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get empty string value value ''.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return empty string value value '' on successful completion of {@link Mono}.
@@ -318,13 +408,29 @@ public final class StringOperationsImpl implements StringOperations {
     /**
      * Get empty string value value ''.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return empty string value value '' on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> getEmptyAsync(Context context) {
+        return getEmptyWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get empty string value value ''.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return empty string value value '' along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> getEmptyWithResponse() {
-        return getEmptyWithResponseAsync().block();
+    public Response<String> getEmptyWithResponse(Context context) {
+        return getEmptyWithResponseAsync(context).block();
     }
 
     /**
@@ -336,7 +442,7 @@ public final class StringOperationsImpl implements StringOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String getEmpty() {
-        return getEmptyWithResponse().getValue();
+        return getEmptyWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -360,6 +466,26 @@ public final class StringOperationsImpl implements StringOperations {
     /**
      * Set string value empty ''.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putEmptyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String stringBody = "";
+        final String accept = "application/json";
+        return service.putEmpty(this.client.getHost(), stringBody, accept, context);
+    }
+
+    /**
+     * Set string value empty ''.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -372,13 +498,29 @@ public final class StringOperationsImpl implements StringOperations {
     /**
      * Set string value empty ''.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putEmptyAsync(Context context) {
+        return putEmptyWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set string value empty ''.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putEmptyWithResponse() {
-        return putEmptyWithResponseAsync().block();
+    public Response<Void> putEmptyWithResponse(Context context) {
+        return putEmptyWithResponseAsync(context).block();
     }
 
     /**
@@ -389,7 +531,7 @@ public final class StringOperationsImpl implements StringOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putEmpty() {
-        putEmptyWithResponse();
+        putEmptyWithResponse(Context.NONE);
     }
 
     /**
@@ -413,6 +555,26 @@ public final class StringOperationsImpl implements StringOperations {
     /**
      * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€' along with
+     *     {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> getMbcsWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getMbcs(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€' on successful
@@ -426,14 +588,31 @@ public final class StringOperationsImpl implements StringOperations {
     /**
      * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€' on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> getMbcsAsync(Context context) {
+        return getMbcsWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€' along with
      *     {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> getMbcsWithResponse() {
-        return getMbcsWithResponseAsync().block();
+    public Response<String> getMbcsWithResponse(Context context) {
+        return getMbcsWithResponseAsync(context).block();
     }
 
     /**
@@ -445,7 +624,7 @@ public final class StringOperationsImpl implements StringOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String getMbcs() {
-        return getMbcsWithResponse().getValue();
+        return getMbcsWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -469,6 +648,26 @@ public final class StringOperationsImpl implements StringOperations {
     /**
      * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putMbcsWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String stringBody = "啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€";
+        final String accept = "application/json";
+        return service.putMbcs(this.client.getHost(), stringBody, accept, context);
+    }
+
+    /**
+     * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -481,13 +680,29 @@ public final class StringOperationsImpl implements StringOperations {
     /**
      * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putMbcsAsync(Context context) {
+        return putMbcsWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putMbcsWithResponse() {
-        return putMbcsWithResponseAsync().block();
+    public Response<Void> putMbcsWithResponse(Context context) {
+        return putMbcsWithResponseAsync(context).block();
     }
 
     /**
@@ -498,7 +713,7 @@ public final class StringOperationsImpl implements StringOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putMbcs() {
-        putMbcsWithResponse();
+        putMbcsWithResponse(Context.NONE);
     }
 
     /**
@@ -525,6 +740,28 @@ public final class StringOperationsImpl implements StringOperations {
      * Get string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
      * all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time
+     *     for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;' along with {@link
+     *     Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> getWhitespaceWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getWhitespace(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
+     * all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time
@@ -540,6 +777,25 @@ public final class StringOperationsImpl implements StringOperations {
      * Get string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
      * all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time
+     *     for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;' on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> getWhitespaceAsync(Context context) {
+        return getWhitespaceWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
+     * all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time
@@ -547,8 +803,8 @@ public final class StringOperationsImpl implements StringOperations {
      *     Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> getWhitespaceWithResponse() {
-        return getWhitespaceWithResponseAsync().block();
+    public Response<String> getWhitespaceWithResponse(Context context) {
+        return getWhitespaceWithResponseAsync(context).block();
     }
 
     /**
@@ -562,7 +818,7 @@ public final class StringOperationsImpl implements StringOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String getWhitespace() {
-        return getWhitespaceWithResponse().getValue();
+        return getWhitespaceWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -589,6 +845,27 @@ public final class StringOperationsImpl implements StringOperations {
      * Set String value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
      * all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putWhitespaceWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String stringBody = "    Now is the time for all good men to come to the aid of their country    ";
+        final String accept = "application/json";
+        return service.putWhitespace(this.client.getHost(), stringBody, accept, context);
+    }
+
+    /**
+     * Set String value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
+     * all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -602,13 +879,30 @@ public final class StringOperationsImpl implements StringOperations {
      * Set String value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
      * all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putWhitespaceAsync(Context context) {
+        return putWhitespaceWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Set String value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
+     * all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putWhitespaceWithResponse() {
-        return putWhitespaceWithResponseAsync().block();
+    public Response<Void> putWhitespaceWithResponse(Context context) {
+        return putWhitespaceWithResponseAsync(context).block();
     }
 
     /**
@@ -620,7 +914,7 @@ public final class StringOperationsImpl implements StringOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putWhitespace() {
-        putWhitespaceWithResponse();
+        putWhitespaceWithResponse(Context.NONE);
     }
 
     /**
@@ -644,6 +938,26 @@ public final class StringOperationsImpl implements StringOperations {
     /**
      * Get String value when no string value is sent in response payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return string value when no string value is sent in response payload along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> getNotProvidedWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNotProvided(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get String value when no string value is sent in response payload.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string value when no string value is sent in response payload on successful completion of {@link Mono}.
@@ -656,13 +970,29 @@ public final class StringOperationsImpl implements StringOperations {
     /**
      * Get String value when no string value is sent in response payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return string value when no string value is sent in response payload on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> getNotProvidedAsync(Context context) {
+        return getNotProvidedWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get String value when no string value is sent in response payload.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string value when no string value is sent in response payload along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> getNotProvidedWithResponse() {
-        return getNotProvidedWithResponseAsync().block();
+    public Response<String> getNotProvidedWithResponse(Context context) {
+        return getNotProvidedWithResponseAsync(context).block();
     }
 
     /**
@@ -674,7 +1004,7 @@ public final class StringOperationsImpl implements StringOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String getNotProvided() {
-        return getNotProvidedWithResponse().getValue();
+        return getNotProvidedWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -697,6 +1027,25 @@ public final class StringOperationsImpl implements StringOperations {
     /**
      * Get value that is base64 encoded.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return value that is base64 encoded along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<byte[]>> getBase64EncodedWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getBase64Encoded(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get value that is base64 encoded.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return value that is base64 encoded on successful completion of {@link Mono}.
@@ -709,13 +1058,29 @@ public final class StringOperationsImpl implements StringOperations {
     /**
      * Get value that is base64 encoded.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return value that is base64 encoded on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<byte[]> getBase64EncodedAsync(Context context) {
+        return getBase64EncodedWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get value that is base64 encoded.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return value that is base64 encoded along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<byte[]> getBase64EncodedWithResponse() {
-        return getBase64EncodedWithResponseAsync().block();
+    public Response<byte[]> getBase64EncodedWithResponse(Context context) {
+        return getBase64EncodedWithResponseAsync(context).block();
     }
 
     /**
@@ -727,7 +1092,7 @@ public final class StringOperationsImpl implements StringOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public byte[] getBase64Encoded() {
-        return getBase64EncodedWithResponse().getValue();
+        return getBase64EncodedWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -750,6 +1115,25 @@ public final class StringOperationsImpl implements StringOperations {
     /**
      * Get value that is base64url encoded.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return value that is base64url encoded along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<byte[]>> getBase64UrlEncodedWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getBase64UrlEncoded(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get value that is base64url encoded.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return value that is base64url encoded on successful completion of {@link Mono}.
@@ -762,13 +1146,29 @@ public final class StringOperationsImpl implements StringOperations {
     /**
      * Get value that is base64url encoded.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return value that is base64url encoded on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<byte[]> getBase64UrlEncodedAsync(Context context) {
+        return getBase64UrlEncodedWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get value that is base64url encoded.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return value that is base64url encoded along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<byte[]> getBase64UrlEncodedWithResponse() {
-        return getBase64UrlEncodedWithResponseAsync().block();
+    public Response<byte[]> getBase64UrlEncodedWithResponse(Context context) {
+        return getBase64UrlEncodedWithResponseAsync(context).block();
     }
 
     /**
@@ -780,7 +1180,7 @@ public final class StringOperationsImpl implements StringOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public byte[] getBase64UrlEncoded() {
-        return getBase64UrlEncodedWithResponse().getValue();
+        return getBase64UrlEncodedWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -811,6 +1211,30 @@ public final class StringOperationsImpl implements StringOperations {
      * Put value that is base64url encoded.
      *
      * @param stringBody string body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putBase64UrlEncodedWithResponseAsync(byte[] stringBody, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (stringBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter stringBody is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        Base64Url stringBodyConverted = Base64Url.encode(stringBody);
+        return service.putBase64UrlEncoded(this.client.getHost(), stringBodyConverted, accept, context);
+    }
+
+    /**
+     * Put value that is base64url encoded.
+     *
+     * @param stringBody string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -825,14 +1249,30 @@ public final class StringOperationsImpl implements StringOperations {
      * Put value that is base64url encoded.
      *
      * @param stringBody string body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putBase64UrlEncodedAsync(byte[] stringBody, Context context) {
+        return putBase64UrlEncodedWithResponseAsync(stringBody, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put value that is base64url encoded.
+     *
+     * @param stringBody string body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putBase64UrlEncodedWithResponse(byte[] stringBody) {
-        return putBase64UrlEncodedWithResponseAsync(stringBody).block();
+    public Response<Void> putBase64UrlEncodedWithResponse(byte[] stringBody, Context context) {
+        return putBase64UrlEncodedWithResponseAsync(stringBody, context).block();
     }
 
     /**
@@ -845,7 +1285,7 @@ public final class StringOperationsImpl implements StringOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putBase64UrlEncoded(byte[] stringBody) {
-        putBase64UrlEncodedWithResponse(stringBody);
+        putBase64UrlEncodedWithResponse(stringBody, Context.NONE);
     }
 
     /**
@@ -869,6 +1309,26 @@ public final class StringOperationsImpl implements StringOperations {
     /**
      * Get null value that is expected to be base64url encoded.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null value that is expected to be base64url encoded along with {@link Response} on successful completion
+     *     of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<byte[]>> getNullBase64UrlEncodedWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNullBase64UrlEncoded(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get null value that is expected to be base64url encoded.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null value that is expected to be base64url encoded on successful completion of {@link Mono}.
@@ -881,13 +1341,29 @@ public final class StringOperationsImpl implements StringOperations {
     /**
      * Get null value that is expected to be base64url encoded.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null value that is expected to be base64url encoded on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<byte[]> getNullBase64UrlEncodedAsync(Context context) {
+        return getNullBase64UrlEncodedWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get null value that is expected to be base64url encoded.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null value that is expected to be base64url encoded along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<byte[]> getNullBase64UrlEncodedWithResponse() {
-        return getNullBase64UrlEncodedWithResponseAsync().block();
+    public Response<byte[]> getNullBase64UrlEncodedWithResponse(Context context) {
+        return getNullBase64UrlEncodedWithResponseAsync(context).block();
     }
 
     /**
@@ -899,6 +1375,6 @@ public final class StringOperationsImpl implements StringOperations {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public byte[] getNullBase64UrlEncoded() {
-        return getNullBase64UrlEncodedWithResponse().getValue();
+        return getNullBase64UrlEncodedWithResponse(Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/constants/Contants.java
+++ b/vanilla-tests/src/main/java/fixtures/constants/Contants.java
@@ -215,6 +215,26 @@ public final class Contants {
      * Puts constants to the testserver.
      *
      * @param input The input parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putNoModelAsStringNoRequiredTwoValueNoDefaultWithResponseAsync(
+            NoModelAsStringNoRequiredTwoValueNoDefaultOpEnum input, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.putNoModelAsStringNoRequiredTwoValueNoDefault(this.client.getHost(), input, context);
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
+     * @param input The input parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -243,6 +263,24 @@ public final class Contants {
      * Puts constants to the testserver.
      *
      * @param input The input parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putNoModelAsStringNoRequiredTwoValueNoDefaultAsync(
+            NoModelAsStringNoRequiredTwoValueNoDefaultOpEnum input, Context context) {
+        return putNoModelAsStringNoRequiredTwoValueNoDefaultWithResponseAsync(input, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
+     * @param input The input parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -250,8 +288,8 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> putNoModelAsStringNoRequiredTwoValueNoDefaultWithResponse(
-            NoModelAsStringNoRequiredTwoValueNoDefaultOpEnum input) {
-        return putNoModelAsStringNoRequiredTwoValueNoDefaultWithResponseAsync(input).block();
+            NoModelAsStringNoRequiredTwoValueNoDefaultOpEnum input, Context context) {
+        return putNoModelAsStringNoRequiredTwoValueNoDefaultWithResponseAsync(input, context).block();
     }
 
     /**
@@ -264,7 +302,7 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putNoModelAsStringNoRequiredTwoValueNoDefault(NoModelAsStringNoRequiredTwoValueNoDefaultOpEnum input) {
-        putNoModelAsStringNoRequiredTwoValueNoDefaultWithResponse(input);
+        putNoModelAsStringNoRequiredTwoValueNoDefaultWithResponse(input, Context.NONE);
     }
 
     /**
@@ -276,7 +314,7 @@ public final class Contants {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putNoModelAsStringNoRequiredTwoValueNoDefault() {
         final NoModelAsStringNoRequiredTwoValueNoDefaultOpEnum input = null;
-        putNoModelAsStringNoRequiredTwoValueNoDefaultWithResponse(input);
+        putNoModelAsStringNoRequiredTwoValueNoDefaultWithResponse(input, Context.NONE);
     }
 
     /**
@@ -297,6 +335,26 @@ public final class Contants {
         }
         return FluxUtil.withContext(
                 context -> service.putNoModelAsStringNoRequiredTwoValueDefault(this.client.getHost(), input, context));
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
+     * @param input The input parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putNoModelAsStringNoRequiredTwoValueDefaultWithResponseAsync(
+            NoModelAsStringNoRequiredTwoValueDefaultOpEnum input, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.putNoModelAsStringNoRequiredTwoValueDefault(this.client.getHost(), input, context);
     }
 
     /**
@@ -331,6 +389,24 @@ public final class Contants {
      * Puts constants to the testserver.
      *
      * @param input The input parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putNoModelAsStringNoRequiredTwoValueDefaultAsync(
+            NoModelAsStringNoRequiredTwoValueDefaultOpEnum input, Context context) {
+        return putNoModelAsStringNoRequiredTwoValueDefaultWithResponseAsync(input, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
+     * @param input The input parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -338,8 +414,8 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> putNoModelAsStringNoRequiredTwoValueDefaultWithResponse(
-            NoModelAsStringNoRequiredTwoValueDefaultOpEnum input) {
-        return putNoModelAsStringNoRequiredTwoValueDefaultWithResponseAsync(input).block();
+            NoModelAsStringNoRequiredTwoValueDefaultOpEnum input, Context context) {
+        return putNoModelAsStringNoRequiredTwoValueDefaultWithResponseAsync(input, context).block();
     }
 
     /**
@@ -352,7 +428,7 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putNoModelAsStringNoRequiredTwoValueDefault(NoModelAsStringNoRequiredTwoValueDefaultOpEnum input) {
-        putNoModelAsStringNoRequiredTwoValueDefaultWithResponse(input);
+        putNoModelAsStringNoRequiredTwoValueDefaultWithResponse(input, Context.NONE);
     }
 
     /**
@@ -364,7 +440,7 @@ public final class Contants {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putNoModelAsStringNoRequiredTwoValueDefault() {
         final NoModelAsStringNoRequiredTwoValueDefaultOpEnum input = null;
-        putNoModelAsStringNoRequiredTwoValueDefaultWithResponse(input);
+        putNoModelAsStringNoRequiredTwoValueDefaultWithResponse(input, Context.NONE);
     }
 
     /**
@@ -389,6 +465,25 @@ public final class Contants {
     /**
      * Puts constants to the testserver.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putNoModelAsStringNoRequiredOneValueNoDefaultWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String input = "value1";
+        return service.putNoModelAsStringNoRequiredOneValueNoDefault(this.client.getHost(), input, context);
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -401,13 +496,29 @@ public final class Contants {
     /**
      * Puts constants to the testserver.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putNoModelAsStringNoRequiredOneValueNoDefaultAsync(Context context) {
+        return putNoModelAsStringNoRequiredOneValueNoDefaultWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putNoModelAsStringNoRequiredOneValueNoDefaultWithResponse() {
-        return putNoModelAsStringNoRequiredOneValueNoDefaultWithResponseAsync().block();
+    public Response<Void> putNoModelAsStringNoRequiredOneValueNoDefaultWithResponse(Context context) {
+        return putNoModelAsStringNoRequiredOneValueNoDefaultWithResponseAsync(context).block();
     }
 
     /**
@@ -418,7 +529,7 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putNoModelAsStringNoRequiredOneValueNoDefault() {
-        putNoModelAsStringNoRequiredOneValueNoDefaultWithResponse();
+        putNoModelAsStringNoRequiredOneValueNoDefaultWithResponse(Context.NONE);
     }
 
     /**
@@ -442,6 +553,25 @@ public final class Contants {
     /**
      * Puts constants to the testserver.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putNoModelAsStringNoRequiredOneValueDefaultWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String input = "value1";
+        return service.putNoModelAsStringNoRequiredOneValueDefault(this.client.getHost(), input, context);
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -454,13 +584,29 @@ public final class Contants {
     /**
      * Puts constants to the testserver.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putNoModelAsStringNoRequiredOneValueDefaultAsync(Context context) {
+        return putNoModelAsStringNoRequiredOneValueDefaultWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putNoModelAsStringNoRequiredOneValueDefaultWithResponse() {
-        return putNoModelAsStringNoRequiredOneValueDefaultWithResponseAsync().block();
+    public Response<Void> putNoModelAsStringNoRequiredOneValueDefaultWithResponse(Context context) {
+        return putNoModelAsStringNoRequiredOneValueDefaultWithResponseAsync(context).block();
     }
 
     /**
@@ -471,7 +617,7 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putNoModelAsStringNoRequiredOneValueDefault() {
-        putNoModelAsStringNoRequiredOneValueDefaultWithResponse();
+        putNoModelAsStringNoRequiredOneValueDefaultWithResponse(Context.NONE);
     }
 
     /**
@@ -501,6 +647,29 @@ public final class Contants {
      * Puts constants to the testserver.
      *
      * @param input The input parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putNoModelAsStringRequiredTwoValueNoDefaultWithResponseAsync(
+            NoModelAsStringRequiredTwoValueNoDefaultOpEnum input, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (input == null) {
+            return Mono.error(new IllegalArgumentException("Parameter input is required and cannot be null."));
+        }
+        return service.putNoModelAsStringRequiredTwoValueNoDefault(this.client.getHost(), input, context);
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
+     * @param input The input parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -516,6 +685,24 @@ public final class Contants {
      * Puts constants to the testserver.
      *
      * @param input The input parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putNoModelAsStringRequiredTwoValueNoDefaultAsync(
+            NoModelAsStringRequiredTwoValueNoDefaultOpEnum input, Context context) {
+        return putNoModelAsStringRequiredTwoValueNoDefaultWithResponseAsync(input, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
+     * @param input The input parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -523,8 +710,8 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> putNoModelAsStringRequiredTwoValueNoDefaultWithResponse(
-            NoModelAsStringRequiredTwoValueNoDefaultOpEnum input) {
-        return putNoModelAsStringRequiredTwoValueNoDefaultWithResponseAsync(input).block();
+            NoModelAsStringRequiredTwoValueNoDefaultOpEnum input, Context context) {
+        return putNoModelAsStringRequiredTwoValueNoDefaultWithResponseAsync(input, context).block();
     }
 
     /**
@@ -537,7 +724,7 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putNoModelAsStringRequiredTwoValueNoDefault(NoModelAsStringRequiredTwoValueNoDefaultOpEnum input) {
-        putNoModelAsStringRequiredTwoValueNoDefaultWithResponse(input);
+        putNoModelAsStringRequiredTwoValueNoDefaultWithResponse(input, Context.NONE);
     }
 
     /**
@@ -567,6 +754,29 @@ public final class Contants {
      * Puts constants to the testserver.
      *
      * @param input The input parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putNoModelAsStringRequiredTwoValueDefaultWithResponseAsync(
+            NoModelAsStringRequiredTwoValueDefaultOpEnum input, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (input == null) {
+            return Mono.error(new IllegalArgumentException("Parameter input is required and cannot be null."));
+        }
+        return service.putNoModelAsStringRequiredTwoValueDefault(this.client.getHost(), input, context);
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
+     * @param input The input parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -582,6 +792,24 @@ public final class Contants {
      * Puts constants to the testserver.
      *
      * @param input The input parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putNoModelAsStringRequiredTwoValueDefaultAsync(
+            NoModelAsStringRequiredTwoValueDefaultOpEnum input, Context context) {
+        return putNoModelAsStringRequiredTwoValueDefaultWithResponseAsync(input, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
+     * @param input The input parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -589,8 +817,8 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> putNoModelAsStringRequiredTwoValueDefaultWithResponse(
-            NoModelAsStringRequiredTwoValueDefaultOpEnum input) {
-        return putNoModelAsStringRequiredTwoValueDefaultWithResponseAsync(input).block();
+            NoModelAsStringRequiredTwoValueDefaultOpEnum input, Context context) {
+        return putNoModelAsStringRequiredTwoValueDefaultWithResponseAsync(input, context).block();
     }
 
     /**
@@ -603,7 +831,7 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putNoModelAsStringRequiredTwoValueDefault(NoModelAsStringRequiredTwoValueDefaultOpEnum input) {
-        putNoModelAsStringRequiredTwoValueDefaultWithResponse(input);
+        putNoModelAsStringRequiredTwoValueDefaultWithResponse(input, Context.NONE);
     }
 
     /**
@@ -627,6 +855,25 @@ public final class Contants {
     /**
      * Puts constants to the testserver.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putNoModelAsStringRequiredOneValueNoDefaultWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String input = "value1";
+        return service.putNoModelAsStringRequiredOneValueNoDefault(this.client.getHost(), input, context);
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -639,13 +886,29 @@ public final class Contants {
     /**
      * Puts constants to the testserver.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putNoModelAsStringRequiredOneValueNoDefaultAsync(Context context) {
+        return putNoModelAsStringRequiredOneValueNoDefaultWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putNoModelAsStringRequiredOneValueNoDefaultWithResponse() {
-        return putNoModelAsStringRequiredOneValueNoDefaultWithResponseAsync().block();
+    public Response<Void> putNoModelAsStringRequiredOneValueNoDefaultWithResponse(Context context) {
+        return putNoModelAsStringRequiredOneValueNoDefaultWithResponseAsync(context).block();
     }
 
     /**
@@ -656,7 +919,7 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putNoModelAsStringRequiredOneValueNoDefault() {
-        putNoModelAsStringRequiredOneValueNoDefaultWithResponse();
+        putNoModelAsStringRequiredOneValueNoDefaultWithResponse(Context.NONE);
     }
 
     /**
@@ -680,6 +943,25 @@ public final class Contants {
     /**
      * Puts constants to the testserver.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putNoModelAsStringRequiredOneValueDefaultWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String input = "value1";
+        return service.putNoModelAsStringRequiredOneValueDefault(this.client.getHost(), input, context);
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -692,13 +974,29 @@ public final class Contants {
     /**
      * Puts constants to the testserver.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putNoModelAsStringRequiredOneValueDefaultAsync(Context context) {
+        return putNoModelAsStringRequiredOneValueDefaultWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putNoModelAsStringRequiredOneValueDefaultWithResponse() {
-        return putNoModelAsStringRequiredOneValueDefaultWithResponseAsync().block();
+    public Response<Void> putNoModelAsStringRequiredOneValueDefaultWithResponse(Context context) {
+        return putNoModelAsStringRequiredOneValueDefaultWithResponseAsync(context).block();
     }
 
     /**
@@ -709,7 +1007,7 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putNoModelAsStringRequiredOneValueDefault() {
-        putNoModelAsStringRequiredOneValueDefaultWithResponse();
+        putNoModelAsStringRequiredOneValueDefaultWithResponse(Context.NONE);
     }
 
     /**
@@ -730,6 +1028,26 @@ public final class Contants {
         }
         return FluxUtil.withContext(
                 context -> service.putModelAsStringNoRequiredTwoValueNoDefault(this.client.getHost(), input, context));
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
+     * @param input The input parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putModelAsStringNoRequiredTwoValueNoDefaultWithResponseAsync(
+            ModelAsStringNoRequiredTwoValueNoDefaultOpEnum input, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.putModelAsStringNoRequiredTwoValueNoDefault(this.client.getHost(), input, context);
     }
 
     /**
@@ -764,6 +1082,24 @@ public final class Contants {
      * Puts constants to the testserver.
      *
      * @param input The input parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putModelAsStringNoRequiredTwoValueNoDefaultAsync(
+            ModelAsStringNoRequiredTwoValueNoDefaultOpEnum input, Context context) {
+        return putModelAsStringNoRequiredTwoValueNoDefaultWithResponseAsync(input, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
+     * @param input The input parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -771,8 +1107,8 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> putModelAsStringNoRequiredTwoValueNoDefaultWithResponse(
-            ModelAsStringNoRequiredTwoValueNoDefaultOpEnum input) {
-        return putModelAsStringNoRequiredTwoValueNoDefaultWithResponseAsync(input).block();
+            ModelAsStringNoRequiredTwoValueNoDefaultOpEnum input, Context context) {
+        return putModelAsStringNoRequiredTwoValueNoDefaultWithResponseAsync(input, context).block();
     }
 
     /**
@@ -785,7 +1121,7 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putModelAsStringNoRequiredTwoValueNoDefault(ModelAsStringNoRequiredTwoValueNoDefaultOpEnum input) {
-        putModelAsStringNoRequiredTwoValueNoDefaultWithResponse(input);
+        putModelAsStringNoRequiredTwoValueNoDefaultWithResponse(input, Context.NONE);
     }
 
     /**
@@ -797,7 +1133,7 @@ public final class Contants {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putModelAsStringNoRequiredTwoValueNoDefault() {
         final ModelAsStringNoRequiredTwoValueNoDefaultOpEnum input = null;
-        putModelAsStringNoRequiredTwoValueNoDefaultWithResponse(input);
+        putModelAsStringNoRequiredTwoValueNoDefaultWithResponse(input, Context.NONE);
     }
 
     /**
@@ -818,6 +1154,26 @@ public final class Contants {
         }
         return FluxUtil.withContext(
                 context -> service.putModelAsStringNoRequiredTwoValueDefault(this.client.getHost(), input, context));
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
+     * @param input The input parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putModelAsStringNoRequiredTwoValueDefaultWithResponseAsync(
+            ModelAsStringNoRequiredTwoValueDefaultOpEnum input, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.putModelAsStringNoRequiredTwoValueDefault(this.client.getHost(), input, context);
     }
 
     /**
@@ -852,6 +1208,24 @@ public final class Contants {
      * Puts constants to the testserver.
      *
      * @param input The input parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putModelAsStringNoRequiredTwoValueDefaultAsync(
+            ModelAsStringNoRequiredTwoValueDefaultOpEnum input, Context context) {
+        return putModelAsStringNoRequiredTwoValueDefaultWithResponseAsync(input, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
+     * @param input The input parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -859,8 +1233,8 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> putModelAsStringNoRequiredTwoValueDefaultWithResponse(
-            ModelAsStringNoRequiredTwoValueDefaultOpEnum input) {
-        return putModelAsStringNoRequiredTwoValueDefaultWithResponseAsync(input).block();
+            ModelAsStringNoRequiredTwoValueDefaultOpEnum input, Context context) {
+        return putModelAsStringNoRequiredTwoValueDefaultWithResponseAsync(input, context).block();
     }
 
     /**
@@ -873,7 +1247,7 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putModelAsStringNoRequiredTwoValueDefault(ModelAsStringNoRequiredTwoValueDefaultOpEnum input) {
-        putModelAsStringNoRequiredTwoValueDefaultWithResponse(input);
+        putModelAsStringNoRequiredTwoValueDefaultWithResponse(input, Context.NONE);
     }
 
     /**
@@ -885,7 +1259,7 @@ public final class Contants {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putModelAsStringNoRequiredTwoValueDefault() {
         final ModelAsStringNoRequiredTwoValueDefaultOpEnum input = null;
-        putModelAsStringNoRequiredTwoValueDefaultWithResponse(input);
+        putModelAsStringNoRequiredTwoValueDefaultWithResponse(input, Context.NONE);
     }
 
     /**
@@ -906,6 +1280,26 @@ public final class Contants {
         }
         return FluxUtil.withContext(
                 context -> service.putModelAsStringNoRequiredOneValueNoDefault(this.client.getHost(), input, context));
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
+     * @param input The input parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putModelAsStringNoRequiredOneValueNoDefaultWithResponseAsync(
+            ModelAsStringNoRequiredOneValueNoDefaultOpEnum input, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.putModelAsStringNoRequiredOneValueNoDefault(this.client.getHost(), input, context);
     }
 
     /**
@@ -940,6 +1334,24 @@ public final class Contants {
      * Puts constants to the testserver.
      *
      * @param input The input parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putModelAsStringNoRequiredOneValueNoDefaultAsync(
+            ModelAsStringNoRequiredOneValueNoDefaultOpEnum input, Context context) {
+        return putModelAsStringNoRequiredOneValueNoDefaultWithResponseAsync(input, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
+     * @param input The input parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -947,8 +1359,8 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> putModelAsStringNoRequiredOneValueNoDefaultWithResponse(
-            ModelAsStringNoRequiredOneValueNoDefaultOpEnum input) {
-        return putModelAsStringNoRequiredOneValueNoDefaultWithResponseAsync(input).block();
+            ModelAsStringNoRequiredOneValueNoDefaultOpEnum input, Context context) {
+        return putModelAsStringNoRequiredOneValueNoDefaultWithResponseAsync(input, context).block();
     }
 
     /**
@@ -961,7 +1373,7 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putModelAsStringNoRequiredOneValueNoDefault(ModelAsStringNoRequiredOneValueNoDefaultOpEnum input) {
-        putModelAsStringNoRequiredOneValueNoDefaultWithResponse(input);
+        putModelAsStringNoRequiredOneValueNoDefaultWithResponse(input, Context.NONE);
     }
 
     /**
@@ -973,7 +1385,7 @@ public final class Contants {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putModelAsStringNoRequiredOneValueNoDefault() {
         final ModelAsStringNoRequiredOneValueNoDefaultOpEnum input = null;
-        putModelAsStringNoRequiredOneValueNoDefaultWithResponse(input);
+        putModelAsStringNoRequiredOneValueNoDefaultWithResponse(input, Context.NONE);
     }
 
     /**
@@ -994,6 +1406,26 @@ public final class Contants {
         }
         return FluxUtil.withContext(
                 context -> service.putModelAsStringNoRequiredOneValueDefault(this.client.getHost(), input, context));
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
+     * @param input The input parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putModelAsStringNoRequiredOneValueDefaultWithResponseAsync(
+            ModelAsStringNoRequiredOneValueDefaultOpEnum input, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.putModelAsStringNoRequiredOneValueDefault(this.client.getHost(), input, context);
     }
 
     /**
@@ -1028,6 +1460,24 @@ public final class Contants {
      * Puts constants to the testserver.
      *
      * @param input The input parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putModelAsStringNoRequiredOneValueDefaultAsync(
+            ModelAsStringNoRequiredOneValueDefaultOpEnum input, Context context) {
+        return putModelAsStringNoRequiredOneValueDefaultWithResponseAsync(input, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
+     * @param input The input parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1035,8 +1485,8 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> putModelAsStringNoRequiredOneValueDefaultWithResponse(
-            ModelAsStringNoRequiredOneValueDefaultOpEnum input) {
-        return putModelAsStringNoRequiredOneValueDefaultWithResponseAsync(input).block();
+            ModelAsStringNoRequiredOneValueDefaultOpEnum input, Context context) {
+        return putModelAsStringNoRequiredOneValueDefaultWithResponseAsync(input, context).block();
     }
 
     /**
@@ -1049,7 +1499,7 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putModelAsStringNoRequiredOneValueDefault(ModelAsStringNoRequiredOneValueDefaultOpEnum input) {
-        putModelAsStringNoRequiredOneValueDefaultWithResponse(input);
+        putModelAsStringNoRequiredOneValueDefaultWithResponse(input, Context.NONE);
     }
 
     /**
@@ -1061,7 +1511,7 @@ public final class Contants {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putModelAsStringNoRequiredOneValueDefault() {
         final ModelAsStringNoRequiredOneValueDefaultOpEnum input = null;
-        putModelAsStringNoRequiredOneValueDefaultWithResponse(input);
+        putModelAsStringNoRequiredOneValueDefaultWithResponse(input, Context.NONE);
     }
 
     /**
@@ -1091,6 +1541,29 @@ public final class Contants {
      * Puts constants to the testserver.
      *
      * @param input The input parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putModelAsStringRequiredTwoValueNoDefaultWithResponseAsync(
+            ModelAsStringRequiredTwoValueNoDefaultOpEnum input, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (input == null) {
+            return Mono.error(new IllegalArgumentException("Parameter input is required and cannot be null."));
+        }
+        return service.putModelAsStringRequiredTwoValueNoDefault(this.client.getHost(), input, context);
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
+     * @param input The input parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1106,6 +1579,24 @@ public final class Contants {
      * Puts constants to the testserver.
      *
      * @param input The input parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putModelAsStringRequiredTwoValueNoDefaultAsync(
+            ModelAsStringRequiredTwoValueNoDefaultOpEnum input, Context context) {
+        return putModelAsStringRequiredTwoValueNoDefaultWithResponseAsync(input, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
+     * @param input The input parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1113,8 +1604,8 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> putModelAsStringRequiredTwoValueNoDefaultWithResponse(
-            ModelAsStringRequiredTwoValueNoDefaultOpEnum input) {
-        return putModelAsStringRequiredTwoValueNoDefaultWithResponseAsync(input).block();
+            ModelAsStringRequiredTwoValueNoDefaultOpEnum input, Context context) {
+        return putModelAsStringRequiredTwoValueNoDefaultWithResponseAsync(input, context).block();
     }
 
     /**
@@ -1127,7 +1618,7 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putModelAsStringRequiredTwoValueNoDefault(ModelAsStringRequiredTwoValueNoDefaultOpEnum input) {
-        putModelAsStringRequiredTwoValueNoDefaultWithResponse(input);
+        putModelAsStringRequiredTwoValueNoDefaultWithResponse(input, Context.NONE);
     }
 
     /**
@@ -1157,6 +1648,29 @@ public final class Contants {
      * Puts constants to the testserver.
      *
      * @param input The input parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putModelAsStringRequiredTwoValueDefaultWithResponseAsync(
+            ModelAsStringRequiredTwoValueDefaultOpEnum input, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (input == null) {
+            return Mono.error(new IllegalArgumentException("Parameter input is required and cannot be null."));
+        }
+        return service.putModelAsStringRequiredTwoValueDefault(this.client.getHost(), input, context);
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
+     * @param input The input parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1171,6 +1685,24 @@ public final class Contants {
      * Puts constants to the testserver.
      *
      * @param input The input parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putModelAsStringRequiredTwoValueDefaultAsync(
+            ModelAsStringRequiredTwoValueDefaultOpEnum input, Context context) {
+        return putModelAsStringRequiredTwoValueDefaultWithResponseAsync(input, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
+     * @param input The input parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1178,8 +1710,8 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> putModelAsStringRequiredTwoValueDefaultWithResponse(
-            ModelAsStringRequiredTwoValueDefaultOpEnum input) {
-        return putModelAsStringRequiredTwoValueDefaultWithResponseAsync(input).block();
+            ModelAsStringRequiredTwoValueDefaultOpEnum input, Context context) {
+        return putModelAsStringRequiredTwoValueDefaultWithResponseAsync(input, context).block();
     }
 
     /**
@@ -1192,7 +1724,7 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putModelAsStringRequiredTwoValueDefault(ModelAsStringRequiredTwoValueDefaultOpEnum input) {
-        putModelAsStringRequiredTwoValueDefaultWithResponse(input);
+        putModelAsStringRequiredTwoValueDefaultWithResponse(input, Context.NONE);
     }
 
     /**
@@ -1222,6 +1754,29 @@ public final class Contants {
      * Puts constants to the testserver.
      *
      * @param input The input parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putModelAsStringRequiredOneValueNoDefaultWithResponseAsync(
+            ModelAsStringRequiredOneValueNoDefaultOpEnum input, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (input == null) {
+            return Mono.error(new IllegalArgumentException("Parameter input is required and cannot be null."));
+        }
+        return service.putModelAsStringRequiredOneValueNoDefault(this.client.getHost(), input, context);
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
+     * @param input The input parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1237,6 +1792,24 @@ public final class Contants {
      * Puts constants to the testserver.
      *
      * @param input The input parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putModelAsStringRequiredOneValueNoDefaultAsync(
+            ModelAsStringRequiredOneValueNoDefaultOpEnum input, Context context) {
+        return putModelAsStringRequiredOneValueNoDefaultWithResponseAsync(input, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
+     * @param input The input parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1244,8 +1817,8 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> putModelAsStringRequiredOneValueNoDefaultWithResponse(
-            ModelAsStringRequiredOneValueNoDefaultOpEnum input) {
-        return putModelAsStringRequiredOneValueNoDefaultWithResponseAsync(input).block();
+            ModelAsStringRequiredOneValueNoDefaultOpEnum input, Context context) {
+        return putModelAsStringRequiredOneValueNoDefaultWithResponseAsync(input, context).block();
     }
 
     /**
@@ -1258,7 +1831,7 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putModelAsStringRequiredOneValueNoDefault(ModelAsStringRequiredOneValueNoDefaultOpEnum input) {
-        putModelAsStringRequiredOneValueNoDefaultWithResponse(input);
+        putModelAsStringRequiredOneValueNoDefaultWithResponse(input, Context.NONE);
     }
 
     /**
@@ -1288,6 +1861,29 @@ public final class Contants {
      * Puts constants to the testserver.
      *
      * @param input The input parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putModelAsStringRequiredOneValueDefaultWithResponseAsync(
+            ModelAsStringRequiredOneValueDefaultOpEnum input, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (input == null) {
+            return Mono.error(new IllegalArgumentException("Parameter input is required and cannot be null."));
+        }
+        return service.putModelAsStringRequiredOneValueDefault(this.client.getHost(), input, context);
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
+     * @param input The input parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1302,6 +1898,24 @@ public final class Contants {
      * Puts constants to the testserver.
      *
      * @param input The input parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putModelAsStringRequiredOneValueDefaultAsync(
+            ModelAsStringRequiredOneValueDefaultOpEnum input, Context context) {
+        return putModelAsStringRequiredOneValueDefaultWithResponseAsync(input, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts constants to the testserver.
+     *
+     * @param input The input parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1309,8 +1923,8 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> putModelAsStringRequiredOneValueDefaultWithResponse(
-            ModelAsStringRequiredOneValueDefaultOpEnum input) {
-        return putModelAsStringRequiredOneValueDefaultWithResponseAsync(input).block();
+            ModelAsStringRequiredOneValueDefaultOpEnum input, Context context) {
+        return putModelAsStringRequiredOneValueDefaultWithResponseAsync(input, context).block();
     }
 
     /**
@@ -1323,7 +1937,7 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putModelAsStringRequiredOneValueDefault(ModelAsStringRequiredOneValueDefaultOpEnum input) {
-        putModelAsStringRequiredOneValueDefaultWithResponse(input);
+        putModelAsStringRequiredOneValueDefaultWithResponse(input, Context.NONE);
     }
 
     /**
@@ -1352,6 +1966,29 @@ public final class Contants {
     /**
      * Pass constants from the client to this function. Will pass in constant path, query, and header parameters.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putClientConstantsWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.putClientConstants(
+                this.client.getHost(),
+                this.client.isHeaderConstant(),
+                this.client.getQueryConstant(),
+                this.client.getPathConstant(),
+                context);
+    }
+
+    /**
+     * Pass constants from the client to this function. Will pass in constant path, query, and header parameters.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1364,13 +2001,29 @@ public final class Contants {
     /**
      * Pass constants from the client to this function. Will pass in constant path, query, and header parameters.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putClientConstantsAsync(Context context) {
+        return putClientConstantsWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Pass constants from the client to this function. Will pass in constant path, query, and header parameters.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putClientConstantsWithResponse() {
-        return putClientConstantsWithResponseAsync().block();
+    public Response<Void> putClientConstantsWithResponse(Context context) {
+        return putClientConstantsWithResponseAsync(context).block();
     }
 
     /**
@@ -1381,6 +2034,6 @@ public final class Contants {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putClientConstants() {
-        putClientConstantsWithResponse();
+        putClientConstantsWithResponse(Context.NONE);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/custombaseuri/Paths.java
+++ b/vanilla-tests/src/main/java/fixtures/custombaseuri/Paths.java
@@ -81,6 +81,29 @@ public final class Paths {
      * Get a 200 to test a valid base uri.
      *
      * @param accountName Account Name.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a 200 to test a valid base uri along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getEmptyWithResponseAsync(String accountName, Context context) {
+        if (accountName == null) {
+            return Mono.error(new IllegalArgumentException("Parameter accountName is required and cannot be null."));
+        }
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getEmpty(accountName, this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get a 200 to test a valid base uri.
+     *
+     * @param accountName Account Name.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -95,14 +118,30 @@ public final class Paths {
      * Get a 200 to test a valid base uri.
      *
      * @param accountName Account Name.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a 200 to test a valid base uri on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getEmptyAsync(String accountName, Context context) {
+        return getEmptyWithResponseAsync(accountName, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get a 200 to test a valid base uri.
+     *
+     * @param accountName Account Name.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a 200 to test a valid base uri along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getEmptyWithResponse(String accountName) {
-        return getEmptyWithResponseAsync(accountName).block();
+    public Response<Void> getEmptyWithResponse(String accountName, Context context) {
+        return getEmptyWithResponseAsync(accountName, context).block();
     }
 
     /**
@@ -115,6 +154,6 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getEmpty(String accountName) {
-        getEmptyWithResponse(accountName);
+        getEmptyWithResponse(accountName, Context.NONE);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/custombaseuri/moreoptions/Paths.java
+++ b/vanilla-tests/src/main/java/fixtures/custombaseuri/moreoptions/Paths.java
@@ -116,6 +116,53 @@ public final class Paths {
      * @param secret Secret value.
      * @param keyName The key name with value 'key1'.
      * @param keyVersion The key version. Default value 'v1'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a 200 to test a valid base uri along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getEmptyWithResponseAsync(
+            String vault, String secret, String keyName, String keyVersion, Context context) {
+        if (vault == null) {
+            return Mono.error(new IllegalArgumentException("Parameter vault is required and cannot be null."));
+        }
+        if (secret == null) {
+            return Mono.error(new IllegalArgumentException("Parameter secret is required and cannot be null."));
+        }
+        if (this.client.getDnsSuffix() == null) {
+            return Mono.error(
+                    new IllegalArgumentException(
+                            "Parameter this.client.getDnsSuffix() is required and cannot be null."));
+        }
+        if (keyName == null) {
+            return Mono.error(new IllegalArgumentException("Parameter keyName is required and cannot be null."));
+        }
+        if (this.client.getSubscriptionId() == null) {
+            return Mono.error(
+                    new IllegalArgumentException(
+                            "Parameter this.client.getSubscriptionId() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getEmpty(
+                vault,
+                secret,
+                this.client.getDnsSuffix(),
+                keyName,
+                this.client.getSubscriptionId(),
+                keyVersion,
+                accept,
+                context);
+    }
+
+    /**
+     * Get a 200 to test a valid base uri.
+     *
+     * @param vault The vault name, e.g. https://myvault.
+     * @param secret Secret value.
+     * @param keyName The key name with value 'key1'.
+     * @param keyVersion The key version. Default value 'v1'.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -150,14 +197,34 @@ public final class Paths {
      * @param secret Secret value.
      * @param keyName The key name with value 'key1'.
      * @param keyVersion The key version. Default value 'v1'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a 200 to test a valid base uri on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getEmptyAsync(String vault, String secret, String keyName, String keyVersion, Context context) {
+        return getEmptyWithResponseAsync(vault, secret, keyName, keyVersion, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get a 200 to test a valid base uri.
+     *
+     * @param vault The vault name, e.g. https://myvault.
+     * @param secret Secret value.
+     * @param keyName The key name with value 'key1'.
+     * @param keyVersion The key version. Default value 'v1'.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a 200 to test a valid base uri along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getEmptyWithResponse(String vault, String secret, String keyName, String keyVersion) {
-        return getEmptyWithResponseAsync(vault, secret, keyName, keyVersion).block();
+    public Response<Void> getEmptyWithResponse(
+            String vault, String secret, String keyName, String keyVersion, Context context) {
+        return getEmptyWithResponseAsync(vault, secret, keyName, keyVersion, context).block();
     }
 
     /**
@@ -173,7 +240,7 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getEmpty(String vault, String secret, String keyName, String keyVersion) {
-        getEmptyWithResponse(vault, secret, keyName, keyVersion);
+        getEmptyWithResponse(vault, secret, keyName, keyVersion, Context.NONE);
     }
 
     /**
@@ -189,6 +256,6 @@ public final class Paths {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getEmpty(String vault, String secret, String keyName) {
         final String keyVersion = null;
-        getEmptyWithResponse(vault, secret, keyName, keyVersion);
+        getEmptyWithResponse(vault, secret, keyName, keyVersion, Context.NONE);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/customhttpexceptionmapping/HeadExceptions.java
+++ b/vanilla-tests/src/main/java/fixtures/customhttpexceptionmapping/HeadExceptions.java
@@ -91,6 +91,25 @@ public final class HeadExceptions {
     /**
      * Return 200 status code if successful.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server.
+     * @throws ResourceExistsException thrown if the request is rejected by server on status code 404.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> head200WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.head200(this.client.getHost(), context);
+    }
+
+    /**
+     * Return 200 status code if successful.
+     *
      * @throws ResourceNotFoundException thrown if the request is rejected by server.
      * @throws ResourceExistsException thrown if the request is rejected by server on status code 404.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -104,14 +123,31 @@ public final class HeadExceptions {
     /**
      * Return 200 status code if successful.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server.
+     * @throws ResourceExistsException thrown if the request is rejected by server on status code 404.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> head200Async(Context context) {
+        return head200WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 200 status code if successful.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ResourceNotFoundException thrown if the request is rejected by server.
      * @throws ResourceExistsException thrown if the request is rejected by server on status code 404.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head200WithResponse() {
-        return head200WithResponseAsync().block();
+    public Response<Void> head200WithResponse(Context context) {
+        return head200WithResponseAsync(context).block();
     }
 
     /**
@@ -123,7 +159,7 @@ public final class HeadExceptions {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head200() {
-        head200WithResponse();
+        head200WithResponse(Context.NONE);
     }
 
     /**
@@ -146,6 +182,25 @@ public final class HeadExceptions {
     /**
      * Return 204 status code if successful.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server.
+     * @throws ResourceExistsException thrown if the request is rejected by server on status code 404.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> head204WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.head204(this.client.getHost(), context);
+    }
+
+    /**
+     * Return 204 status code if successful.
+     *
      * @throws ResourceNotFoundException thrown if the request is rejected by server.
      * @throws ResourceExistsException thrown if the request is rejected by server on status code 404.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -159,14 +214,31 @@ public final class HeadExceptions {
     /**
      * Return 204 status code if successful.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server.
+     * @throws ResourceExistsException thrown if the request is rejected by server on status code 404.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> head204Async(Context context) {
+        return head204WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 204 status code if successful.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ResourceNotFoundException thrown if the request is rejected by server.
      * @throws ResourceExistsException thrown if the request is rejected by server on status code 404.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head204WithResponse() {
-        return head204WithResponseAsync().block();
+    public Response<Void> head204WithResponse(Context context) {
+        return head204WithResponseAsync(context).block();
     }
 
     /**
@@ -178,7 +250,7 @@ public final class HeadExceptions {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head204() {
-        head204WithResponse();
+        head204WithResponse(Context.NONE);
     }
 
     /**
@@ -201,6 +273,25 @@ public final class HeadExceptions {
     /**
      * Return 404 status code if successful.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server.
+     * @throws ResourceExistsException thrown if the request is rejected by server on status code 404.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> head404WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.head404(this.client.getHost(), context);
+    }
+
+    /**
+     * Return 404 status code if successful.
+     *
      * @throws ResourceNotFoundException thrown if the request is rejected by server.
      * @throws ResourceExistsException thrown if the request is rejected by server on status code 404.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -214,14 +305,31 @@ public final class HeadExceptions {
     /**
      * Return 404 status code if successful.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server.
+     * @throws ResourceExistsException thrown if the request is rejected by server on status code 404.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> head404Async(Context context) {
+        return head404WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 404 status code if successful.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ResourceNotFoundException thrown if the request is rejected by server.
      * @throws ResourceExistsException thrown if the request is rejected by server on status code 404.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head404WithResponse() {
-        return head404WithResponseAsync().block();
+    public Response<Void> head404WithResponse(Context context) {
+        return head404WithResponseAsync(context).block();
     }
 
     /**
@@ -233,6 +341,6 @@ public final class HeadExceptions {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head404() {
-        head404WithResponse();
+        head404WithResponse(Context.NONE);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/discriminatorflattening/MetricAlerts.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorflattening/MetricAlerts.java
@@ -74,6 +74,25 @@ public final class MetricAlerts {
     /**
      * Retrieve an alert rule definition.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the metric alert resource along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<MetricAlertResource>> getWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Retrieve an alert rule definition.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the metric alert resource on successful completion of {@link Mono}.
@@ -86,13 +105,29 @@ public final class MetricAlerts {
     /**
      * Retrieve an alert rule definition.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the metric alert resource on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<MetricAlertResource> getAsync(Context context) {
+        return getWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Retrieve an alert rule definition.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the metric alert resource along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<MetricAlertResource> getWithResponse() {
-        return getWithResponseAsync().block();
+    public Response<MetricAlertResource> getWithResponse(Context context) {
+        return getWithResponseAsync(context).block();
     }
 
     /**
@@ -104,6 +139,6 @@ public final class MetricAlerts {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MetricAlertResource get() {
-        return getWithResponse().getValue();
+        return getWithResponse(Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/discriminatorflattening/clientflatten/MetricAlerts.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorflattening/clientflatten/MetricAlerts.java
@@ -74,6 +74,25 @@ public final class MetricAlerts {
     /**
      * Retrieve an alert rule definition.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the metric alert resource along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<MetricAlertResource>> getWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Retrieve an alert rule definition.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the metric alert resource on successful completion of {@link Mono}.
@@ -86,13 +105,29 @@ public final class MetricAlerts {
     /**
      * Retrieve an alert rule definition.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the metric alert resource on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<MetricAlertResource> getAsync(Context context) {
+        return getWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Retrieve an alert rule definition.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the metric alert resource along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<MetricAlertResource> getWithResponse() {
-        return getWithResponseAsync().block();
+    public Response<MetricAlertResource> getWithResponse(Context context) {
+        return getWithResponseAsync(context).block();
     }
 
     /**
@@ -104,6 +139,6 @@ public final class MetricAlerts {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MetricAlertResource get() {
-        return getWithResponse().getValue();
+        return getWithResponse(Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/discriminatorflattening/noflatten/MetricAlerts.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorflattening/noflatten/MetricAlerts.java
@@ -74,6 +74,25 @@ public final class MetricAlerts {
     /**
      * Retrieve an alert rule definition.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the metric alert resource along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<MetricAlertResource>> getWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Retrieve an alert rule definition.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the metric alert resource on successful completion of {@link Mono}.
@@ -86,13 +105,29 @@ public final class MetricAlerts {
     /**
      * Retrieve an alert rule definition.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the metric alert resource on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<MetricAlertResource> getAsync(Context context) {
+        return getWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Retrieve an alert rule definition.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the metric alert resource along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<MetricAlertResource> getWithResponse() {
-        return getWithResponseAsync().block();
+    public Response<MetricAlertResource> getWithResponse(Context context) {
+        return getWithResponseAsync(context).block();
     }
 
     /**
@@ -104,6 +139,6 @@ public final class MetricAlerts {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MetricAlertResource get() {
-        return getWithResponse().getValue();
+        return getWithResponse(Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/discriminatorflattening/requirexmsflattened/MetricAlerts.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorflattening/requirexmsflattened/MetricAlerts.java
@@ -74,6 +74,25 @@ public final class MetricAlerts {
     /**
      * Retrieve an alert rule definition.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the metric alert resource along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<MetricAlertResource>> getWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Retrieve an alert rule definition.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the metric alert resource on successful completion of {@link Mono}.
@@ -86,13 +105,29 @@ public final class MetricAlerts {
     /**
      * Retrieve an alert rule definition.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the metric alert resource on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<MetricAlertResource> getAsync(Context context) {
+        return getWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Retrieve an alert rule definition.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the metric alert resource along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<MetricAlertResource> getWithResponse() {
-        return getWithResponseAsync().block();
+    public Response<MetricAlertResource> getWithResponse(Context context) {
+        return getWithResponseAsync(context).block();
     }
 
     /**
@@ -104,6 +139,6 @@ public final class MetricAlerts {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MetricAlertResource get() {
-        return getWithResponse().getValue();
+        return getWithResponse(Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/extensibleenums/Pets.java
+++ b/vanilla-tests/src/main/java/fixtures/extensibleenums/Pets.java
@@ -94,6 +94,29 @@ public final class Pets {
      * get pet by id.
      *
      * @param petId Pet id.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return pet by id along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Pet>> getByPetIdWithResponseAsync(String petId, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (petId == null) {
+            return Mono.error(new IllegalArgumentException("Parameter petId is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getByPetId(this.client.getHost(), petId, accept, context);
+    }
+
+    /**
+     * get pet by id.
+     *
+     * @param petId Pet id.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -108,14 +131,30 @@ public final class Pets {
      * get pet by id.
      *
      * @param petId Pet id.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return pet by id on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Pet> getByPetIdAsync(String petId, Context context) {
+        return getByPetIdWithResponseAsync(petId, context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * get pet by id.
+     *
+     * @param petId Pet id.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return pet by id along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Pet> getByPetIdWithResponse(String petId) {
-        return getByPetIdWithResponseAsync(petId).block();
+    public Response<Pet> getByPetIdWithResponse(String petId, Context context) {
+        return getByPetIdWithResponseAsync(petId, context).block();
     }
 
     /**
@@ -129,7 +168,7 @@ public final class Pets {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Pet getByPetId(String petId) {
-        return getByPetIdWithResponse(petId).getValue();
+        return getByPetIdWithResponse(petId, Context.NONE).getValue();
     }
 
     /**
@@ -152,6 +191,29 @@ public final class Pets {
         }
         final String accept = "application/json";
         return FluxUtil.withContext(context -> service.addPet(this.client.getHost(), petParam, accept, context));
+    }
+
+    /**
+     * add pet.
+     *
+     * @param petParam pet param.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Pet>> addPetWithResponseAsync(Pet petParam, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (petParam != null) {
+            petParam.validate();
+        }
+        final String accept = "application/json";
+        return service.addPet(this.client.getHost(), petParam, accept, context);
     }
 
     /**
@@ -185,14 +247,30 @@ public final class Pets {
      * add pet.
      *
      * @param petParam pet param.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Pet> addPetAsync(Pet petParam, Context context) {
+        return addPetWithResponseAsync(petParam, context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * add pet.
+     *
+     * @param petParam pet param.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Pet> addPetWithResponse(Pet petParam) {
-        return addPetWithResponseAsync(petParam).block();
+    public Response<Pet> addPetWithResponse(Pet petParam, Context context) {
+        return addPetWithResponseAsync(petParam, context).block();
     }
 
     /**
@@ -206,7 +284,7 @@ public final class Pets {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Pet addPet(Pet petParam) {
-        return addPetWithResponse(petParam).getValue();
+        return addPetWithResponse(petParam, Context.NONE).getValue();
     }
 
     /**
@@ -219,6 +297,6 @@ public final class Pets {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Pet addPet() {
         final Pet petParam = null;
-        return addPetWithResponse(petParam).getValue();
+        return addPetWithResponse(petParam, Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/head/HttpSuccess.java
+++ b/vanilla-tests/src/main/java/fixtures/head/HttpSuccess.java
@@ -80,6 +80,24 @@ public final class HttpSuccess {
     /**
      * Return 200 status code if successful.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return whether resource exists along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Boolean>> head200WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.head200(this.client.getHost(), context);
+    }
+
+    /**
+     * Return 200 status code if successful.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return whether resource exists on successful completion of {@link Mono}.
@@ -92,13 +110,29 @@ public final class HttpSuccess {
     /**
      * Return 200 status code if successful.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return whether resource exists on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Boolean> head200Async(Context context) {
+        return head200WithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Return 200 status code if successful.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return whether resource exists along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Boolean> head200WithResponse() {
-        return head200WithResponseAsync().block();
+    public Response<Boolean> head200WithResponse(Context context) {
+        return head200WithResponseAsync(context).block();
     }
 
     /**
@@ -110,7 +144,7 @@ public final class HttpSuccess {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean head200() {
-        return head200WithResponse().getValue();
+        return head200WithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -132,6 +166,24 @@ public final class HttpSuccess {
     /**
      * Return 204 status code if successful.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return whether resource exists along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Boolean>> head204WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.head204(this.client.getHost(), context);
+    }
+
+    /**
+     * Return 204 status code if successful.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return whether resource exists on successful completion of {@link Mono}.
@@ -144,13 +196,29 @@ public final class HttpSuccess {
     /**
      * Return 204 status code if successful.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return whether resource exists on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Boolean> head204Async(Context context) {
+        return head204WithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Return 204 status code if successful.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return whether resource exists along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Boolean> head204WithResponse() {
-        return head204WithResponseAsync().block();
+    public Response<Boolean> head204WithResponse(Context context) {
+        return head204WithResponseAsync(context).block();
     }
 
     /**
@@ -162,7 +230,7 @@ public final class HttpSuccess {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean head204() {
-        return head204WithResponse().getValue();
+        return head204WithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -184,6 +252,24 @@ public final class HttpSuccess {
     /**
      * Return 404 status code if successful.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return whether resource exists along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Boolean>> head404WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.head404(this.client.getHost(), context);
+    }
+
+    /**
+     * Return 404 status code if successful.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return whether resource exists on successful completion of {@link Mono}.
@@ -196,13 +282,29 @@ public final class HttpSuccess {
     /**
      * Return 404 status code if successful.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return whether resource exists on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Boolean> head404Async(Context context) {
+        return head404WithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Return 404 status code if successful.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return whether resource exists along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Boolean> head404WithResponse() {
-        return head404WithResponseAsync().block();
+    public Response<Boolean> head404WithResponse(Context context) {
+        return head404WithResponseAsync(context).block();
     }
 
     /**
@@ -214,6 +316,6 @@ public final class HttpSuccess {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean head404() {
-        return head404WithResponse().getValue();
+        return head404WithResponse(Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/headexceptions/HeadExceptions.java
+++ b/vanilla-tests/src/main/java/fixtures/headexceptions/HeadExceptions.java
@@ -80,6 +80,24 @@ public final class HeadExceptions {
     /**
      * Return 200 status code if successful.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> head200WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.head200(this.client.getHost(), context);
+    }
+
+    /**
+     * Return 200 status code if successful.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -92,13 +110,29 @@ public final class HeadExceptions {
     /**
      * Return 200 status code if successful.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> head200Async(Context context) {
+        return head200WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 200 status code if successful.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head200WithResponse() {
-        return head200WithResponseAsync().block();
+    public Response<Void> head200WithResponse(Context context) {
+        return head200WithResponseAsync(context).block();
     }
 
     /**
@@ -109,7 +143,7 @@ public final class HeadExceptions {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head200() {
-        head200WithResponse();
+        head200WithResponse(Context.NONE);
     }
 
     /**
@@ -131,6 +165,24 @@ public final class HeadExceptions {
     /**
      * Return 204 status code if successful.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> head204WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.head204(this.client.getHost(), context);
+    }
+
+    /**
+     * Return 204 status code if successful.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -143,13 +195,29 @@ public final class HeadExceptions {
     /**
      * Return 204 status code if successful.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> head204Async(Context context) {
+        return head204WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 204 status code if successful.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head204WithResponse() {
-        return head204WithResponseAsync().block();
+    public Response<Void> head204WithResponse(Context context) {
+        return head204WithResponseAsync(context).block();
     }
 
     /**
@@ -160,7 +228,7 @@ public final class HeadExceptions {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head204() {
-        head204WithResponse();
+        head204WithResponse(Context.NONE);
     }
 
     /**
@@ -182,6 +250,24 @@ public final class HeadExceptions {
     /**
      * Return 404 status code if successful.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> head404WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.head404(this.client.getHost(), context);
+    }
+
+    /**
+     * Return 404 status code if successful.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -194,13 +280,29 @@ public final class HeadExceptions {
     /**
      * Return 404 status code if successful.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> head404Async(Context context) {
+        return head404WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 404 status code if successful.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head404WithResponse() {
-        return head404WithResponseAsync().block();
+    public Response<Void> head404WithResponse(Context context) {
+        return head404WithResponseAsync(context).block();
     }
 
     /**
@@ -211,6 +313,6 @@ public final class HeadExceptions {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head404() {
-        head404WithResponse();
+        head404WithResponse(Context.NONE);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/httpinfrastructure/HttpClientFailures.java
+++ b/vanilla-tests/src/main/java/fixtures/httpinfrastructure/HttpClientFailures.java
@@ -243,6 +243,25 @@ public final class HttpClientFailures {
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> head400WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.head400(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -255,13 +274,29 @@ public final class HttpClientFailures {
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> head400Async(Context context) {
+        return head400WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head400WithResponse() {
-        return head400WithResponseAsync().block();
+    public Response<Void> head400WithResponse(Context context) {
+        return head400WithResponseAsync(context).block();
     }
 
     /**
@@ -272,7 +307,7 @@ public final class HttpClientFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head400() {
-        head400WithResponse();
+        head400WithResponse(Context.NONE);
     }
 
     /**
@@ -295,6 +330,25 @@ public final class HttpClientFailures {
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> get400WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get400(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -307,13 +361,29 @@ public final class HttpClientFailures {
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> get400Async(Context context) {
+        return get400WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get400WithResponse() {
-        return get400WithResponseAsync().block();
+    public Response<Void> get400WithResponse(Context context) {
+        return get400WithResponseAsync(context).block();
     }
 
     /**
@@ -324,7 +394,7 @@ public final class HttpClientFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get400() {
-        get400WithResponse();
+        get400WithResponse(Context.NONE);
     }
 
     /**
@@ -347,6 +417,25 @@ public final class HttpClientFailures {
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> options400WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.options400(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -359,13 +448,29 @@ public final class HttpClientFailures {
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> options400Async(Context context) {
+        return options400WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> options400WithResponse() {
-        return options400WithResponseAsync().block();
+    public Response<Void> options400WithResponse(Context context) {
+        return options400WithResponseAsync(context).block();
     }
 
     /**
@@ -376,7 +481,7 @@ public final class HttpClientFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void options400() {
-        options400WithResponse();
+        options400WithResponse(Context.NONE);
     }
 
     /**
@@ -400,6 +505,26 @@ public final class HttpClientFailures {
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> put400WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.put400(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -412,13 +537,29 @@ public final class HttpClientFailures {
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> put400Async(Context context) {
+        return put400WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put400WithResponse() {
-        return put400WithResponseAsync().block();
+    public Response<Void> put400WithResponse(Context context) {
+        return put400WithResponseAsync(context).block();
     }
 
     /**
@@ -429,7 +570,7 @@ public final class HttpClientFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void put400() {
-        put400WithResponse();
+        put400WithResponse(Context.NONE);
     }
 
     /**
@@ -453,6 +594,26 @@ public final class HttpClientFailures {
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> patch400WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.patch400(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -465,13 +626,29 @@ public final class HttpClientFailures {
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> patch400Async(Context context) {
+        return patch400WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> patch400WithResponse() {
-        return patch400WithResponseAsync().block();
+    public Response<Void> patch400WithResponse(Context context) {
+        return patch400WithResponseAsync(context).block();
     }
 
     /**
@@ -482,7 +659,7 @@ public final class HttpClientFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void patch400() {
-        patch400WithResponse();
+        patch400WithResponse(Context.NONE);
     }
 
     /**
@@ -506,6 +683,26 @@ public final class HttpClientFailures {
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> post400WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.post400(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -518,13 +715,29 @@ public final class HttpClientFailures {
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> post400Async(Context context) {
+        return post400WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post400WithResponse() {
-        return post400WithResponseAsync().block();
+    public Response<Void> post400WithResponse(Context context) {
+        return post400WithResponseAsync(context).block();
     }
 
     /**
@@ -535,7 +748,7 @@ public final class HttpClientFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void post400() {
-        post400WithResponse();
+        post400WithResponse(Context.NONE);
     }
 
     /**
@@ -559,6 +772,26 @@ public final class HttpClientFailures {
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> delete400WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.delete400(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -571,13 +804,29 @@ public final class HttpClientFailures {
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> delete400Async(Context context) {
+        return delete400WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> delete400WithResponse() {
-        return delete400WithResponseAsync().block();
+    public Response<Void> delete400WithResponse(Context context) {
+        return delete400WithResponseAsync(context).block();
     }
 
     /**
@@ -588,7 +837,7 @@ public final class HttpClientFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void delete400() {
-        delete400WithResponse();
+        delete400WithResponse(Context.NONE);
     }
 
     /**
@@ -611,6 +860,25 @@ public final class HttpClientFailures {
     /**
      * Return 401 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> head401WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.head401(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Return 401 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -623,13 +891,29 @@ public final class HttpClientFailures {
     /**
      * Return 401 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> head401Async(Context context) {
+        return head401WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 401 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head401WithResponse() {
-        return head401WithResponseAsync().block();
+    public Response<Void> head401WithResponse(Context context) {
+        return head401WithResponseAsync(context).block();
     }
 
     /**
@@ -640,7 +924,7 @@ public final class HttpClientFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head401() {
-        head401WithResponse();
+        head401WithResponse(Context.NONE);
     }
 
     /**
@@ -663,6 +947,25 @@ public final class HttpClientFailures {
     /**
      * Return 402 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> get402WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get402(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Return 402 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -675,13 +978,29 @@ public final class HttpClientFailures {
     /**
      * Return 402 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> get402Async(Context context) {
+        return get402WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 402 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get402WithResponse() {
-        return get402WithResponseAsync().block();
+    public Response<Void> get402WithResponse(Context context) {
+        return get402WithResponseAsync(context).block();
     }
 
     /**
@@ -692,7 +1011,7 @@ public final class HttpClientFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get402() {
-        get402WithResponse();
+        get402WithResponse(Context.NONE);
     }
 
     /**
@@ -715,6 +1034,25 @@ public final class HttpClientFailures {
     /**
      * Return 403 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> options403WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.options403(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Return 403 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -727,13 +1065,29 @@ public final class HttpClientFailures {
     /**
      * Return 403 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> options403Async(Context context) {
+        return options403WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 403 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> options403WithResponse() {
-        return options403WithResponseAsync().block();
+    public Response<Void> options403WithResponse(Context context) {
+        return options403WithResponseAsync(context).block();
     }
 
     /**
@@ -744,7 +1098,7 @@ public final class HttpClientFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void options403() {
-        options403WithResponse();
+        options403WithResponse(Context.NONE);
     }
 
     /**
@@ -767,6 +1121,25 @@ public final class HttpClientFailures {
     /**
      * Return 403 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> get403WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get403(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Return 403 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -779,13 +1152,29 @@ public final class HttpClientFailures {
     /**
      * Return 403 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> get403Async(Context context) {
+        return get403WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 403 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get403WithResponse() {
-        return get403WithResponseAsync().block();
+    public Response<Void> get403WithResponse(Context context) {
+        return get403WithResponseAsync(context).block();
     }
 
     /**
@@ -796,7 +1185,7 @@ public final class HttpClientFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get403() {
-        get403WithResponse();
+        get403WithResponse(Context.NONE);
     }
 
     /**
@@ -820,6 +1209,26 @@ public final class HttpClientFailures {
     /**
      * Return 404 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> put404WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.put404(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Return 404 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -832,13 +1241,29 @@ public final class HttpClientFailures {
     /**
      * Return 404 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> put404Async(Context context) {
+        return put404WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 404 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put404WithResponse() {
-        return put404WithResponseAsync().block();
+    public Response<Void> put404WithResponse(Context context) {
+        return put404WithResponseAsync(context).block();
     }
 
     /**
@@ -849,7 +1274,7 @@ public final class HttpClientFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void put404() {
-        put404WithResponse();
+        put404WithResponse(Context.NONE);
     }
 
     /**
@@ -873,6 +1298,26 @@ public final class HttpClientFailures {
     /**
      * Return 405 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> patch405WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.patch405(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Return 405 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -885,13 +1330,29 @@ public final class HttpClientFailures {
     /**
      * Return 405 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> patch405Async(Context context) {
+        return patch405WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 405 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> patch405WithResponse() {
-        return patch405WithResponseAsync().block();
+    public Response<Void> patch405WithResponse(Context context) {
+        return patch405WithResponseAsync(context).block();
     }
 
     /**
@@ -902,7 +1363,7 @@ public final class HttpClientFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void patch405() {
-        patch405WithResponse();
+        patch405WithResponse(Context.NONE);
     }
 
     /**
@@ -926,6 +1387,26 @@ public final class HttpClientFailures {
     /**
      * Return 406 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> post406WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.post406(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Return 406 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -938,13 +1419,29 @@ public final class HttpClientFailures {
     /**
      * Return 406 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> post406Async(Context context) {
+        return post406WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 406 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post406WithResponse() {
-        return post406WithResponseAsync().block();
+    public Response<Void> post406WithResponse(Context context) {
+        return post406WithResponseAsync(context).block();
     }
 
     /**
@@ -955,7 +1452,7 @@ public final class HttpClientFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void post406() {
-        post406WithResponse();
+        post406WithResponse(Context.NONE);
     }
 
     /**
@@ -979,6 +1476,26 @@ public final class HttpClientFailures {
     /**
      * Return 407 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> delete407WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.delete407(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Return 407 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -991,13 +1508,29 @@ public final class HttpClientFailures {
     /**
      * Return 407 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> delete407Async(Context context) {
+        return delete407WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 407 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> delete407WithResponse() {
-        return delete407WithResponseAsync().block();
+    public Response<Void> delete407WithResponse(Context context) {
+        return delete407WithResponseAsync(context).block();
     }
 
     /**
@@ -1008,7 +1541,7 @@ public final class HttpClientFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void delete407() {
-        delete407WithResponse();
+        delete407WithResponse(Context.NONE);
     }
 
     /**
@@ -1032,6 +1565,26 @@ public final class HttpClientFailures {
     /**
      * Return 409 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> put409WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.put409(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Return 409 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1044,13 +1597,29 @@ public final class HttpClientFailures {
     /**
      * Return 409 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> put409Async(Context context) {
+        return put409WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 409 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put409WithResponse() {
-        return put409WithResponseAsync().block();
+    public Response<Void> put409WithResponse(Context context) {
+        return put409WithResponseAsync(context).block();
     }
 
     /**
@@ -1061,7 +1630,7 @@ public final class HttpClientFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void put409() {
-        put409WithResponse();
+        put409WithResponse(Context.NONE);
     }
 
     /**
@@ -1084,6 +1653,25 @@ public final class HttpClientFailures {
     /**
      * Return 410 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> head410WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.head410(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Return 410 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1096,13 +1684,29 @@ public final class HttpClientFailures {
     /**
      * Return 410 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> head410Async(Context context) {
+        return head410WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 410 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head410WithResponse() {
-        return head410WithResponseAsync().block();
+    public Response<Void> head410WithResponse(Context context) {
+        return head410WithResponseAsync(context).block();
     }
 
     /**
@@ -1113,7 +1717,7 @@ public final class HttpClientFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head410() {
-        head410WithResponse();
+        head410WithResponse(Context.NONE);
     }
 
     /**
@@ -1136,6 +1740,25 @@ public final class HttpClientFailures {
     /**
      * Return 411 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> get411WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get411(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Return 411 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1148,13 +1771,29 @@ public final class HttpClientFailures {
     /**
      * Return 411 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> get411Async(Context context) {
+        return get411WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 411 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get411WithResponse() {
-        return get411WithResponseAsync().block();
+    public Response<Void> get411WithResponse(Context context) {
+        return get411WithResponseAsync(context).block();
     }
 
     /**
@@ -1165,7 +1804,7 @@ public final class HttpClientFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get411() {
-        get411WithResponse();
+        get411WithResponse(Context.NONE);
     }
 
     /**
@@ -1188,6 +1827,25 @@ public final class HttpClientFailures {
     /**
      * Return 412 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> options412WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.options412(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Return 412 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1200,13 +1858,29 @@ public final class HttpClientFailures {
     /**
      * Return 412 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> options412Async(Context context) {
+        return options412WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 412 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> options412WithResponse() {
-        return options412WithResponseAsync().block();
+    public Response<Void> options412WithResponse(Context context) {
+        return options412WithResponseAsync(context).block();
     }
 
     /**
@@ -1217,7 +1891,7 @@ public final class HttpClientFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void options412() {
-        options412WithResponse();
+        options412WithResponse(Context.NONE);
     }
 
     /**
@@ -1240,6 +1914,25 @@ public final class HttpClientFailures {
     /**
      * Return 412 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> get412WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get412(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Return 412 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1252,13 +1945,29 @@ public final class HttpClientFailures {
     /**
      * Return 412 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> get412Async(Context context) {
+        return get412WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 412 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get412WithResponse() {
-        return get412WithResponseAsync().block();
+    public Response<Void> get412WithResponse(Context context) {
+        return get412WithResponseAsync(context).block();
     }
 
     /**
@@ -1269,7 +1978,7 @@ public final class HttpClientFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get412() {
-        get412WithResponse();
+        get412WithResponse(Context.NONE);
     }
 
     /**
@@ -1293,6 +2002,26 @@ public final class HttpClientFailures {
     /**
      * Return 413 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> put413WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.put413(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Return 413 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1305,13 +2034,29 @@ public final class HttpClientFailures {
     /**
      * Return 413 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> put413Async(Context context) {
+        return put413WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 413 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put413WithResponse() {
-        return put413WithResponseAsync().block();
+    public Response<Void> put413WithResponse(Context context) {
+        return put413WithResponseAsync(context).block();
     }
 
     /**
@@ -1322,7 +2067,7 @@ public final class HttpClientFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void put413() {
-        put413WithResponse();
+        put413WithResponse(Context.NONE);
     }
 
     /**
@@ -1346,6 +2091,26 @@ public final class HttpClientFailures {
     /**
      * Return 414 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> patch414WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.patch414(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Return 414 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1358,13 +2123,29 @@ public final class HttpClientFailures {
     /**
      * Return 414 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> patch414Async(Context context) {
+        return patch414WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 414 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> patch414WithResponse() {
-        return patch414WithResponseAsync().block();
+    public Response<Void> patch414WithResponse(Context context) {
+        return patch414WithResponseAsync(context).block();
     }
 
     /**
@@ -1375,7 +2156,7 @@ public final class HttpClientFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void patch414() {
-        patch414WithResponse();
+        patch414WithResponse(Context.NONE);
     }
 
     /**
@@ -1399,6 +2180,26 @@ public final class HttpClientFailures {
     /**
      * Return 415 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> post415WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.post415(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Return 415 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1411,13 +2212,29 @@ public final class HttpClientFailures {
     /**
      * Return 415 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> post415Async(Context context) {
+        return post415WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 415 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post415WithResponse() {
-        return post415WithResponseAsync().block();
+    public Response<Void> post415WithResponse(Context context) {
+        return post415WithResponseAsync(context).block();
     }
 
     /**
@@ -1428,7 +2245,7 @@ public final class HttpClientFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void post415() {
-        post415WithResponse();
+        post415WithResponse(Context.NONE);
     }
 
     /**
@@ -1451,6 +2268,25 @@ public final class HttpClientFailures {
     /**
      * Return 416 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> get416WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get416(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Return 416 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1463,13 +2299,29 @@ public final class HttpClientFailures {
     /**
      * Return 416 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> get416Async(Context context) {
+        return get416WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 416 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get416WithResponse() {
-        return get416WithResponseAsync().block();
+    public Response<Void> get416WithResponse(Context context) {
+        return get416WithResponseAsync(context).block();
     }
 
     /**
@@ -1480,7 +2332,7 @@ public final class HttpClientFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get416() {
-        get416WithResponse();
+        get416WithResponse(Context.NONE);
     }
 
     /**
@@ -1504,6 +2356,26 @@ public final class HttpClientFailures {
     /**
      * Return 417 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> delete417WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.delete417(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Return 417 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1516,13 +2388,29 @@ public final class HttpClientFailures {
     /**
      * Return 417 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> delete417Async(Context context) {
+        return delete417WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 417 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> delete417WithResponse() {
-        return delete417WithResponseAsync().block();
+    public Response<Void> delete417WithResponse(Context context) {
+        return delete417WithResponseAsync(context).block();
     }
 
     /**
@@ -1533,7 +2421,7 @@ public final class HttpClientFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void delete417() {
-        delete417WithResponse();
+        delete417WithResponse(Context.NONE);
     }
 
     /**
@@ -1556,6 +2444,25 @@ public final class HttpClientFailures {
     /**
      * Return 429 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> head429WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.head429(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Return 429 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1568,13 +2475,29 @@ public final class HttpClientFailures {
     /**
      * Return 429 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> head429Async(Context context) {
+        return head429WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 429 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head429WithResponse() {
-        return head429WithResponseAsync().block();
+    public Response<Void> head429WithResponse(Context context) {
+        return head429WithResponseAsync(context).block();
     }
 
     /**
@@ -1585,6 +2508,6 @@ public final class HttpClientFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head429() {
-        head429WithResponse();
+        head429WithResponse(Context.NONE);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/httpinfrastructure/HttpFailures.java
+++ b/vanilla-tests/src/main/java/fixtures/httpinfrastructure/HttpFailures.java
@@ -86,6 +86,25 @@ public final class HttpFailures {
     /**
      * Get empty error form server.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return empty error form server along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Boolean>> getEmptyErrorWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getEmptyError(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get empty error form server.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return empty error form server on successful completion of {@link Mono}.
@@ -98,13 +117,29 @@ public final class HttpFailures {
     /**
      * Get empty error form server.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return empty error form server on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Boolean> getEmptyErrorAsync(Context context) {
+        return getEmptyErrorWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get empty error form server.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return empty error form server along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Boolean> getEmptyErrorWithResponse() {
-        return getEmptyErrorWithResponseAsync().block();
+    public Response<Boolean> getEmptyErrorWithResponse(Context context) {
+        return getEmptyErrorWithResponseAsync(context).block();
     }
 
     /**
@@ -116,7 +151,7 @@ public final class HttpFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean getEmptyError() {
-        return getEmptyErrorWithResponse().getValue();
+        return getEmptyErrorWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -139,6 +174,25 @@ public final class HttpFailures {
     /**
      * Get empty error form server.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return empty error form server along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Boolean>> getNoModelErrorWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNoModelError(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get empty error form server.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return empty error form server on successful completion of {@link Mono}.
@@ -151,13 +205,29 @@ public final class HttpFailures {
     /**
      * Get empty error form server.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return empty error form server on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Boolean> getNoModelErrorAsync(Context context) {
+        return getNoModelErrorWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get empty error form server.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return empty error form server along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Boolean> getNoModelErrorWithResponse() {
-        return getNoModelErrorWithResponseAsync().block();
+    public Response<Boolean> getNoModelErrorWithResponse(Context context) {
+        return getNoModelErrorWithResponseAsync(context).block();
     }
 
     /**
@@ -169,7 +239,7 @@ public final class HttpFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean getNoModelError() {
-        return getNoModelErrorWithResponse().getValue();
+        return getNoModelErrorWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -192,6 +262,25 @@ public final class HttpFailures {
     /**
      * Get empty response from server.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return empty response from server along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Boolean>> getNoModelEmptyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNoModelEmpty(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get empty response from server.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return empty response from server on successful completion of {@link Mono}.
@@ -204,13 +293,29 @@ public final class HttpFailures {
     /**
      * Get empty response from server.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return empty response from server on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Boolean> getNoModelEmptyAsync(Context context) {
+        return getNoModelEmptyWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get empty response from server.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return empty response from server along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Boolean> getNoModelEmptyWithResponse() {
-        return getNoModelEmptyWithResponseAsync().block();
+    public Response<Boolean> getNoModelEmptyWithResponse(Context context) {
+        return getNoModelEmptyWithResponseAsync(context).block();
     }
 
     /**
@@ -222,6 +327,6 @@ public final class HttpFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean getNoModelEmpty() {
-        return getNoModelEmptyWithResponse().getValue();
+        return getNoModelEmptyWithResponse(Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/httpinfrastructure/HttpRedirects.java
+++ b/vanilla-tests/src/main/java/fixtures/httpinfrastructure/HttpRedirects.java
@@ -207,6 +207,25 @@ public final class HttpRedirects {
     /**
      * Return 300 status code and redirect to /http/success/200.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HttpRedirectsHead300Response> head300WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.head300(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Return 300 status code and redirect to /http/success/200.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -219,13 +238,29 @@ public final class HttpRedirects {
     /**
      * Return 300 status code and redirect to /http/success/200.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> head300Async(Context context) {
+        return head300WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 300 status code and redirect to /http/success/200.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public HttpRedirectsHead300Response head300WithResponse() {
-        return head300WithResponseAsync().block();
+    public HttpRedirectsHead300Response head300WithResponse(Context context) {
+        return head300WithResponseAsync(context).block();
     }
 
     /**
@@ -236,7 +271,7 @@ public final class HttpRedirects {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head300() {
-        head300WithResponse();
+        head300WithResponse(Context.NONE);
     }
 
     /**
@@ -259,6 +294,25 @@ public final class HttpRedirects {
     /**
      * Return 300 status code and redirect to /http/success/200.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HttpRedirectsGet300Response> get300WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get300(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Return 300 status code and redirect to /http/success/200.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body on successful completion of {@link Mono}.
@@ -271,13 +325,29 @@ public final class HttpRedirects {
     /**
      * Return 300 status code and redirect to /http/success/200.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<String>> get300Async(Context context) {
+        return get300WithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Return 300 status code and redirect to /http/success/200.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public HttpRedirectsGet300Response get300WithResponse() {
-        return get300WithResponseAsync().block();
+    public HttpRedirectsGet300Response get300WithResponse(Context context) {
+        return get300WithResponseAsync(context).block();
     }
 
     /**
@@ -289,7 +359,7 @@ public final class HttpRedirects {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<String> get300() {
-        return get300WithResponse().getValue();
+        return get300WithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -312,6 +382,25 @@ public final class HttpRedirects {
     /**
      * Return 301 status code and redirect to /http/success/200.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HttpRedirectsHead301Response> head301WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.head301(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Return 301 status code and redirect to /http/success/200.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -324,13 +413,29 @@ public final class HttpRedirects {
     /**
      * Return 301 status code and redirect to /http/success/200.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> head301Async(Context context) {
+        return head301WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 301 status code and redirect to /http/success/200.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public HttpRedirectsHead301Response head301WithResponse() {
-        return head301WithResponseAsync().block();
+    public HttpRedirectsHead301Response head301WithResponse(Context context) {
+        return head301WithResponseAsync(context).block();
     }
 
     /**
@@ -341,7 +446,7 @@ public final class HttpRedirects {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head301() {
-        head301WithResponse();
+        head301WithResponse(Context.NONE);
     }
 
     /**
@@ -364,6 +469,25 @@ public final class HttpRedirects {
     /**
      * Return 301 status code and redirect to /http/success/200.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HttpRedirectsGet301Response> get301WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get301(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Return 301 status code and redirect to /http/success/200.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -376,13 +500,29 @@ public final class HttpRedirects {
     /**
      * Return 301 status code and redirect to /http/success/200.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> get301Async(Context context) {
+        return get301WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 301 status code and redirect to /http/success/200.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public HttpRedirectsGet301Response get301WithResponse() {
-        return get301WithResponseAsync().block();
+    public HttpRedirectsGet301Response get301WithResponse(Context context) {
+        return get301WithResponseAsync(context).block();
     }
 
     /**
@@ -393,7 +533,7 @@ public final class HttpRedirects {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get301() {
-        get301WithResponse();
+        get301WithResponse(Context.NONE);
     }
 
     /**
@@ -419,6 +559,27 @@ public final class HttpRedirects {
      * Put true Boolean value in request returns 301. This request should not be automatically redirected, but should
      * return the received 301 to the caller for evaluation.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HttpRedirectsPut301Response> put301WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.put301(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Put true Boolean value in request returns 301. This request should not be automatically redirected, but should
+     * return the received 301 to the caller for evaluation.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -432,13 +593,30 @@ public final class HttpRedirects {
      * Put true Boolean value in request returns 301. This request should not be automatically redirected, but should
      * return the received 301 to the caller for evaluation.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> put301Async(Context context) {
+        return put301WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put true Boolean value in request returns 301. This request should not be automatically redirected, but should
+     * return the received 301 to the caller for evaluation.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public HttpRedirectsPut301Response put301WithResponse() {
-        return put301WithResponseAsync().block();
+    public HttpRedirectsPut301Response put301WithResponse(Context context) {
+        return put301WithResponseAsync(context).block();
     }
 
     /**
@@ -450,7 +628,7 @@ public final class HttpRedirects {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void put301() {
-        put301WithResponse();
+        put301WithResponse(Context.NONE);
     }
 
     /**
@@ -473,6 +651,25 @@ public final class HttpRedirects {
     /**
      * Return 302 status code and redirect to /http/success/200.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HttpRedirectsHead302Response> head302WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.head302(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Return 302 status code and redirect to /http/success/200.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -485,13 +682,29 @@ public final class HttpRedirects {
     /**
      * Return 302 status code and redirect to /http/success/200.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> head302Async(Context context) {
+        return head302WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 302 status code and redirect to /http/success/200.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public HttpRedirectsHead302Response head302WithResponse() {
-        return head302WithResponseAsync().block();
+    public HttpRedirectsHead302Response head302WithResponse(Context context) {
+        return head302WithResponseAsync(context).block();
     }
 
     /**
@@ -502,7 +715,7 @@ public final class HttpRedirects {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head302() {
-        head302WithResponse();
+        head302WithResponse(Context.NONE);
     }
 
     /**
@@ -525,6 +738,25 @@ public final class HttpRedirects {
     /**
      * Return 302 status code and redirect to /http/success/200.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HttpRedirectsGet302Response> get302WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get302(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Return 302 status code and redirect to /http/success/200.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -537,13 +769,29 @@ public final class HttpRedirects {
     /**
      * Return 302 status code and redirect to /http/success/200.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> get302Async(Context context) {
+        return get302WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 302 status code and redirect to /http/success/200.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public HttpRedirectsGet302Response get302WithResponse() {
-        return get302WithResponseAsync().block();
+    public HttpRedirectsGet302Response get302WithResponse(Context context) {
+        return get302WithResponseAsync(context).block();
     }
 
     /**
@@ -554,7 +802,7 @@ public final class HttpRedirects {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get302() {
-        get302WithResponse();
+        get302WithResponse(Context.NONE);
     }
 
     /**
@@ -580,6 +828,27 @@ public final class HttpRedirects {
      * Patch true Boolean value in request returns 302. This request should not be automatically redirected, but should
      * return the received 302 to the caller for evaluation.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HttpRedirectsPatch302Response> patch302WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.patch302(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Patch true Boolean value in request returns 302. This request should not be automatically redirected, but should
+     * return the received 302 to the caller for evaluation.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -593,13 +862,30 @@ public final class HttpRedirects {
      * Patch true Boolean value in request returns 302. This request should not be automatically redirected, but should
      * return the received 302 to the caller for evaluation.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> patch302Async(Context context) {
+        return patch302WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Patch true Boolean value in request returns 302. This request should not be automatically redirected, but should
+     * return the received 302 to the caller for evaluation.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public HttpRedirectsPatch302Response patch302WithResponse() {
-        return patch302WithResponseAsync().block();
+    public HttpRedirectsPatch302Response patch302WithResponse(Context context) {
+        return patch302WithResponseAsync(context).block();
     }
 
     /**
@@ -611,7 +897,7 @@ public final class HttpRedirects {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void patch302() {
-        patch302WithResponse();
+        patch302WithResponse(Context.NONE);
     }
 
     /**
@@ -637,6 +923,27 @@ public final class HttpRedirects {
      * Post true Boolean value in request returns 303. This request should be automatically redirected usign a get,
      * ultimately returning a 200 status code.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HttpRedirectsPost303Response> post303WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.post303(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Post true Boolean value in request returns 303. This request should be automatically redirected usign a get,
+     * ultimately returning a 200 status code.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -650,13 +957,30 @@ public final class HttpRedirects {
      * Post true Boolean value in request returns 303. This request should be automatically redirected usign a get,
      * ultimately returning a 200 status code.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> post303Async(Context context) {
+        return post303WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Post true Boolean value in request returns 303. This request should be automatically redirected usign a get,
+     * ultimately returning a 200 status code.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public HttpRedirectsPost303Response post303WithResponse() {
-        return post303WithResponseAsync().block();
+    public HttpRedirectsPost303Response post303WithResponse(Context context) {
+        return post303WithResponseAsync(context).block();
     }
 
     /**
@@ -668,7 +992,7 @@ public final class HttpRedirects {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void post303() {
-        post303WithResponse();
+        post303WithResponse(Context.NONE);
     }
 
     /**
@@ -691,6 +1015,25 @@ public final class HttpRedirects {
     /**
      * Redirect with 307, resulting in a 200 success.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HttpRedirectsHead307Response> head307WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.head307(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Redirect with 307, resulting in a 200 success.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -703,13 +1046,29 @@ public final class HttpRedirects {
     /**
      * Redirect with 307, resulting in a 200 success.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> head307Async(Context context) {
+        return head307WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Redirect with 307, resulting in a 200 success.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public HttpRedirectsHead307Response head307WithResponse() {
-        return head307WithResponseAsync().block();
+    public HttpRedirectsHead307Response head307WithResponse(Context context) {
+        return head307WithResponseAsync(context).block();
     }
 
     /**
@@ -720,7 +1079,7 @@ public final class HttpRedirects {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head307() {
-        head307WithResponse();
+        head307WithResponse(Context.NONE);
     }
 
     /**
@@ -743,6 +1102,25 @@ public final class HttpRedirects {
     /**
      * Redirect get with 307, resulting in a 200 success.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HttpRedirectsGet307Response> get307WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get307(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Redirect get with 307, resulting in a 200 success.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -755,13 +1133,29 @@ public final class HttpRedirects {
     /**
      * Redirect get with 307, resulting in a 200 success.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> get307Async(Context context) {
+        return get307WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Redirect get with 307, resulting in a 200 success.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public HttpRedirectsGet307Response get307WithResponse() {
-        return get307WithResponseAsync().block();
+    public HttpRedirectsGet307Response get307WithResponse(Context context) {
+        return get307WithResponseAsync(context).block();
     }
 
     /**
@@ -772,7 +1166,7 @@ public final class HttpRedirects {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get307() {
-        get307WithResponse();
+        get307WithResponse(Context.NONE);
     }
 
     /**
@@ -795,6 +1189,25 @@ public final class HttpRedirects {
     /**
      * options redirected with 307, resulting in a 200 after redirect.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HttpRedirectsOptions307Response> options307WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.options307(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * options redirected with 307, resulting in a 200 after redirect.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -807,13 +1220,29 @@ public final class HttpRedirects {
     /**
      * options redirected with 307, resulting in a 200 after redirect.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> options307Async(Context context) {
+        return options307WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * options redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public HttpRedirectsOptions307Response options307WithResponse() {
-        return options307WithResponseAsync().block();
+    public HttpRedirectsOptions307Response options307WithResponse(Context context) {
+        return options307WithResponseAsync(context).block();
     }
 
     /**
@@ -824,7 +1253,7 @@ public final class HttpRedirects {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void options307() {
-        options307WithResponse();
+        options307WithResponse(Context.NONE);
     }
 
     /**
@@ -848,6 +1277,26 @@ public final class HttpRedirects {
     /**
      * Put redirected with 307, resulting in a 200 after redirect.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HttpRedirectsPut307Response> put307WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.put307(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Put redirected with 307, resulting in a 200 after redirect.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -860,13 +1309,29 @@ public final class HttpRedirects {
     /**
      * Put redirected with 307, resulting in a 200 after redirect.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> put307Async(Context context) {
+        return put307WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public HttpRedirectsPut307Response put307WithResponse() {
-        return put307WithResponseAsync().block();
+    public HttpRedirectsPut307Response put307WithResponse(Context context) {
+        return put307WithResponseAsync(context).block();
     }
 
     /**
@@ -877,7 +1342,7 @@ public final class HttpRedirects {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void put307() {
-        put307WithResponse();
+        put307WithResponse(Context.NONE);
     }
 
     /**
@@ -901,6 +1366,26 @@ public final class HttpRedirects {
     /**
      * Patch redirected with 307, resulting in a 200 after redirect.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HttpRedirectsPatch307Response> patch307WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.patch307(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Patch redirected with 307, resulting in a 200 after redirect.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -913,13 +1398,29 @@ public final class HttpRedirects {
     /**
      * Patch redirected with 307, resulting in a 200 after redirect.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> patch307Async(Context context) {
+        return patch307WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Patch redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public HttpRedirectsPatch307Response patch307WithResponse() {
-        return patch307WithResponseAsync().block();
+    public HttpRedirectsPatch307Response patch307WithResponse(Context context) {
+        return patch307WithResponseAsync(context).block();
     }
 
     /**
@@ -930,7 +1431,7 @@ public final class HttpRedirects {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void patch307() {
-        patch307WithResponse();
+        patch307WithResponse(Context.NONE);
     }
 
     /**
@@ -954,6 +1455,26 @@ public final class HttpRedirects {
     /**
      * Post redirected with 307, resulting in a 200 after redirect.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HttpRedirectsPost307Response> post307WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.post307(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Post redirected with 307, resulting in a 200 after redirect.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -966,13 +1487,29 @@ public final class HttpRedirects {
     /**
      * Post redirected with 307, resulting in a 200 after redirect.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> post307Async(Context context) {
+        return post307WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Post redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public HttpRedirectsPost307Response post307WithResponse() {
-        return post307WithResponseAsync().block();
+    public HttpRedirectsPost307Response post307WithResponse(Context context) {
+        return post307WithResponseAsync(context).block();
     }
 
     /**
@@ -983,7 +1520,7 @@ public final class HttpRedirects {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void post307() {
-        post307WithResponse();
+        post307WithResponse(Context.NONE);
     }
 
     /**
@@ -1007,6 +1544,26 @@ public final class HttpRedirects {
     /**
      * Delete redirected with 307, resulting in a 200 after redirect.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HttpRedirectsDelete307Response> delete307WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.delete307(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Delete redirected with 307, resulting in a 200 after redirect.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1019,13 +1576,29 @@ public final class HttpRedirects {
     /**
      * Delete redirected with 307, resulting in a 200 after redirect.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> delete307Async(Context context) {
+        return delete307WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Delete redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public HttpRedirectsDelete307Response delete307WithResponse() {
-        return delete307WithResponseAsync().block();
+    public HttpRedirectsDelete307Response delete307WithResponse(Context context) {
+        return delete307WithResponseAsync(context).block();
     }
 
     /**
@@ -1036,6 +1609,6 @@ public final class HttpRedirects {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void delete307() {
-        delete307WithResponse();
+        delete307WithResponse(Context.NONE);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/httpinfrastructure/HttpRetries.java
+++ b/vanilla-tests/src/main/java/fixtures/httpinfrastructure/HttpRetries.java
@@ -146,6 +146,25 @@ public final class HttpRetries {
     /**
      * Return 408 status code, then 200 after retry.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> head408WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.head408(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Return 408 status code, then 200 after retry.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -158,13 +177,29 @@ public final class HttpRetries {
     /**
      * Return 408 status code, then 200 after retry.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> head408Async(Context context) {
+        return head408WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 408 status code, then 200 after retry.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head408WithResponse() {
-        return head408WithResponseAsync().block();
+    public Response<Void> head408WithResponse(Context context) {
+        return head408WithResponseAsync(context).block();
     }
 
     /**
@@ -175,7 +210,7 @@ public final class HttpRetries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head408() {
-        head408WithResponse();
+        head408WithResponse(Context.NONE);
     }
 
     /**
@@ -199,6 +234,26 @@ public final class HttpRetries {
     /**
      * Return 500 status code, then 200 after retry.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> put500WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.put500(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Return 500 status code, then 200 after retry.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -211,13 +266,29 @@ public final class HttpRetries {
     /**
      * Return 500 status code, then 200 after retry.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> put500Async(Context context) {
+        return put500WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 500 status code, then 200 after retry.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put500WithResponse() {
-        return put500WithResponseAsync().block();
+    public Response<Void> put500WithResponse(Context context) {
+        return put500WithResponseAsync(context).block();
     }
 
     /**
@@ -228,7 +299,7 @@ public final class HttpRetries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void put500() {
-        put500WithResponse();
+        put500WithResponse(Context.NONE);
     }
 
     /**
@@ -252,6 +323,26 @@ public final class HttpRetries {
     /**
      * Return 500 status code, then 200 after retry.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> patch500WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.patch500(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Return 500 status code, then 200 after retry.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -264,13 +355,29 @@ public final class HttpRetries {
     /**
      * Return 500 status code, then 200 after retry.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> patch500Async(Context context) {
+        return patch500WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 500 status code, then 200 after retry.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> patch500WithResponse() {
-        return patch500WithResponseAsync().block();
+    public Response<Void> patch500WithResponse(Context context) {
+        return patch500WithResponseAsync(context).block();
     }
 
     /**
@@ -281,7 +388,7 @@ public final class HttpRetries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void patch500() {
-        patch500WithResponse();
+        patch500WithResponse(Context.NONE);
     }
 
     /**
@@ -304,6 +411,25 @@ public final class HttpRetries {
     /**
      * Return 502 status code, then 200 after retry.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> get502WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get502(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Return 502 status code, then 200 after retry.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -316,13 +442,29 @@ public final class HttpRetries {
     /**
      * Return 502 status code, then 200 after retry.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> get502Async(Context context) {
+        return get502WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 502 status code, then 200 after retry.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get502WithResponse() {
-        return get502WithResponseAsync().block();
+    public Response<Void> get502WithResponse(Context context) {
+        return get502WithResponseAsync(context).block();
     }
 
     /**
@@ -333,7 +475,7 @@ public final class HttpRetries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get502() {
-        get502WithResponse();
+        get502WithResponse(Context.NONE);
     }
 
     /**
@@ -356,6 +498,25 @@ public final class HttpRetries {
     /**
      * Return 502 status code, then 200 after retry.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return simple boolean along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Boolean>> options502WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.options502(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Return 502 status code, then 200 after retry.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return simple boolean on successful completion of {@link Mono}.
@@ -368,13 +529,29 @@ public final class HttpRetries {
     /**
      * Return 502 status code, then 200 after retry.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return simple boolean on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Boolean> options502Async(Context context) {
+        return options502WithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Return 502 status code, then 200 after retry.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return simple boolean along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Boolean> options502WithResponse() {
-        return options502WithResponseAsync().block();
+    public Response<Boolean> options502WithResponse(Context context) {
+        return options502WithResponseAsync(context).block();
     }
 
     /**
@@ -386,7 +563,7 @@ public final class HttpRetries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean options502() {
-        return options502WithResponse().getValue();
+        return options502WithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -410,6 +587,26 @@ public final class HttpRetries {
     /**
      * Return 503 status code, then 200 after retry.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> post503WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.post503(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Return 503 status code, then 200 after retry.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -422,13 +619,29 @@ public final class HttpRetries {
     /**
      * Return 503 status code, then 200 after retry.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> post503Async(Context context) {
+        return post503WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 503 status code, then 200 after retry.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post503WithResponse() {
-        return post503WithResponseAsync().block();
+    public Response<Void> post503WithResponse(Context context) {
+        return post503WithResponseAsync(context).block();
     }
 
     /**
@@ -439,7 +652,7 @@ public final class HttpRetries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void post503() {
-        post503WithResponse();
+        post503WithResponse(Context.NONE);
     }
 
     /**
@@ -463,6 +676,26 @@ public final class HttpRetries {
     /**
      * Return 503 status code, then 200 after retry.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> delete503WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.delete503(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Return 503 status code, then 200 after retry.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -475,13 +708,29 @@ public final class HttpRetries {
     /**
      * Return 503 status code, then 200 after retry.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> delete503Async(Context context) {
+        return delete503WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 503 status code, then 200 after retry.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> delete503WithResponse() {
-        return delete503WithResponseAsync().block();
+    public Response<Void> delete503WithResponse(Context context) {
+        return delete503WithResponseAsync(context).block();
     }
 
     /**
@@ -492,7 +741,7 @@ public final class HttpRetries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void delete503() {
-        delete503WithResponse();
+        delete503WithResponse(Context.NONE);
     }
 
     /**
@@ -516,6 +765,26 @@ public final class HttpRetries {
     /**
      * Return 504 status code, then 200 after retry.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> put504WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.put504(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Return 504 status code, then 200 after retry.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -528,13 +797,29 @@ public final class HttpRetries {
     /**
      * Return 504 status code, then 200 after retry.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> put504Async(Context context) {
+        return put504WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 504 status code, then 200 after retry.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put504WithResponse() {
-        return put504WithResponseAsync().block();
+    public Response<Void> put504WithResponse(Context context) {
+        return put504WithResponseAsync(context).block();
     }
 
     /**
@@ -545,7 +830,7 @@ public final class HttpRetries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void put504() {
-        put504WithResponse();
+        put504WithResponse(Context.NONE);
     }
 
     /**
@@ -569,6 +854,26 @@ public final class HttpRetries {
     /**
      * Return 504 status code, then 200 after retry.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> patch504WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.patch504(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Return 504 status code, then 200 after retry.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -581,13 +886,29 @@ public final class HttpRetries {
     /**
      * Return 504 status code, then 200 after retry.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> patch504Async(Context context) {
+        return patch504WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 504 status code, then 200 after retry.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> patch504WithResponse() {
-        return patch504WithResponseAsync().block();
+    public Response<Void> patch504WithResponse(Context context) {
+        return patch504WithResponseAsync(context).block();
     }
 
     /**
@@ -598,6 +919,6 @@ public final class HttpRetries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void patch504() {
-        patch504WithResponse();
+        patch504WithResponse(Context.NONE);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/httpinfrastructure/HttpServerFailures.java
+++ b/vanilla-tests/src/main/java/fixtures/httpinfrastructure/HttpServerFailures.java
@@ -97,6 +97,25 @@ public final class HttpServerFailures {
     /**
      * Return 501 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> head501WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.head501(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Return 501 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -109,13 +128,29 @@ public final class HttpServerFailures {
     /**
      * Return 501 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> head501Async(Context context) {
+        return head501WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 501 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head501WithResponse() {
-        return head501WithResponseAsync().block();
+    public Response<Void> head501WithResponse(Context context) {
+        return head501WithResponseAsync(context).block();
     }
 
     /**
@@ -126,7 +161,7 @@ public final class HttpServerFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head501() {
-        head501WithResponse();
+        head501WithResponse(Context.NONE);
     }
 
     /**
@@ -149,6 +184,25 @@ public final class HttpServerFailures {
     /**
      * Return 501 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> get501WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get501(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Return 501 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -161,13 +215,29 @@ public final class HttpServerFailures {
     /**
      * Return 501 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> get501Async(Context context) {
+        return get501WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 501 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get501WithResponse() {
-        return get501WithResponseAsync().block();
+    public Response<Void> get501WithResponse(Context context) {
+        return get501WithResponseAsync(context).block();
     }
 
     /**
@@ -178,7 +248,7 @@ public final class HttpServerFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get501() {
-        get501WithResponse();
+        get501WithResponse(Context.NONE);
     }
 
     /**
@@ -202,6 +272,26 @@ public final class HttpServerFailures {
     /**
      * Return 505 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> post505WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.post505(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -214,13 +304,29 @@ public final class HttpServerFailures {
     /**
      * Return 505 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> post505Async(Context context) {
+        return post505WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post505WithResponse() {
-        return post505WithResponseAsync().block();
+    public Response<Void> post505WithResponse(Context context) {
+        return post505WithResponseAsync(context).block();
     }
 
     /**
@@ -231,7 +337,7 @@ public final class HttpServerFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void post505() {
-        post505WithResponse();
+        post505WithResponse(Context.NONE);
     }
 
     /**
@@ -255,6 +361,26 @@ public final class HttpServerFailures {
     /**
      * Return 505 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> delete505WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.delete505(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -267,13 +393,29 @@ public final class HttpServerFailures {
     /**
      * Return 505 status code - should be represented in the client as an error.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> delete505Async(Context context) {
+        return delete505WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> delete505WithResponse() {
-        return delete505WithResponseAsync().block();
+    public Response<Void> delete505WithResponse(Context context) {
+        return delete505WithResponseAsync(context).block();
     }
 
     /**
@@ -284,6 +426,6 @@ public final class HttpServerFailures {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void delete505() {
-        delete505WithResponse();
+        delete505WithResponse(Context.NONE);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/httpinfrastructure/HttpSuccess.java
+++ b/vanilla-tests/src/main/java/fixtures/httpinfrastructure/HttpSuccess.java
@@ -230,6 +230,25 @@ public final class HttpSuccess {
     /**
      * Return 200 status code if successful.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> head200WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.head200(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Return 200 status code if successful.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -242,13 +261,29 @@ public final class HttpSuccess {
     /**
      * Return 200 status code if successful.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> head200Async(Context context) {
+        return head200WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 200 status code if successful.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head200WithResponse() {
-        return head200WithResponseAsync().block();
+    public Response<Void> head200WithResponse(Context context) {
+        return head200WithResponseAsync(context).block();
     }
 
     /**
@@ -259,7 +294,7 @@ public final class HttpSuccess {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head200() {
-        head200WithResponse();
+        head200WithResponse(Context.NONE);
     }
 
     /**
@@ -282,6 +317,25 @@ public final class HttpSuccess {
     /**
      * Get 200 success.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return 200 success along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Boolean>> get200WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get200(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get 200 success.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return 200 success on successful completion of {@link Mono}.
@@ -294,13 +348,29 @@ public final class HttpSuccess {
     /**
      * Get 200 success.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return 200 success on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Boolean> get200Async(Context context) {
+        return get200WithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get 200 success.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return 200 success along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Boolean> get200WithResponse() {
-        return get200WithResponseAsync().block();
+    public Response<Boolean> get200WithResponse(Context context) {
+        return get200WithResponseAsync(context).block();
     }
 
     /**
@@ -312,7 +382,7 @@ public final class HttpSuccess {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean get200() {
-        return get200WithResponse().getValue();
+        return get200WithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -335,6 +405,25 @@ public final class HttpSuccess {
     /**
      * Options 200 success.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return simple boolean along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Boolean>> options200WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.options200(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Options 200 success.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return simple boolean on successful completion of {@link Mono}.
@@ -347,13 +436,29 @@ public final class HttpSuccess {
     /**
      * Options 200 success.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return simple boolean on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Boolean> options200Async(Context context) {
+        return options200WithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Options 200 success.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return simple boolean along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Boolean> options200WithResponse() {
-        return options200WithResponseAsync().block();
+    public Response<Boolean> options200WithResponse(Context context) {
+        return options200WithResponseAsync(context).block();
     }
 
     /**
@@ -365,7 +470,7 @@ public final class HttpSuccess {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean options200() {
-        return options200WithResponse().getValue();
+        return options200WithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -389,6 +494,26 @@ public final class HttpSuccess {
     /**
      * Put boolean value true returning 200 success.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> put200WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.put200(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Put boolean value true returning 200 success.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -401,13 +526,29 @@ public final class HttpSuccess {
     /**
      * Put boolean value true returning 200 success.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> put200Async(Context context) {
+        return put200WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put boolean value true returning 200 success.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put200WithResponse() {
-        return put200WithResponseAsync().block();
+    public Response<Void> put200WithResponse(Context context) {
+        return put200WithResponseAsync(context).block();
     }
 
     /**
@@ -418,7 +559,7 @@ public final class HttpSuccess {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void put200() {
-        put200WithResponse();
+        put200WithResponse(Context.NONE);
     }
 
     /**
@@ -442,6 +583,26 @@ public final class HttpSuccess {
     /**
      * Patch true Boolean value in request returning 200.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> patch200WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.patch200(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Patch true Boolean value in request returning 200.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -454,13 +615,29 @@ public final class HttpSuccess {
     /**
      * Patch true Boolean value in request returning 200.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> patch200Async(Context context) {
+        return patch200WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Patch true Boolean value in request returning 200.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> patch200WithResponse() {
-        return patch200WithResponseAsync().block();
+    public Response<Void> patch200WithResponse(Context context) {
+        return patch200WithResponseAsync(context).block();
     }
 
     /**
@@ -471,7 +648,7 @@ public final class HttpSuccess {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void patch200() {
-        patch200WithResponse();
+        patch200WithResponse(Context.NONE);
     }
 
     /**
@@ -495,6 +672,26 @@ public final class HttpSuccess {
     /**
      * Post bollean value true in request that returns a 200.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> post200WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.post200(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Post bollean value true in request that returns a 200.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -507,13 +704,29 @@ public final class HttpSuccess {
     /**
      * Post bollean value true in request that returns a 200.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> post200Async(Context context) {
+        return post200WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Post bollean value true in request that returns a 200.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post200WithResponse() {
-        return post200WithResponseAsync().block();
+    public Response<Void> post200WithResponse(Context context) {
+        return post200WithResponseAsync(context).block();
     }
 
     /**
@@ -524,7 +737,7 @@ public final class HttpSuccess {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void post200() {
-        post200WithResponse();
+        post200WithResponse(Context.NONE);
     }
 
     /**
@@ -548,6 +761,26 @@ public final class HttpSuccess {
     /**
      * Delete simple boolean value true returns 200.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> delete200WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.delete200(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Delete simple boolean value true returns 200.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -560,13 +793,29 @@ public final class HttpSuccess {
     /**
      * Delete simple boolean value true returns 200.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> delete200Async(Context context) {
+        return delete200WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Delete simple boolean value true returns 200.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> delete200WithResponse() {
-        return delete200WithResponseAsync().block();
+    public Response<Void> delete200WithResponse(Context context) {
+        return delete200WithResponseAsync(context).block();
     }
 
     /**
@@ -577,7 +826,7 @@ public final class HttpSuccess {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void delete200() {
-        delete200WithResponse();
+        delete200WithResponse(Context.NONE);
     }
 
     /**
@@ -601,6 +850,26 @@ public final class HttpSuccess {
     /**
      * Put true Boolean value in request returns 201.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> put201WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.put201(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Put true Boolean value in request returns 201.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -613,13 +882,29 @@ public final class HttpSuccess {
     /**
      * Put true Boolean value in request returns 201.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> put201Async(Context context) {
+        return put201WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put true Boolean value in request returns 201.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put201WithResponse() {
-        return put201WithResponseAsync().block();
+    public Response<Void> put201WithResponse(Context context) {
+        return put201WithResponseAsync(context).block();
     }
 
     /**
@@ -630,7 +915,7 @@ public final class HttpSuccess {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void put201() {
-        put201WithResponse();
+        put201WithResponse(Context.NONE);
     }
 
     /**
@@ -654,6 +939,26 @@ public final class HttpSuccess {
     /**
      * Post true Boolean value in request returns 201 (Created).
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> post201WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.post201(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Post true Boolean value in request returns 201 (Created).
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -666,13 +971,29 @@ public final class HttpSuccess {
     /**
      * Post true Boolean value in request returns 201 (Created).
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> post201Async(Context context) {
+        return post201WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Post true Boolean value in request returns 201 (Created).
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post201WithResponse() {
-        return post201WithResponseAsync().block();
+    public Response<Void> post201WithResponse(Context context) {
+        return post201WithResponseAsync(context).block();
     }
 
     /**
@@ -683,7 +1004,7 @@ public final class HttpSuccess {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void post201() {
-        post201WithResponse();
+        post201WithResponse(Context.NONE);
     }
 
     /**
@@ -707,6 +1028,26 @@ public final class HttpSuccess {
     /**
      * Put true Boolean value in request returns 202 (Accepted).
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> put202WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.put202(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Put true Boolean value in request returns 202 (Accepted).
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -719,13 +1060,29 @@ public final class HttpSuccess {
     /**
      * Put true Boolean value in request returns 202 (Accepted).
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> put202Async(Context context) {
+        return put202WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put true Boolean value in request returns 202 (Accepted).
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put202WithResponse() {
-        return put202WithResponseAsync().block();
+    public Response<Void> put202WithResponse(Context context) {
+        return put202WithResponseAsync(context).block();
     }
 
     /**
@@ -736,7 +1093,7 @@ public final class HttpSuccess {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void put202() {
-        put202WithResponse();
+        put202WithResponse(Context.NONE);
     }
 
     /**
@@ -760,6 +1117,26 @@ public final class HttpSuccess {
     /**
      * Patch true Boolean value in request returns 202.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> patch202WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.patch202(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Patch true Boolean value in request returns 202.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -772,13 +1149,29 @@ public final class HttpSuccess {
     /**
      * Patch true Boolean value in request returns 202.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> patch202Async(Context context) {
+        return patch202WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Patch true Boolean value in request returns 202.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> patch202WithResponse() {
-        return patch202WithResponseAsync().block();
+    public Response<Void> patch202WithResponse(Context context) {
+        return patch202WithResponseAsync(context).block();
     }
 
     /**
@@ -789,7 +1182,7 @@ public final class HttpSuccess {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void patch202() {
-        patch202WithResponse();
+        patch202WithResponse(Context.NONE);
     }
 
     /**
@@ -813,6 +1206,26 @@ public final class HttpSuccess {
     /**
      * Post true Boolean value in request returns 202 (Accepted).
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> post202WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.post202(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Post true Boolean value in request returns 202 (Accepted).
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -825,13 +1238,29 @@ public final class HttpSuccess {
     /**
      * Post true Boolean value in request returns 202 (Accepted).
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> post202Async(Context context) {
+        return post202WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Post true Boolean value in request returns 202 (Accepted).
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post202WithResponse() {
-        return post202WithResponseAsync().block();
+    public Response<Void> post202WithResponse(Context context) {
+        return post202WithResponseAsync(context).block();
     }
 
     /**
@@ -842,7 +1271,7 @@ public final class HttpSuccess {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void post202() {
-        post202WithResponse();
+        post202WithResponse(Context.NONE);
     }
 
     /**
@@ -866,6 +1295,26 @@ public final class HttpSuccess {
     /**
      * Delete true Boolean value in request returns 202 (accepted).
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> delete202WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.delete202(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Delete true Boolean value in request returns 202 (accepted).
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -878,13 +1327,29 @@ public final class HttpSuccess {
     /**
      * Delete true Boolean value in request returns 202 (accepted).
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> delete202Async(Context context) {
+        return delete202WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Delete true Boolean value in request returns 202 (accepted).
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> delete202WithResponse() {
-        return delete202WithResponseAsync().block();
+    public Response<Void> delete202WithResponse(Context context) {
+        return delete202WithResponseAsync(context).block();
     }
 
     /**
@@ -895,7 +1360,7 @@ public final class HttpSuccess {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void delete202() {
-        delete202WithResponse();
+        delete202WithResponse(Context.NONE);
     }
 
     /**
@@ -918,6 +1383,25 @@ public final class HttpSuccess {
     /**
      * Return 204 status code if successful.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> head204WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.head204(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Return 204 status code if successful.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -930,13 +1414,29 @@ public final class HttpSuccess {
     /**
      * Return 204 status code if successful.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> head204Async(Context context) {
+        return head204WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Return 204 status code if successful.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head204WithResponse() {
-        return head204WithResponseAsync().block();
+    public Response<Void> head204WithResponse(Context context) {
+        return head204WithResponseAsync(context).block();
     }
 
     /**
@@ -947,7 +1447,7 @@ public final class HttpSuccess {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head204() {
-        head204WithResponse();
+        head204WithResponse(Context.NONE);
     }
 
     /**
@@ -971,6 +1471,26 @@ public final class HttpSuccess {
     /**
      * Put true Boolean value in request returns 204 (no content).
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> put204WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.put204(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Put true Boolean value in request returns 204 (no content).
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -983,13 +1503,29 @@ public final class HttpSuccess {
     /**
      * Put true Boolean value in request returns 204 (no content).
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> put204Async(Context context) {
+        return put204WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put true Boolean value in request returns 204 (no content).
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put204WithResponse() {
-        return put204WithResponseAsync().block();
+    public Response<Void> put204WithResponse(Context context) {
+        return put204WithResponseAsync(context).block();
     }
 
     /**
@@ -1000,7 +1536,7 @@ public final class HttpSuccess {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void put204() {
-        put204WithResponse();
+        put204WithResponse(Context.NONE);
     }
 
     /**
@@ -1024,6 +1560,26 @@ public final class HttpSuccess {
     /**
      * Patch true Boolean value in request returns 204 (no content).
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> patch204WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.patch204(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Patch true Boolean value in request returns 204 (no content).
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1036,13 +1592,29 @@ public final class HttpSuccess {
     /**
      * Patch true Boolean value in request returns 204 (no content).
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> patch204Async(Context context) {
+        return patch204WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Patch true Boolean value in request returns 204 (no content).
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> patch204WithResponse() {
-        return patch204WithResponseAsync().block();
+    public Response<Void> patch204WithResponse(Context context) {
+        return patch204WithResponseAsync(context).block();
     }
 
     /**
@@ -1053,7 +1625,7 @@ public final class HttpSuccess {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void patch204() {
-        patch204WithResponse();
+        patch204WithResponse(Context.NONE);
     }
 
     /**
@@ -1077,6 +1649,26 @@ public final class HttpSuccess {
     /**
      * Post true Boolean value in request returns 204 (no content).
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> post204WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.post204(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Post true Boolean value in request returns 204 (no content).
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1089,13 +1681,29 @@ public final class HttpSuccess {
     /**
      * Post true Boolean value in request returns 204 (no content).
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> post204Async(Context context) {
+        return post204WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Post true Boolean value in request returns 204 (no content).
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post204WithResponse() {
-        return post204WithResponseAsync().block();
+    public Response<Void> post204WithResponse(Context context) {
+        return post204WithResponseAsync(context).block();
     }
 
     /**
@@ -1106,7 +1714,7 @@ public final class HttpSuccess {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void post204() {
-        post204WithResponse();
+        post204WithResponse(Context.NONE);
     }
 
     /**
@@ -1130,6 +1738,26 @@ public final class HttpSuccess {
     /**
      * Delete true Boolean value in request returns 204 (no content).
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> delete204WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final Boolean booleanValue = true;
+        final String accept = "application/json";
+        return service.delete204(this.client.getHost(), booleanValue, accept, context);
+    }
+
+    /**
+     * Delete true Boolean value in request returns 204 (no content).
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1142,13 +1770,29 @@ public final class HttpSuccess {
     /**
      * Delete true Boolean value in request returns 204 (no content).
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> delete204Async(Context context) {
+        return delete204WithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Delete true Boolean value in request returns 204 (no content).
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> delete204WithResponse() {
-        return delete204WithResponseAsync().block();
+    public Response<Void> delete204WithResponse(Context context) {
+        return delete204WithResponseAsync(context).block();
     }
 
     /**
@@ -1159,7 +1803,7 @@ public final class HttpSuccess {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void delete204() {
-        delete204WithResponse();
+        delete204WithResponse(Context.NONE);
     }
 
     /**
@@ -1182,6 +1826,25 @@ public final class HttpSuccess {
     /**
      * Return 404 status code.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return whether resource exists along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Boolean>> head404WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.head404(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Return 404 status code.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return whether resource exists on successful completion of {@link Mono}.
@@ -1194,13 +1857,29 @@ public final class HttpSuccess {
     /**
      * Return 404 status code.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return whether resource exists on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Boolean> head404Async(Context context) {
+        return head404WithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Return 404 status code.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return whether resource exists along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Boolean> head404WithResponse() {
-        return head404WithResponseAsync().block();
+    public Response<Boolean> head404WithResponse(Context context) {
+        return head404WithResponseAsync(context).block();
     }
 
     /**
@@ -1212,6 +1891,6 @@ public final class HttpSuccess {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean head404() {
-        return head404WithResponse().getValue();
+        return head404WithResponse(Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/httpinfrastructure/MultipleResponses.java
+++ b/vanilla-tests/src/main/java/fixtures/httpinfrastructure/MultipleResponses.java
@@ -268,6 +268,25 @@ public final class MultipleResponses {
     /**
      * Send a 200 response with valid payload: {'statusCode': '200'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<MyException>> get200Model204NoModelDefaultError200ValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get200Model204NoModelDefaultError200Valid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body on successful completion of {@link Mono}.
@@ -281,13 +300,30 @@ public final class MultipleResponses {
     /**
      * Send a 200 response with valid payload: {'statusCode': '200'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<MyException> get200Model204NoModelDefaultError200ValidAsync(Context context) {
+        return get200Model204NoModelDefaultError200ValidWithResponseAsync(context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<MyException> get200Model204NoModelDefaultError200ValidWithResponse() {
-        return get200Model204NoModelDefaultError200ValidWithResponseAsync().block();
+    public Response<MyException> get200Model204NoModelDefaultError200ValidWithResponse(Context context) {
+        return get200Model204NoModelDefaultError200ValidWithResponseAsync(context).block();
     }
 
     /**
@@ -299,7 +335,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200Model204NoModelDefaultError200Valid() {
-        return get200Model204NoModelDefaultError200ValidWithResponse().getValue();
+        return get200Model204NoModelDefaultError200ValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -323,6 +359,25 @@ public final class MultipleResponses {
     /**
      * Send a 204 response with no payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<MyException>> get200Model204NoModelDefaultError204ValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get200Model204NoModelDefaultError204Valid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Send a 204 response with no payload.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body on successful completion of {@link Mono}.
@@ -336,13 +391,30 @@ public final class MultipleResponses {
     /**
      * Send a 204 response with no payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<MyException> get200Model204NoModelDefaultError204ValidAsync(Context context) {
+        return get200Model204NoModelDefaultError204ValidWithResponseAsync(context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Send a 204 response with no payload.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<MyException> get200Model204NoModelDefaultError204ValidWithResponse() {
-        return get200Model204NoModelDefaultError204ValidWithResponseAsync().block();
+    public Response<MyException> get200Model204NoModelDefaultError204ValidWithResponse(Context context) {
+        return get200Model204NoModelDefaultError204ValidWithResponseAsync(context).block();
     }
 
     /**
@@ -354,7 +426,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200Model204NoModelDefaultError204Valid() {
-        return get200Model204NoModelDefaultError204ValidWithResponse().getValue();
+        return get200Model204NoModelDefaultError204ValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -378,6 +450,25 @@ public final class MultipleResponses {
     /**
      * Send a 201 response with valid payload: {'statusCode': '201'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<MyException>> get200Model204NoModelDefaultError201InvalidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get200Model204NoModelDefaultError201Invalid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Send a 201 response with valid payload: {'statusCode': '201'}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body on successful completion of {@link Mono}.
@@ -391,13 +482,30 @@ public final class MultipleResponses {
     /**
      * Send a 201 response with valid payload: {'statusCode': '201'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<MyException> get200Model204NoModelDefaultError201InvalidAsync(Context context) {
+        return get200Model204NoModelDefaultError201InvalidWithResponseAsync(context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Send a 201 response with valid payload: {'statusCode': '201'}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<MyException> get200Model204NoModelDefaultError201InvalidWithResponse() {
-        return get200Model204NoModelDefaultError201InvalidWithResponseAsync().block();
+    public Response<MyException> get200Model204NoModelDefaultError201InvalidWithResponse(Context context) {
+        return get200Model204NoModelDefaultError201InvalidWithResponseAsync(context).block();
     }
 
     /**
@@ -409,7 +517,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200Model204NoModelDefaultError201Invalid() {
-        return get200Model204NoModelDefaultError201InvalidWithResponse().getValue();
+        return get200Model204NoModelDefaultError201InvalidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -433,6 +541,25 @@ public final class MultipleResponses {
     /**
      * Send a 202 response with no payload:.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<MyException>> get200Model204NoModelDefaultError202NoneWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get200Model204NoModelDefaultError202None(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Send a 202 response with no payload:.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body on successful completion of {@link Mono}.
@@ -446,13 +573,30 @@ public final class MultipleResponses {
     /**
      * Send a 202 response with no payload:.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<MyException> get200Model204NoModelDefaultError202NoneAsync(Context context) {
+        return get200Model204NoModelDefaultError202NoneWithResponseAsync(context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Send a 202 response with no payload:.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<MyException> get200Model204NoModelDefaultError202NoneWithResponse() {
-        return get200Model204NoModelDefaultError202NoneWithResponseAsync().block();
+    public Response<MyException> get200Model204NoModelDefaultError202NoneWithResponse(Context context) {
+        return get200Model204NoModelDefaultError202NoneWithResponseAsync(context).block();
     }
 
     /**
@@ -464,7 +608,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200Model204NoModelDefaultError202None() {
-        return get200Model204NoModelDefaultError202NoneWithResponse().getValue();
+        return get200Model204NoModelDefaultError202NoneWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -488,6 +632,25 @@ public final class MultipleResponses {
     /**
      * Send a 400 response with valid error payload: {'status': 400, 'message': 'client error'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<MyException>> get200Model204NoModelDefaultError400ValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get200Model204NoModelDefaultError400Valid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Send a 400 response with valid error payload: {'status': 400, 'message': 'client error'}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body on successful completion of {@link Mono}.
@@ -501,13 +664,30 @@ public final class MultipleResponses {
     /**
      * Send a 400 response with valid error payload: {'status': 400, 'message': 'client error'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<MyException> get200Model204NoModelDefaultError400ValidAsync(Context context) {
+        return get200Model204NoModelDefaultError400ValidWithResponseAsync(context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Send a 400 response with valid error payload: {'status': 400, 'message': 'client error'}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<MyException> get200Model204NoModelDefaultError400ValidWithResponse() {
-        return get200Model204NoModelDefaultError400ValidWithResponseAsync().block();
+    public Response<MyException> get200Model204NoModelDefaultError400ValidWithResponse(Context context) {
+        return get200Model204NoModelDefaultError400ValidWithResponseAsync(context).block();
     }
 
     /**
@@ -519,7 +699,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200Model204NoModelDefaultError400Valid() {
-        return get200Model204NoModelDefaultError400ValidWithResponse().getValue();
+        return get200Model204NoModelDefaultError400ValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -543,6 +723,25 @@ public final class MultipleResponses {
     /**
      * Send a 200 response with valid payload: {'statusCode': '200'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<MyException>> get200Model201ModelDefaultError200ValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get200Model201ModelDefaultError200Valid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body on successful completion of {@link Mono}.
@@ -556,13 +755,30 @@ public final class MultipleResponses {
     /**
      * Send a 200 response with valid payload: {'statusCode': '200'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<MyException> get200Model201ModelDefaultError200ValidAsync(Context context) {
+        return get200Model201ModelDefaultError200ValidWithResponseAsync(context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<MyException> get200Model201ModelDefaultError200ValidWithResponse() {
-        return get200Model201ModelDefaultError200ValidWithResponseAsync().block();
+    public Response<MyException> get200Model201ModelDefaultError200ValidWithResponse(Context context) {
+        return get200Model201ModelDefaultError200ValidWithResponseAsync(context).block();
     }
 
     /**
@@ -574,7 +790,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200Model201ModelDefaultError200Valid() {
-        return get200Model201ModelDefaultError200ValidWithResponse().getValue();
+        return get200Model201ModelDefaultError200ValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -598,6 +814,25 @@ public final class MultipleResponses {
     /**
      * Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<MyException>> get200Model201ModelDefaultError201ValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get200Model201ModelDefaultError201Valid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body on successful completion of {@link Mono}.
@@ -611,13 +846,30 @@ public final class MultipleResponses {
     /**
      * Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<MyException> get200Model201ModelDefaultError201ValidAsync(Context context) {
+        return get200Model201ModelDefaultError201ValidWithResponseAsync(context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<MyException> get200Model201ModelDefaultError201ValidWithResponse() {
-        return get200Model201ModelDefaultError201ValidWithResponseAsync().block();
+    public Response<MyException> get200Model201ModelDefaultError201ValidWithResponse(Context context) {
+        return get200Model201ModelDefaultError201ValidWithResponseAsync(context).block();
     }
 
     /**
@@ -629,7 +881,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200Model201ModelDefaultError201Valid() {
-        return get200Model201ModelDefaultError201ValidWithResponse().getValue();
+        return get200Model201ModelDefaultError201ValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -653,6 +905,25 @@ public final class MultipleResponses {
     /**
      * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<MyException>> get200Model201ModelDefaultError400ValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get200Model201ModelDefaultError400Valid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body on successful completion of {@link Mono}.
@@ -666,13 +937,30 @@ public final class MultipleResponses {
     /**
      * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<MyException> get200Model201ModelDefaultError400ValidAsync(Context context) {
+        return get200Model201ModelDefaultError400ValidWithResponseAsync(context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<MyException> get200Model201ModelDefaultError400ValidWithResponse() {
-        return get200Model201ModelDefaultError400ValidWithResponseAsync().block();
+    public Response<MyException> get200Model201ModelDefaultError400ValidWithResponse(Context context) {
+        return get200Model201ModelDefaultError400ValidWithResponseAsync(context).block();
     }
 
     /**
@@ -684,7 +972,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200Model201ModelDefaultError400Valid() {
-        return get200Model201ModelDefaultError400ValidWithResponse().getValue();
+        return get200Model201ModelDefaultError400ValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -710,6 +998,25 @@ public final class MultipleResponses {
     /**
      * Send a 200 response with valid payload: {'statusCode': '200'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Object>> get200ModelA201ModelC404ModelDDefaultError200ValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get200ModelA201ModelC404ModelDDefaultError200Valid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body on successful completion of {@link Mono}.
@@ -723,13 +1030,30 @@ public final class MultipleResponses {
     /**
      * Send a 200 response with valid payload: {'statusCode': '200'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Object> get200ModelA201ModelC404ModelDDefaultError200ValidAsync(Context context) {
+        return get200ModelA201ModelC404ModelDDefaultError200ValidWithResponseAsync(context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Object> get200ModelA201ModelC404ModelDDefaultError200ValidWithResponse() {
-        return get200ModelA201ModelC404ModelDDefaultError200ValidWithResponseAsync().block();
+    public Response<Object> get200ModelA201ModelC404ModelDDefaultError200ValidWithResponse(Context context) {
+        return get200ModelA201ModelC404ModelDDefaultError200ValidWithResponseAsync(context).block();
     }
 
     /**
@@ -741,7 +1065,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Object get200ModelA201ModelC404ModelDDefaultError200Valid() {
-        return get200ModelA201ModelC404ModelDDefaultError200ValidWithResponse().getValue();
+        return get200ModelA201ModelC404ModelDDefaultError200ValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -767,6 +1091,25 @@ public final class MultipleResponses {
     /**
      * Send a 200 response with valid payload: {'httpCode': '201'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Object>> get200ModelA201ModelC404ModelDDefaultError201ValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get200ModelA201ModelC404ModelDDefaultError201Valid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Send a 200 response with valid payload: {'httpCode': '201'}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body on successful completion of {@link Mono}.
@@ -780,13 +1123,30 @@ public final class MultipleResponses {
     /**
      * Send a 200 response with valid payload: {'httpCode': '201'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Object> get200ModelA201ModelC404ModelDDefaultError201ValidAsync(Context context) {
+        return get200ModelA201ModelC404ModelDDefaultError201ValidWithResponseAsync(context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Send a 200 response with valid payload: {'httpCode': '201'}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Object> get200ModelA201ModelC404ModelDDefaultError201ValidWithResponse() {
-        return get200ModelA201ModelC404ModelDDefaultError201ValidWithResponseAsync().block();
+    public Response<Object> get200ModelA201ModelC404ModelDDefaultError201ValidWithResponse(Context context) {
+        return get200ModelA201ModelC404ModelDDefaultError201ValidWithResponseAsync(context).block();
     }
 
     /**
@@ -798,7 +1158,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Object get200ModelA201ModelC404ModelDDefaultError201Valid() {
-        return get200ModelA201ModelC404ModelDDefaultError201ValidWithResponse().getValue();
+        return get200ModelA201ModelC404ModelDDefaultError201ValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -824,6 +1184,25 @@ public final class MultipleResponses {
     /**
      * Send a 200 response with valid payload: {'httpStatusCode': '404'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Object>> get200ModelA201ModelC404ModelDDefaultError404ValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get200ModelA201ModelC404ModelDDefaultError404Valid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Send a 200 response with valid payload: {'httpStatusCode': '404'}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body on successful completion of {@link Mono}.
@@ -837,13 +1216,30 @@ public final class MultipleResponses {
     /**
      * Send a 200 response with valid payload: {'httpStatusCode': '404'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Object> get200ModelA201ModelC404ModelDDefaultError404ValidAsync(Context context) {
+        return get200ModelA201ModelC404ModelDDefaultError404ValidWithResponseAsync(context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Send a 200 response with valid payload: {'httpStatusCode': '404'}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Object> get200ModelA201ModelC404ModelDDefaultError404ValidWithResponse() {
-        return get200ModelA201ModelC404ModelDDefaultError404ValidWithResponseAsync().block();
+    public Response<Object> get200ModelA201ModelC404ModelDDefaultError404ValidWithResponse(Context context) {
+        return get200ModelA201ModelC404ModelDDefaultError404ValidWithResponseAsync(context).block();
     }
 
     /**
@@ -855,7 +1251,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Object get200ModelA201ModelC404ModelDDefaultError404Valid() {
-        return get200ModelA201ModelC404ModelDDefaultError404ValidWithResponse().getValue();
+        return get200ModelA201ModelC404ModelDDefaultError404ValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -881,6 +1277,25 @@ public final class MultipleResponses {
     /**
      * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Object>> get200ModelA201ModelC404ModelDDefaultError400ValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get200ModelA201ModelC404ModelDDefaultError400Valid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body on successful completion of {@link Mono}.
@@ -894,13 +1309,30 @@ public final class MultipleResponses {
     /**
      * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Object> get200ModelA201ModelC404ModelDDefaultError400ValidAsync(Context context) {
+        return get200ModelA201ModelC404ModelDDefaultError400ValidWithResponseAsync(context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Object> get200ModelA201ModelC404ModelDDefaultError400ValidWithResponse() {
-        return get200ModelA201ModelC404ModelDDefaultError400ValidWithResponseAsync().block();
+    public Response<Object> get200ModelA201ModelC404ModelDDefaultError400ValidWithResponse(Context context) {
+        return get200ModelA201ModelC404ModelDDefaultError400ValidWithResponseAsync(context).block();
     }
 
     /**
@@ -912,7 +1344,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Object get200ModelA201ModelC404ModelDDefaultError400Valid() {
-        return get200ModelA201ModelC404ModelDDefaultError400ValidWithResponse().getValue();
+        return get200ModelA201ModelC404ModelDDefaultError400ValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -936,6 +1368,25 @@ public final class MultipleResponses {
     /**
      * Send a 202 response with no payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> get202None204NoneDefaultError202NoneWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get202None204NoneDefaultError202None(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Send a 202 response with no payload.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -948,13 +1399,29 @@ public final class MultipleResponses {
     /**
      * Send a 202 response with no payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> get202None204NoneDefaultError202NoneAsync(Context context) {
+        return get202None204NoneDefaultError202NoneWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Send a 202 response with no payload.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get202None204NoneDefaultError202NoneWithResponse() {
-        return get202None204NoneDefaultError202NoneWithResponseAsync().block();
+    public Response<Void> get202None204NoneDefaultError202NoneWithResponse(Context context) {
+        return get202None204NoneDefaultError202NoneWithResponseAsync(context).block();
     }
 
     /**
@@ -965,7 +1432,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get202None204NoneDefaultError202None() {
-        get202None204NoneDefaultError202NoneWithResponse();
+        get202None204NoneDefaultError202NoneWithResponse(Context.NONE);
     }
 
     /**
@@ -989,6 +1456,25 @@ public final class MultipleResponses {
     /**
      * Send a 204 response with no payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> get202None204NoneDefaultError204NoneWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get202None204NoneDefaultError204None(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Send a 204 response with no payload.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1001,13 +1487,29 @@ public final class MultipleResponses {
     /**
      * Send a 204 response with no payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> get202None204NoneDefaultError204NoneAsync(Context context) {
+        return get202None204NoneDefaultError204NoneWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Send a 204 response with no payload.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get202None204NoneDefaultError204NoneWithResponse() {
-        return get202None204NoneDefaultError204NoneWithResponseAsync().block();
+    public Response<Void> get202None204NoneDefaultError204NoneWithResponse(Context context) {
+        return get202None204NoneDefaultError204NoneWithResponseAsync(context).block();
     }
 
     /**
@@ -1018,7 +1520,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get202None204NoneDefaultError204None() {
-        get202None204NoneDefaultError204NoneWithResponse();
+        get202None204NoneDefaultError204NoneWithResponse(Context.NONE);
     }
 
     /**
@@ -1042,6 +1544,25 @@ public final class MultipleResponses {
     /**
      * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> get202None204NoneDefaultError400ValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get202None204NoneDefaultError400Valid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1054,13 +1575,29 @@ public final class MultipleResponses {
     /**
      * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> get202None204NoneDefaultError400ValidAsync(Context context) {
+        return get202None204NoneDefaultError400ValidWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get202None204NoneDefaultError400ValidWithResponse() {
-        return get202None204NoneDefaultError400ValidWithResponseAsync().block();
+    public Response<Void> get202None204NoneDefaultError400ValidWithResponse(Context context) {
+        return get202None204NoneDefaultError400ValidWithResponseAsync(context).block();
     }
 
     /**
@@ -1071,7 +1608,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get202None204NoneDefaultError400Valid() {
-        get202None204NoneDefaultError400ValidWithResponse();
+        get202None204NoneDefaultError400ValidWithResponse(Context.NONE);
     }
 
     /**
@@ -1094,6 +1631,24 @@ public final class MultipleResponses {
     /**
      * Send a 202 response with an unexpected payload {'property': 'value'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> get202None204NoneDefaultNone202InvalidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.get202None204NoneDefaultNone202Invalid(this.client.getHost(), context);
+    }
+
+    /**
+     * Send a 202 response with an unexpected payload {'property': 'value'}.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1106,13 +1661,29 @@ public final class MultipleResponses {
     /**
      * Send a 202 response with an unexpected payload {'property': 'value'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> get202None204NoneDefaultNone202InvalidAsync(Context context) {
+        return get202None204NoneDefaultNone202InvalidWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Send a 202 response with an unexpected payload {'property': 'value'}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get202None204NoneDefaultNone202InvalidWithResponse() {
-        return get202None204NoneDefaultNone202InvalidWithResponseAsync().block();
+    public Response<Void> get202None204NoneDefaultNone202InvalidWithResponse(Context context) {
+        return get202None204NoneDefaultNone202InvalidWithResponseAsync(context).block();
     }
 
     /**
@@ -1123,7 +1694,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get202None204NoneDefaultNone202Invalid() {
-        get202None204NoneDefaultNone202InvalidWithResponse();
+        get202None204NoneDefaultNone202InvalidWithResponse(Context.NONE);
     }
 
     /**
@@ -1146,6 +1717,24 @@ public final class MultipleResponses {
     /**
      * Send a 204 response with no payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> get202None204NoneDefaultNone204NoneWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.get202None204NoneDefaultNone204None(this.client.getHost(), context);
+    }
+
+    /**
+     * Send a 204 response with no payload.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1158,13 +1747,29 @@ public final class MultipleResponses {
     /**
      * Send a 204 response with no payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> get202None204NoneDefaultNone204NoneAsync(Context context) {
+        return get202None204NoneDefaultNone204NoneWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Send a 204 response with no payload.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get202None204NoneDefaultNone204NoneWithResponse() {
-        return get202None204NoneDefaultNone204NoneWithResponseAsync().block();
+    public Response<Void> get202None204NoneDefaultNone204NoneWithResponse(Context context) {
+        return get202None204NoneDefaultNone204NoneWithResponseAsync(context).block();
     }
 
     /**
@@ -1175,7 +1780,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get202None204NoneDefaultNone204None() {
-        get202None204NoneDefaultNone204NoneWithResponse();
+        get202None204NoneDefaultNone204NoneWithResponse(Context.NONE);
     }
 
     /**
@@ -1198,6 +1803,24 @@ public final class MultipleResponses {
     /**
      * Send a 400 response with no payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> get202None204NoneDefaultNone400NoneWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.get202None204NoneDefaultNone400None(this.client.getHost(), context);
+    }
+
+    /**
+     * Send a 400 response with no payload.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1210,13 +1833,29 @@ public final class MultipleResponses {
     /**
      * Send a 400 response with no payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> get202None204NoneDefaultNone400NoneAsync(Context context) {
+        return get202None204NoneDefaultNone400NoneWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Send a 400 response with no payload.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get202None204NoneDefaultNone400NoneWithResponse() {
-        return get202None204NoneDefaultNone400NoneWithResponseAsync().block();
+    public Response<Void> get202None204NoneDefaultNone400NoneWithResponse(Context context) {
+        return get202None204NoneDefaultNone400NoneWithResponseAsync(context).block();
     }
 
     /**
@@ -1227,7 +1866,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get202None204NoneDefaultNone400None() {
-        get202None204NoneDefaultNone400NoneWithResponse();
+        get202None204NoneDefaultNone400NoneWithResponse(Context.NONE);
     }
 
     /**
@@ -1250,6 +1889,24 @@ public final class MultipleResponses {
     /**
      * Send a 400 response with an unexpected payload {'property': 'value'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> get202None204NoneDefaultNone400InvalidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.get202None204NoneDefaultNone400Invalid(this.client.getHost(), context);
+    }
+
+    /**
+     * Send a 400 response with an unexpected payload {'property': 'value'}.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1262,13 +1919,29 @@ public final class MultipleResponses {
     /**
      * Send a 400 response with an unexpected payload {'property': 'value'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> get202None204NoneDefaultNone400InvalidAsync(Context context) {
+        return get202None204NoneDefaultNone400InvalidWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Send a 400 response with an unexpected payload {'property': 'value'}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get202None204NoneDefaultNone400InvalidWithResponse() {
-        return get202None204NoneDefaultNone400InvalidWithResponseAsync().block();
+    public Response<Void> get202None204NoneDefaultNone400InvalidWithResponse(Context context) {
+        return get202None204NoneDefaultNone400InvalidWithResponseAsync(context).block();
     }
 
     /**
@@ -1279,7 +1952,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get202None204NoneDefaultNone400Invalid() {
-        get202None204NoneDefaultNone400InvalidWithResponse();
+        get202None204NoneDefaultNone400InvalidWithResponse(Context.NONE);
     }
 
     /**
@@ -1303,6 +1976,25 @@ public final class MultipleResponses {
     /**
      * Send a 200 response with valid payload: {'statusCode': '200'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<MyException>> getDefaultModelA200ValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDefaultModelA200Valid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body on successful completion of {@link Mono}.
@@ -1315,13 +2007,29 @@ public final class MultipleResponses {
     /**
      * Send a 200 response with valid payload: {'statusCode': '200'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<MyException> getDefaultModelA200ValidAsync(Context context) {
+        return getDefaultModelA200ValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<MyException> getDefaultModelA200ValidWithResponse() {
-        return getDefaultModelA200ValidWithResponseAsync().block();
+    public Response<MyException> getDefaultModelA200ValidWithResponse(Context context) {
+        return getDefaultModelA200ValidWithResponseAsync(context).block();
     }
 
     /**
@@ -1333,7 +2041,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException getDefaultModelA200Valid() {
-        return getDefaultModelA200ValidWithResponse().getValue();
+        return getDefaultModelA200ValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1356,6 +2064,25 @@ public final class MultipleResponses {
     /**
      * Send a 200 response with no payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<MyException>> getDefaultModelA200NoneWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDefaultModelA200None(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Send a 200 response with no payload.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body on successful completion of {@link Mono}.
@@ -1368,13 +2095,29 @@ public final class MultipleResponses {
     /**
      * Send a 200 response with no payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<MyException> getDefaultModelA200NoneAsync(Context context) {
+        return getDefaultModelA200NoneWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Send a 200 response with no payload.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<MyException> getDefaultModelA200NoneWithResponse() {
-        return getDefaultModelA200NoneWithResponseAsync().block();
+    public Response<MyException> getDefaultModelA200NoneWithResponse(Context context) {
+        return getDefaultModelA200NoneWithResponseAsync(context).block();
     }
 
     /**
@@ -1386,7 +2129,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException getDefaultModelA200None() {
-        return getDefaultModelA200NoneWithResponse().getValue();
+        return getDefaultModelA200NoneWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1410,6 +2153,25 @@ public final class MultipleResponses {
     /**
      * Send a 400 response with valid payload: {'statusCode': '400'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws MyExceptionException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getDefaultModelA400ValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDefaultModelA400Valid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Send a 400 response with valid payload: {'statusCode': '400'}.
+     *
      * @throws MyExceptionException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1422,13 +2184,29 @@ public final class MultipleResponses {
     /**
      * Send a 400 response with valid payload: {'statusCode': '400'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws MyExceptionException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getDefaultModelA400ValidAsync(Context context) {
+        return getDefaultModelA400ValidWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Send a 400 response with valid payload: {'statusCode': '400'}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws MyExceptionException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getDefaultModelA400ValidWithResponse() {
-        return getDefaultModelA400ValidWithResponseAsync().block();
+    public Response<Void> getDefaultModelA400ValidWithResponse(Context context) {
+        return getDefaultModelA400ValidWithResponseAsync(context).block();
     }
 
     /**
@@ -1439,7 +2217,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getDefaultModelA400Valid() {
-        getDefaultModelA400ValidWithResponse();
+        getDefaultModelA400ValidWithResponse(Context.NONE);
     }
 
     /**
@@ -1462,6 +2240,25 @@ public final class MultipleResponses {
     /**
      * Send a 400 response with no payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws MyExceptionException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getDefaultModelA400NoneWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDefaultModelA400None(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Send a 400 response with no payload.
+     *
      * @throws MyExceptionException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1474,13 +2271,29 @@ public final class MultipleResponses {
     /**
      * Send a 400 response with no payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws MyExceptionException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getDefaultModelA400NoneAsync(Context context) {
+        return getDefaultModelA400NoneWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Send a 400 response with no payload.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws MyExceptionException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getDefaultModelA400NoneWithResponse() {
-        return getDefaultModelA400NoneWithResponseAsync().block();
+    public Response<Void> getDefaultModelA400NoneWithResponse(Context context) {
+        return getDefaultModelA400NoneWithResponseAsync(context).block();
     }
 
     /**
@@ -1491,7 +2304,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getDefaultModelA400None() {
-        getDefaultModelA400NoneWithResponse();
+        getDefaultModelA400NoneWithResponse(Context.NONE);
     }
 
     /**
@@ -1513,6 +2326,24 @@ public final class MultipleResponses {
     /**
      * Send a 200 response with invalid payload: {'statusCode': '200'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getDefaultNone200InvalidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.getDefaultNone200Invalid(this.client.getHost(), context);
+    }
+
+    /**
+     * Send a 200 response with invalid payload: {'statusCode': '200'}.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1525,13 +2356,29 @@ public final class MultipleResponses {
     /**
      * Send a 200 response with invalid payload: {'statusCode': '200'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getDefaultNone200InvalidAsync(Context context) {
+        return getDefaultNone200InvalidWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Send a 200 response with invalid payload: {'statusCode': '200'}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getDefaultNone200InvalidWithResponse() {
-        return getDefaultNone200InvalidWithResponseAsync().block();
+    public Response<Void> getDefaultNone200InvalidWithResponse(Context context) {
+        return getDefaultNone200InvalidWithResponseAsync(context).block();
     }
 
     /**
@@ -1542,7 +2389,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getDefaultNone200Invalid() {
-        getDefaultNone200InvalidWithResponse();
+        getDefaultNone200InvalidWithResponse(Context.NONE);
     }
 
     /**
@@ -1564,6 +2411,24 @@ public final class MultipleResponses {
     /**
      * Send a 200 response with no payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getDefaultNone200NoneWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.getDefaultNone200None(this.client.getHost(), context);
+    }
+
+    /**
+     * Send a 200 response with no payload.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1576,13 +2441,29 @@ public final class MultipleResponses {
     /**
      * Send a 200 response with no payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getDefaultNone200NoneAsync(Context context) {
+        return getDefaultNone200NoneWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Send a 200 response with no payload.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getDefaultNone200NoneWithResponse() {
-        return getDefaultNone200NoneWithResponseAsync().block();
+    public Response<Void> getDefaultNone200NoneWithResponse(Context context) {
+        return getDefaultNone200NoneWithResponseAsync(context).block();
     }
 
     /**
@@ -1593,7 +2474,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getDefaultNone200None() {
-        getDefaultNone200NoneWithResponse();
+        getDefaultNone200NoneWithResponse(Context.NONE);
     }
 
     /**
@@ -1615,6 +2496,24 @@ public final class MultipleResponses {
     /**
      * Send a 400 response with valid payload: {'statusCode': '400'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getDefaultNone400InvalidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.getDefaultNone400Invalid(this.client.getHost(), context);
+    }
+
+    /**
+     * Send a 400 response with valid payload: {'statusCode': '400'}.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1627,13 +2526,29 @@ public final class MultipleResponses {
     /**
      * Send a 400 response with valid payload: {'statusCode': '400'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getDefaultNone400InvalidAsync(Context context) {
+        return getDefaultNone400InvalidWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Send a 400 response with valid payload: {'statusCode': '400'}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getDefaultNone400InvalidWithResponse() {
-        return getDefaultNone400InvalidWithResponseAsync().block();
+    public Response<Void> getDefaultNone400InvalidWithResponse(Context context) {
+        return getDefaultNone400InvalidWithResponseAsync(context).block();
     }
 
     /**
@@ -1644,7 +2559,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getDefaultNone400Invalid() {
-        getDefaultNone400InvalidWithResponse();
+        getDefaultNone400InvalidWithResponse(Context.NONE);
     }
 
     /**
@@ -1666,6 +2581,24 @@ public final class MultipleResponses {
     /**
      * Send a 400 response with no payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getDefaultNone400NoneWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.getDefaultNone400None(this.client.getHost(), context);
+    }
+
+    /**
+     * Send a 400 response with no payload.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -1678,13 +2611,29 @@ public final class MultipleResponses {
     /**
      * Send a 400 response with no payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getDefaultNone400NoneAsync(Context context) {
+        return getDefaultNone400NoneWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Send a 400 response with no payload.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getDefaultNone400NoneWithResponse() {
-        return getDefaultNone400NoneWithResponseAsync().block();
+    public Response<Void> getDefaultNone400NoneWithResponse(Context context) {
+        return getDefaultNone400NoneWithResponseAsync(context).block();
     }
 
     /**
@@ -1695,7 +2644,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getDefaultNone400None() {
-        getDefaultNone400NoneWithResponse();
+        getDefaultNone400NoneWithResponse(Context.NONE);
     }
 
     /**
@@ -1720,6 +2669,26 @@ public final class MultipleResponses {
      * Send a 200 response with no payload, when a payload is expected - client should return a null object of thde type
      * for model A.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<MyException>> get200ModelA200NoneWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get200ModelA200None(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Send a 200 response with no payload, when a payload is expected - client should return a null object of thde type
+     * for model A.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body on successful completion of {@link Mono}.
@@ -1733,13 +2702,30 @@ public final class MultipleResponses {
      * Send a 200 response with no payload, when a payload is expected - client should return a null object of thde type
      * for model A.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<MyException> get200ModelA200NoneAsync(Context context) {
+        return get200ModelA200NoneWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Send a 200 response with no payload, when a payload is expected - client should return a null object of thde type
+     * for model A.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<MyException> get200ModelA200NoneWithResponse() {
-        return get200ModelA200NoneWithResponseAsync().block();
+    public Response<MyException> get200ModelA200NoneWithResponse(Context context) {
+        return get200ModelA200NoneWithResponseAsync(context).block();
     }
 
     /**
@@ -1752,7 +2738,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200ModelA200None() {
-        return get200ModelA200NoneWithResponse().getValue();
+        return get200ModelA200NoneWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1775,6 +2761,25 @@ public final class MultipleResponses {
     /**
      * Send a 200 response with payload {'statusCode': '200'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<MyException>> get200ModelA200ValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get200ModelA200Valid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Send a 200 response with payload {'statusCode': '200'}.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body on successful completion of {@link Mono}.
@@ -1787,13 +2792,29 @@ public final class MultipleResponses {
     /**
      * Send a 200 response with payload {'statusCode': '200'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<MyException> get200ModelA200ValidAsync(Context context) {
+        return get200ModelA200ValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Send a 200 response with payload {'statusCode': '200'}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<MyException> get200ModelA200ValidWithResponse() {
-        return get200ModelA200ValidWithResponseAsync().block();
+    public Response<MyException> get200ModelA200ValidWithResponse(Context context) {
+        return get200ModelA200ValidWithResponseAsync(context).block();
     }
 
     /**
@@ -1805,7 +2826,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200ModelA200Valid() {
-        return get200ModelA200ValidWithResponse().getValue();
+        return get200ModelA200ValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1828,6 +2849,25 @@ public final class MultipleResponses {
     /**
      * Send a 200 response with invalid payload {'statusCodeInvalid': '200'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<MyException>> get200ModelA200InvalidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get200ModelA200Invalid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Send a 200 response with invalid payload {'statusCodeInvalid': '200'}.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body on successful completion of {@link Mono}.
@@ -1840,13 +2880,29 @@ public final class MultipleResponses {
     /**
      * Send a 200 response with invalid payload {'statusCodeInvalid': '200'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<MyException> get200ModelA200InvalidAsync(Context context) {
+        return get200ModelA200InvalidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Send a 200 response with invalid payload {'statusCodeInvalid': '200'}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<MyException> get200ModelA200InvalidWithResponse() {
-        return get200ModelA200InvalidWithResponseAsync().block();
+    public Response<MyException> get200ModelA200InvalidWithResponse(Context context) {
+        return get200ModelA200InvalidWithResponseAsync(context).block();
     }
 
     /**
@@ -1858,7 +2914,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200ModelA200Invalid() {
-        return get200ModelA200InvalidWithResponse().getValue();
+        return get200ModelA200InvalidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1881,6 +2937,25 @@ public final class MultipleResponses {
     /**
      * Send a 400 response with no payload client should treat as an http error with no error model.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<MyException>> get200ModelA400NoneWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get200ModelA400None(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Send a 400 response with no payload client should treat as an http error with no error model.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body on successful completion of {@link Mono}.
@@ -1893,13 +2968,29 @@ public final class MultipleResponses {
     /**
      * Send a 400 response with no payload client should treat as an http error with no error model.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<MyException> get200ModelA400NoneAsync(Context context) {
+        return get200ModelA400NoneWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Send a 400 response with no payload client should treat as an http error with no error model.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<MyException> get200ModelA400NoneWithResponse() {
-        return get200ModelA400NoneWithResponseAsync().block();
+    public Response<MyException> get200ModelA400NoneWithResponse(Context context) {
+        return get200ModelA400NoneWithResponseAsync(context).block();
     }
 
     /**
@@ -1911,7 +3002,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200ModelA400None() {
-        return get200ModelA400NoneWithResponse().getValue();
+        return get200ModelA400NoneWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1934,6 +3025,25 @@ public final class MultipleResponses {
     /**
      * Send a 200 response with payload {'statusCode': '400'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<MyException>> get200ModelA400ValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get200ModelA400Valid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Send a 200 response with payload {'statusCode': '400'}.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body on successful completion of {@link Mono}.
@@ -1946,13 +3056,29 @@ public final class MultipleResponses {
     /**
      * Send a 200 response with payload {'statusCode': '400'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<MyException> get200ModelA400ValidAsync(Context context) {
+        return get200ModelA400ValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Send a 200 response with payload {'statusCode': '400'}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<MyException> get200ModelA400ValidWithResponse() {
-        return get200ModelA400ValidWithResponseAsync().block();
+    public Response<MyException> get200ModelA400ValidWithResponse(Context context) {
+        return get200ModelA400ValidWithResponseAsync(context).block();
     }
 
     /**
@@ -1964,7 +3090,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200ModelA400Valid() {
-        return get200ModelA400ValidWithResponse().getValue();
+        return get200ModelA400ValidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1987,6 +3113,25 @@ public final class MultipleResponses {
     /**
      * Send a 200 response with invalid payload {'statusCodeInvalid': '400'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<MyException>> get200ModelA400InvalidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get200ModelA400Invalid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Send a 200 response with invalid payload {'statusCodeInvalid': '400'}.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body on successful completion of {@link Mono}.
@@ -1999,13 +3144,29 @@ public final class MultipleResponses {
     /**
      * Send a 200 response with invalid payload {'statusCodeInvalid': '400'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<MyException> get200ModelA400InvalidAsync(Context context) {
+        return get200ModelA400InvalidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Send a 200 response with invalid payload {'statusCodeInvalid': '400'}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<MyException> get200ModelA400InvalidWithResponse() {
-        return get200ModelA400InvalidWithResponseAsync().block();
+    public Response<MyException> get200ModelA400InvalidWithResponse(Context context) {
+        return get200ModelA400InvalidWithResponseAsync(context).block();
     }
 
     /**
@@ -2017,7 +3178,7 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200ModelA400Invalid() {
-        return get200ModelA400InvalidWithResponse().getValue();
+        return get200ModelA400InvalidWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2040,6 +3201,25 @@ public final class MultipleResponses {
     /**
      * Send a 202 response with payload {'statusCode': '202'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<MyException>> get200ModelA202ValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get200ModelA202Valid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Send a 202 response with payload {'statusCode': '202'}.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body on successful completion of {@link Mono}.
@@ -2052,13 +3232,29 @@ public final class MultipleResponses {
     /**
      * Send a 202 response with payload {'statusCode': '202'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<MyException> get200ModelA202ValidAsync(Context context) {
+        return get200ModelA202ValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Send a 202 response with payload {'statusCode': '202'}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<MyException> get200ModelA202ValidWithResponse() {
-        return get200ModelA202ValidWithResponseAsync().block();
+    public Response<MyException> get200ModelA202ValidWithResponse(Context context) {
+        return get200ModelA202ValidWithResponseAsync(context).block();
     }
 
     /**
@@ -2070,6 +3266,6 @@ public final class MultipleResponses {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200ModelA202Valid() {
-        return get200ModelA202ValidWithResponse().getValue();
+        return get200ModelA202ValidWithResponse(Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/inheritance/donotpassdiscriminator/MetricAlerts.java
+++ b/vanilla-tests/src/main/java/fixtures/inheritance/donotpassdiscriminator/MetricAlerts.java
@@ -74,6 +74,25 @@ public final class MetricAlerts {
     /**
      * Retrieve an alert rule definition.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the metric alert resource along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<MetricAlertResource>> getWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Retrieve an alert rule definition.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the metric alert resource on successful completion of {@link Mono}.
@@ -86,13 +105,29 @@ public final class MetricAlerts {
     /**
      * Retrieve an alert rule definition.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the metric alert resource on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<MetricAlertResource> getAsync(Context context) {
+        return getWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Retrieve an alert rule definition.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the metric alert resource along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<MetricAlertResource> getWithResponse() {
-        return getWithResponseAsync().block();
+    public Response<MetricAlertResource> getWithResponse(Context context) {
+        return getWithResponseAsync(context).block();
     }
 
     /**
@@ -104,6 +139,6 @@ public final class MetricAlerts {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MetricAlertResource get() {
-        return getWithResponse().getValue();
+        return getWithResponse(Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/inheritance/passdiscriminator/MetricAlerts.java
+++ b/vanilla-tests/src/main/java/fixtures/inheritance/passdiscriminator/MetricAlerts.java
@@ -74,6 +74,25 @@ public final class MetricAlerts {
     /**
      * Retrieve an alert rule definition.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the metric alert resource along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<MetricAlertResource>> getWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Retrieve an alert rule definition.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the metric alert resource on successful completion of {@link Mono}.
@@ -86,13 +105,29 @@ public final class MetricAlerts {
     /**
      * Retrieve an alert rule definition.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the metric alert resource on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<MetricAlertResource> getAsync(Context context) {
+        return getWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Retrieve an alert rule definition.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the metric alert resource along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<MetricAlertResource> getWithResponse() {
-        return getWithResponseAsync().block();
+    public Response<MetricAlertResource> getWithResponse(Context context) {
+        return getWithResponseAsync(context).block();
     }
 
     /**
@@ -104,6 +139,6 @@ public final class MetricAlerts {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MetricAlertResource get() {
-        return getWithResponse().getValue();
+        return getWithResponse(Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
+++ b/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
@@ -312,6 +312,31 @@ public final class MediaTypesClient {
      * @param contentType Upload file type.
      * @param input Input parameter.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> analyzeBodyWithResponseAsync(
+            ContentType contentType, Flux<ByteBuffer> input, Long contentLength, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (contentType == null) {
+            return Mono.error(new IllegalArgumentException("Parameter contentType is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.analyzeBody(this.getHost(), contentType, input, contentLength, accept, context);
+    }
+
+    /**
+     * Analyze body, that could be different media types.
+     *
+     * @param contentType Upload file type.
+     * @param input Input parameter.
+     * @param contentLength The Content-Length header for the request.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -346,6 +371,26 @@ public final class MediaTypesClient {
      * @param contentType Upload file type.
      * @param input Input parameter.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> analyzeBodyAsync(
+            ContentType contentType, Flux<ByteBuffer> input, Long contentLength, Context context) {
+        return analyzeBodyWithResponseAsync(contentType, input, contentLength, context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Analyze body, that could be different media types.
+     *
+     * @param contentType Upload file type.
+     * @param input Input parameter.
+     * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -353,8 +398,8 @@ public final class MediaTypesClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<String> analyzeBodyWithResponse(
-            ContentType contentType, Flux<ByteBuffer> input, Long contentLength) {
-        return analyzeBodyWithResponseAsync(contentType, input, contentLength).block();
+            ContentType contentType, Flux<ByteBuffer> input, Long contentLength, Context context) {
+        return analyzeBodyWithResponseAsync(contentType, input, contentLength, context).block();
     }
 
     /**
@@ -370,7 +415,7 @@ public final class MediaTypesClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String analyzeBody(ContentType contentType, Flux<ByteBuffer> input, Long contentLength) {
-        return analyzeBodyWithResponse(contentType, input, contentLength).getValue();
+        return analyzeBodyWithResponse(contentType, input, contentLength, Context.NONE).getValue();
     }
 
     /**
@@ -386,7 +431,7 @@ public final class MediaTypesClient {
     public String analyzeBody(ContentType contentType) {
         final Flux<ByteBuffer> input = null;
         final Long contentLength = null;
-        return analyzeBodyWithResponse(contentType, input, contentLength).getValue();
+        return analyzeBodyWithResponse(contentType, input, contentLength, Context.NONE).getValue();
     }
 
     /**
@@ -420,6 +465,31 @@ public final class MediaTypesClient {
      * @param contentType Upload file type.
      * @param input Input parameter.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> analyzeBodyWithResponseAsync(
+            ContentType contentType, BinaryData input, Long contentLength, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (contentType == null) {
+            return Mono.error(new IllegalArgumentException("Parameter contentType is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.analyzeBody(this.getHost(), contentType, input, contentLength, accept, context);
+    }
+
+    /**
+     * Analyze body, that could be different media types.
+     *
+     * @param contentType Upload file type.
+     * @param input Input parameter.
+     * @param contentLength The Content-Length header for the request.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -437,14 +507,35 @@ public final class MediaTypesClient {
      * @param contentType Upload file type.
      * @param input Input parameter.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> analyzeBodyAsync(
+            ContentType contentType, BinaryData input, Long contentLength, Context context) {
+        return analyzeBodyWithResponseAsync(contentType, input, contentLength, context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Analyze body, that could be different media types.
+     *
+     * @param contentType Upload file type.
+     * @param input Input parameter.
+     * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> analyzeBodyWithResponse(ContentType contentType, BinaryData input, Long contentLength) {
-        return analyzeBodyWithResponseAsync(contentType, input, contentLength).block();
+    public Response<String> analyzeBodyWithResponse(
+            ContentType contentType, BinaryData input, Long contentLength, Context context) {
+        return analyzeBodyWithResponseAsync(contentType, input, contentLength, context).block();
     }
 
     /**
@@ -460,7 +551,7 @@ public final class MediaTypesClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String analyzeBody(ContentType contentType, BinaryData input, Long contentLength) {
-        return analyzeBodyWithResponse(contentType, input, contentLength).getValue();
+        return analyzeBodyWithResponse(contentType, input, contentLength, Context.NONE).getValue();
     }
 
     /**
@@ -485,6 +576,31 @@ public final class MediaTypesClient {
         }
         SourcePath input = inputInternal;
         return FluxUtil.withContext(context -> service.analyzeBody(this.getHost(), input, accept, context));
+    }
+
+    /**
+     * Analyze body, that could be different media types.
+     *
+     * @param source File source path.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> analyzeBodyWithResponseAsync(String source, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        SourcePath inputInternal = null;
+        if (source != null) {
+            inputInternal = new SourcePath();
+            inputInternal.setSource(source);
+        }
+        SourcePath input = inputInternal;
+        return service.analyzeBody(this.getHost(), input, accept, context);
     }
 
     /**
@@ -518,14 +634,30 @@ public final class MediaTypesClient {
      * Analyze body, that could be different media types.
      *
      * @param source File source path.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> analyzeBodyAsync(String source, Context context) {
+        return analyzeBodyWithResponseAsync(source, context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Analyze body, that could be different media types.
+     *
+     * @param source File source path.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> analyzeBodyWithResponse(String source) {
-        return analyzeBodyWithResponseAsync(source).block();
+    public Response<String> analyzeBodyWithResponse(String source, Context context) {
+        return analyzeBodyWithResponseAsync(source, context).block();
     }
 
     /**
@@ -539,7 +671,7 @@ public final class MediaTypesClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String analyzeBody(String source) {
-        return analyzeBodyWithResponse(source).getValue();
+        return analyzeBodyWithResponse(source, Context.NONE).getValue();
     }
 
     /**
@@ -552,7 +684,7 @@ public final class MediaTypesClient {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String analyzeBody() {
         final String source = null;
-        return analyzeBodyWithResponse(source).getValue();
+        return analyzeBodyWithResponse(source, Context.NONE).getValue();
     }
 
     /**
@@ -578,6 +710,30 @@ public final class MediaTypesClient {
         return FluxUtil.withContext(
                 context ->
                         service.analyzeBodyNoAcceptHeader(this.getHost(), contentType, input, contentLength, context));
+    }
+
+    /**
+     * Analyze body, that could be different media types. Adds to AnalyzeBody by not having an accept type.
+     *
+     * @param contentType Upload file type.
+     * @param input Input parameter.
+     * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> analyzeBodyNoAcceptHeaderWithResponseAsync(
+            ContentType contentType, Flux<ByteBuffer> input, Long contentLength, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (contentType == null) {
+            return Mono.error(new IllegalArgumentException("Parameter contentType is required and cannot be null."));
+        }
+        return service.analyzeBodyNoAcceptHeader(this.getHost(), contentType, input, contentLength, context);
     }
 
     /**
@@ -621,6 +777,26 @@ public final class MediaTypesClient {
      * @param contentType Upload file type.
      * @param input Input parameter.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> analyzeBodyNoAcceptHeaderAsync(
+            ContentType contentType, Flux<ByteBuffer> input, Long contentLength, Context context) {
+        return analyzeBodyNoAcceptHeaderWithResponseAsync(contentType, input, contentLength, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Analyze body, that could be different media types. Adds to AnalyzeBody by not having an accept type.
+     *
+     * @param contentType Upload file type.
+     * @param input Input parameter.
+     * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -628,8 +804,8 @@ public final class MediaTypesClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> analyzeBodyNoAcceptHeaderWithResponse(
-            ContentType contentType, Flux<ByteBuffer> input, Long contentLength) {
-        return analyzeBodyNoAcceptHeaderWithResponseAsync(contentType, input, contentLength).block();
+            ContentType contentType, Flux<ByteBuffer> input, Long contentLength, Context context) {
+        return analyzeBodyNoAcceptHeaderWithResponseAsync(contentType, input, contentLength, context).block();
     }
 
     /**
@@ -644,7 +820,7 @@ public final class MediaTypesClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void analyzeBodyNoAcceptHeader(ContentType contentType, Flux<ByteBuffer> input, Long contentLength) {
-        analyzeBodyNoAcceptHeaderWithResponse(contentType, input, contentLength);
+        analyzeBodyNoAcceptHeaderWithResponse(contentType, input, contentLength, Context.NONE);
     }
 
     /**
@@ -659,7 +835,7 @@ public final class MediaTypesClient {
     public void analyzeBodyNoAcceptHeader(ContentType contentType) {
         final Flux<ByteBuffer> input = null;
         final Long contentLength = null;
-        analyzeBodyNoAcceptHeaderWithResponse(contentType, input, contentLength);
+        analyzeBodyNoAcceptHeaderWithResponse(contentType, input, contentLength, Context.NONE);
     }
 
     /**
@@ -693,6 +869,30 @@ public final class MediaTypesClient {
      * @param contentType Upload file type.
      * @param input Input parameter.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> analyzeBodyNoAcceptHeaderWithResponseAsync(
+            ContentType contentType, BinaryData input, Long contentLength, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (contentType == null) {
+            return Mono.error(new IllegalArgumentException("Parameter contentType is required and cannot be null."));
+        }
+        return service.analyzeBodyNoAcceptHeader(this.getHost(), contentType, input, contentLength, context);
+    }
+
+    /**
+     * Analyze body, that could be different media types. Adds to AnalyzeBody by not having an accept type.
+     *
+     * @param contentType Upload file type.
+     * @param input Input parameter.
+     * @param contentLength The Content-Length header for the request.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -710,6 +910,26 @@ public final class MediaTypesClient {
      * @param contentType Upload file type.
      * @param input Input parameter.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> analyzeBodyNoAcceptHeaderAsync(
+            ContentType contentType, BinaryData input, Long contentLength, Context context) {
+        return analyzeBodyNoAcceptHeaderWithResponseAsync(contentType, input, contentLength, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Analyze body, that could be different media types. Adds to AnalyzeBody by not having an accept type.
+     *
+     * @param contentType Upload file type.
+     * @param input Input parameter.
+     * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -717,8 +937,8 @@ public final class MediaTypesClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> analyzeBodyNoAcceptHeaderWithResponse(
-            ContentType contentType, BinaryData input, Long contentLength) {
-        return analyzeBodyNoAcceptHeaderWithResponseAsync(contentType, input, contentLength).block();
+            ContentType contentType, BinaryData input, Long contentLength, Context context) {
+        return analyzeBodyNoAcceptHeaderWithResponseAsync(contentType, input, contentLength, context).block();
     }
 
     /**
@@ -733,7 +953,7 @@ public final class MediaTypesClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void analyzeBodyNoAcceptHeader(ContentType contentType, BinaryData input, Long contentLength) {
-        analyzeBodyNoAcceptHeaderWithResponse(contentType, input, contentLength);
+        analyzeBodyNoAcceptHeaderWithResponse(contentType, input, contentLength, Context.NONE);
     }
 
     /**
@@ -757,6 +977,30 @@ public final class MediaTypesClient {
         }
         SourcePath input = inputInternal;
         return FluxUtil.withContext(context -> service.analyzeBodyNoAcceptHeader(this.getHost(), input, context));
+    }
+
+    /**
+     * Analyze body, that could be different media types. Adds to AnalyzeBody by not having an accept type.
+     *
+     * @param source File source path.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> analyzeBodyNoAcceptHeaderWithResponseAsync(String source, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        SourcePath inputInternal = null;
+        if (source != null) {
+            inputInternal = new SourcePath();
+            inputInternal.setSource(source);
+        }
+        SourcePath input = inputInternal;
+        return service.analyzeBodyNoAcceptHeader(this.getHost(), input, context);
     }
 
     /**
@@ -790,14 +1034,30 @@ public final class MediaTypesClient {
      * Analyze body, that could be different media types. Adds to AnalyzeBody by not having an accept type.
      *
      * @param source File source path.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> analyzeBodyNoAcceptHeaderAsync(String source, Context context) {
+        return analyzeBodyNoAcceptHeaderWithResponseAsync(source, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Analyze body, that could be different media types. Adds to AnalyzeBody by not having an accept type.
+     *
+     * @param source File source path.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> analyzeBodyNoAcceptHeaderWithResponse(String source) {
-        return analyzeBodyNoAcceptHeaderWithResponseAsync(source).block();
+    public Response<Void> analyzeBodyNoAcceptHeaderWithResponse(String source, Context context) {
+        return analyzeBodyNoAcceptHeaderWithResponseAsync(source, context).block();
     }
 
     /**
@@ -810,7 +1070,7 @@ public final class MediaTypesClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void analyzeBodyNoAcceptHeader(String source) {
-        analyzeBodyNoAcceptHeaderWithResponse(source);
+        analyzeBodyNoAcceptHeaderWithResponse(source, Context.NONE);
     }
 
     /**
@@ -822,7 +1082,7 @@ public final class MediaTypesClient {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void analyzeBodyNoAcceptHeader() {
         final String source = null;
-        analyzeBodyNoAcceptHeaderWithResponse(source);
+        analyzeBodyNoAcceptHeaderWithResponse(source, Context.NONE);
     }
 
     /**
@@ -841,6 +1101,25 @@ public final class MediaTypesClient {
         }
         final String accept = "application/json";
         return FluxUtil.withContext(context -> service.contentTypeWithEncoding(this.getHost(), input, accept, context));
+    }
+
+    /**
+     * Pass in contentType 'text/plain; charset=UTF-8' to pass test. Value for input does not matter.
+     *
+     * @param input Input parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> contentTypeWithEncodingWithResponseAsync(String input, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.contentTypeWithEncoding(this.getHost(), input, accept, context);
     }
 
     /**
@@ -874,14 +1153,31 @@ public final class MediaTypesClient {
      * Pass in contentType 'text/plain; charset=UTF-8' to pass test. Value for input does not matter.
      *
      * @param input Input parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> contentTypeWithEncodingAsync(String input, Context context) {
+        return contentTypeWithEncodingWithResponseAsync(input, context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Pass in contentType 'text/plain; charset=UTF-8' to pass test. Value for input does not matter.
+     *
+     * @param input Input parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> contentTypeWithEncodingWithResponse(String input) {
-        return contentTypeWithEncodingWithResponseAsync(input).block();
+    public Response<String> contentTypeWithEncodingWithResponse(String input, Context context) {
+        return contentTypeWithEncodingWithResponseAsync(input, context).block();
     }
 
     /**
@@ -895,7 +1191,7 @@ public final class MediaTypesClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String contentTypeWithEncoding(String input) {
-        return contentTypeWithEncodingWithResponse(input).getValue();
+        return contentTypeWithEncodingWithResponse(input, Context.NONE).getValue();
     }
 
     /**
@@ -908,7 +1204,7 @@ public final class MediaTypesClient {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String contentTypeWithEncoding() {
         final String input = null;
-        return contentTypeWithEncodingWithResponse(input).getValue();
+        return contentTypeWithEncodingWithResponse(input, Context.NONE).getValue();
     }
 
     /**
@@ -949,6 +1245,36 @@ public final class MediaTypesClient {
      * @param contentType Upload file type.
      * @param message The payload body.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> binaryBodyWithTwoContentTypesWithResponseAsync(
+            ContentType1 contentType, Flux<ByteBuffer> message, long contentLength, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (contentType == null) {
+            return Mono.error(new IllegalArgumentException("Parameter contentType is required and cannot be null."));
+        }
+        if (message == null) {
+            return Mono.error(new IllegalArgumentException("Parameter message is required and cannot be null."));
+        }
+        final String accept = "text/plain";
+        return service.binaryBodyWithTwoContentTypes(
+                this.getHost(), contentType, message, contentLength, accept, context);
+    }
+
+    /**
+     * Binary body with two content types. Pass in of {'hello': 'world'} for the application/json content type, and a
+     * byte stream of 'hello, world!' for application/octet-stream.
+     *
+     * @param contentType Upload file type.
+     * @param message The payload body.
+     * @param contentLength The Content-Length header for the request.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -968,6 +1294,27 @@ public final class MediaTypesClient {
      * @param contentType Upload file type.
      * @param message The payload body.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> binaryBodyWithTwoContentTypesAsync(
+            ContentType1 contentType, Flux<ByteBuffer> message, long contentLength, Context context) {
+        return binaryBodyWithTwoContentTypesWithResponseAsync(contentType, message, contentLength, context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Binary body with two content types. Pass in of {'hello': 'world'} for the application/json content type, and a
+     * byte stream of 'hello, world!' for application/octet-stream.
+     *
+     * @param contentType Upload file type.
+     * @param message The payload body.
+     * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -975,8 +1322,8 @@ public final class MediaTypesClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<String> binaryBodyWithTwoContentTypesWithResponse(
-            ContentType1 contentType, Flux<ByteBuffer> message, long contentLength) {
-        return binaryBodyWithTwoContentTypesWithResponseAsync(contentType, message, contentLength).block();
+            ContentType1 contentType, Flux<ByteBuffer> message, long contentLength, Context context) {
+        return binaryBodyWithTwoContentTypesWithResponseAsync(contentType, message, contentLength, context).block();
     }
 
     /**
@@ -994,7 +1341,7 @@ public final class MediaTypesClient {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String binaryBodyWithTwoContentTypes(
             ContentType1 contentType, Flux<ByteBuffer> message, long contentLength) {
-        return binaryBodyWithTwoContentTypesWithResponse(contentType, message, contentLength).getValue();
+        return binaryBodyWithTwoContentTypesWithResponse(contentType, message, contentLength, Context.NONE).getValue();
     }
 
     /**
@@ -1035,6 +1382,36 @@ public final class MediaTypesClient {
      * @param contentType Upload file type.
      * @param message The payload body.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> binaryBodyWithTwoContentTypesWithResponseAsync(
+            ContentType1 contentType, BinaryData message, long contentLength, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (contentType == null) {
+            return Mono.error(new IllegalArgumentException("Parameter contentType is required and cannot be null."));
+        }
+        if (message == null) {
+            return Mono.error(new IllegalArgumentException("Parameter message is required and cannot be null."));
+        }
+        final String accept = "text/plain";
+        return service.binaryBodyWithTwoContentTypes(
+                this.getHost(), contentType, message, contentLength, accept, context);
+    }
+
+    /**
+     * Binary body with two content types. Pass in of {'hello': 'world'} for the application/json content type, and a
+     * byte stream of 'hello, world!' for application/octet-stream.
+     *
+     * @param contentType Upload file type.
+     * @param message The payload body.
+     * @param contentLength The Content-Length header for the request.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1054,6 +1431,27 @@ public final class MediaTypesClient {
      * @param contentType Upload file type.
      * @param message The payload body.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> binaryBodyWithTwoContentTypesAsync(
+            ContentType1 contentType, BinaryData message, long contentLength, Context context) {
+        return binaryBodyWithTwoContentTypesWithResponseAsync(contentType, message, contentLength, context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Binary body with two content types. Pass in of {'hello': 'world'} for the application/json content type, and a
+     * byte stream of 'hello, world!' for application/octet-stream.
+     *
+     * @param contentType Upload file type.
+     * @param message The payload body.
+     * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1061,8 +1459,8 @@ public final class MediaTypesClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<String> binaryBodyWithTwoContentTypesWithResponse(
-            ContentType1 contentType, BinaryData message, long contentLength) {
-        return binaryBodyWithTwoContentTypesWithResponseAsync(contentType, message, contentLength).block();
+            ContentType1 contentType, BinaryData message, long contentLength, Context context) {
+        return binaryBodyWithTwoContentTypesWithResponseAsync(contentType, message, contentLength, context).block();
     }
 
     /**
@@ -1079,7 +1477,7 @@ public final class MediaTypesClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String binaryBodyWithTwoContentTypes(ContentType1 contentType, BinaryData message, long contentLength) {
-        return binaryBodyWithTwoContentTypesWithResponse(contentType, message, contentLength).getValue();
+        return binaryBodyWithTwoContentTypesWithResponse(contentType, message, contentLength, Context.NONE).getValue();
     }
 
     /**
@@ -1120,6 +1518,36 @@ public final class MediaTypesClient {
      * @param contentType Upload file type.
      * @param message The payload body.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> binaryBodyWithThreeContentTypesWithResponseAsync(
+            ContentType2 contentType, Flux<ByteBuffer> message, long contentLength, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (contentType == null) {
+            return Mono.error(new IllegalArgumentException("Parameter contentType is required and cannot be null."));
+        }
+        if (message == null) {
+            return Mono.error(new IllegalArgumentException("Parameter message is required and cannot be null."));
+        }
+        final String accept = "text/plain";
+        return service.binaryBodyWithThreeContentTypes(
+                this.getHost(), contentType, message, contentLength, accept, context);
+    }
+
+    /**
+     * Binary body with three content types. Pass in string 'hello, world' with content type 'text/plain', {'hello':
+     * world'} with content type 'application/json' and a byte string for 'application/octet-stream'.
+     *
+     * @param contentType Upload file type.
+     * @param message The payload body.
+     * @param contentLength The Content-Length header for the request.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1139,6 +1567,27 @@ public final class MediaTypesClient {
      * @param contentType Upload file type.
      * @param message The payload body.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> binaryBodyWithThreeContentTypesAsync(
+            ContentType2 contentType, Flux<ByteBuffer> message, long contentLength, Context context) {
+        return binaryBodyWithThreeContentTypesWithResponseAsync(contentType, message, contentLength, context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Binary body with three content types. Pass in string 'hello, world' with content type 'text/plain', {'hello':
+     * world'} with content type 'application/json' and a byte string for 'application/octet-stream'.
+     *
+     * @param contentType Upload file type.
+     * @param message The payload body.
+     * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1146,8 +1595,8 @@ public final class MediaTypesClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<String> binaryBodyWithThreeContentTypesWithResponse(
-            ContentType2 contentType, Flux<ByteBuffer> message, long contentLength) {
-        return binaryBodyWithThreeContentTypesWithResponseAsync(contentType, message, contentLength).block();
+            ContentType2 contentType, Flux<ByteBuffer> message, long contentLength, Context context) {
+        return binaryBodyWithThreeContentTypesWithResponseAsync(contentType, message, contentLength, context).block();
     }
 
     /**
@@ -1165,7 +1614,8 @@ public final class MediaTypesClient {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String binaryBodyWithThreeContentTypes(
             ContentType2 contentType, Flux<ByteBuffer> message, long contentLength) {
-        return binaryBodyWithThreeContentTypesWithResponse(contentType, message, contentLength).getValue();
+        return binaryBodyWithThreeContentTypesWithResponse(contentType, message, contentLength, Context.NONE)
+                .getValue();
     }
 
     /**
@@ -1206,6 +1656,36 @@ public final class MediaTypesClient {
      * @param contentType Upload file type.
      * @param message The payload body.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> binaryBodyWithThreeContentTypesWithResponseAsync(
+            ContentType2 contentType, BinaryData message, long contentLength, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (contentType == null) {
+            return Mono.error(new IllegalArgumentException("Parameter contentType is required and cannot be null."));
+        }
+        if (message == null) {
+            return Mono.error(new IllegalArgumentException("Parameter message is required and cannot be null."));
+        }
+        final String accept = "text/plain";
+        return service.binaryBodyWithThreeContentTypes(
+                this.getHost(), contentType, message, contentLength, accept, context);
+    }
+
+    /**
+     * Binary body with three content types. Pass in string 'hello, world' with content type 'text/plain', {'hello':
+     * world'} with content type 'application/json' and a byte string for 'application/octet-stream'.
+     *
+     * @param contentType Upload file type.
+     * @param message The payload body.
+     * @param contentLength The Content-Length header for the request.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1225,6 +1705,27 @@ public final class MediaTypesClient {
      * @param contentType Upload file type.
      * @param message The payload body.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> binaryBodyWithThreeContentTypesAsync(
+            ContentType2 contentType, BinaryData message, long contentLength, Context context) {
+        return binaryBodyWithThreeContentTypesWithResponseAsync(contentType, message, contentLength, context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Binary body with three content types. Pass in string 'hello, world' with content type 'text/plain', {'hello':
+     * world'} with content type 'application/json' and a byte string for 'application/octet-stream'.
+     *
+     * @param contentType Upload file type.
+     * @param message The payload body.
+     * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1232,8 +1733,8 @@ public final class MediaTypesClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<String> binaryBodyWithThreeContentTypesWithResponse(
-            ContentType2 contentType, BinaryData message, long contentLength) {
-        return binaryBodyWithThreeContentTypesWithResponseAsync(contentType, message, contentLength).block();
+            ContentType2 contentType, BinaryData message, long contentLength, Context context) {
+        return binaryBodyWithThreeContentTypesWithResponseAsync(contentType, message, contentLength, context).block();
     }
 
     /**
@@ -1250,7 +1751,8 @@ public final class MediaTypesClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String binaryBodyWithThreeContentTypes(ContentType2 contentType, BinaryData message, long contentLength) {
-        return binaryBodyWithThreeContentTypesWithResponse(contentType, message, contentLength).getValue();
+        return binaryBodyWithThreeContentTypesWithResponse(contentType, message, contentLength, Context.NONE)
+                .getValue();
     }
 
     /**
@@ -1285,6 +1787,32 @@ public final class MediaTypesClient {
      *
      * @param message The payload body.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> bodyThreeTypesWithResponseAsync(
+            Flux<ByteBuffer> message, long contentLength, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (message == null) {
+            return Mono.error(new IllegalArgumentException("Parameter message is required and cannot be null."));
+        }
+        final String accept = "text/plain";
+        return service.bodyThreeTypes(this.getHost(), message, contentLength, accept, context);
+    }
+
+    /**
+     * Body with three types. Can be stream, string, or JSON. Pass in string 'hello, world' with content type
+     * 'text/plain', {'hello': world'} with content type 'application/json' and a byte string for
+     * 'application/octet-stream'.
+     *
+     * @param message The payload body.
+     * @param contentLength The Content-Length header for the request.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1302,14 +1830,34 @@ public final class MediaTypesClient {
      *
      * @param message The payload body.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> bodyThreeTypesAsync(Flux<ByteBuffer> message, long contentLength, Context context) {
+        return bodyThreeTypesWithResponseAsync(message, contentLength, context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Body with three types. Can be stream, string, or JSON. Pass in string 'hello, world' with content type
+     * 'text/plain', {'hello': world'} with content type 'application/json' and a byte string for
+     * 'application/octet-stream'.
+     *
+     * @param message The payload body.
+     * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> bodyThreeTypesWithResponse(Flux<ByteBuffer> message, long contentLength) {
-        return bodyThreeTypesWithResponseAsync(message, contentLength).block();
+    public Response<String> bodyThreeTypesWithResponse(Flux<ByteBuffer> message, long contentLength, Context context) {
+        return bodyThreeTypesWithResponseAsync(message, contentLength, context).block();
     }
 
     /**
@@ -1326,7 +1874,7 @@ public final class MediaTypesClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String bodyThreeTypes(Flux<ByteBuffer> message, long contentLength) {
-        return bodyThreeTypesWithResponse(message, contentLength).getValue();
+        return bodyThreeTypesWithResponse(message, contentLength, Context.NONE).getValue();
     }
 
     /**
@@ -1361,6 +1909,32 @@ public final class MediaTypesClient {
      *
      * @param message The payload body.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> bodyThreeTypesWithResponseAsync(
+            BinaryData message, long contentLength, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (message == null) {
+            return Mono.error(new IllegalArgumentException("Parameter message is required and cannot be null."));
+        }
+        final String accept = "text/plain";
+        return service.bodyThreeTypes(this.getHost(), message, contentLength, accept, context);
+    }
+
+    /**
+     * Body with three types. Can be stream, string, or JSON. Pass in string 'hello, world' with content type
+     * 'text/plain', {'hello': world'} with content type 'application/json' and a byte string for
+     * 'application/octet-stream'.
+     *
+     * @param message The payload body.
+     * @param contentLength The Content-Length header for the request.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1378,14 +1952,34 @@ public final class MediaTypesClient {
      *
      * @param message The payload body.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> bodyThreeTypesAsync(BinaryData message, long contentLength, Context context) {
+        return bodyThreeTypesWithResponseAsync(message, contentLength, context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Body with three types. Can be stream, string, or JSON. Pass in string 'hello, world' with content type
+     * 'text/plain', {'hello': world'} with content type 'application/json' and a byte string for
+     * 'application/octet-stream'.
+     *
+     * @param message The payload body.
+     * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> bodyThreeTypesWithResponse(BinaryData message, long contentLength) {
-        return bodyThreeTypesWithResponseAsync(message, contentLength).block();
+    public Response<String> bodyThreeTypesWithResponse(BinaryData message, long contentLength, Context context) {
+        return bodyThreeTypesWithResponseAsync(message, contentLength, context).block();
     }
 
     /**
@@ -1402,7 +1996,7 @@ public final class MediaTypesClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String bodyThreeTypes(BinaryData message, long contentLength) {
-        return bodyThreeTypesWithResponse(message, contentLength).getValue();
+        return bodyThreeTypesWithResponse(message, contentLength, Context.NONE).getValue();
     }
 
     /**
@@ -1434,6 +2028,30 @@ public final class MediaTypesClient {
      * 'application/octet-stream'.
      *
      * @param message The payload body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> bodyThreeTypesWithResponseAsync(String message, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (message == null) {
+            return Mono.error(new IllegalArgumentException("Parameter message is required and cannot be null."));
+        }
+        final String accept = "text/plain";
+        return service.bodyThreeTypes(this.getHost(), message, accept, context);
+    }
+
+    /**
+     * Body with three types. Can be stream, string, or JSON. Pass in string 'hello, world' with content type
+     * 'text/plain', {'hello': world'} with content type 'application/json' and a byte string for
+     * 'application/octet-stream'.
+     *
+     * @param message The payload body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1450,14 +2068,32 @@ public final class MediaTypesClient {
      * 'application/octet-stream'.
      *
      * @param message The payload body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> bodyThreeTypesAsync(String message, Context context) {
+        return bodyThreeTypesWithResponseAsync(message, context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Body with three types. Can be stream, string, or JSON. Pass in string 'hello, world' with content type
+     * 'text/plain', {'hello': world'} with content type 'application/json' and a byte string for
+     * 'application/octet-stream'.
+     *
+     * @param message The payload body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> bodyThreeTypesWithResponse(String message) {
-        return bodyThreeTypesWithResponseAsync(message).block();
+    public Response<String> bodyThreeTypesWithResponse(String message, Context context) {
+        return bodyThreeTypesWithResponseAsync(message, context).block();
     }
 
     /**
@@ -1473,7 +2109,7 @@ public final class MediaTypesClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String bodyThreeTypes(String message) {
-        return bodyThreeTypesWithResponse(message).getValue();
+        return bodyThreeTypesWithResponse(message, Context.NONE).getValue();
     }
 
     /**
@@ -1505,6 +2141,30 @@ public final class MediaTypesClient {
      * 'application/octet-stream'.
      *
      * @param message The payload body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> bodyThreeTypesWithResponseAsync(Object message, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (message == null) {
+            return Mono.error(new IllegalArgumentException("Parameter message is required and cannot be null."));
+        }
+        final String accept = "text/plain";
+        return service.bodyThreeTypes(this.getHost(), message, accept, context);
+    }
+
+    /**
+     * Body with three types. Can be stream, string, or JSON. Pass in string 'hello, world' with content type
+     * 'text/plain', {'hello': world'} with content type 'application/json' and a byte string for
+     * 'application/octet-stream'.
+     *
+     * @param message The payload body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1521,14 +2181,32 @@ public final class MediaTypesClient {
      * 'application/octet-stream'.
      *
      * @param message The payload body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> bodyThreeTypesAsync(Object message, Context context) {
+        return bodyThreeTypesWithResponseAsync(message, context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Body with three types. Can be stream, string, or JSON. Pass in string 'hello, world' with content type
+     * 'text/plain', {'hello': world'} with content type 'application/json' and a byte string for
+     * 'application/octet-stream'.
+     *
+     * @param message The payload body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> bodyThreeTypesWithResponse(Object message) {
-        return bodyThreeTypesWithResponseAsync(message).block();
+    public Response<String> bodyThreeTypesWithResponse(Object message, Context context) {
+        return bodyThreeTypesWithResponseAsync(message, context).block();
     }
 
     /**
@@ -1544,7 +2222,7 @@ public final class MediaTypesClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String bodyThreeTypes(Object message) {
-        return bodyThreeTypesWithResponse(message).getValue();
+        return bodyThreeTypesWithResponse(message, Context.NONE).getValue();
     }
 
     /**
@@ -1578,6 +2256,33 @@ public final class MediaTypesClient {
      *
      * @param contentType Upload file type.
      * @param message The payload body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> putTextAndJsonBodyWithResponseAsync(
+            ContentType3 contentType, String message, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (contentType == null) {
+            return Mono.error(new IllegalArgumentException("Parameter contentType is required and cannot be null."));
+        }
+        if (message == null) {
+            return Mono.error(new IllegalArgumentException("Parameter message is required and cannot be null."));
+        }
+        final String accept = "text/plain";
+        return service.putTextAndJsonBody(this.getHost(), contentType, message, accept, context);
+    }
+
+    /**
+     * Body that's either text/plain or application/json.
+     *
+     * @param contentType Upload file type.
+     * @param message The payload body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1594,14 +2299,32 @@ public final class MediaTypesClient {
      *
      * @param contentType Upload file type.
      * @param message The payload body.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> putTextAndJsonBodyAsync(ContentType3 contentType, String message, Context context) {
+        return putTextAndJsonBodyWithResponseAsync(contentType, message, context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Body that's either text/plain or application/json.
+     *
+     * @param contentType Upload file type.
+     * @param message The payload body.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> putTextAndJsonBodyWithResponse(ContentType3 contentType, String message) {
-        return putTextAndJsonBodyWithResponseAsync(contentType, message).block();
+    public Response<String> putTextAndJsonBodyWithResponse(ContentType3 contentType, String message, Context context) {
+        return putTextAndJsonBodyWithResponseAsync(contentType, message, context).block();
     }
 
     /**
@@ -1616,6 +2339,6 @@ public final class MediaTypesClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String putTextAndJsonBody(ContentType3 contentType, String message) {
-        return putTextAndJsonBodyWithResponse(contentType, message).getValue();
+        return putTextAndJsonBodyWithResponse(contentType, message, Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/modelflattening/AutoRestResourceFlatteningTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/modelflattening/AutoRestResourceFlatteningTestService.java
@@ -245,6 +245,28 @@ public final class AutoRestResourceFlatteningTestService {
      * Put External Resource as an Array.
      *
      * @param resourceArray External Resource as an Array to put.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putArrayWithResponseAsync(List<Resource> resourceArray, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (resourceArray != null) {
+            resourceArray.forEach(e -> e.validate());
+        }
+        final String accept = "application/json";
+        return service.putArray(this.getHost(), resourceArray, accept, context);
+    }
+
+    /**
+     * Put External Resource as an Array.
+     *
+     * @param resourceArray External Resource as an Array to put.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -272,14 +294,30 @@ public final class AutoRestResourceFlatteningTestService {
      * Put External Resource as an Array.
      *
      * @param resourceArray External Resource as an Array to put.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putArrayAsync(List<Resource> resourceArray, Context context) {
+        return putArrayWithResponseAsync(resourceArray, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put External Resource as an Array.
+     *
+     * @param resourceArray External Resource as an Array to put.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putArrayWithResponse(List<Resource> resourceArray) {
-        return putArrayWithResponseAsync(resourceArray).block();
+    public Response<Void> putArrayWithResponse(List<Resource> resourceArray, Context context) {
+        return putArrayWithResponseAsync(resourceArray, context).block();
     }
 
     /**
@@ -292,7 +330,7 @@ public final class AutoRestResourceFlatteningTestService {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putArray(List<Resource> resourceArray) {
-        putArrayWithResponse(resourceArray);
+        putArrayWithResponse(resourceArray, Context.NONE);
     }
 
     /**
@@ -304,7 +342,7 @@ public final class AutoRestResourceFlatteningTestService {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putArray() {
         final List<Resource> resourceArray = null;
-        putArrayWithResponse(resourceArray);
+        putArrayWithResponse(resourceArray, Context.NONE);
     }
 
     /**
@@ -326,6 +364,24 @@ public final class AutoRestResourceFlatteningTestService {
     /**
      * Get External Resource as an Array.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return external Resource as an Array along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<FlattenedProduct>>> getArrayWithResponseAsync(Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getArray(this.getHost(), accept, context);
+    }
+
+    /**
+     * Get External Resource as an Array.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return external Resource as an Array on successful completion of {@link Mono}.
@@ -338,13 +394,29 @@ public final class AutoRestResourceFlatteningTestService {
     /**
      * Get External Resource as an Array.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return external Resource as an Array on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<FlattenedProduct>> getArrayAsync(Context context) {
+        return getArrayWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get External Resource as an Array.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return external Resource as an Array along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<FlattenedProduct>> getArrayWithResponse() {
-        return getArrayWithResponseAsync().block();
+    public Response<List<FlattenedProduct>> getArrayWithResponse(Context context) {
+        return getArrayWithResponseAsync(context).block();
     }
 
     /**
@@ -356,7 +428,7 @@ public final class AutoRestResourceFlatteningTestService {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<FlattenedProduct> getArray() {
-        return getArrayWithResponse().getValue();
+        return getArrayWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -379,6 +451,29 @@ public final class AutoRestResourceFlatteningTestService {
         }
         final String accept = "application/json";
         return FluxUtil.withContext(context -> service.putWrappedArray(this.getHost(), resourceArray, accept, context));
+    }
+
+    /**
+     * No need to have a route in Express server for this operation. Used to verify the type flattened is not removed if
+     * it's referenced in an array.
+     *
+     * @param resourceArray External Resource as an Array to put.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putWrappedArrayWithResponseAsync(List<WrappedProduct> resourceArray, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (resourceArray != null) {
+            resourceArray.forEach(e -> e.validate());
+        }
+        final String accept = "application/json";
+        return service.putWrappedArray(this.getHost(), resourceArray, accept, context);
     }
 
     /**
@@ -415,14 +510,31 @@ public final class AutoRestResourceFlatteningTestService {
      * it's referenced in an array.
      *
      * @param resourceArray External Resource as an Array to put.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putWrappedArrayAsync(List<WrappedProduct> resourceArray, Context context) {
+        return putWrappedArrayWithResponseAsync(resourceArray, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * No need to have a route in Express server for this operation. Used to verify the type flattened is not removed if
+     * it's referenced in an array.
+     *
+     * @param resourceArray External Resource as an Array to put.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putWrappedArrayWithResponse(List<WrappedProduct> resourceArray) {
-        return putWrappedArrayWithResponseAsync(resourceArray).block();
+    public Response<Void> putWrappedArrayWithResponse(List<WrappedProduct> resourceArray, Context context) {
+        return putWrappedArrayWithResponseAsync(resourceArray, context).block();
     }
 
     /**
@@ -436,7 +548,7 @@ public final class AutoRestResourceFlatteningTestService {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putWrappedArray(List<WrappedProduct> resourceArray) {
-        putWrappedArrayWithResponse(resourceArray);
+        putWrappedArrayWithResponse(resourceArray, Context.NONE);
     }
 
     /**
@@ -449,7 +561,7 @@ public final class AutoRestResourceFlatteningTestService {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putWrappedArray() {
         final List<WrappedProduct> resourceArray = null;
-        putWrappedArrayWithResponse(resourceArray);
+        putWrappedArrayWithResponse(resourceArray, Context.NONE);
     }
 
     /**
@@ -473,6 +585,25 @@ public final class AutoRestResourceFlatteningTestService {
      * No need to have a route in Express server for this operation. Used to verify the type flattened is not removed if
      * it's referenced in an array.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return array of ProductWrapper along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<ProductWrapper>>> getWrappedArrayWithResponseAsync(Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getWrappedArray(this.getHost(), accept, context);
+    }
+
+    /**
+     * No need to have a route in Express server for this operation. Used to verify the type flattened is not removed if
+     * it's referenced in an array.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return array of ProductWrapper on successful completion of {@link Mono}.
@@ -486,13 +617,30 @@ public final class AutoRestResourceFlatteningTestService {
      * No need to have a route in Express server for this operation. Used to verify the type flattened is not removed if
      * it's referenced in an array.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return array of ProductWrapper on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<ProductWrapper>> getWrappedArrayAsync(Context context) {
+        return getWrappedArrayWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * No need to have a route in Express server for this operation. Used to verify the type flattened is not removed if
+     * it's referenced in an array.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return array of ProductWrapper along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<ProductWrapper>> getWrappedArrayWithResponse() {
-        return getWrappedArrayWithResponseAsync().block();
+    public Response<List<ProductWrapper>> getWrappedArrayWithResponse(Context context) {
+        return getWrappedArrayWithResponseAsync(context).block();
     }
 
     /**
@@ -505,7 +653,7 @@ public final class AutoRestResourceFlatteningTestService {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<ProductWrapper> getWrappedArray() {
-        return getWrappedArrayWithResponse().getValue();
+        return getWrappedArrayWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -541,6 +689,36 @@ public final class AutoRestResourceFlatteningTestService {
      * Put External Resource as a Dictionary.
      *
      * @param resourceDictionary External Resource as a Dictionary to put.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putDictionaryWithResponseAsync(
+            Map<String, FlattenedProduct> resourceDictionary, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (resourceDictionary != null) {
+            resourceDictionary
+                    .values()
+                    .forEach(
+                            e -> {
+                                if (e != null) {
+                                    e.validate();
+                                }
+                            });
+        }
+        final String accept = "application/json";
+        return service.putDictionary(this.getHost(), resourceDictionary, accept, context);
+    }
+
+    /**
+     * Put External Resource as a Dictionary.
+     *
+     * @param resourceDictionary External Resource as a Dictionary to put.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -568,14 +746,30 @@ public final class AutoRestResourceFlatteningTestService {
      * Put External Resource as a Dictionary.
      *
      * @param resourceDictionary External Resource as a Dictionary to put.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putDictionaryAsync(Map<String, FlattenedProduct> resourceDictionary, Context context) {
+        return putDictionaryWithResponseAsync(resourceDictionary, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put External Resource as a Dictionary.
+     *
+     * @param resourceDictionary External Resource as a Dictionary to put.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDictionaryWithResponse(Map<String, FlattenedProduct> resourceDictionary) {
-        return putDictionaryWithResponseAsync(resourceDictionary).block();
+    public Response<Void> putDictionaryWithResponse(Map<String, FlattenedProduct> resourceDictionary, Context context) {
+        return putDictionaryWithResponseAsync(resourceDictionary, context).block();
     }
 
     /**
@@ -588,7 +782,7 @@ public final class AutoRestResourceFlatteningTestService {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDictionary(Map<String, FlattenedProduct> resourceDictionary) {
-        putDictionaryWithResponse(resourceDictionary);
+        putDictionaryWithResponse(resourceDictionary, Context.NONE);
     }
 
     /**
@@ -600,7 +794,7 @@ public final class AutoRestResourceFlatteningTestService {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDictionary() {
         final Map<String, FlattenedProduct> resourceDictionary = null;
-        putDictionaryWithResponse(resourceDictionary);
+        putDictionaryWithResponse(resourceDictionary, Context.NONE);
     }
 
     /**
@@ -622,6 +816,24 @@ public final class AutoRestResourceFlatteningTestService {
     /**
      * Get External Resource as a Dictionary.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return external Resource as a Dictionary along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, FlattenedProduct>>> getDictionaryWithResponseAsync(Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDictionary(this.getHost(), accept, context);
+    }
+
+    /**
+     * Get External Resource as a Dictionary.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return external Resource as a Dictionary on successful completion of {@link Mono}.
@@ -634,13 +846,29 @@ public final class AutoRestResourceFlatteningTestService {
     /**
      * Get External Resource as a Dictionary.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return external Resource as a Dictionary on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, FlattenedProduct>> getDictionaryAsync(Context context) {
+        return getDictionaryWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get External Resource as a Dictionary.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return external Resource as a Dictionary along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, FlattenedProduct>> getDictionaryWithResponse() {
-        return getDictionaryWithResponseAsync().block();
+    public Response<Map<String, FlattenedProduct>> getDictionaryWithResponse(Context context) {
+        return getDictionaryWithResponseAsync(context).block();
     }
 
     /**
@@ -652,7 +880,7 @@ public final class AutoRestResourceFlatteningTestService {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, FlattenedProduct> getDictionary() {
-        return getDictionaryWithResponse().getValue();
+        return getDictionaryWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -675,6 +903,29 @@ public final class AutoRestResourceFlatteningTestService {
         final String accept = "application/json";
         return FluxUtil.withContext(
                 context -> service.putResourceCollection(this.getHost(), resourceComplexObject, accept, context));
+    }
+
+    /**
+     * Put External Resource as a ResourceCollection.
+     *
+     * @param resourceComplexObject External Resource as a ResourceCollection to put.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putResourceCollectionWithResponseAsync(
+            ResourceCollection resourceComplexObject, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (resourceComplexObject != null) {
+            resourceComplexObject.validate();
+        }
+        final String accept = "application/json";
+        return service.putResourceCollection(this.getHost(), resourceComplexObject, accept, context);
     }
 
     /**
@@ -708,14 +959,30 @@ public final class AutoRestResourceFlatteningTestService {
      * Put External Resource as a ResourceCollection.
      *
      * @param resourceComplexObject External Resource as a ResourceCollection to put.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putResourceCollectionAsync(ResourceCollection resourceComplexObject, Context context) {
+        return putResourceCollectionWithResponseAsync(resourceComplexObject, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put External Resource as a ResourceCollection.
+     *
+     * @param resourceComplexObject External Resource as a ResourceCollection to put.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putResourceCollectionWithResponse(ResourceCollection resourceComplexObject) {
-        return putResourceCollectionWithResponseAsync(resourceComplexObject).block();
+    public Response<Void> putResourceCollectionWithResponse(ResourceCollection resourceComplexObject, Context context) {
+        return putResourceCollectionWithResponseAsync(resourceComplexObject, context).block();
     }
 
     /**
@@ -728,7 +995,7 @@ public final class AutoRestResourceFlatteningTestService {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putResourceCollection(ResourceCollection resourceComplexObject) {
-        putResourceCollectionWithResponse(resourceComplexObject);
+        putResourceCollectionWithResponse(resourceComplexObject, Context.NONE);
     }
 
     /**
@@ -740,7 +1007,7 @@ public final class AutoRestResourceFlatteningTestService {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putResourceCollection() {
         final ResourceCollection resourceComplexObject = null;
-        putResourceCollectionWithResponse(resourceComplexObject);
+        putResourceCollectionWithResponse(resourceComplexObject, Context.NONE);
     }
 
     /**
@@ -763,6 +1030,25 @@ public final class AutoRestResourceFlatteningTestService {
     /**
      * Get External Resource as a ResourceCollection.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return external Resource as a ResourceCollection along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<ResourceCollection>> getResourceCollectionWithResponseAsync(Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getResourceCollection(this.getHost(), accept, context);
+    }
+
+    /**
+     * Get External Resource as a ResourceCollection.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return external Resource as a ResourceCollection on successful completion of {@link Mono}.
@@ -775,13 +1061,29 @@ public final class AutoRestResourceFlatteningTestService {
     /**
      * Get External Resource as a ResourceCollection.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return external Resource as a ResourceCollection on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<ResourceCollection> getResourceCollectionAsync(Context context) {
+        return getResourceCollectionWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get External Resource as a ResourceCollection.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return external Resource as a ResourceCollection along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<ResourceCollection> getResourceCollectionWithResponse() {
-        return getResourceCollectionWithResponseAsync().block();
+    public Response<ResourceCollection> getResourceCollectionWithResponse(Context context) {
+        return getResourceCollectionWithResponseAsync(context).block();
     }
 
     /**
@@ -793,7 +1095,7 @@ public final class AutoRestResourceFlatteningTestService {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ResourceCollection getResourceCollection() {
-        return getResourceCollectionWithResponse().getValue();
+        return getResourceCollectionWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -816,6 +1118,29 @@ public final class AutoRestResourceFlatteningTestService {
         final String accept = "application/json";
         return FluxUtil.withContext(
                 context -> service.putSimpleProduct(this.getHost(), simpleBodyProduct, accept, context));
+    }
+
+    /**
+     * Put Simple Product with client flattening true on the model.
+     *
+     * @param simpleBodyProduct Simple body product to put.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the product documentation along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<SimpleProduct>> putSimpleProductWithResponseAsync(
+            SimpleProduct simpleBodyProduct, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (simpleBodyProduct != null) {
+            simpleBodyProduct.validate();
+        }
+        final String accept = "application/json";
+        return service.putSimpleProduct(this.getHost(), simpleBodyProduct, accept, context);
     }
 
     /**
@@ -849,14 +1174,31 @@ public final class AutoRestResourceFlatteningTestService {
      * Put Simple Product with client flattening true on the model.
      *
      * @param simpleBodyProduct Simple body product to put.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the product documentation on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<SimpleProduct> putSimpleProductAsync(SimpleProduct simpleBodyProduct, Context context) {
+        return putSimpleProductWithResponseAsync(simpleBodyProduct, context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Put Simple Product with client flattening true on the model.
+     *
+     * @param simpleBodyProduct Simple body product to put.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the product documentation along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<SimpleProduct> putSimpleProductWithResponse(SimpleProduct simpleBodyProduct) {
-        return putSimpleProductWithResponseAsync(simpleBodyProduct).block();
+    public Response<SimpleProduct> putSimpleProductWithResponse(SimpleProduct simpleBodyProduct, Context context) {
+        return putSimpleProductWithResponseAsync(simpleBodyProduct, context).block();
     }
 
     /**
@@ -870,7 +1212,7 @@ public final class AutoRestResourceFlatteningTestService {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public SimpleProduct putSimpleProduct(SimpleProduct simpleBodyProduct) {
-        return putSimpleProductWithResponse(simpleBodyProduct).getValue();
+        return putSimpleProductWithResponse(simpleBodyProduct, Context.NONE).getValue();
     }
 
     /**
@@ -883,7 +1225,7 @@ public final class AutoRestResourceFlatteningTestService {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public SimpleProduct putSimpleProduct() {
         final SimpleProduct simpleBodyProduct = null;
-        return putSimpleProductWithResponse(simpleBodyProduct).getValue();
+        return putSimpleProductWithResponse(simpleBodyProduct, Context.NONE).getValue();
     }
 
     /**
@@ -933,6 +1275,56 @@ public final class AutoRestResourceFlatteningTestService {
         SimpleProduct simpleBodyProduct = simpleBodyProductInternal;
         return FluxUtil.withContext(
                 context -> service.postFlattenedSimpleProduct(this.getHost(), simpleBodyProduct, accept, context));
+    }
+
+    /**
+     * Put Flattened Simple Product with client flattening true on the parameter.
+     *
+     * @param productId Unique identifier representing a specific product for a given latitude &amp; longitude. For
+     *     example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.
+     * @param description Description of product.
+     * @param maxProductDisplayName Display name of product.
+     * @param capacity Capacity of product. For example, 4 people.
+     * @param genericValue Generic URL value.
+     * @param odataValue URL value.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the product documentation along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<SimpleProduct>> postFlattenedSimpleProductWithResponseAsync(
+            String productId,
+            String description,
+            String maxProductDisplayName,
+            SimpleProductPropertiesMaxProductCapacity capacity,
+            String genericValue,
+            String odataValue,
+            Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (productId == null) {
+            return Mono.error(new IllegalArgumentException("Parameter productId is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        SimpleProduct simpleBodyProductInternal = null;
+        if (description != null
+                || maxProductDisplayName != null
+                || capacity != null
+                || genericValue != null
+                || odataValue != null) {
+            simpleBodyProductInternal = new SimpleProduct();
+            simpleBodyProductInternal.setProductId(productId);
+            simpleBodyProductInternal.setDescription(description);
+            simpleBodyProductInternal.setMaxProductDisplayName(maxProductDisplayName);
+            simpleBodyProductInternal.setCapacity(capacity);
+            simpleBodyProductInternal.setGenericValue(genericValue);
+            simpleBodyProductInternal.setOdataValue(odataValue);
+        }
+        SimpleProduct simpleBodyProduct = simpleBodyProductInternal;
+        return service.postFlattenedSimpleProduct(this.getHost(), simpleBodyProduct, accept, context);
     }
 
     /**
@@ -995,6 +1387,37 @@ public final class AutoRestResourceFlatteningTestService {
      * @param capacity Capacity of product. For example, 4 people.
      * @param genericValue Generic URL value.
      * @param odataValue URL value.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the product documentation on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<SimpleProduct> postFlattenedSimpleProductAsync(
+            String productId,
+            String description,
+            String maxProductDisplayName,
+            SimpleProductPropertiesMaxProductCapacity capacity,
+            String genericValue,
+            String odataValue,
+            Context context) {
+        return postFlattenedSimpleProductWithResponseAsync(
+                        productId, description, maxProductDisplayName, capacity, genericValue, odataValue, context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Put Flattened Simple Product with client flattening true on the parameter.
+     *
+     * @param productId Unique identifier representing a specific product for a given latitude &amp; longitude. For
+     *     example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.
+     * @param description Description of product.
+     * @param maxProductDisplayName Display name of product.
+     * @param capacity Capacity of product. For example, 4 people.
+     * @param genericValue Generic URL value.
+     * @param odataValue URL value.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1007,9 +1430,10 @@ public final class AutoRestResourceFlatteningTestService {
             String maxProductDisplayName,
             SimpleProductPropertiesMaxProductCapacity capacity,
             String genericValue,
-            String odataValue) {
+            String odataValue,
+            Context context) {
         return postFlattenedSimpleProductWithResponseAsync(
-                        productId, description, maxProductDisplayName, capacity, genericValue, odataValue)
+                        productId, description, maxProductDisplayName, capacity, genericValue, odataValue, context)
                 .block();
     }
 
@@ -1037,7 +1461,7 @@ public final class AutoRestResourceFlatteningTestService {
             String genericValue,
             String odataValue) {
         return postFlattenedSimpleProductWithResponse(
-                        productId, description, maxProductDisplayName, capacity, genericValue, odataValue)
+                        productId, description, maxProductDisplayName, capacity, genericValue, odataValue, Context.NONE)
                 .getValue();
     }
 
@@ -1059,7 +1483,7 @@ public final class AutoRestResourceFlatteningTestService {
         final String genericValue = null;
         final String odataValue = null;
         return postFlattenedSimpleProductWithResponse(
-                        productId, description, maxProductDisplayName, capacity, genericValue, odataValue)
+                        productId, description, maxProductDisplayName, capacity, genericValue, odataValue, Context.NONE)
                 .getValue();
     }
 
@@ -1102,6 +1526,40 @@ public final class AutoRestResourceFlatteningTestService {
      * Put Simple Product with client flattening true on the model.
      *
      * @param flattenParameterGroup Parameter group.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the product documentation along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<SimpleProduct>> putSimpleProductWithGroupingWithResponseAsync(
+            FlattenParameterGroup flattenParameterGroup, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (flattenParameterGroup == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter flattenParameterGroup is required and cannot be null."));
+        } else {
+            flattenParameterGroup.validate();
+        }
+        final String accept = "application/json";
+        String name = flattenParameterGroup.getName();
+        SimpleProduct simpleBodyProduct = new SimpleProduct();
+        simpleBodyProduct.setProductId(flattenParameterGroup.getProductId());
+        simpleBodyProduct.setDescription(flattenParameterGroup.getDescription());
+        simpleBodyProduct.setMaxProductDisplayName(flattenParameterGroup.getMaxProductDisplayName());
+        simpleBodyProduct.setCapacity(flattenParameterGroup.getCapacity());
+        simpleBodyProduct.setGenericValue(flattenParameterGroup.getGenericValue());
+        simpleBodyProduct.setOdataValue(flattenParameterGroup.getOdataValue());
+        return service.putSimpleProductWithGrouping(this.getHost(), name, simpleBodyProduct, accept, context);
+    }
+
+    /**
+     * Put Simple Product with client flattening true on the model.
+     *
+     * @param flattenParameterGroup Parameter group.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1117,6 +1575,24 @@ public final class AutoRestResourceFlatteningTestService {
      * Put Simple Product with client flattening true on the model.
      *
      * @param flattenParameterGroup Parameter group.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the product documentation on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<SimpleProduct> putSimpleProductWithGroupingAsync(
+            FlattenParameterGroup flattenParameterGroup, Context context) {
+        return putSimpleProductWithGroupingWithResponseAsync(flattenParameterGroup, context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Put Simple Product with client flattening true on the model.
+     *
+     * @param flattenParameterGroup Parameter group.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1124,8 +1600,8 @@ public final class AutoRestResourceFlatteningTestService {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<SimpleProduct> putSimpleProductWithGroupingWithResponse(
-            FlattenParameterGroup flattenParameterGroup) {
-        return putSimpleProductWithGroupingWithResponseAsync(flattenParameterGroup).block();
+            FlattenParameterGroup flattenParameterGroup, Context context) {
+        return putSimpleProductWithGroupingWithResponseAsync(flattenParameterGroup, context).block();
     }
 
     /**
@@ -1139,6 +1615,6 @@ public final class AutoRestResourceFlatteningTestService {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public SimpleProduct putSimpleProductWithGrouping(FlattenParameterGroup flattenParameterGroup) {
-        return putSimpleProductWithGroupingWithResponse(flattenParameterGroup).getValue();
+        return putSimpleProductWithGroupingWithResponse(flattenParameterGroup, Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/multipleinheritance/MultipleInheritanceServiceClient.java
+++ b/vanilla-tests/src/main/java/fixtures/multipleinheritance/MultipleInheritanceServiceClient.java
@@ -219,6 +219,25 @@ public final class MultipleInheritanceServiceClient {
     /**
      * Get a horse with name 'Fred' and isAShowHorse true.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a horse with name 'Fred' and isAShowHorse true along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Horse>> getHorseWithResponseAsync(Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getHorse(this.getHost(), accept, context);
+    }
+
+    /**
+     * Get a horse with name 'Fred' and isAShowHorse true.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a horse with name 'Fred' and isAShowHorse true on successful completion of {@link Mono}.
@@ -231,13 +250,29 @@ public final class MultipleInheritanceServiceClient {
     /**
      * Get a horse with name 'Fred' and isAShowHorse true.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a horse with name 'Fred' and isAShowHorse true on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Horse> getHorseAsync(Context context) {
+        return getHorseWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get a horse with name 'Fred' and isAShowHorse true.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a horse with name 'Fred' and isAShowHorse true along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Horse> getHorseWithResponse() {
-        return getHorseWithResponseAsync().block();
+    public Response<Horse> getHorseWithResponse(Context context) {
+        return getHorseWithResponseAsync(context).block();
     }
 
     /**
@@ -249,7 +284,7 @@ public final class MultipleInheritanceServiceClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Horse getHorse() {
-        return getHorseWithResponse().getValue();
+        return getHorseWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -279,6 +314,30 @@ public final class MultipleInheritanceServiceClient {
      * Put a horse with name 'General' and isAShowHorse false.
      *
      * @param horse Put a horse with name 'General' and isAShowHorse false.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> putHorseWithResponseAsync(Horse horse, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (horse == null) {
+            return Mono.error(new IllegalArgumentException("Parameter horse is required and cannot be null."));
+        } else {
+            horse.validate();
+        }
+        final String accept = "application/json";
+        return service.putHorse(this.getHost(), horse, accept, context);
+    }
+
+    /**
+     * Put a horse with name 'General' and isAShowHorse false.
+     *
+     * @param horse Put a horse with name 'General' and isAShowHorse false.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -293,14 +352,30 @@ public final class MultipleInheritanceServiceClient {
      * Put a horse with name 'General' and isAShowHorse false.
      *
      * @param horse Put a horse with name 'General' and isAShowHorse false.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> putHorseAsync(Horse horse, Context context) {
+        return putHorseWithResponseAsync(horse, context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Put a horse with name 'General' and isAShowHorse false.
+     *
+     * @param horse Put a horse with name 'General' and isAShowHorse false.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> putHorseWithResponse(Horse horse) {
-        return putHorseWithResponseAsync(horse).block();
+    public Response<String> putHorseWithResponse(Horse horse, Context context) {
+        return putHorseWithResponseAsync(horse, context).block();
     }
 
     /**
@@ -314,7 +389,7 @@ public final class MultipleInheritanceServiceClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String putHorse(Horse horse) {
-        return putHorseWithResponse(horse).getValue();
+        return putHorseWithResponse(horse, Context.NONE).getValue();
     }
 
     /**
@@ -336,6 +411,24 @@ public final class MultipleInheritanceServiceClient {
     /**
      * Get a pet with name 'Peanut'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a pet with name 'Peanut' along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Pet>> getPetWithResponseAsync(Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getPet(this.getHost(), accept, context);
+    }
+
+    /**
+     * Get a pet with name 'Peanut'.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a pet with name 'Peanut' on successful completion of {@link Mono}.
@@ -348,13 +441,29 @@ public final class MultipleInheritanceServiceClient {
     /**
      * Get a pet with name 'Peanut'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a pet with name 'Peanut' on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Pet> getPetAsync(Context context) {
+        return getPetWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get a pet with name 'Peanut'.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a pet with name 'Peanut' along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Pet> getPetWithResponse() {
-        return getPetWithResponseAsync().block();
+    public Response<Pet> getPetWithResponse(Context context) {
+        return getPetWithResponseAsync(context).block();
     }
 
     /**
@@ -366,7 +475,7 @@ public final class MultipleInheritanceServiceClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Pet getPet() {
-        return getPetWithResponse().getValue();
+        return getPetWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -396,6 +505,30 @@ public final class MultipleInheritanceServiceClient {
      * Put a pet with name 'Butter'.
      *
      * @param pet Put a pet with name 'Butter'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> putPetWithResponseAsync(Pet pet, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (pet == null) {
+            return Mono.error(new IllegalArgumentException("Parameter pet is required and cannot be null."));
+        } else {
+            pet.validate();
+        }
+        final String accept = "application/json";
+        return service.putPet(this.getHost(), pet, accept, context);
+    }
+
+    /**
+     * Put a pet with name 'Butter'.
+     *
+     * @param pet Put a pet with name 'Butter'.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -410,14 +543,30 @@ public final class MultipleInheritanceServiceClient {
      * Put a pet with name 'Butter'.
      *
      * @param pet Put a pet with name 'Butter'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> putPetAsync(Pet pet, Context context) {
+        return putPetWithResponseAsync(pet, context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Put a pet with name 'Butter'.
+     *
+     * @param pet Put a pet with name 'Butter'.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> putPetWithResponse(Pet pet) {
-        return putPetWithResponseAsync(pet).block();
+    public Response<String> putPetWithResponse(Pet pet, Context context) {
+        return putPetWithResponseAsync(pet, context).block();
     }
 
     /**
@@ -431,7 +580,7 @@ public final class MultipleInheritanceServiceClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String putPet(Pet pet) {
-        return putPetWithResponse(pet).getValue();
+        return putPetWithResponse(pet, Context.NONE).getValue();
     }
 
     /**
@@ -454,6 +603,25 @@ public final class MultipleInheritanceServiceClient {
     /**
      * Get a feline where meows and hisses are true.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a feline where meows and hisses are true along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Feline>> getFelineWithResponseAsync(Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getFeline(this.getHost(), accept, context);
+    }
+
+    /**
+     * Get a feline where meows and hisses are true.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a feline where meows and hisses are true on successful completion of {@link Mono}.
@@ -466,13 +634,29 @@ public final class MultipleInheritanceServiceClient {
     /**
      * Get a feline where meows and hisses are true.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a feline where meows and hisses are true on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Feline> getFelineAsync(Context context) {
+        return getFelineWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get a feline where meows and hisses are true.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a feline where meows and hisses are true along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Feline> getFelineWithResponse() {
-        return getFelineWithResponseAsync().block();
+    public Response<Feline> getFelineWithResponse(Context context) {
+        return getFelineWithResponseAsync(context).block();
     }
 
     /**
@@ -484,7 +668,7 @@ public final class MultipleInheritanceServiceClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Feline getFeline() {
-        return getFelineWithResponse().getValue();
+        return getFelineWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -514,6 +698,30 @@ public final class MultipleInheritanceServiceClient {
      * Put a feline who hisses and doesn't meow.
      *
      * @param feline Put a feline who hisses and doesn't meow.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> putFelineWithResponseAsync(Feline feline, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (feline == null) {
+            return Mono.error(new IllegalArgumentException("Parameter feline is required and cannot be null."));
+        } else {
+            feline.validate();
+        }
+        final String accept = "application/json";
+        return service.putFeline(this.getHost(), feline, accept, context);
+    }
+
+    /**
+     * Put a feline who hisses and doesn't meow.
+     *
+     * @param feline Put a feline who hisses and doesn't meow.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -528,14 +736,30 @@ public final class MultipleInheritanceServiceClient {
      * Put a feline who hisses and doesn't meow.
      *
      * @param feline Put a feline who hisses and doesn't meow.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> putFelineAsync(Feline feline, Context context) {
+        return putFelineWithResponseAsync(feline, context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Put a feline who hisses and doesn't meow.
+     *
+     * @param feline Put a feline who hisses and doesn't meow.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> putFelineWithResponse(Feline feline) {
-        return putFelineWithResponseAsync(feline).block();
+    public Response<String> putFelineWithResponse(Feline feline, Context context) {
+        return putFelineWithResponseAsync(feline, context).block();
     }
 
     /**
@@ -549,7 +773,7 @@ public final class MultipleInheritanceServiceClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String putFeline(Feline feline) {
-        return putFelineWithResponse(feline).getValue();
+        return putFelineWithResponse(feline, Context.NONE).getValue();
     }
 
     /**
@@ -572,6 +796,25 @@ public final class MultipleInheritanceServiceClient {
     /**
      * Get a cat with name 'Whiskers' where likesMilk, meows, and hisses is true.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a cat with name 'Whiskers' where likesMilk, meows, and hisses is true along with {@link Response} on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Cat>> getCatWithResponseAsync(Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getCat(this.getHost(), accept, context);
+    }
+
+    /**
+     * Get a cat with name 'Whiskers' where likesMilk, meows, and hisses is true.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a cat with name 'Whiskers' where likesMilk, meows, and hisses is true on successful completion of {@link
@@ -585,13 +828,30 @@ public final class MultipleInheritanceServiceClient {
     /**
      * Get a cat with name 'Whiskers' where likesMilk, meows, and hisses is true.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a cat with name 'Whiskers' where likesMilk, meows, and hisses is true on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Cat> getCatAsync(Context context) {
+        return getCatWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get a cat with name 'Whiskers' where likesMilk, meows, and hisses is true.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a cat with name 'Whiskers' where likesMilk, meows, and hisses is true along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Cat> getCatWithResponse() {
-        return getCatWithResponseAsync().block();
+    public Response<Cat> getCatWithResponse(Context context) {
+        return getCatWithResponseAsync(context).block();
     }
 
     /**
@@ -603,7 +863,7 @@ public final class MultipleInheritanceServiceClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Cat getCat() {
-        return getCatWithResponse().getValue();
+        return getCatWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -633,6 +893,30 @@ public final class MultipleInheritanceServiceClient {
      * Put a cat with name 'Boots' where likesMilk and hisses is false, meows is true.
      *
      * @param cat Put a cat with name 'Boots' where likesMilk and hisses is false, meows is true.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> putCatWithResponseAsync(Cat cat, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (cat == null) {
+            return Mono.error(new IllegalArgumentException("Parameter cat is required and cannot be null."));
+        } else {
+            cat.validate();
+        }
+        final String accept = "application/json";
+        return service.putCat(this.getHost(), cat, accept, context);
+    }
+
+    /**
+     * Put a cat with name 'Boots' where likesMilk and hisses is false, meows is true.
+     *
+     * @param cat Put a cat with name 'Boots' where likesMilk and hisses is false, meows is true.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -647,14 +931,30 @@ public final class MultipleInheritanceServiceClient {
      * Put a cat with name 'Boots' where likesMilk and hisses is false, meows is true.
      *
      * @param cat Put a cat with name 'Boots' where likesMilk and hisses is false, meows is true.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> putCatAsync(Cat cat, Context context) {
+        return putCatWithResponseAsync(cat, context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Put a cat with name 'Boots' where likesMilk and hisses is false, meows is true.
+     *
+     * @param cat Put a cat with name 'Boots' where likesMilk and hisses is false, meows is true.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> putCatWithResponse(Cat cat) {
-        return putCatWithResponseAsync(cat).block();
+    public Response<String> putCatWithResponse(Cat cat, Context context) {
+        return putCatWithResponseAsync(cat, context).block();
     }
 
     /**
@@ -668,7 +968,7 @@ public final class MultipleInheritanceServiceClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String putCat(Cat cat) {
-        return putCatWithResponse(cat).getValue();
+        return putCatWithResponse(cat, Context.NONE).getValue();
     }
 
     /**
@@ -691,6 +991,25 @@ public final class MultipleInheritanceServiceClient {
     /**
      * Get a kitten with name 'Gatito' where likesMilk and meows is true, and hisses and eatsMiceYet is false.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a kitten with name 'Gatito' where likesMilk and meows is true, and hisses and eatsMiceYet is false along
+     *     with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Kitten>> getKittenWithResponseAsync(Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getKitten(this.getHost(), accept, context);
+    }
+
+    /**
+     * Get a kitten with name 'Gatito' where likesMilk and meows is true, and hisses and eatsMiceYet is false.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a kitten with name 'Gatito' where likesMilk and meows is true, and hisses and eatsMiceYet is false on
@@ -704,14 +1023,31 @@ public final class MultipleInheritanceServiceClient {
     /**
      * Get a kitten with name 'Gatito' where likesMilk and meows is true, and hisses and eatsMiceYet is false.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a kitten with name 'Gatito' where likesMilk and meows is true, and hisses and eatsMiceYet is false on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Kitten> getKittenAsync(Context context) {
+        return getKittenWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get a kitten with name 'Gatito' where likesMilk and meows is true, and hisses and eatsMiceYet is false.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a kitten with name 'Gatito' where likesMilk and meows is true, and hisses and eatsMiceYet is false along
      *     with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Kitten> getKittenWithResponse() {
-        return getKittenWithResponseAsync().block();
+    public Response<Kitten> getKittenWithResponse(Context context) {
+        return getKittenWithResponseAsync(context).block();
     }
 
     /**
@@ -723,7 +1059,7 @@ public final class MultipleInheritanceServiceClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Kitten getKitten() {
-        return getKittenWithResponse().getValue();
+        return getKittenWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -753,6 +1089,30 @@ public final class MultipleInheritanceServiceClient {
      * Put a kitten with name 'Kitty' where likesMilk and hisses is false, meows and eatsMiceYet is true.
      *
      * @param kitten Put a kitten with name 'Kitty' where likesMilk and hisses is false, meows and eatsMiceYet is true.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> putKittenWithResponseAsync(Kitten kitten, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (kitten == null) {
+            return Mono.error(new IllegalArgumentException("Parameter kitten is required and cannot be null."));
+        } else {
+            kitten.validate();
+        }
+        final String accept = "application/json";
+        return service.putKitten(this.getHost(), kitten, accept, context);
+    }
+
+    /**
+     * Put a kitten with name 'Kitty' where likesMilk and hisses is false, meows and eatsMiceYet is true.
+     *
+     * @param kitten Put a kitten with name 'Kitty' where likesMilk and hisses is false, meows and eatsMiceYet is true.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -767,14 +1127,30 @@ public final class MultipleInheritanceServiceClient {
      * Put a kitten with name 'Kitty' where likesMilk and hisses is false, meows and eatsMiceYet is true.
      *
      * @param kitten Put a kitten with name 'Kitty' where likesMilk and hisses is false, meows and eatsMiceYet is true.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> putKittenAsync(Kitten kitten, Context context) {
+        return putKittenWithResponseAsync(kitten, context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Put a kitten with name 'Kitty' where likesMilk and hisses is false, meows and eatsMiceYet is true.
+     *
+     * @param kitten Put a kitten with name 'Kitty' where likesMilk and hisses is false, meows and eatsMiceYet is true.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> putKittenWithResponse(Kitten kitten) {
-        return putKittenWithResponseAsync(kitten).block();
+    public Response<String> putKittenWithResponse(Kitten kitten, Context context) {
+        return putKittenWithResponseAsync(kitten, context).block();
     }
 
     /**
@@ -788,6 +1164,6 @@ public final class MultipleInheritanceServiceClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String putKitten(Kitten kitten) {
-        return putKittenWithResponse(kitten).getValue();
+        return putKittenWithResponse(kitten, Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/nonstringenum/FloatOperationClient.java
+++ b/vanilla-tests/src/main/java/fixtures/nonstringenum/FloatOperationClient.java
@@ -9,6 +9,7 @@ import com.azure.core.annotation.ReturnType;
 import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.Response;
+import com.azure.core.util.Context;
 import fixtures.nonstringenum.implementation.FloatOperationsImpl;
 import fixtures.nonstringenum.models.FloatEnum;
 
@@ -30,6 +31,7 @@ public final class FloatOperationClient {
      * Put a float enum.
      *
      * @param input Input float enum.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -37,8 +39,8 @@ public final class FloatOperationClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> putWithResponse(FloatEnum input) {
-        return this.serviceClient.putWithResponse(input);
+    public Response<String> putWithResponse(FloatEnum input, Context context) {
+        return this.serviceClient.putWithResponse(input, context);
     }
 
     /**
@@ -72,14 +74,16 @@ public final class FloatOperationClient {
     /**
      * Get a float enum.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a float enum along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<FloatEnum> getWithResponse() {
-        return this.serviceClient.getWithResponse();
+    public Response<FloatEnum> getWithResponse(Context context) {
+        return this.serviceClient.getWithResponse(context);
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/nonstringenum/IntClient.java
+++ b/vanilla-tests/src/main/java/fixtures/nonstringenum/IntClient.java
@@ -9,6 +9,7 @@ import com.azure.core.annotation.ReturnType;
 import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.Response;
+import com.azure.core.util.Context;
 import fixtures.nonstringenum.implementation.IntsImpl;
 import fixtures.nonstringenum.models.IntEnum;
 
@@ -30,6 +31,7 @@ public final class IntClient {
      * Put an int enum.
      *
      * @param input Input int enum.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -37,8 +39,8 @@ public final class IntClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> putWithResponse(IntEnum input) {
-        return this.serviceClient.putWithResponse(input);
+    public Response<String> putWithResponse(IntEnum input, Context context) {
+        return this.serviceClient.putWithResponse(input, context);
     }
 
     /**
@@ -72,14 +74,16 @@ public final class IntClient {
     /**
      * Get an int enum.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an int enum along with {@link Response}.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<IntEnum> getWithResponse() {
-        return this.serviceClient.getWithResponse();
+    public Response<IntEnum> getWithResponse(Context context) {
+        return this.serviceClient.getWithResponse(context);
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/nonstringenum/implementation/FloatOperationsImpl.java
+++ b/vanilla-tests/src/main/java/fixtures/nonstringenum/implementation/FloatOperationsImpl.java
@@ -88,6 +88,26 @@ public final class FloatOperationsImpl {
      * Put a float enum.
      *
      * @param input Input float enum.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> putWithResponseAsync(FloatEnum input, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.put(this.client.getHost(), input, accept, context);
+    }
+
+    /**
+     * Put a float enum.
+     *
+     * @param input Input float enum.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -115,14 +135,30 @@ public final class FloatOperationsImpl {
      * Put a float enum.
      *
      * @param input Input float enum.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> putAsync(FloatEnum input, Context context) {
+        return putWithResponseAsync(input, context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Put a float enum.
+     *
+     * @param input Input float enum.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> putWithResponse(FloatEnum input) {
-        return putWithResponseAsync(input).block();
+    public Response<String> putWithResponse(FloatEnum input, Context context) {
+        return putWithResponseAsync(input, context).block();
     }
 
     /**
@@ -136,7 +172,7 @@ public final class FloatOperationsImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String put(FloatEnum input) {
-        return putWithResponse(input).getValue();
+        return putWithResponse(input, Context.NONE).getValue();
     }
 
     /**
@@ -149,7 +185,7 @@ public final class FloatOperationsImpl {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String put() {
         final FloatEnum input = null;
-        return putWithResponse(input).getValue();
+        return putWithResponse(input, Context.NONE).getValue();
     }
 
     /**
@@ -172,6 +208,25 @@ public final class FloatOperationsImpl {
     /**
      * Get a float enum.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a float enum along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<FloatEnum>> getWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get a float enum.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a float enum on successful completion of {@link Mono}.
@@ -184,13 +239,29 @@ public final class FloatOperationsImpl {
     /**
      * Get a float enum.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a float enum on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<FloatEnum> getAsync(Context context) {
+        return getWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get a float enum.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a float enum along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<FloatEnum> getWithResponse() {
-        return getWithResponseAsync().block();
+    public Response<FloatEnum> getWithResponse(Context context) {
+        return getWithResponseAsync(context).block();
     }
 
     /**
@@ -202,6 +273,6 @@ public final class FloatOperationsImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public FloatEnum get() {
-        return getWithResponse().getValue();
+        return getWithResponse(Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/nonstringenum/implementation/IntsImpl.java
+++ b/vanilla-tests/src/main/java/fixtures/nonstringenum/implementation/IntsImpl.java
@@ -87,6 +87,26 @@ public final class IntsImpl {
      * Put an int enum.
      *
      * @param input Input int enum.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> putWithResponseAsync(IntEnum input, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.put(this.client.getHost(), input, accept, context);
+    }
+
+    /**
+     * Put an int enum.
+     *
+     * @param input Input int enum.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -114,14 +134,30 @@ public final class IntsImpl {
      * Put an int enum.
      *
      * @param input Input int enum.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> putAsync(IntEnum input, Context context) {
+        return putWithResponseAsync(input, context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Put an int enum.
+     *
+     * @param input Input int enum.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> putWithResponse(IntEnum input) {
-        return putWithResponseAsync(input).block();
+    public Response<String> putWithResponse(IntEnum input, Context context) {
+        return putWithResponseAsync(input, context).block();
     }
 
     /**
@@ -135,7 +171,7 @@ public final class IntsImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String put(IntEnum input) {
-        return putWithResponse(input).getValue();
+        return putWithResponse(input, Context.NONE).getValue();
     }
 
     /**
@@ -148,7 +184,7 @@ public final class IntsImpl {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String put() {
         final IntEnum input = null;
-        return putWithResponse(input).getValue();
+        return putWithResponse(input, Context.NONE).getValue();
     }
 
     /**
@@ -171,6 +207,25 @@ public final class IntsImpl {
     /**
      * Get an int enum.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an int enum along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<IntEnum>> getWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.get(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get an int enum.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an int enum on successful completion of {@link Mono}.
@@ -183,13 +238,29 @@ public final class IntsImpl {
     /**
      * Get an int enum.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an int enum on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<IntEnum> getAsync(Context context) {
+        return getWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get an int enum.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an int enum along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<IntEnum> getWithResponse() {
-        return getWithResponseAsync().block();
+    public Response<IntEnum> getWithResponse(Context context) {
+        return getWithResponseAsync(context).block();
     }
 
     /**
@@ -201,6 +272,6 @@ public final class IntsImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public IntEnum get() {
-        return getWithResponse().getValue();
+        return getWithResponse(Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/parameterflattening/AvailabilitySets.java
+++ b/vanilla-tests/src/main/java/fixtures/parameterflattening/AvailabilitySets.java
@@ -103,6 +103,45 @@ public final class AvailabilitySets {
      * @param resourceGroupName The name of the resource group.
      * @param avset The name of the storage availability set.
      * @param availabilitySetUpdateParametersTags A description about the set of tags.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> updateWithResponseAsync(
+            String resourceGroupName,
+            String avset,
+            Map<String, String> availabilitySetUpdateParametersTags,
+            Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (resourceGroupName == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter resourceGroupName is required and cannot be null."));
+        }
+        if (avset == null) {
+            return Mono.error(new IllegalArgumentException("Parameter avset is required and cannot be null."));
+        }
+        if (availabilitySetUpdateParametersTags == null) {
+            return Mono.error(
+                    new IllegalArgumentException(
+                            "Parameter availabilitySetUpdateParametersTags is required and cannot be null."));
+        }
+        AvailabilitySetUpdateParameters tags = new AvailabilitySetUpdateParameters();
+        tags.setTags(availabilitySetUpdateParametersTags);
+        return service.update(this.client.getHost(), resourceGroupName, avset, tags, context);
+    }
+
+    /**
+     * Updates the tags for an availability set.
+     *
+     * @param resourceGroupName The name of the resource group.
+     * @param avset The name of the storage availability set.
+     * @param availabilitySetUpdateParametersTags A description about the set of tags.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -121,6 +160,29 @@ public final class AvailabilitySets {
      * @param resourceGroupName The name of the resource group.
      * @param avset The name of the storage availability set.
      * @param availabilitySetUpdateParametersTags A description about the set of tags.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> updateAsync(
+            String resourceGroupName,
+            String avset,
+            Map<String, String> availabilitySetUpdateParametersTags,
+            Context context) {
+        return updateWithResponseAsync(resourceGroupName, avset, availabilitySetUpdateParametersTags, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Updates the tags for an availability set.
+     *
+     * @param resourceGroupName The name of the resource group.
+     * @param avset The name of the storage availability set.
+     * @param availabilitySetUpdateParametersTags A description about the set of tags.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -128,8 +190,11 @@ public final class AvailabilitySets {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> updateWithResponse(
-            String resourceGroupName, String avset, Map<String, String> availabilitySetUpdateParametersTags) {
-        return updateWithResponseAsync(resourceGroupName, avset, availabilitySetUpdateParametersTags).block();
+            String resourceGroupName,
+            String avset,
+            Map<String, String> availabilitySetUpdateParametersTags,
+            Context context) {
+        return updateWithResponseAsync(resourceGroupName, avset, availabilitySetUpdateParametersTags, context).block();
     }
 
     /**
@@ -145,6 +210,6 @@ public final class AvailabilitySets {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void update(
             String resourceGroupName, String avset, Map<String, String> availabilitySetUpdateParametersTags) {
-        updateWithResponse(resourceGroupName, avset, availabilitySetUpdateParametersTags);
+        updateWithResponse(resourceGroupName, avset, availabilitySetUpdateParametersTags, Context.NONE);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/report/AutoRestReportService.java
+++ b/vanilla-tests/src/main/java/fixtures/report/AutoRestReportService.java
@@ -159,6 +159,26 @@ public final class AutoRestReportService {
      *
      * @param qualifier If specified, qualifies the generated report further (e.g. '2.7' vs '3.5' in for Python). The
      *     only effect is, that generators that run all tests several times, can distinguish the generated reports.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return test coverage report along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Integer>>> getReportWithResponseAsync(String qualifier, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getReport(this.getHost(), qualifier, accept, context);
+    }
+
+    /**
+     * Get test coverage report.
+     *
+     * @param qualifier If specified, qualifies the generated report further (e.g. '2.7' vs '3.5' in for Python). The
+     *     only effect is, that generators that run all tests several times, can distinguish the generated reports.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -187,14 +207,31 @@ public final class AutoRestReportService {
      *
      * @param qualifier If specified, qualifies the generated report further (e.g. '2.7' vs '3.5' in for Python). The
      *     only effect is, that generators that run all tests several times, can distinguish the generated reports.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return test coverage report on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Integer>> getReportAsync(String qualifier, Context context) {
+        return getReportWithResponseAsync(qualifier, context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get test coverage report.
+     *
+     * @param qualifier If specified, qualifies the generated report further (e.g. '2.7' vs '3.5' in for Python). The
+     *     only effect is, that generators that run all tests several times, can distinguish the generated reports.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return test coverage report along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Integer>> getReportWithResponse(String qualifier) {
-        return getReportWithResponseAsync(qualifier).block();
+    public Response<Map<String, Integer>> getReportWithResponse(String qualifier, Context context) {
+        return getReportWithResponseAsync(qualifier, context).block();
     }
 
     /**
@@ -209,7 +246,7 @@ public final class AutoRestReportService {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Integer> getReport(String qualifier) {
-        return getReportWithResponse(qualifier).getValue();
+        return getReportWithResponse(qualifier, Context.NONE).getValue();
     }
 
     /**
@@ -222,7 +259,7 @@ public final class AutoRestReportService {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Integer> getReport() {
         final String qualifier = null;
-        return getReportWithResponse(qualifier).getValue();
+        return getReportWithResponse(qualifier, Context.NONE).getValue();
     }
 
     /**
@@ -242,6 +279,26 @@ public final class AutoRestReportService {
         }
         final String accept = "application/json";
         return FluxUtil.withContext(context -> service.getOptionalReport(this.getHost(), qualifier, accept, context));
+    }
+
+    /**
+     * Get optional test coverage report.
+     *
+     * @param qualifier If specified, qualifies the generated report further (e.g. '2.7' vs '3.5' in for Python). The
+     *     only effect is, that generators that run all tests several times, can distinguish the generated reports.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return optional test coverage report along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Map<String, Integer>>> getOptionalReportWithResponseAsync(String qualifier, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getOptionalReport(this.getHost(), qualifier, accept, context);
     }
 
     /**
@@ -277,14 +334,31 @@ public final class AutoRestReportService {
      *
      * @param qualifier If specified, qualifies the generated report further (e.g. '2.7' vs '3.5' in for Python). The
      *     only effect is, that generators that run all tests several times, can distinguish the generated reports.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return optional test coverage report on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Map<String, Integer>> getOptionalReportAsync(String qualifier, Context context) {
+        return getOptionalReportWithResponseAsync(qualifier, context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get optional test coverage report.
+     *
+     * @param qualifier If specified, qualifies the generated report further (e.g. '2.7' vs '3.5' in for Python). The
+     *     only effect is, that generators that run all tests several times, can distinguish the generated reports.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return optional test coverage report along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Map<String, Integer>> getOptionalReportWithResponse(String qualifier) {
-        return getOptionalReportWithResponseAsync(qualifier).block();
+    public Response<Map<String, Integer>> getOptionalReportWithResponse(String qualifier, Context context) {
+        return getOptionalReportWithResponseAsync(qualifier, context).block();
     }
 
     /**
@@ -299,7 +373,7 @@ public final class AutoRestReportService {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Integer> getOptionalReport(String qualifier) {
-        return getOptionalReportWithResponse(qualifier).getValue();
+        return getOptionalReportWithResponse(qualifier, Context.NONE).getValue();
     }
 
     /**
@@ -312,6 +386,6 @@ public final class AutoRestReportService {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Integer> getOptionalReport() {
         final String qualifier = null;
-        return getOptionalReportWithResponse(qualifier).getValue();
+        return getOptionalReportWithResponse(qualifier, Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/requiredoptional/Explicits.java
+++ b/vanilla-tests/src/main/java/fixtures/requiredoptional/Explicits.java
@@ -331,6 +331,28 @@ public final class Explicits {
      *
      * @param bodyParameter The bodyParameter parameter.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putOptionalBinaryBodyWithResponseAsync(
+            Flux<ByteBuffer> bodyParameter, Long contentLength, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putOptionalBinaryBody(this.client.getHost(), bodyParameter, contentLength, accept, context);
+    }
+
+    /**
+     * Test explicitly optional body parameter.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param contentLength The Content-Length header for the request.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -360,14 +382,33 @@ public final class Explicits {
      *
      * @param bodyParameter The bodyParameter parameter.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putOptionalBinaryBodyAsync(Flux<ByteBuffer> bodyParameter, Long contentLength, Context context) {
+        return putOptionalBinaryBodyWithResponseAsync(bodyParameter, contentLength, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test explicitly optional body parameter.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putOptionalBinaryBodyWithResponse(Flux<ByteBuffer> bodyParameter, Long contentLength) {
-        return putOptionalBinaryBodyWithResponseAsync(bodyParameter, contentLength).block();
+    public Response<Void> putOptionalBinaryBodyWithResponse(
+            Flux<ByteBuffer> bodyParameter, Long contentLength, Context context) {
+        return putOptionalBinaryBodyWithResponseAsync(bodyParameter, contentLength, context).block();
     }
 
     /**
@@ -381,7 +422,7 @@ public final class Explicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putOptionalBinaryBody(Flux<ByteBuffer> bodyParameter, Long contentLength) {
-        putOptionalBinaryBodyWithResponse(bodyParameter, contentLength);
+        putOptionalBinaryBodyWithResponse(bodyParameter, contentLength, Context.NONE);
     }
 
     /**
@@ -394,7 +435,7 @@ public final class Explicits {
     public void putOptionalBinaryBody() {
         final Flux<ByteBuffer> bodyParameter = null;
         final Long contentLength = null;
-        putOptionalBinaryBodyWithResponse(bodyParameter, contentLength);
+        putOptionalBinaryBodyWithResponse(bodyParameter, contentLength, Context.NONE);
     }
 
     /**
@@ -425,6 +466,28 @@ public final class Explicits {
      *
      * @param bodyParameter The bodyParameter parameter.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putOptionalBinaryBodyWithResponseAsync(
+            BinaryData bodyParameter, Long contentLength, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putOptionalBinaryBody(this.client.getHost(), bodyParameter, contentLength, accept, context);
+    }
+
+    /**
+     * Test explicitly optional body parameter.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param contentLength The Content-Length header for the request.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -440,14 +503,33 @@ public final class Explicits {
      *
      * @param bodyParameter The bodyParameter parameter.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putOptionalBinaryBodyAsync(BinaryData bodyParameter, Long contentLength, Context context) {
+        return putOptionalBinaryBodyWithResponseAsync(bodyParameter, contentLength, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test explicitly optional body parameter.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putOptionalBinaryBodyWithResponse(BinaryData bodyParameter, Long contentLength) {
-        return putOptionalBinaryBodyWithResponseAsync(bodyParameter, contentLength).block();
+    public Response<Void> putOptionalBinaryBodyWithResponse(
+            BinaryData bodyParameter, Long contentLength, Context context) {
+        return putOptionalBinaryBodyWithResponseAsync(bodyParameter, contentLength, context).block();
     }
 
     /**
@@ -461,7 +543,7 @@ public final class Explicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putOptionalBinaryBody(BinaryData bodyParameter, Long contentLength) {
-        putOptionalBinaryBodyWithResponse(bodyParameter, contentLength);
+        putOptionalBinaryBodyWithResponse(bodyParameter, contentLength, Context.NONE);
     }
 
     /**
@@ -496,6 +578,31 @@ public final class Explicits {
      *
      * @param bodyParameter The bodyParameter parameter.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putRequiredBinaryBodyWithResponseAsync(
+            Flux<ByteBuffer> bodyParameter, long contentLength, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (bodyParameter == null) {
+            return Mono.error(new IllegalArgumentException("Parameter bodyParameter is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putRequiredBinaryBody(this.client.getHost(), bodyParameter, contentLength, accept, context);
+    }
+
+    /**
+     * Test explicitly required body parameter.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param contentLength The Content-Length header for the request.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -511,14 +618,33 @@ public final class Explicits {
      *
      * @param bodyParameter The bodyParameter parameter.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putRequiredBinaryBodyAsync(Flux<ByteBuffer> bodyParameter, long contentLength, Context context) {
+        return putRequiredBinaryBodyWithResponseAsync(bodyParameter, contentLength, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test explicitly required body parameter.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putRequiredBinaryBodyWithResponse(Flux<ByteBuffer> bodyParameter, long contentLength) {
-        return putRequiredBinaryBodyWithResponseAsync(bodyParameter, contentLength).block();
+    public Response<Void> putRequiredBinaryBodyWithResponse(
+            Flux<ByteBuffer> bodyParameter, long contentLength, Context context) {
+        return putRequiredBinaryBodyWithResponseAsync(bodyParameter, contentLength, context).block();
     }
 
     /**
@@ -532,7 +658,7 @@ public final class Explicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putRequiredBinaryBody(Flux<ByteBuffer> bodyParameter, long contentLength) {
-        putRequiredBinaryBodyWithResponse(bodyParameter, contentLength);
+        putRequiredBinaryBodyWithResponse(bodyParameter, contentLength, Context.NONE);
     }
 
     /**
@@ -566,6 +692,31 @@ public final class Explicits {
      *
      * @param bodyParameter The bodyParameter parameter.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putRequiredBinaryBodyWithResponseAsync(
+            BinaryData bodyParameter, long contentLength, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (bodyParameter == null) {
+            return Mono.error(new IllegalArgumentException("Parameter bodyParameter is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putRequiredBinaryBody(this.client.getHost(), bodyParameter, contentLength, accept, context);
+    }
+
+    /**
+     * Test explicitly required body parameter.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param contentLength The Content-Length header for the request.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -581,14 +732,33 @@ public final class Explicits {
      *
      * @param bodyParameter The bodyParameter parameter.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putRequiredBinaryBodyAsync(BinaryData bodyParameter, long contentLength, Context context) {
+        return putRequiredBinaryBodyWithResponseAsync(bodyParameter, contentLength, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test explicitly required body parameter.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putRequiredBinaryBodyWithResponse(BinaryData bodyParameter, long contentLength) {
-        return putRequiredBinaryBodyWithResponseAsync(bodyParameter, contentLength).block();
+    public Response<Void> putRequiredBinaryBodyWithResponse(
+            BinaryData bodyParameter, long contentLength, Context context) {
+        return putRequiredBinaryBodyWithResponseAsync(bodyParameter, contentLength, context).block();
     }
 
     /**
@@ -602,7 +772,7 @@ public final class Explicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putRequiredBinaryBody(BinaryData bodyParameter, long contentLength) {
-        putRequiredBinaryBodyWithResponse(bodyParameter, contentLength);
+        putRequiredBinaryBodyWithResponse(bodyParameter, contentLength, Context.NONE);
     }
 
     /**
@@ -629,6 +799,26 @@ public final class Explicits {
      * Test explicitly required integer. Please put null and the client library should throw before the request is sent.
      *
      * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> postRequiredIntegerParameterWithResponseAsync(int bodyParameter, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.postRequiredIntegerParameter(this.client.getHost(), bodyParameter, accept, context);
+    }
+
+    /**
+     * Test explicitly required integer. Please put null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter The bodyParameter parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -643,14 +833,30 @@ public final class Explicits {
      * Test explicitly required integer. Please put null and the client library should throw before the request is sent.
      *
      * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> postRequiredIntegerParameterAsync(int bodyParameter, Context context) {
+        return postRequiredIntegerParameterWithResponseAsync(bodyParameter, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test explicitly required integer. Please put null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> postRequiredIntegerParameterWithResponse(int bodyParameter) {
-        return postRequiredIntegerParameterWithResponseAsync(bodyParameter).block();
+    public Response<Void> postRequiredIntegerParameterWithResponse(int bodyParameter, Context context) {
+        return postRequiredIntegerParameterWithResponseAsync(bodyParameter, context).block();
     }
 
     /**
@@ -663,7 +869,7 @@ public final class Explicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postRequiredIntegerParameter(int bodyParameter) {
-        postRequiredIntegerParameterWithResponse(bodyParameter);
+        postRequiredIntegerParameterWithResponse(bodyParameter, Context.NONE);
     }
 
     /**
@@ -684,6 +890,26 @@ public final class Explicits {
         final String accept = "application/json";
         return FluxUtil.withContext(
                 context -> service.postOptionalIntegerParameter(this.client.getHost(), bodyParameter, accept, context));
+    }
+
+    /**
+     * Test explicitly optional integer. Please put null.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> postOptionalIntegerParameterWithResponseAsync(Integer bodyParameter, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.postOptionalIntegerParameter(this.client.getHost(), bodyParameter, accept, context);
     }
 
     /**
@@ -717,14 +943,30 @@ public final class Explicits {
      * Test explicitly optional integer. Please put null.
      *
      * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> postOptionalIntegerParameterAsync(Integer bodyParameter, Context context) {
+        return postOptionalIntegerParameterWithResponseAsync(bodyParameter, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test explicitly optional integer. Please put null.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> postOptionalIntegerParameterWithResponse(Integer bodyParameter) {
-        return postOptionalIntegerParameterWithResponseAsync(bodyParameter).block();
+    public Response<Void> postOptionalIntegerParameterWithResponse(Integer bodyParameter, Context context) {
+        return postOptionalIntegerParameterWithResponseAsync(bodyParameter, context).block();
     }
 
     /**
@@ -737,7 +979,7 @@ public final class Explicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalIntegerParameter(Integer bodyParameter) {
-        postOptionalIntegerParameterWithResponse(bodyParameter);
+        postOptionalIntegerParameterWithResponse(bodyParameter, Context.NONE);
     }
 
     /**
@@ -749,7 +991,7 @@ public final class Explicits {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalIntegerParameter() {
         final Integer bodyParameter = null;
-        postOptionalIntegerParameterWithResponse(bodyParameter);
+        postOptionalIntegerParameterWithResponse(bodyParameter, Context.NONE);
     }
 
     /**
@@ -783,6 +1025,33 @@ public final class Explicits {
      * should throw before the request is sent.
      *
      * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> postRequiredIntegerPropertyWithResponseAsync(
+            IntWrapper bodyParameter, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (bodyParameter == null) {
+            return Mono.error(new IllegalArgumentException("Parameter bodyParameter is required and cannot be null."));
+        } else {
+            bodyParameter.validate();
+        }
+        final String accept = "application/json";
+        return service.postRequiredIntegerProperty(this.client.getHost(), bodyParameter, accept, context);
+    }
+
+    /**
+     * Test explicitly required integer. Please put a valid int-wrapper with 'value' = null and the client library
+     * should throw before the request is sent.
+     *
+     * @param bodyParameter The bodyParameter parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -798,14 +1067,31 @@ public final class Explicits {
      * should throw before the request is sent.
      *
      * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> postRequiredIntegerPropertyAsync(IntWrapper bodyParameter, Context context) {
+        return postRequiredIntegerPropertyWithResponseAsync(bodyParameter, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test explicitly required integer. Please put a valid int-wrapper with 'value' = null and the client library
+     * should throw before the request is sent.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> postRequiredIntegerPropertyWithResponse(IntWrapper bodyParameter) {
-        return postRequiredIntegerPropertyWithResponseAsync(bodyParameter).block();
+    public Response<Void> postRequiredIntegerPropertyWithResponse(IntWrapper bodyParameter, Context context) {
+        return postRequiredIntegerPropertyWithResponseAsync(bodyParameter, context).block();
     }
 
     /**
@@ -819,7 +1105,7 @@ public final class Explicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postRequiredIntegerProperty(IntWrapper bodyParameter) {
-        postRequiredIntegerPropertyWithResponse(bodyParameter);
+        postRequiredIntegerPropertyWithResponse(bodyParameter, Context.NONE);
     }
 
     /**
@@ -843,6 +1129,30 @@ public final class Explicits {
         final String accept = "application/json";
         return FluxUtil.withContext(
                 context -> service.postOptionalIntegerProperty(this.client.getHost(), bodyParameter, accept, context));
+    }
+
+    /**
+     * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> postOptionalIntegerPropertyWithResponseAsync(
+            IntOptionalWrapper bodyParameter, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (bodyParameter != null) {
+            bodyParameter.validate();
+        }
+        final String accept = "application/json";
+        return service.postOptionalIntegerProperty(this.client.getHost(), bodyParameter, accept, context);
     }
 
     /**
@@ -876,14 +1186,30 @@ public final class Explicits {
      * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
      *
      * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> postOptionalIntegerPropertyAsync(IntOptionalWrapper bodyParameter, Context context) {
+        return postOptionalIntegerPropertyWithResponseAsync(bodyParameter, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> postOptionalIntegerPropertyWithResponse(IntOptionalWrapper bodyParameter) {
-        return postOptionalIntegerPropertyWithResponseAsync(bodyParameter).block();
+    public Response<Void> postOptionalIntegerPropertyWithResponse(IntOptionalWrapper bodyParameter, Context context) {
+        return postOptionalIntegerPropertyWithResponseAsync(bodyParameter, context).block();
     }
 
     /**
@@ -896,7 +1222,7 @@ public final class Explicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalIntegerProperty(IntOptionalWrapper bodyParameter) {
-        postOptionalIntegerPropertyWithResponse(bodyParameter);
+        postOptionalIntegerPropertyWithResponse(bodyParameter, Context.NONE);
     }
 
     /**
@@ -908,7 +1234,7 @@ public final class Explicits {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalIntegerProperty() {
         final IntOptionalWrapper bodyParameter = null;
-        postOptionalIntegerPropertyWithResponse(bodyParameter);
+        postOptionalIntegerPropertyWithResponse(bodyParameter, Context.NONE);
     }
 
     /**
@@ -937,6 +1263,27 @@ public final class Explicits {
      * throw before the request is sent.
      *
      * @param headerParameter The headerParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> postRequiredIntegerHeaderWithResponseAsync(int headerParameter, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.postRequiredIntegerHeader(this.client.getHost(), headerParameter, accept, context);
+    }
+
+    /**
+     * Test explicitly required integer. Please put a header 'headerParameter' =&gt; null and the client library should
+     * throw before the request is sent.
+     *
+     * @param headerParameter The headerParameter parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -952,14 +1299,31 @@ public final class Explicits {
      * throw before the request is sent.
      *
      * @param headerParameter The headerParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> postRequiredIntegerHeaderAsync(int headerParameter, Context context) {
+        return postRequiredIntegerHeaderWithResponseAsync(headerParameter, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test explicitly required integer. Please put a header 'headerParameter' =&gt; null and the client library should
+     * throw before the request is sent.
+     *
+     * @param headerParameter The headerParameter parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> postRequiredIntegerHeaderWithResponse(int headerParameter) {
-        return postRequiredIntegerHeaderWithResponseAsync(headerParameter).block();
+    public Response<Void> postRequiredIntegerHeaderWithResponse(int headerParameter, Context context) {
+        return postRequiredIntegerHeaderWithResponseAsync(headerParameter, context).block();
     }
 
     /**
@@ -973,7 +1337,7 @@ public final class Explicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postRequiredIntegerHeader(int headerParameter) {
-        postRequiredIntegerHeaderWithResponse(headerParameter);
+        postRequiredIntegerHeaderWithResponse(headerParameter, Context.NONE);
     }
 
     /**
@@ -994,6 +1358,26 @@ public final class Explicits {
         final String accept = "application/json";
         return FluxUtil.withContext(
                 context -> service.postOptionalIntegerHeader(this.client.getHost(), headerParameter, accept, context));
+    }
+
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @param headerParameter The headerParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> postOptionalIntegerHeaderWithResponseAsync(Integer headerParameter, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.postOptionalIntegerHeader(this.client.getHost(), headerParameter, accept, context);
     }
 
     /**
@@ -1027,14 +1411,30 @@ public final class Explicits {
      * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
      *
      * @param headerParameter The headerParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> postOptionalIntegerHeaderAsync(Integer headerParameter, Context context) {
+        return postOptionalIntegerHeaderWithResponseAsync(headerParameter, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @param headerParameter The headerParameter parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> postOptionalIntegerHeaderWithResponse(Integer headerParameter) {
-        return postOptionalIntegerHeaderWithResponseAsync(headerParameter).block();
+    public Response<Void> postOptionalIntegerHeaderWithResponse(Integer headerParameter, Context context) {
+        return postOptionalIntegerHeaderWithResponseAsync(headerParameter, context).block();
     }
 
     /**
@@ -1047,7 +1447,7 @@ public final class Explicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalIntegerHeader(Integer headerParameter) {
-        postOptionalIntegerHeaderWithResponse(headerParameter);
+        postOptionalIntegerHeaderWithResponse(headerParameter, Context.NONE);
     }
 
     /**
@@ -1059,7 +1459,7 @@ public final class Explicits {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalIntegerHeader() {
         final Integer headerParameter = null;
-        postOptionalIntegerHeaderWithResponse(headerParameter);
+        postOptionalIntegerHeaderWithResponse(headerParameter, Context.NONE);
     }
 
     /**
@@ -1089,6 +1489,29 @@ public final class Explicits {
      * Test explicitly required string. Please put null and the client library should throw before the request is sent.
      *
      * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> postRequiredStringParameterWithResponseAsync(String bodyParameter, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (bodyParameter == null) {
+            return Mono.error(new IllegalArgumentException("Parameter bodyParameter is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.postRequiredStringParameter(this.client.getHost(), bodyParameter, accept, context);
+    }
+
+    /**
+     * Test explicitly required string. Please put null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter The bodyParameter parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1103,14 +1526,30 @@ public final class Explicits {
      * Test explicitly required string. Please put null and the client library should throw before the request is sent.
      *
      * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> postRequiredStringParameterAsync(String bodyParameter, Context context) {
+        return postRequiredStringParameterWithResponseAsync(bodyParameter, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test explicitly required string. Please put null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> postRequiredStringParameterWithResponse(String bodyParameter) {
-        return postRequiredStringParameterWithResponseAsync(bodyParameter).block();
+    public Response<Void> postRequiredStringParameterWithResponse(String bodyParameter, Context context) {
+        return postRequiredStringParameterWithResponseAsync(bodyParameter, context).block();
     }
 
     /**
@@ -1123,7 +1562,7 @@ public final class Explicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postRequiredStringParameter(String bodyParameter) {
-        postRequiredStringParameterWithResponse(bodyParameter);
+        postRequiredStringParameterWithResponse(bodyParameter, Context.NONE);
     }
 
     /**
@@ -1144,6 +1583,26 @@ public final class Explicits {
         final String accept = "application/json";
         return FluxUtil.withContext(
                 context -> service.postOptionalStringParameter(this.client.getHost(), bodyParameter, accept, context));
+    }
+
+    /**
+     * Test explicitly optional string. Please put null.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> postOptionalStringParameterWithResponseAsync(String bodyParameter, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.postOptionalStringParameter(this.client.getHost(), bodyParameter, accept, context);
     }
 
     /**
@@ -1177,14 +1636,30 @@ public final class Explicits {
      * Test explicitly optional string. Please put null.
      *
      * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> postOptionalStringParameterAsync(String bodyParameter, Context context) {
+        return postOptionalStringParameterWithResponseAsync(bodyParameter, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test explicitly optional string. Please put null.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> postOptionalStringParameterWithResponse(String bodyParameter) {
-        return postOptionalStringParameterWithResponseAsync(bodyParameter).block();
+    public Response<Void> postOptionalStringParameterWithResponse(String bodyParameter, Context context) {
+        return postOptionalStringParameterWithResponseAsync(bodyParameter, context).block();
     }
 
     /**
@@ -1197,7 +1672,7 @@ public final class Explicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalStringParameter(String bodyParameter) {
-        postOptionalStringParameterWithResponse(bodyParameter);
+        postOptionalStringParameterWithResponse(bodyParameter, Context.NONE);
     }
 
     /**
@@ -1209,7 +1684,7 @@ public final class Explicits {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalStringParameter() {
         final String bodyParameter = null;
-        postOptionalStringParameterWithResponse(bodyParameter);
+        postOptionalStringParameterWithResponse(bodyParameter, Context.NONE);
     }
 
     /**
@@ -1243,6 +1718,33 @@ public final class Explicits {
      * should throw before the request is sent.
      *
      * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> postRequiredStringPropertyWithResponseAsync(
+            StringWrapper bodyParameter, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (bodyParameter == null) {
+            return Mono.error(new IllegalArgumentException("Parameter bodyParameter is required and cannot be null."));
+        } else {
+            bodyParameter.validate();
+        }
+        final String accept = "application/json";
+        return service.postRequiredStringProperty(this.client.getHost(), bodyParameter, accept, context);
+    }
+
+    /**
+     * Test explicitly required string. Please put a valid string-wrapper with 'value' = null and the client library
+     * should throw before the request is sent.
+     *
+     * @param bodyParameter The bodyParameter parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1258,14 +1760,31 @@ public final class Explicits {
      * should throw before the request is sent.
      *
      * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> postRequiredStringPropertyAsync(StringWrapper bodyParameter, Context context) {
+        return postRequiredStringPropertyWithResponseAsync(bodyParameter, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test explicitly required string. Please put a valid string-wrapper with 'value' = null and the client library
+     * should throw before the request is sent.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> postRequiredStringPropertyWithResponse(StringWrapper bodyParameter) {
-        return postRequiredStringPropertyWithResponseAsync(bodyParameter).block();
+    public Response<Void> postRequiredStringPropertyWithResponse(StringWrapper bodyParameter, Context context) {
+        return postRequiredStringPropertyWithResponseAsync(bodyParameter, context).block();
     }
 
     /**
@@ -1279,7 +1798,7 @@ public final class Explicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postRequiredStringProperty(StringWrapper bodyParameter) {
-        postRequiredStringPropertyWithResponse(bodyParameter);
+        postRequiredStringPropertyWithResponse(bodyParameter, Context.NONE);
     }
 
     /**
@@ -1303,6 +1822,30 @@ public final class Explicits {
         final String accept = "application/json";
         return FluxUtil.withContext(
                 context -> service.postOptionalStringProperty(this.client.getHost(), bodyParameter, accept, context));
+    }
+
+    /**
+     * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> postOptionalStringPropertyWithResponseAsync(
+            StringOptionalWrapper bodyParameter, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (bodyParameter != null) {
+            bodyParameter.validate();
+        }
+        final String accept = "application/json";
+        return service.postOptionalStringProperty(this.client.getHost(), bodyParameter, accept, context);
     }
 
     /**
@@ -1336,14 +1879,30 @@ public final class Explicits {
      * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
      *
      * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> postOptionalStringPropertyAsync(StringOptionalWrapper bodyParameter, Context context) {
+        return postOptionalStringPropertyWithResponseAsync(bodyParameter, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> postOptionalStringPropertyWithResponse(StringOptionalWrapper bodyParameter) {
-        return postOptionalStringPropertyWithResponseAsync(bodyParameter).block();
+    public Response<Void> postOptionalStringPropertyWithResponse(StringOptionalWrapper bodyParameter, Context context) {
+        return postOptionalStringPropertyWithResponseAsync(bodyParameter, context).block();
     }
 
     /**
@@ -1356,7 +1915,7 @@ public final class Explicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalStringProperty(StringOptionalWrapper bodyParameter) {
-        postOptionalStringPropertyWithResponse(bodyParameter);
+        postOptionalStringPropertyWithResponse(bodyParameter, Context.NONE);
     }
 
     /**
@@ -1368,7 +1927,7 @@ public final class Explicits {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalStringProperty() {
         final StringOptionalWrapper bodyParameter = null;
-        postOptionalStringPropertyWithResponse(bodyParameter);
+        postOptionalStringPropertyWithResponse(bodyParameter, Context.NONE);
     }
 
     /**
@@ -1401,6 +1960,31 @@ public final class Explicits {
      * throw before the request is sent.
      *
      * @param headerParameter The headerParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> postRequiredStringHeaderWithResponseAsync(String headerParameter, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (headerParameter == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter headerParameter is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.postRequiredStringHeader(this.client.getHost(), headerParameter, accept, context);
+    }
+
+    /**
+     * Test explicitly required string. Please put a header 'headerParameter' =&gt; null and the client library should
+     * throw before the request is sent.
+     *
+     * @param headerParameter The headerParameter parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1416,14 +2000,31 @@ public final class Explicits {
      * throw before the request is sent.
      *
      * @param headerParameter The headerParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> postRequiredStringHeaderAsync(String headerParameter, Context context) {
+        return postRequiredStringHeaderWithResponseAsync(headerParameter, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test explicitly required string. Please put a header 'headerParameter' =&gt; null and the client library should
+     * throw before the request is sent.
+     *
+     * @param headerParameter The headerParameter parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> postRequiredStringHeaderWithResponse(String headerParameter) {
-        return postRequiredStringHeaderWithResponseAsync(headerParameter).block();
+    public Response<Void> postRequiredStringHeaderWithResponse(String headerParameter, Context context) {
+        return postRequiredStringHeaderWithResponseAsync(headerParameter, context).block();
     }
 
     /**
@@ -1437,7 +2038,7 @@ public final class Explicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postRequiredStringHeader(String headerParameter) {
-        postRequiredStringHeaderWithResponse(headerParameter);
+        postRequiredStringHeaderWithResponse(headerParameter, Context.NONE);
     }
 
     /**
@@ -1458,6 +2059,26 @@ public final class Explicits {
         final String accept = "application/json";
         return FluxUtil.withContext(
                 context -> service.postOptionalStringHeader(this.client.getHost(), bodyParameter, accept, context));
+    }
+
+    /**
+     * Test explicitly optional string. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> postOptionalStringHeaderWithResponseAsync(String bodyParameter, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.postOptionalStringHeader(this.client.getHost(), bodyParameter, accept, context);
     }
 
     /**
@@ -1491,14 +2112,30 @@ public final class Explicits {
      * Test explicitly optional string. Please put a header 'headerParameter' =&gt; null.
      *
      * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> postOptionalStringHeaderAsync(String bodyParameter, Context context) {
+        return postOptionalStringHeaderWithResponseAsync(bodyParameter, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test explicitly optional string. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> postOptionalStringHeaderWithResponse(String bodyParameter) {
-        return postOptionalStringHeaderWithResponseAsync(bodyParameter).block();
+    public Response<Void> postOptionalStringHeaderWithResponse(String bodyParameter, Context context) {
+        return postOptionalStringHeaderWithResponseAsync(bodyParameter, context).block();
     }
 
     /**
@@ -1511,7 +2148,7 @@ public final class Explicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalStringHeader(String bodyParameter) {
-        postOptionalStringHeaderWithResponse(bodyParameter);
+        postOptionalStringHeaderWithResponse(bodyParameter, Context.NONE);
     }
 
     /**
@@ -1523,7 +2160,7 @@ public final class Explicits {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalStringHeader() {
         final String bodyParameter = null;
-        postOptionalStringHeaderWithResponse(bodyParameter);
+        postOptionalStringHeaderWithResponse(bodyParameter, Context.NONE);
     }
 
     /**
@@ -1557,6 +2194,32 @@ public final class Explicits {
      * is sent.
      *
      * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> postRequiredClassParameterWithResponseAsync(Product bodyParameter, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (bodyParameter == null) {
+            return Mono.error(new IllegalArgumentException("Parameter bodyParameter is required and cannot be null."));
+        } else {
+            bodyParameter.validate();
+        }
+        final String accept = "application/json";
+        return service.postRequiredClassParameter(this.client.getHost(), bodyParameter, accept, context);
+    }
+
+    /**
+     * Test explicitly required complex object. Please put null and the client library should throw before the request
+     * is sent.
+     *
+     * @param bodyParameter The bodyParameter parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1572,14 +2235,31 @@ public final class Explicits {
      * is sent.
      *
      * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> postRequiredClassParameterAsync(Product bodyParameter, Context context) {
+        return postRequiredClassParameterWithResponseAsync(bodyParameter, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test explicitly required complex object. Please put null and the client library should throw before the request
+     * is sent.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> postRequiredClassParameterWithResponse(Product bodyParameter) {
-        return postRequiredClassParameterWithResponseAsync(bodyParameter).block();
+    public Response<Void> postRequiredClassParameterWithResponse(Product bodyParameter, Context context) {
+        return postRequiredClassParameterWithResponseAsync(bodyParameter, context).block();
     }
 
     /**
@@ -1593,7 +2273,7 @@ public final class Explicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postRequiredClassParameter(Product bodyParameter) {
-        postRequiredClassParameterWithResponse(bodyParameter);
+        postRequiredClassParameterWithResponse(bodyParameter, Context.NONE);
     }
 
     /**
@@ -1617,6 +2297,29 @@ public final class Explicits {
         final String accept = "application/json";
         return FluxUtil.withContext(
                 context -> service.postOptionalClassParameter(this.client.getHost(), bodyParameter, accept, context));
+    }
+
+    /**
+     * Test explicitly optional complex object. Please put null.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> postOptionalClassParameterWithResponseAsync(Product bodyParameter, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (bodyParameter != null) {
+            bodyParameter.validate();
+        }
+        final String accept = "application/json";
+        return service.postOptionalClassParameter(this.client.getHost(), bodyParameter, accept, context);
     }
 
     /**
@@ -1650,14 +2353,30 @@ public final class Explicits {
      * Test explicitly optional complex object. Please put null.
      *
      * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> postOptionalClassParameterAsync(Product bodyParameter, Context context) {
+        return postOptionalClassParameterWithResponseAsync(bodyParameter, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test explicitly optional complex object. Please put null.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> postOptionalClassParameterWithResponse(Product bodyParameter) {
-        return postOptionalClassParameterWithResponseAsync(bodyParameter).block();
+    public Response<Void> postOptionalClassParameterWithResponse(Product bodyParameter, Context context) {
+        return postOptionalClassParameterWithResponseAsync(bodyParameter, context).block();
     }
 
     /**
@@ -1670,7 +2389,7 @@ public final class Explicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalClassParameter(Product bodyParameter) {
-        postOptionalClassParameterWithResponse(bodyParameter);
+        postOptionalClassParameterWithResponse(bodyParameter, Context.NONE);
     }
 
     /**
@@ -1682,7 +2401,7 @@ public final class Explicits {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalClassParameter() {
         final Product bodyParameter = null;
-        postOptionalClassParameterWithResponse(bodyParameter);
+        postOptionalClassParameterWithResponse(bodyParameter, Context.NONE);
     }
 
     /**
@@ -1716,6 +2435,33 @@ public final class Explicits {
      * library should throw before the request is sent.
      *
      * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> postRequiredClassPropertyWithResponseAsync(
+            ClassWrapper bodyParameter, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (bodyParameter == null) {
+            return Mono.error(new IllegalArgumentException("Parameter bodyParameter is required and cannot be null."));
+        } else {
+            bodyParameter.validate();
+        }
+        final String accept = "application/json";
+        return service.postRequiredClassProperty(this.client.getHost(), bodyParameter, accept, context);
+    }
+
+    /**
+     * Test explicitly required complex object. Please put a valid class-wrapper with 'value' = null and the client
+     * library should throw before the request is sent.
+     *
+     * @param bodyParameter The bodyParameter parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1731,14 +2477,31 @@ public final class Explicits {
      * library should throw before the request is sent.
      *
      * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> postRequiredClassPropertyAsync(ClassWrapper bodyParameter, Context context) {
+        return postRequiredClassPropertyWithResponseAsync(bodyParameter, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test explicitly required complex object. Please put a valid class-wrapper with 'value' = null and the client
+     * library should throw before the request is sent.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> postRequiredClassPropertyWithResponse(ClassWrapper bodyParameter) {
-        return postRequiredClassPropertyWithResponseAsync(bodyParameter).block();
+    public Response<Void> postRequiredClassPropertyWithResponse(ClassWrapper bodyParameter, Context context) {
+        return postRequiredClassPropertyWithResponseAsync(bodyParameter, context).block();
     }
 
     /**
@@ -1752,7 +2515,7 @@ public final class Explicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postRequiredClassProperty(ClassWrapper bodyParameter) {
-        postRequiredClassPropertyWithResponse(bodyParameter);
+        postRequiredClassPropertyWithResponse(bodyParameter, Context.NONE);
     }
 
     /**
@@ -1776,6 +2539,30 @@ public final class Explicits {
         final String accept = "application/json";
         return FluxUtil.withContext(
                 context -> service.postOptionalClassProperty(this.client.getHost(), bodyParameter, accept, context));
+    }
+
+    /**
+     * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> postOptionalClassPropertyWithResponseAsync(
+            ClassOptionalWrapper bodyParameter, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (bodyParameter != null) {
+            bodyParameter.validate();
+        }
+        final String accept = "application/json";
+        return service.postOptionalClassProperty(this.client.getHost(), bodyParameter, accept, context);
     }
 
     /**
@@ -1809,14 +2596,30 @@ public final class Explicits {
      * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
      *
      * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> postOptionalClassPropertyAsync(ClassOptionalWrapper bodyParameter, Context context) {
+        return postOptionalClassPropertyWithResponseAsync(bodyParameter, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> postOptionalClassPropertyWithResponse(ClassOptionalWrapper bodyParameter) {
-        return postOptionalClassPropertyWithResponseAsync(bodyParameter).block();
+    public Response<Void> postOptionalClassPropertyWithResponse(ClassOptionalWrapper bodyParameter, Context context) {
+        return postOptionalClassPropertyWithResponseAsync(bodyParameter, context).block();
     }
 
     /**
@@ -1829,7 +2632,7 @@ public final class Explicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalClassProperty(ClassOptionalWrapper bodyParameter) {
-        postOptionalClassPropertyWithResponse(bodyParameter);
+        postOptionalClassPropertyWithResponse(bodyParameter, Context.NONE);
     }
 
     /**
@@ -1841,7 +2644,7 @@ public final class Explicits {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalClassProperty() {
         final ClassOptionalWrapper bodyParameter = null;
-        postOptionalClassPropertyWithResponse(bodyParameter);
+        postOptionalClassPropertyWithResponse(bodyParameter, Context.NONE);
     }
 
     /**
@@ -1871,6 +2674,30 @@ public final class Explicits {
      * Test explicitly required array. Please put null and the client library should throw before the request is sent.
      *
      * @param bodyParameter Array of PostContentSchemaItem.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> postRequiredArrayParameterWithResponseAsync(
+            List<String> bodyParameter, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (bodyParameter == null) {
+            return Mono.error(new IllegalArgumentException("Parameter bodyParameter is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.postRequiredArrayParameter(this.client.getHost(), bodyParameter, accept, context);
+    }
+
+    /**
+     * Test explicitly required array. Please put null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter Array of PostContentSchemaItem.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1885,14 +2712,30 @@ public final class Explicits {
      * Test explicitly required array. Please put null and the client library should throw before the request is sent.
      *
      * @param bodyParameter Array of PostContentSchemaItem.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> postRequiredArrayParameterAsync(List<String> bodyParameter, Context context) {
+        return postRequiredArrayParameterWithResponseAsync(bodyParameter, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test explicitly required array. Please put null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter Array of PostContentSchemaItem.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> postRequiredArrayParameterWithResponse(List<String> bodyParameter) {
-        return postRequiredArrayParameterWithResponseAsync(bodyParameter).block();
+    public Response<Void> postRequiredArrayParameterWithResponse(List<String> bodyParameter, Context context) {
+        return postRequiredArrayParameterWithResponseAsync(bodyParameter, context).block();
     }
 
     /**
@@ -1905,7 +2748,7 @@ public final class Explicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postRequiredArrayParameter(List<String> bodyParameter) {
-        postRequiredArrayParameterWithResponse(bodyParameter);
+        postRequiredArrayParameterWithResponse(bodyParameter, Context.NONE);
     }
 
     /**
@@ -1926,6 +2769,27 @@ public final class Explicits {
         final String accept = "application/json";
         return FluxUtil.withContext(
                 context -> service.postOptionalArrayParameter(this.client.getHost(), bodyParameter, accept, context));
+    }
+
+    /**
+     * Test explicitly optional array. Please put null.
+     *
+     * @param bodyParameter Array of String.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> postOptionalArrayParameterWithResponseAsync(
+            List<String> bodyParameter, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.postOptionalArrayParameter(this.client.getHost(), bodyParameter, accept, context);
     }
 
     /**
@@ -1959,14 +2823,30 @@ public final class Explicits {
      * Test explicitly optional array. Please put null.
      *
      * @param bodyParameter Array of String.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> postOptionalArrayParameterAsync(List<String> bodyParameter, Context context) {
+        return postOptionalArrayParameterWithResponseAsync(bodyParameter, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test explicitly optional array. Please put null.
+     *
+     * @param bodyParameter Array of String.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> postOptionalArrayParameterWithResponse(List<String> bodyParameter) {
-        return postOptionalArrayParameterWithResponseAsync(bodyParameter).block();
+    public Response<Void> postOptionalArrayParameterWithResponse(List<String> bodyParameter, Context context) {
+        return postOptionalArrayParameterWithResponseAsync(bodyParameter, context).block();
     }
 
     /**
@@ -1979,7 +2859,7 @@ public final class Explicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalArrayParameter(List<String> bodyParameter) {
-        postOptionalArrayParameterWithResponse(bodyParameter);
+        postOptionalArrayParameterWithResponse(bodyParameter, Context.NONE);
     }
 
     /**
@@ -1991,7 +2871,7 @@ public final class Explicits {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalArrayParameter() {
         final List<String> bodyParameter = null;
-        postOptionalArrayParameterWithResponse(bodyParameter);
+        postOptionalArrayParameterWithResponse(bodyParameter, Context.NONE);
     }
 
     /**
@@ -2025,6 +2905,33 @@ public final class Explicits {
      * should throw before the request is sent.
      *
      * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> postRequiredArrayPropertyWithResponseAsync(
+            ArrayWrapper bodyParameter, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (bodyParameter == null) {
+            return Mono.error(new IllegalArgumentException("Parameter bodyParameter is required and cannot be null."));
+        } else {
+            bodyParameter.validate();
+        }
+        final String accept = "application/json";
+        return service.postRequiredArrayProperty(this.client.getHost(), bodyParameter, accept, context);
+    }
+
+    /**
+     * Test explicitly required array. Please put a valid array-wrapper with 'value' = null and the client library
+     * should throw before the request is sent.
+     *
+     * @param bodyParameter The bodyParameter parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -2040,14 +2947,31 @@ public final class Explicits {
      * should throw before the request is sent.
      *
      * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> postRequiredArrayPropertyAsync(ArrayWrapper bodyParameter, Context context) {
+        return postRequiredArrayPropertyWithResponseAsync(bodyParameter, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test explicitly required array. Please put a valid array-wrapper with 'value' = null and the client library
+     * should throw before the request is sent.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> postRequiredArrayPropertyWithResponse(ArrayWrapper bodyParameter) {
-        return postRequiredArrayPropertyWithResponseAsync(bodyParameter).block();
+    public Response<Void> postRequiredArrayPropertyWithResponse(ArrayWrapper bodyParameter, Context context) {
+        return postRequiredArrayPropertyWithResponseAsync(bodyParameter, context).block();
     }
 
     /**
@@ -2061,7 +2985,7 @@ public final class Explicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postRequiredArrayProperty(ArrayWrapper bodyParameter) {
-        postRequiredArrayPropertyWithResponse(bodyParameter);
+        postRequiredArrayPropertyWithResponse(bodyParameter, Context.NONE);
     }
 
     /**
@@ -2085,6 +3009,30 @@ public final class Explicits {
         final String accept = "application/json";
         return FluxUtil.withContext(
                 context -> service.postOptionalArrayProperty(this.client.getHost(), bodyParameter, accept, context));
+    }
+
+    /**
+     * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> postOptionalArrayPropertyWithResponseAsync(
+            ArrayOptionalWrapper bodyParameter, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (bodyParameter != null) {
+            bodyParameter.validate();
+        }
+        final String accept = "application/json";
+        return service.postOptionalArrayProperty(this.client.getHost(), bodyParameter, accept, context);
     }
 
     /**
@@ -2118,14 +3066,30 @@ public final class Explicits {
      * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
      *
      * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> postOptionalArrayPropertyAsync(ArrayOptionalWrapper bodyParameter, Context context) {
+        return postOptionalArrayPropertyWithResponseAsync(bodyParameter, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> postOptionalArrayPropertyWithResponse(ArrayOptionalWrapper bodyParameter) {
-        return postOptionalArrayPropertyWithResponseAsync(bodyParameter).block();
+    public Response<Void> postOptionalArrayPropertyWithResponse(ArrayOptionalWrapper bodyParameter, Context context) {
+        return postOptionalArrayPropertyWithResponseAsync(bodyParameter, context).block();
     }
 
     /**
@@ -2138,7 +3102,7 @@ public final class Explicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalArrayProperty(ArrayOptionalWrapper bodyParameter) {
-        postOptionalArrayPropertyWithResponse(bodyParameter);
+        postOptionalArrayPropertyWithResponse(bodyParameter, Context.NONE);
     }
 
     /**
@@ -2150,7 +3114,7 @@ public final class Explicits {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalArrayProperty() {
         final ArrayOptionalWrapper bodyParameter = null;
-        postOptionalArrayPropertyWithResponse(bodyParameter);
+        postOptionalArrayPropertyWithResponse(bodyParameter, Context.NONE);
     }
 
     /**
@@ -2187,6 +3151,34 @@ public final class Explicits {
      * throw before the request is sent.
      *
      * @param headerParameter Array of Post0ItemsItem.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> postRequiredArrayHeaderWithResponseAsync(
+            List<String> headerParameter, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (headerParameter == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter headerParameter is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        String headerParameterConverted =
+                headerParameter.stream().map(value -> Objects.toString(value, "")).collect(Collectors.joining(","));
+        return service.postRequiredArrayHeader(this.client.getHost(), headerParameterConverted, accept, context);
+    }
+
+    /**
+     * Test explicitly required array. Please put a header 'headerParameter' =&gt; null and the client library should
+     * throw before the request is sent.
+     *
+     * @param headerParameter Array of Post0ItemsItem.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -2202,14 +3194,31 @@ public final class Explicits {
      * throw before the request is sent.
      *
      * @param headerParameter Array of Post0ItemsItem.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> postRequiredArrayHeaderAsync(List<String> headerParameter, Context context) {
+        return postRequiredArrayHeaderWithResponseAsync(headerParameter, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test explicitly required array. Please put a header 'headerParameter' =&gt; null and the client library should
+     * throw before the request is sent.
+     *
+     * @param headerParameter Array of Post0ItemsItem.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> postRequiredArrayHeaderWithResponse(List<String> headerParameter) {
-        return postRequiredArrayHeaderWithResponseAsync(headerParameter).block();
+    public Response<Void> postRequiredArrayHeaderWithResponse(List<String> headerParameter, Context context) {
+        return postRequiredArrayHeaderWithResponseAsync(headerParameter, context).block();
     }
 
     /**
@@ -2223,7 +3232,7 @@ public final class Explicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postRequiredArrayHeader(List<String> headerParameter) {
-        postRequiredArrayHeaderWithResponse(headerParameter);
+        postRequiredArrayHeaderWithResponse(headerParameter, Context.NONE);
     }
 
     /**
@@ -2258,6 +3267,33 @@ public final class Explicits {
      * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
      *
      * @param headerParameter Array of String.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> postOptionalArrayHeaderWithResponseAsync(
+            List<String> headerParameter, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        String headerParameterConverted =
+                (headerParameter == null)
+                        ? null
+                        : headerParameter.stream()
+                                .map(value -> Objects.toString(value, ""))
+                                .collect(Collectors.joining(","));
+        return service.postOptionalArrayHeader(this.client.getHost(), headerParameterConverted, accept, context);
+    }
+
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @param headerParameter Array of String.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -2285,14 +3321,30 @@ public final class Explicits {
      * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
      *
      * @param headerParameter Array of String.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> postOptionalArrayHeaderAsync(List<String> headerParameter, Context context) {
+        return postOptionalArrayHeaderWithResponseAsync(headerParameter, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @param headerParameter Array of String.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> postOptionalArrayHeaderWithResponse(List<String> headerParameter) {
-        return postOptionalArrayHeaderWithResponseAsync(headerParameter).block();
+    public Response<Void> postOptionalArrayHeaderWithResponse(List<String> headerParameter, Context context) {
+        return postOptionalArrayHeaderWithResponseAsync(headerParameter, context).block();
     }
 
     /**
@@ -2305,7 +3357,7 @@ public final class Explicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalArrayHeader(List<String> headerParameter) {
-        postOptionalArrayHeaderWithResponse(headerParameter);
+        postOptionalArrayHeaderWithResponse(headerParameter, Context.NONE);
     }
 
     /**
@@ -2317,6 +3369,6 @@ public final class Explicits {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalArrayHeader() {
         final List<String> headerParameter = null;
-        postOptionalArrayHeaderWithResponse(headerParameter);
+        postOptionalArrayHeaderWithResponse(headerParameter, Context.NONE);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/requiredoptional/Implicits.java
+++ b/vanilla-tests/src/main/java/fixtures/requiredoptional/Implicits.java
@@ -164,6 +164,29 @@ public final class Implicits {
      * Test implicitly required path parameter.
      *
      * @param pathParameter The pathParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getRequiredPathWithResponseAsync(String pathParameter, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (pathParameter == null) {
+            return Mono.error(new IllegalArgumentException("Parameter pathParameter is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getRequiredPath(this.client.getHost(), pathParameter, accept, context);
+    }
+
+    /**
+     * Test implicitly required path parameter.
+     *
+     * @param pathParameter The pathParameter parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -178,14 +201,30 @@ public final class Implicits {
      * Test implicitly required path parameter.
      *
      * @param pathParameter The pathParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getRequiredPathAsync(String pathParameter, Context context) {
+        return getRequiredPathWithResponseAsync(pathParameter, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test implicitly required path parameter.
+     *
+     * @param pathParameter The pathParameter parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getRequiredPathWithResponse(String pathParameter) {
-        return getRequiredPathWithResponseAsync(pathParameter).block();
+    public Response<Void> getRequiredPathWithResponse(String pathParameter, Context context) {
+        return getRequiredPathWithResponseAsync(pathParameter, context).block();
     }
 
     /**
@@ -198,7 +237,7 @@ public final class Implicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getRequiredPath(String pathParameter) {
-        getRequiredPathWithResponse(pathParameter);
+        getRequiredPathWithResponse(pathParameter, Context.NONE);
     }
 
     /**
@@ -219,6 +258,26 @@ public final class Implicits {
         final String accept = "application/json";
         return FluxUtil.withContext(
                 context -> service.putOptionalQuery(this.client.getHost(), queryParameter, accept, context));
+    }
+
+    /**
+     * Test implicitly optional query parameter.
+     *
+     * @param queryParameter The queryParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putOptionalQueryWithResponseAsync(String queryParameter, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putOptionalQuery(this.client.getHost(), queryParameter, accept, context);
     }
 
     /**
@@ -252,14 +311,30 @@ public final class Implicits {
      * Test implicitly optional query parameter.
      *
      * @param queryParameter The queryParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putOptionalQueryAsync(String queryParameter, Context context) {
+        return putOptionalQueryWithResponseAsync(queryParameter, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test implicitly optional query parameter.
+     *
+     * @param queryParameter The queryParameter parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putOptionalQueryWithResponse(String queryParameter) {
-        return putOptionalQueryWithResponseAsync(queryParameter).block();
+    public Response<Void> putOptionalQueryWithResponse(String queryParameter, Context context) {
+        return putOptionalQueryWithResponseAsync(queryParameter, context).block();
     }
 
     /**
@@ -272,7 +347,7 @@ public final class Implicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putOptionalQuery(String queryParameter) {
-        putOptionalQueryWithResponse(queryParameter);
+        putOptionalQueryWithResponse(queryParameter, Context.NONE);
     }
 
     /**
@@ -284,7 +359,7 @@ public final class Implicits {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putOptionalQuery() {
         final String queryParameter = null;
-        putOptionalQueryWithResponse(queryParameter);
+        putOptionalQueryWithResponse(queryParameter, Context.NONE);
     }
 
     /**
@@ -305,6 +380,26 @@ public final class Implicits {
         final String accept = "application/json";
         return FluxUtil.withContext(
                 context -> service.putOptionalHeader(this.client.getHost(), queryParameter, accept, context));
+    }
+
+    /**
+     * Test implicitly optional header parameter.
+     *
+     * @param queryParameter The queryParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putOptionalHeaderWithResponseAsync(String queryParameter, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putOptionalHeader(this.client.getHost(), queryParameter, accept, context);
     }
 
     /**
@@ -338,14 +433,30 @@ public final class Implicits {
      * Test implicitly optional header parameter.
      *
      * @param queryParameter The queryParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putOptionalHeaderAsync(String queryParameter, Context context) {
+        return putOptionalHeaderWithResponseAsync(queryParameter, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test implicitly optional header parameter.
+     *
+     * @param queryParameter The queryParameter parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putOptionalHeaderWithResponse(String queryParameter) {
-        return putOptionalHeaderWithResponseAsync(queryParameter).block();
+    public Response<Void> putOptionalHeaderWithResponse(String queryParameter, Context context) {
+        return putOptionalHeaderWithResponseAsync(queryParameter, context).block();
     }
 
     /**
@@ -358,7 +469,7 @@ public final class Implicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putOptionalHeader(String queryParameter) {
-        putOptionalHeaderWithResponse(queryParameter);
+        putOptionalHeaderWithResponse(queryParameter, Context.NONE);
     }
 
     /**
@@ -370,7 +481,7 @@ public final class Implicits {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putOptionalHeader() {
         final String queryParameter = null;
-        putOptionalHeaderWithResponse(queryParameter);
+        putOptionalHeaderWithResponse(queryParameter, Context.NONE);
     }
 
     /**
@@ -391,6 +502,26 @@ public final class Implicits {
         final String accept = "application/json";
         return FluxUtil.withContext(
                 context -> service.putOptionalBody(this.client.getHost(), bodyParameter, accept, context));
+    }
+
+    /**
+     * Test implicitly optional body parameter.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putOptionalBodyWithResponseAsync(String bodyParameter, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putOptionalBody(this.client.getHost(), bodyParameter, accept, context);
     }
 
     /**
@@ -424,14 +555,30 @@ public final class Implicits {
      * Test implicitly optional body parameter.
      *
      * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putOptionalBodyAsync(String bodyParameter, Context context) {
+        return putOptionalBodyWithResponseAsync(bodyParameter, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test implicitly optional body parameter.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putOptionalBodyWithResponse(String bodyParameter) {
-        return putOptionalBodyWithResponseAsync(bodyParameter).block();
+    public Response<Void> putOptionalBodyWithResponse(String bodyParameter, Context context) {
+        return putOptionalBodyWithResponseAsync(bodyParameter, context).block();
     }
 
     /**
@@ -444,7 +591,7 @@ public final class Implicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putOptionalBody(String bodyParameter) {
-        putOptionalBodyWithResponse(bodyParameter);
+        putOptionalBodyWithResponse(bodyParameter, Context.NONE);
     }
 
     /**
@@ -456,7 +603,7 @@ public final class Implicits {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putOptionalBody() {
         final String bodyParameter = null;
-        putOptionalBodyWithResponse(bodyParameter);
+        putOptionalBodyWithResponse(bodyParameter, Context.NONE);
     }
 
     /**
@@ -481,6 +628,28 @@ public final class Implicits {
                 context ->
                         service.putOptionalBinaryBody(
                                 this.client.getHost(), bodyParameter, contentLength, accept, context));
+    }
+
+    /**
+     * Test implicitly optional body parameter.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putOptionalBinaryBodyWithResponseAsync(
+            Flux<ByteBuffer> bodyParameter, Long contentLength, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putOptionalBinaryBody(this.client.getHost(), bodyParameter, contentLength, accept, context);
     }
 
     /**
@@ -517,14 +686,33 @@ public final class Implicits {
      *
      * @param bodyParameter The bodyParameter parameter.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putOptionalBinaryBodyAsync(Flux<ByteBuffer> bodyParameter, Long contentLength, Context context) {
+        return putOptionalBinaryBodyWithResponseAsync(bodyParameter, contentLength, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test implicitly optional body parameter.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putOptionalBinaryBodyWithResponse(Flux<ByteBuffer> bodyParameter, Long contentLength) {
-        return putOptionalBinaryBodyWithResponseAsync(bodyParameter, contentLength).block();
+    public Response<Void> putOptionalBinaryBodyWithResponse(
+            Flux<ByteBuffer> bodyParameter, Long contentLength, Context context) {
+        return putOptionalBinaryBodyWithResponseAsync(bodyParameter, contentLength, context).block();
     }
 
     /**
@@ -538,7 +726,7 @@ public final class Implicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putOptionalBinaryBody(Flux<ByteBuffer> bodyParameter, Long contentLength) {
-        putOptionalBinaryBodyWithResponse(bodyParameter, contentLength);
+        putOptionalBinaryBodyWithResponse(bodyParameter, contentLength, Context.NONE);
     }
 
     /**
@@ -551,7 +739,7 @@ public final class Implicits {
     public void putOptionalBinaryBody() {
         final Flux<ByteBuffer> bodyParameter = null;
         final Long contentLength = null;
-        putOptionalBinaryBodyWithResponse(bodyParameter, contentLength);
+        putOptionalBinaryBodyWithResponse(bodyParameter, contentLength, Context.NONE);
     }
 
     /**
@@ -582,6 +770,28 @@ public final class Implicits {
      *
      * @param bodyParameter The bodyParameter parameter.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putOptionalBinaryBodyWithResponseAsync(
+            BinaryData bodyParameter, Long contentLength, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.putOptionalBinaryBody(this.client.getHost(), bodyParameter, contentLength, accept, context);
+    }
+
+    /**
+     * Test implicitly optional body parameter.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param contentLength The Content-Length header for the request.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -597,14 +807,33 @@ public final class Implicits {
      *
      * @param bodyParameter The bodyParameter parameter.
      * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putOptionalBinaryBodyAsync(BinaryData bodyParameter, Long contentLength, Context context) {
+        return putOptionalBinaryBodyWithResponseAsync(bodyParameter, contentLength, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test implicitly optional body parameter.
+     *
+     * @param bodyParameter The bodyParameter parameter.
+     * @param contentLength The Content-Length header for the request.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putOptionalBinaryBodyWithResponse(BinaryData bodyParameter, Long contentLength) {
-        return putOptionalBinaryBodyWithResponseAsync(bodyParameter, contentLength).block();
+    public Response<Void> putOptionalBinaryBodyWithResponse(
+            BinaryData bodyParameter, Long contentLength, Context context) {
+        return putOptionalBinaryBodyWithResponseAsync(bodyParameter, contentLength, context).block();
     }
 
     /**
@@ -618,7 +847,7 @@ public final class Implicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putOptionalBinaryBody(BinaryData bodyParameter, Long contentLength) {
-        putOptionalBinaryBodyWithResponse(bodyParameter, contentLength);
+        putOptionalBinaryBodyWithResponse(bodyParameter, contentLength, Context.NONE);
     }
 
     /**
@@ -649,6 +878,31 @@ public final class Implicits {
     /**
      * Test implicitly required path parameter.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getRequiredGlobalPathWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (this.client.getRequiredGlobalPath() == null) {
+            return Mono.error(
+                    new IllegalArgumentException(
+                            "Parameter this.client.getRequiredGlobalPath() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getRequiredGlobalPath(
+                this.client.getHost(), this.client.getRequiredGlobalPath(), accept, context);
+    }
+
+    /**
+     * Test implicitly required path parameter.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -661,13 +915,29 @@ public final class Implicits {
     /**
      * Test implicitly required path parameter.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getRequiredGlobalPathAsync(Context context) {
+        return getRequiredGlobalPathWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test implicitly required path parameter.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getRequiredGlobalPathWithResponse() {
-        return getRequiredGlobalPathWithResponseAsync().block();
+    public Response<Void> getRequiredGlobalPathWithResponse(Context context) {
+        return getRequiredGlobalPathWithResponseAsync(context).block();
     }
 
     /**
@@ -678,7 +948,7 @@ public final class Implicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getRequiredGlobalPath() {
-        getRequiredGlobalPathWithResponse();
+        getRequiredGlobalPathWithResponse(Context.NONE);
     }
 
     /**
@@ -709,6 +979,31 @@ public final class Implicits {
     /**
      * Test implicitly required query parameter.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getRequiredGlobalQueryWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (this.client.getRequiredGlobalQuery() == null) {
+            return Mono.error(
+                    new IllegalArgumentException(
+                            "Parameter this.client.getRequiredGlobalQuery() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getRequiredGlobalQuery(
+                this.client.getHost(), this.client.getRequiredGlobalQuery(), accept, context);
+    }
+
+    /**
+     * Test implicitly required query parameter.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -721,13 +1016,29 @@ public final class Implicits {
     /**
      * Test implicitly required query parameter.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getRequiredGlobalQueryAsync(Context context) {
+        return getRequiredGlobalQueryWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test implicitly required query parameter.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getRequiredGlobalQueryWithResponse() {
-        return getRequiredGlobalQueryWithResponseAsync().block();
+    public Response<Void> getRequiredGlobalQueryWithResponse(Context context) {
+        return getRequiredGlobalQueryWithResponseAsync(context).block();
     }
 
     /**
@@ -738,7 +1049,7 @@ public final class Implicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getRequiredGlobalQuery() {
-        getRequiredGlobalQueryWithResponse();
+        getRequiredGlobalQueryWithResponse(Context.NONE);
     }
 
     /**
@@ -764,6 +1075,26 @@ public final class Implicits {
     /**
      * Test implicitly optional query parameter.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getOptionalGlobalQueryWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getOptionalGlobalQuery(
+                this.client.getHost(), this.client.getOptionalGlobalQuery(), accept, context);
+    }
+
+    /**
+     * Test implicitly optional query parameter.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -776,13 +1107,29 @@ public final class Implicits {
     /**
      * Test implicitly optional query parameter.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getOptionalGlobalQueryAsync(Context context) {
+        return getOptionalGlobalQueryWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Test implicitly optional query parameter.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getOptionalGlobalQueryWithResponse() {
-        return getOptionalGlobalQueryWithResponseAsync().block();
+    public Response<Void> getOptionalGlobalQueryWithResponse(Context context) {
+        return getOptionalGlobalQueryWithResponseAsync(context).block();
     }
 
     /**
@@ -793,6 +1140,6 @@ public final class Implicits {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getOptionalGlobalQuery() {
-        getOptionalGlobalQueryWithResponse();
+        getOptionalGlobalQueryWithResponse(Context.NONE);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/specialheader/Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/specialheader/Headers.java
@@ -141,6 +141,28 @@ public final class Headers {
     /**
      * Send a post request with header Repeatability-Request-ID and Repeatability-First-Sent.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return any object along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Object>> paramRepeatabilityRequestWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        String repeatabilityRequestId = UUID.randomUUID().toString();
+        String repeatabilityFirstSent = DateTimeRfc1123.toRfc1123String(OffsetDateTime.now());
+        return service.paramRepeatabilityRequest(
+                this.client.getHost(), accept, repeatabilityRequestId, repeatabilityFirstSent, context);
+    }
+
+    /**
+     * Send a post request with header Repeatability-Request-ID and Repeatability-First-Sent.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return any object on successful completion of {@link Mono}.
@@ -153,13 +175,29 @@ public final class Headers {
     /**
      * Send a post request with header Repeatability-Request-ID and Repeatability-First-Sent.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return any object on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Object> paramRepeatabilityRequestAsync(Context context) {
+        return paramRepeatabilityRequestWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Send a post request with header Repeatability-Request-ID and Repeatability-First-Sent.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return any object along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Object> paramRepeatabilityRequestWithResponse() {
-        return paramRepeatabilityRequestWithResponseAsync().block();
+    public Response<Object> paramRepeatabilityRequestWithResponse(Context context) {
+        return paramRepeatabilityRequestWithResponseAsync(context).block();
     }
 
     /**
@@ -171,7 +209,7 @@ public final class Headers {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Object paramRepeatabilityRequest() {
-        return paramRepeatabilityRequestWithResponse().getValue();
+        return paramRepeatabilityRequestWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -203,6 +241,28 @@ public final class Headers {
     /**
      * Send a put request with header Repeatability-Request-ID and Repeatability-First-Sent.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return any object along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Object>> paramRepeatabilityRequestPutWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        String repeatabilityRequestId = UUID.randomUUID().toString();
+        String repeatabilityFirstSent = DateTimeRfc1123.toRfc1123String(OffsetDateTime.now());
+        return service.paramRepeatabilityRequestPut(
+                this.client.getHost(), accept, repeatabilityRequestId, repeatabilityFirstSent, context);
+    }
+
+    /**
+     * Send a put request with header Repeatability-Request-ID and Repeatability-First-Sent.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return any object on successful completion of {@link Mono}.
@@ -215,13 +275,29 @@ public final class Headers {
     /**
      * Send a put request with header Repeatability-Request-ID and Repeatability-First-Sent.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return any object on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Object> paramRepeatabilityRequestPutAsync(Context context) {
+        return paramRepeatabilityRequestPutWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Send a put request with header Repeatability-Request-ID and Repeatability-First-Sent.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return any object along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Object> paramRepeatabilityRequestPutWithResponse() {
-        return paramRepeatabilityRequestPutWithResponseAsync().block();
+    public Response<Object> paramRepeatabilityRequestPutWithResponse(Context context) {
+        return paramRepeatabilityRequestPutWithResponseAsync(context).block();
     }
 
     /**
@@ -233,7 +309,7 @@ public final class Headers {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Object paramRepeatabilityRequestPut() {
-        return paramRepeatabilityRequestPutWithResponse().getValue();
+        return paramRepeatabilityRequestPutWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -257,6 +333,25 @@ public final class Headers {
     /**
      * Send a get request without header Repeatability-Request-ID and Repeatability-First-Sent.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return any object along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Object>> paramRepeatabilityRequestGetWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.paramRepeatabilityRequestGet(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Send a get request without header Repeatability-Request-ID and Repeatability-First-Sent.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return any object on successful completion of {@link Mono}.
@@ -269,13 +364,29 @@ public final class Headers {
     /**
      * Send a get request without header Repeatability-Request-ID and Repeatability-First-Sent.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return any object on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Object> paramRepeatabilityRequestGetAsync(Context context) {
+        return paramRepeatabilityRequestGetWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Send a get request without header Repeatability-Request-ID and Repeatability-First-Sent.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return any object along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Object> paramRepeatabilityRequestGetWithResponse() {
-        return paramRepeatabilityRequestGetWithResponseAsync().block();
+    public Response<Object> paramRepeatabilityRequestGetWithResponse(Context context) {
+        return paramRepeatabilityRequestGetWithResponseAsync(context).block();
     }
 
     /**
@@ -287,7 +398,7 @@ public final class Headers {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Object paramRepeatabilityRequestGet() {
-        return paramRepeatabilityRequestGetWithResponse().getValue();
+        return paramRepeatabilityRequestGetWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -319,6 +430,28 @@ public final class Headers {
     /**
      * Send a post request with header Repeatability-Request-ID and Repeatability-First-Sent.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return any object along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Object>> paramRepeatabilityRequestLROWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        String repeatabilityRequestId = UUID.randomUUID().toString();
+        String repeatabilityFirstSent = DateTimeRfc1123.toRfc1123String(OffsetDateTime.now());
+        return service.paramRepeatabilityRequestLRO(
+                this.client.getHost(), accept, repeatabilityRequestId, repeatabilityFirstSent, context);
+    }
+
+    /**
+     * Send a post request with header Repeatability-Request-ID and Repeatability-First-Sent.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return any object on successful completion of {@link Mono}.
@@ -331,13 +464,29 @@ public final class Headers {
     /**
      * Send a post request with header Repeatability-Request-ID and Repeatability-First-Sent.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return any object on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Object> paramRepeatabilityRequestLROAsync(Context context) {
+        return paramRepeatabilityRequestLROWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Send a post request with header Repeatability-Request-ID and Repeatability-First-Sent.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return any object along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Object> paramRepeatabilityRequestLROWithResponse() {
-        return paramRepeatabilityRequestLROWithResponseAsync().block();
+    public Response<Object> paramRepeatabilityRequestLROWithResponse(Context context) {
+        return paramRepeatabilityRequestLROWithResponseAsync(context).block();
     }
 
     /**
@@ -349,7 +498,7 @@ public final class Headers {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Object paramRepeatabilityRequestLRO() {
-        return paramRepeatabilityRequestLROWithResponse().getValue();
+        return paramRepeatabilityRequestLROWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -390,6 +539,37 @@ public final class Headers {
     /**
      * Send a post request with header Repeatability-Request-ID and Repeatability-First-Sent.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<PagedResponse<Object>> paramRepeatabilityRequestPageableSinglePageAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        String repeatabilityRequestId = UUID.randomUUID().toString();
+        String repeatabilityFirstSent = DateTimeRfc1123.toRfc1123String(OffsetDateTime.now());
+        return service.paramRepeatabilityRequestPageable(
+                        this.client.getHost(), accept, repeatabilityRequestId, repeatabilityFirstSent, context)
+                .map(
+                        res ->
+                                new PagedResponseBase<>(
+                                        res.getRequest(),
+                                        res.getStatusCode(),
+                                        res.getHeaders(),
+                                        res.getValue().getValue(),
+                                        res.getValue().getNextLink(),
+                                        null));
+    }
+
+    /**
+     * Send a post request with header Repeatability-Request-ID and Repeatability-First-Sent.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the paginated response with {@link PagedFlux}.
@@ -399,6 +579,22 @@ public final class Headers {
         return new PagedFlux<>(
                 () -> paramRepeatabilityRequestPageableSinglePageAsync(),
                 nextLink -> paramRepeatabilityRequestPageableNextSinglePageAsync(nextLink));
+    }
+
+    /**
+     * Send a post request with header Repeatability-Request-ID and Repeatability-First-Sent.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Object> paramRepeatabilityRequestPageableAsync(Context context) {
+        return new PagedFlux<>(
+                () -> paramRepeatabilityRequestPageableSinglePageAsync(context),
+                nextLink -> paramRepeatabilityRequestPageableNextSinglePageAsync(nextLink, context));
     }
 
     /**
@@ -416,6 +612,20 @@ public final class Headers {
     /**
      * Send a post request with header Repeatability-Request-ID and Repeatability-First-Sent.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link PagedResponse}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public PagedResponse<Object> paramRepeatabilityRequestPageableSinglePage(Context context) {
+        return paramRepeatabilityRequestPageableSinglePageAsync(context).block();
+    }
+
+    /**
+     * Send a post request with header Repeatability-Request-ID and Repeatability-First-Sent.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the paginated response with {@link PagedIterable}.
@@ -423,6 +633,20 @@ public final class Headers {
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedIterable<Object> paramRepeatabilityRequestPageable() {
         return new PagedIterable<>(paramRepeatabilityRequestPageableAsync());
+    }
+
+    /**
+     * Send a post request with header Repeatability-Request-ID and Repeatability-First-Sent.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Object> paramRepeatabilityRequestPageable(Context context) {
+        return new PagedIterable<>(paramRepeatabilityRequestPageableAsync(context));
     }
 
     /**
@@ -465,6 +689,40 @@ public final class Headers {
      *
      * @param nextLink The URL to get the next list of items
      *     <p>The nextLink parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<PagedResponse<Object>> paramRepeatabilityRequestPageableNextSinglePageAsync(
+            String nextLink, Context context) {
+        if (nextLink == null) {
+            return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
+        }
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.paramRepeatabilityRequestPageableNext(nextLink, this.client.getHost(), accept, context)
+                .map(
+                        res ->
+                                new PagedResponseBase<>(
+                                        res.getRequest(),
+                                        res.getStatusCode(),
+                                        res.getHeaders(),
+                                        res.getValue().getValue(),
+                                        res.getValue().getNextLink(),
+                                        null));
+    }
+
+    /**
+     * Get the next page of items.
+     *
+     * @param nextLink The URL to get the next list of items
+     *     <p>The nextLink parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -473,5 +731,21 @@ public final class Headers {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Object> paramRepeatabilityRequestPageableNextSinglePage(String nextLink) {
         return paramRepeatabilityRequestPageableNextSinglePageAsync(nextLink).block();
+    }
+
+    /**
+     * Get the next page of items.
+     *
+     * @param nextLink The URL to get the next list of items
+     *     <p>The nextLink parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link PagedResponse}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public PagedResponse<Object> paramRepeatabilityRequestPageableNextSinglePage(String nextLink, Context context) {
+        return paramRepeatabilityRequestPageableNextSinglePageAsync(nextLink, context).block();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Arrays.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Arrays.java
@@ -243,7 +243,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ArrayWrapper getValidSync(Context context) {
-        return getValidSyncWithResponse(context, Context.NONE).getValue();
+        return getValidSyncWithResponse(context).getValue();
     }
 
     /**
@@ -409,7 +409,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValidSync(ArrayWrapper complexBody, Context context) {
-        putValidSyncWithResponse(complexBody, context, Context.NONE);
+        putValidSyncWithResponse(complexBody, context);
     }
 
     /**
@@ -535,7 +535,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ArrayWrapper getEmptySync(Context context) {
-        return getEmptySyncWithResponse(context, Context.NONE).getValue();
+        return getEmptySyncWithResponse(context).getValue();
     }
 
     /**
@@ -693,7 +693,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putEmptySync(ArrayWrapper complexBody, Context context) {
-        putEmptySyncWithResponse(complexBody, context, Context.NONE);
+        putEmptySyncWithResponse(complexBody, context);
     }
 
     /**
@@ -823,7 +823,7 @@ public final class Arrays {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ArrayWrapper getNotProvidedSync(Context context) {
-        return getNotProvidedSyncWithResponse(context, Context.NONE).getValue();
+        return getNotProvidedSyncWithResponse(context).getValue();
     }
 
     private static final ClientLogger LOGGER = new ClientLogger(Arrays.class);

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Arrays.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Arrays.java
@@ -142,6 +142,25 @@ public final class Arrays {
     /**
      * Get complex types with array property.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with array property along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<ArrayWrapper>> getValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with array property.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with array property on successful completion of {@link Mono}.
@@ -149,6 +168,20 @@ public final class Arrays {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<ArrayWrapper> getValidAsync() {
         return getValidWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with array property.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with array property on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<ArrayWrapper> getValidAsync(Context context) {
+        return getValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -171,13 +204,46 @@ public final class Arrays {
     /**
      * Get complex types with array property.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with array property along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<ArrayWrapper> getValidSyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getValidSync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with array property.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with array property.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ArrayWrapper getValidSync() {
-        return getValidSyncWithResponse().getValue();
+        return getValidSyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get complex types with array property.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with array property.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public ArrayWrapper getValidSync(Context context) {
+        return getValidSyncWithResponse(context, Context.NONE).getValue();
     }
 
     /**
@@ -211,6 +277,33 @@ public final class Arrays {
      *
      * @param complexBody Please put an array with 4 items: "1, 2, 3, 4", "", null, "&amp;S#$(*Y", "The quick brown fox
      *     jumps over the lazy dog".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putValidWithResponseAsync(ArrayWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putValid(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with array property.
+     *
+     * @param complexBody Please put an array with 4 items: "1, 2, 3, 4", "", null, "&amp;S#$(*Y", "The quick brown fox
+     *     jumps over the lazy dog".
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -219,6 +312,22 @@ public final class Arrays {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putValidAsync(ArrayWrapper complexBody) {
         return putValidWithResponseAsync(complexBody).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with array property.
+     *
+     * @param complexBody Please put an array with 4 items: "1, 2, 3, 4", "", null, "&amp;S#$(*Y", "The quick brown fox
+     *     jumps over the lazy dog".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putValidAsync(ArrayWrapper complexBody, Context context) {
+        return putValidWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
     }
 
     /**
@@ -252,13 +361,55 @@ public final class Arrays {
      *
      * @param complexBody Please put an array with 4 items: "1, 2, 3, 4", "", null, "&amp;S#$(*Y", "The quick brown fox
      *     jumps over the lazy dog".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> putValidSyncWithResponse(ArrayWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putValidSync(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with array property.
+     *
+     * @param complexBody Please put an array with 4 items: "1, 2, 3, 4", "", null, "&amp;S#$(*Y", "The quick brown fox
+     *     jumps over the lazy dog".
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValidSync(ArrayWrapper complexBody) {
-        putValidSyncWithResponse(complexBody);
+        putValidSyncWithResponse(complexBody, Context.NONE);
+    }
+
+    /**
+     * Put complex types with array property.
+     *
+     * @param complexBody Please put an array with 4 items: "1, 2, 3, 4", "", null, "&amp;S#$(*Y", "The quick brown fox
+     *     jumps over the lazy dog".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putValidSync(ArrayWrapper complexBody, Context context) {
+        putValidSyncWithResponse(complexBody, context, Context.NONE);
     }
 
     /**
@@ -282,6 +433,26 @@ public final class Arrays {
     /**
      * Get complex types with array property which is empty.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with array property which is empty along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<ArrayWrapper>> getEmptyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getEmpty(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with array property which is empty.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with array property which is empty on successful completion of {@link Mono}.
@@ -289,6 +460,20 @@ public final class Arrays {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<ArrayWrapper> getEmptyAsync() {
         return getEmptyWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with array property which is empty.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with array property which is empty on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<ArrayWrapper> getEmptyAsync(Context context) {
+        return getEmptyWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -311,13 +496,46 @@ public final class Arrays {
     /**
      * Get complex types with array property which is empty.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with array property which is empty along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<ArrayWrapper> getEmptySyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getEmptySync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with array property which is empty.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with array property which is empty.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ArrayWrapper getEmptySync() {
-        return getEmptySyncWithResponse().getValue();
+        return getEmptySyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get complex types with array property which is empty.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with array property which is empty.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public ArrayWrapper getEmptySync(Context context) {
+        return getEmptySyncWithResponse(context, Context.NONE).getValue();
     }
 
     /**
@@ -349,6 +567,32 @@ public final class Arrays {
      * Put complex types with array property which is empty.
      *
      * @param complexBody Please put an empty array.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putEmptyWithResponseAsync(ArrayWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putEmpty(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with array property which is empty.
+     *
+     * @param complexBody Please put an empty array.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -357,6 +601,21 @@ public final class Arrays {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putEmptyAsync(ArrayWrapper complexBody) {
         return putEmptyWithResponseAsync(complexBody).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with array property which is empty.
+     *
+     * @param complexBody Please put an empty array.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putEmptyAsync(ArrayWrapper complexBody, Context context) {
+        return putEmptyWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
     }
 
     /**
@@ -388,13 +647,53 @@ public final class Arrays {
      * Put complex types with array property which is empty.
      *
      * @param complexBody Please put an empty array.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> putEmptySyncWithResponse(ArrayWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putEmptySync(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with array property which is empty.
+     *
+     * @param complexBody Please put an empty array.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putEmptySync(ArrayWrapper complexBody) {
-        putEmptySyncWithResponse(complexBody);
+        putEmptySyncWithResponse(complexBody, Context.NONE);
+    }
+
+    /**
+     * Put complex types with array property which is empty.
+     *
+     * @param complexBody Please put an empty array.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putEmptySync(ArrayWrapper complexBody, Context context) {
+        putEmptySyncWithResponse(complexBody, context, Context.NONE);
     }
 
     /**
@@ -418,6 +717,26 @@ public final class Arrays {
     /**
      * Get complex types with array property while server doesn't provide a response payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with array property while server doesn't provide a response payload along with {@link
+     *     Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<ArrayWrapper>> getNotProvidedWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNotProvided(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with array property while server doesn't provide a response payload.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with array property while server doesn't provide a response payload on successful
@@ -426,6 +745,21 @@ public final class Arrays {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<ArrayWrapper> getNotProvidedAsync() {
         return getNotProvidedWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with array property while server doesn't provide a response payload.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with array property while server doesn't provide a response payload on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<ArrayWrapper> getNotProvidedAsync(Context context) {
+        return getNotProvidedWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -449,13 +783,47 @@ public final class Arrays {
     /**
      * Get complex types with array property while server doesn't provide a response payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with array property while server doesn't provide a response payload along with {@link
+     *     Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<ArrayWrapper> getNotProvidedSyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNotProvidedSync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with array property while server doesn't provide a response payload.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with array property while server doesn't provide a response payload.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ArrayWrapper getNotProvidedSync() {
-        return getNotProvidedSyncWithResponse().getValue();
+        return getNotProvidedSyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get complex types with array property while server doesn't provide a response payload.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with array property while server doesn't provide a response payload.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public ArrayWrapper getNotProvidedSync(Context context) {
+        return getNotProvidedSyncWithResponse(context, Context.NONE).getValue();
     }
 
     private static final ClientLogger LOGGER = new ClientLogger(Arrays.class);

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Basics.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Basics.java
@@ -254,7 +254,7 @@ public final class Basics {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Basic getValidSync(Context context) {
-        return getValidSyncWithResponse(context, Context.NONE).getValue();
+        return getValidSyncWithResponse(context).getValue();
     }
 
     /**
@@ -416,7 +416,7 @@ public final class Basics {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValidSync(Basic complexBody, Context context) {
-        putValidSyncWithResponse(complexBody, context, Context.NONE);
+        putValidSyncWithResponse(complexBody, context);
     }
 
     /**
@@ -542,7 +542,7 @@ public final class Basics {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Basic getInvalidSync(Context context) {
-        return getInvalidSyncWithResponse(context, Context.NONE).getValue();
+        return getInvalidSyncWithResponse(context).getValue();
     }
 
     /**
@@ -666,7 +666,7 @@ public final class Basics {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Basic getEmptySync(Context context) {
-        return getEmptySyncWithResponse(context, Context.NONE).getValue();
+        return getEmptySyncWithResponse(context).getValue();
     }
 
     /**
@@ -792,7 +792,7 @@ public final class Basics {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Basic getNullSync(Context context) {
-        return getNullSyncWithResponse(context, Context.NONE).getValue();
+        return getNullSyncWithResponse(context).getValue();
     }
 
     /**
@@ -920,7 +920,7 @@ public final class Basics {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Basic getNotProvidedSync(Context context) {
-        return getNotProvidedSyncWithResponse(context, Context.NONE).getValue();
+        return getNotProvidedSyncWithResponse(context).getValue();
     }
 
     private static final ClientLogger LOGGER = new ClientLogger(Basics.class);

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Basics.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Basics.java
@@ -152,6 +152,26 @@ public final class Basics {
     /**
      * Get complex type {id: 2, name: 'abc', color: 'YELLOW'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex type {id: 2, name: 'abc', color: 'YELLOW'} along with {@link Response} on successful completion
+     *     of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Basic>> getValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex type {id: 2, name: 'abc', color: 'YELLOW'}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex type {id: 2, name: 'abc', color: 'YELLOW'} on successful completion of {@link Mono}.
@@ -159,6 +179,20 @@ public final class Basics {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Basic> getValidAsync() {
         return getValidWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex type {id: 2, name: 'abc', color: 'YELLOW'}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex type {id: 2, name: 'abc', color: 'YELLOW'} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Basic> getValidAsync(Context context) {
+        return getValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -181,13 +215,46 @@ public final class Basics {
     /**
      * Get complex type {id: 2, name: 'abc', color: 'YELLOW'}.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex type {id: 2, name: 'abc', color: 'YELLOW'} along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Basic> getValidSyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getValidSync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex type {id: 2, name: 'abc', color: 'YELLOW'}.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex type {id: 2, name: 'abc', color: 'YELLOW'}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Basic getValidSync() {
-        return getValidSyncWithResponse().getValue();
+        return getValidSyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get complex type {id: 2, name: 'abc', color: 'YELLOW'}.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex type {id: 2, name: 'abc', color: 'YELLOW'}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Basic getValidSync(Context context) {
+        return getValidSyncWithResponse(context, Context.NONE).getValue();
     }
 
     /**
@@ -222,6 +289,32 @@ public final class Basics {
      * Please put {id: 2, name: 'abc', color: 'Magenta'}.
      *
      * @param complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putValidWithResponseAsync(Basic complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putValid(this.client.getHost(), this.client.getApiVersion(), complexBody, accept, context);
+    }
+
+    /**
+     * Please put {id: 2, name: 'abc', color: 'Magenta'}.
+     *
+     * @param complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -230,6 +323,21 @@ public final class Basics {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putValidAsync(Basic complexBody) {
         return putValidWithResponseAsync(complexBody).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Please put {id: 2, name: 'abc', color: 'Magenta'}.
+     *
+     * @param complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putValidAsync(Basic complexBody, Context context) {
+        return putValidWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
     }
 
     /**
@@ -262,13 +370,53 @@ public final class Basics {
      * Please put {id: 2, name: 'abc', color: 'Magenta'}.
      *
      * @param complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> putValidSyncWithResponse(Basic complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putValidSync(this.client.getHost(), this.client.getApiVersion(), complexBody, accept, context);
+    }
+
+    /**
+     * Please put {id: 2, name: 'abc', color: 'Magenta'}.
+     *
+     * @param complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValidSync(Basic complexBody) {
-        putValidSyncWithResponse(complexBody);
+        putValidSyncWithResponse(complexBody, Context.NONE);
+    }
+
+    /**
+     * Please put {id: 2, name: 'abc', color: 'Magenta'}.
+     *
+     * @param complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putValidSync(Basic complexBody, Context context) {
+        putValidSyncWithResponse(complexBody, context, Context.NONE);
     }
 
     /**
@@ -292,6 +440,26 @@ public final class Basics {
     /**
      * Get a basic complex type that is invalid for the local strong type.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a basic complex type that is invalid for the local strong type along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Basic>> getInvalidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getInvalid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get a basic complex type that is invalid for the local strong type.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a basic complex type that is invalid for the local strong type on successful completion of {@link Mono}.
@@ -299,6 +467,20 @@ public final class Basics {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Basic> getInvalidAsync() {
         return getInvalidWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get a basic complex type that is invalid for the local strong type.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a basic complex type that is invalid for the local strong type on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Basic> getInvalidAsync(Context context) {
+        return getInvalidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -321,13 +503,46 @@ public final class Basics {
     /**
      * Get a basic complex type that is invalid for the local strong type.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a basic complex type that is invalid for the local strong type along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Basic> getInvalidSyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getInvalidSync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get a basic complex type that is invalid for the local strong type.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a basic complex type that is invalid for the local strong type.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Basic getInvalidSync() {
-        return getInvalidSyncWithResponse().getValue();
+        return getInvalidSyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get a basic complex type that is invalid for the local strong type.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a basic complex type that is invalid for the local strong type.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Basic getInvalidSync(Context context) {
+        return getInvalidSyncWithResponse(context, Context.NONE).getValue();
     }
 
     /**
@@ -350,6 +565,25 @@ public final class Basics {
     /**
      * Get a basic complex type that is empty.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a basic complex type that is empty along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Basic>> getEmptyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getEmpty(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get a basic complex type that is empty.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a basic complex type that is empty on successful completion of {@link Mono}.
@@ -357,6 +591,20 @@ public final class Basics {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Basic> getEmptyAsync() {
         return getEmptyWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get a basic complex type that is empty.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a basic complex type that is empty on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Basic> getEmptyAsync(Context context) {
+        return getEmptyWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -379,13 +627,46 @@ public final class Basics {
     /**
      * Get a basic complex type that is empty.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a basic complex type that is empty along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Basic> getEmptySyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getEmptySync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get a basic complex type that is empty.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a basic complex type that is empty.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Basic getEmptySync() {
-        return getEmptySyncWithResponse().getValue();
+        return getEmptySyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get a basic complex type that is empty.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a basic complex type that is empty.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Basic getEmptySync(Context context) {
+        return getEmptySyncWithResponse(context, Context.NONE).getValue();
     }
 
     /**
@@ -409,6 +690,26 @@ public final class Basics {
     /**
      * Get a basic complex type whose properties are null.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a basic complex type whose properties are null along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Basic>> getNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get a basic complex type whose properties are null.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a basic complex type whose properties are null on successful completion of {@link Mono}.
@@ -416,6 +717,20 @@ public final class Basics {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Basic> getNullAsync() {
         return getNullWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get a basic complex type whose properties are null.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a basic complex type whose properties are null on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Basic> getNullAsync(Context context) {
+        return getNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -438,13 +753,46 @@ public final class Basics {
     /**
      * Get a basic complex type whose properties are null.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a basic complex type whose properties are null along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Basic> getNullSyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNullSync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get a basic complex type whose properties are null.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a basic complex type whose properties are null.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Basic getNullSync() {
-        return getNullSyncWithResponse().getValue();
+        return getNullSyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get a basic complex type whose properties are null.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a basic complex type whose properties are null.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Basic getNullSync(Context context) {
+        return getNullSyncWithResponse(context, Context.NONE).getValue();
     }
 
     /**
@@ -468,6 +816,26 @@ public final class Basics {
     /**
      * Get a basic complex type while the server doesn't provide a response payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a basic complex type while the server doesn't provide a response payload along with {@link Response} on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Basic>> getNotProvidedWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNotProvided(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get a basic complex type while the server doesn't provide a response payload.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a basic complex type while the server doesn't provide a response payload on successful completion of
@@ -476,6 +844,21 @@ public final class Basics {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Basic> getNotProvidedAsync() {
         return getNotProvidedWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get a basic complex type while the server doesn't provide a response payload.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a basic complex type while the server doesn't provide a response payload on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Basic> getNotProvidedAsync(Context context) {
+        return getNotProvidedWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -498,13 +881,46 @@ public final class Basics {
     /**
      * Get a basic complex type while the server doesn't provide a response payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a basic complex type while the server doesn't provide a response payload along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Basic> getNotProvidedSyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNotProvidedSync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get a basic complex type while the server doesn't provide a response payload.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a basic complex type while the server doesn't provide a response payload.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Basic getNotProvidedSync() {
-        return getNotProvidedSyncWithResponse().getValue();
+        return getNotProvidedSyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get a basic complex type while the server doesn't provide a response payload.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a basic complex type while the server doesn't provide a response payload.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Basic getNotProvidedSync(Context context) {
+        return getNotProvidedSyncWithResponse(context, Context.NONE).getValue();
     }
 
     private static final ClientLogger LOGGER = new ClientLogger(Basics.class);

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Dictionaries.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Dictionaries.java
@@ -258,7 +258,7 @@ public final class Dictionaries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DictionaryWrapper getValidSync(Context context) {
-        return getValidSyncWithResponse(context, Context.NONE).getValue();
+        return getValidSyncWithResponse(context).getValue();
     }
 
     /**
@@ -424,7 +424,7 @@ public final class Dictionaries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValidSync(DictionaryWrapper complexBody, Context context) {
-        putValidSyncWithResponse(complexBody, context, Context.NONE);
+        putValidSyncWithResponse(complexBody, context);
     }
 
     /**
@@ -550,7 +550,7 @@ public final class Dictionaries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DictionaryWrapper getEmptySync(Context context) {
-        return getEmptySyncWithResponse(context, Context.NONE).getValue();
+        return getEmptySyncWithResponse(context).getValue();
     }
 
     /**
@@ -708,7 +708,7 @@ public final class Dictionaries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putEmptySync(DictionaryWrapper complexBody, Context context) {
-        putEmptySyncWithResponse(complexBody, context, Context.NONE);
+        putEmptySyncWithResponse(complexBody, context);
     }
 
     /**
@@ -834,7 +834,7 @@ public final class Dictionaries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DictionaryWrapper getNullSync(Context context) {
-        return getNullSyncWithResponse(context, Context.NONE).getValue();
+        return getNullSyncWithResponse(context).getValue();
     }
 
     /**
@@ -964,7 +964,7 @@ public final class Dictionaries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DictionaryWrapper getNotProvidedSync(Context context) {
-        return getNotProvidedSyncWithResponse(context, Context.NONE).getValue();
+        return getNotProvidedSyncWithResponse(context).getValue();
     }
 
     private static final ClientLogger LOGGER = new ClientLogger(Dictionaries.class);

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Dictionaries.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Dictionaries.java
@@ -156,6 +156,26 @@ public final class Dictionaries {
     /**
      * Get complex types with dictionary property.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with dictionary property along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<DictionaryWrapper>> getValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with dictionary property.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with dictionary property on successful completion of {@link Mono}.
@@ -163,6 +183,20 @@ public final class Dictionaries {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<DictionaryWrapper> getValidAsync() {
         return getValidWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with dictionary property.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with dictionary property on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<DictionaryWrapper> getValidAsync(Context context) {
+        return getValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -185,13 +219,46 @@ public final class Dictionaries {
     /**
      * Get complex types with dictionary property.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with dictionary property along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<DictionaryWrapper> getValidSyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getValidSync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with dictionary property.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with dictionary property.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DictionaryWrapper getValidSync() {
-        return getValidSyncWithResponse().getValue();
+        return getValidSyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get complex types with dictionary property.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with dictionary property.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public DictionaryWrapper getValidSync(Context context) {
+        return getValidSyncWithResponse(context, Context.NONE).getValue();
     }
 
     /**
@@ -225,6 +292,33 @@ public final class Dictionaries {
      *
      * @param complexBody Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint",
      *     "xls":"excel", "exe":"", "":null.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putValidWithResponseAsync(DictionaryWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putValid(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with dictionary property.
+     *
+     * @param complexBody Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint",
+     *     "xls":"excel", "exe":"", "":null.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -233,6 +327,22 @@ public final class Dictionaries {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putValidAsync(DictionaryWrapper complexBody) {
         return putValidWithResponseAsync(complexBody).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with dictionary property.
+     *
+     * @param complexBody Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint",
+     *     "xls":"excel", "exe":"", "":null.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putValidAsync(DictionaryWrapper complexBody, Context context) {
+        return putValidWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
     }
 
     /**
@@ -266,13 +376,55 @@ public final class Dictionaries {
      *
      * @param complexBody Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint",
      *     "xls":"excel", "exe":"", "":null.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> putValidSyncWithResponse(DictionaryWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putValidSync(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with dictionary property.
+     *
+     * @param complexBody Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint",
+     *     "xls":"excel", "exe":"", "":null.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValidSync(DictionaryWrapper complexBody) {
-        putValidSyncWithResponse(complexBody);
+        putValidSyncWithResponse(complexBody, Context.NONE);
+    }
+
+    /**
+     * Put complex types with dictionary property.
+     *
+     * @param complexBody Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint",
+     *     "xls":"excel", "exe":"", "":null.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putValidSync(DictionaryWrapper complexBody, Context context) {
+        putValidSyncWithResponse(complexBody, context, Context.NONE);
     }
 
     /**
@@ -296,6 +448,26 @@ public final class Dictionaries {
     /**
      * Get complex types with dictionary property which is empty.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with dictionary property which is empty along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<DictionaryWrapper>> getEmptyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getEmpty(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with dictionary property which is empty.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with dictionary property which is empty on successful completion of {@link Mono}.
@@ -303,6 +475,20 @@ public final class Dictionaries {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<DictionaryWrapper> getEmptyAsync() {
         return getEmptyWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with dictionary property which is empty.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with dictionary property which is empty on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<DictionaryWrapper> getEmptyAsync(Context context) {
+        return getEmptyWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -325,13 +511,46 @@ public final class Dictionaries {
     /**
      * Get complex types with dictionary property which is empty.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with dictionary property which is empty along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<DictionaryWrapper> getEmptySyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getEmptySync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with dictionary property which is empty.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with dictionary property which is empty.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DictionaryWrapper getEmptySync() {
-        return getEmptySyncWithResponse().getValue();
+        return getEmptySyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get complex types with dictionary property which is empty.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with dictionary property which is empty.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public DictionaryWrapper getEmptySync(Context context) {
+        return getEmptySyncWithResponse(context, Context.NONE).getValue();
     }
 
     /**
@@ -363,6 +582,32 @@ public final class Dictionaries {
      * Put complex types with dictionary property which is empty.
      *
      * @param complexBody Please put an empty dictionary.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putEmptyWithResponseAsync(DictionaryWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putEmpty(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with dictionary property which is empty.
+     *
+     * @param complexBody Please put an empty dictionary.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -371,6 +616,21 @@ public final class Dictionaries {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putEmptyAsync(DictionaryWrapper complexBody) {
         return putEmptyWithResponseAsync(complexBody).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with dictionary property which is empty.
+     *
+     * @param complexBody Please put an empty dictionary.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putEmptyAsync(DictionaryWrapper complexBody, Context context) {
+        return putEmptyWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
     }
 
     /**
@@ -402,13 +662,53 @@ public final class Dictionaries {
      * Put complex types with dictionary property which is empty.
      *
      * @param complexBody Please put an empty dictionary.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> putEmptySyncWithResponse(DictionaryWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putEmptySync(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with dictionary property which is empty.
+     *
+     * @param complexBody Please put an empty dictionary.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putEmptySync(DictionaryWrapper complexBody) {
-        putEmptySyncWithResponse(complexBody);
+        putEmptySyncWithResponse(complexBody, Context.NONE);
+    }
+
+    /**
+     * Put complex types with dictionary property which is empty.
+     *
+     * @param complexBody Please put an empty dictionary.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putEmptySync(DictionaryWrapper complexBody, Context context) {
+        putEmptySyncWithResponse(complexBody, context, Context.NONE);
     }
 
     /**
@@ -432,6 +732,26 @@ public final class Dictionaries {
     /**
      * Get complex types with dictionary property which is null.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with dictionary property which is null along with {@link Response} on successful completion
+     *     of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<DictionaryWrapper>> getNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNull(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with dictionary property which is null.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with dictionary property which is null on successful completion of {@link Mono}.
@@ -439,6 +759,20 @@ public final class Dictionaries {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<DictionaryWrapper> getNullAsync() {
         return getNullWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with dictionary property which is null.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with dictionary property which is null on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<DictionaryWrapper> getNullAsync(Context context) {
+        return getNullWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -461,13 +795,46 @@ public final class Dictionaries {
     /**
      * Get complex types with dictionary property which is null.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with dictionary property which is null along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<DictionaryWrapper> getNullSyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNullSync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with dictionary property which is null.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with dictionary property which is null.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DictionaryWrapper getNullSync() {
-        return getNullSyncWithResponse().getValue();
+        return getNullSyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get complex types with dictionary property which is null.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with dictionary property which is null.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public DictionaryWrapper getNullSync(Context context) {
+        return getNullSyncWithResponse(context, Context.NONE).getValue();
     }
 
     /**
@@ -491,6 +858,26 @@ public final class Dictionaries {
     /**
      * Get complex types with dictionary property while server doesn't provide a response payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with dictionary property while server doesn't provide a response payload along with {@link
+     *     Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<DictionaryWrapper>> getNotProvidedWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNotProvided(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with dictionary property while server doesn't provide a response payload.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with dictionary property while server doesn't provide a response payload on successful
@@ -499,6 +886,21 @@ public final class Dictionaries {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<DictionaryWrapper> getNotProvidedAsync() {
         return getNotProvidedWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with dictionary property while server doesn't provide a response payload.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with dictionary property while server doesn't provide a response payload on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<DictionaryWrapper> getNotProvidedAsync(Context context) {
+        return getNotProvidedWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -522,13 +924,47 @@ public final class Dictionaries {
     /**
      * Get complex types with dictionary property while server doesn't provide a response payload.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with dictionary property while server doesn't provide a response payload along with {@link
+     *     Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<DictionaryWrapper> getNotProvidedSyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getNotProvidedSync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with dictionary property while server doesn't provide a response payload.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with dictionary property while server doesn't provide a response payload.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DictionaryWrapper getNotProvidedSync() {
-        return getNotProvidedSyncWithResponse().getValue();
+        return getNotProvidedSyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get complex types with dictionary property while server doesn't provide a response payload.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with dictionary property while server doesn't provide a response payload.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public DictionaryWrapper getNotProvidedSync(Context context) {
+        return getNotProvidedSyncWithResponse(context, Context.NONE).getValue();
     }
 
     private static final ClientLogger LOGGER = new ClientLogger(Dictionaries.class);

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Flattencomplexes.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Flattencomplexes.java
@@ -82,6 +82,25 @@ public final class Flattencomplexes {
     /**
      * The getValid operation.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<MyBaseType>> getValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * The getValid operation.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body on successful completion of {@link Mono}.
@@ -89,6 +108,20 @@ public final class Flattencomplexes {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<MyBaseType> getValidAsync() {
         return getValidWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * The getValid operation.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<MyBaseType> getValidAsync(Context context) {
+        return getValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -111,13 +144,46 @@ public final class Flattencomplexes {
     /**
      * The getValid operation.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<MyBaseType> getValidSyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getValidSync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * The getValid operation.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyBaseType getValidSync() {
-        return getValidSyncWithResponse().getValue();
+        return getValidSyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * The getValid operation.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public MyBaseType getValidSync(Context context) {
+        return getValidSyncWithResponse(context, Context.NONE).getValue();
     }
 
     private static final ClientLogger LOGGER = new ClientLogger(Flattencomplexes.class);

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Flattencomplexes.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Flattencomplexes.java
@@ -183,7 +183,7 @@ public final class Flattencomplexes {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyBaseType getValidSync(Context context) {
-        return getValidSyncWithResponse(context, Context.NONE).getValue();
+        return getValidSyncWithResponse(context).getValue();
     }
 
     private static final ClientLogger LOGGER = new ClientLogger(Flattencomplexes.class);

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Inheritances.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Inheritances.java
@@ -202,7 +202,7 @@ public final class Inheritances {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Siamese getValidSync(Context context) {
-        return getValidSyncWithResponse(context, Context.NONE).getValue();
+        return getValidSyncWithResponse(context).getValue();
     }
 
     /**
@@ -376,7 +376,7 @@ public final class Inheritances {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValidSync(Siamese complexBody, Context context) {
-        putValidSyncWithResponse(complexBody, context, Context.NONE);
+        putValidSyncWithResponse(complexBody, context);
     }
 
     private static final ClientLogger LOGGER = new ClientLogger(Inheritances.class);

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Inheritances.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Inheritances.java
@@ -101,6 +101,25 @@ public final class Inheritances {
     /**
      * Get complex types that extend others.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that extend others along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Siamese>> getValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types that extend others.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types that extend others on successful completion of {@link Mono}.
@@ -108,6 +127,20 @@ public final class Inheritances {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Siamese> getValidAsync() {
         return getValidWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types that extend others.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that extend others on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Siamese> getValidAsync(Context context) {
+        return getValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -130,13 +163,46 @@ public final class Inheritances {
     /**
      * Get complex types that extend others.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that extend others along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Siamese> getValidSyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getValidSync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types that extend others.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types that extend others.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Siamese getValidSync() {
-        return getValidSyncWithResponse().getValue();
+        return getValidSyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get complex types that extend others.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that extend others.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Siamese getValidSync(Context context) {
+        return getValidSyncWithResponse(context, Context.NONE).getValue();
     }
 
     /**
@@ -172,6 +238,34 @@ public final class Inheritances {
      * @param complexBody Please put a siamese with id=2, name="Siameee", color=green, breed=persion, which hates 2
      *     dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1 and
      *     food="french fries".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putValidWithResponseAsync(Siamese complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putValid(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types that extend others.
+     *
+     * @param complexBody Please put a siamese with id=2, name="Siameee", color=green, breed=persion, which hates 2
+     *     dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1 and
+     *     food="french fries".
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -180,6 +274,23 @@ public final class Inheritances {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putValidAsync(Siamese complexBody) {
         return putValidWithResponseAsync(complexBody).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types that extend others.
+     *
+     * @param complexBody Please put a siamese with id=2, name="Siameee", color=green, breed=persion, which hates 2
+     *     dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1 and
+     *     food="french fries".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putValidAsync(Siamese complexBody, Context context) {
+        return putValidWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
     }
 
     /**
@@ -215,13 +326,57 @@ public final class Inheritances {
      * @param complexBody Please put a siamese with id=2, name="Siameee", color=green, breed=persion, which hates 2
      *     dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1 and
      *     food="french fries".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> putValidSyncWithResponse(Siamese complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putValidSync(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types that extend others.
+     *
+     * @param complexBody Please put a siamese with id=2, name="Siameee", color=green, breed=persion, which hates 2
+     *     dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1 and
+     *     food="french fries".
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValidSync(Siamese complexBody) {
-        putValidSyncWithResponse(complexBody);
+        putValidSyncWithResponse(complexBody, Context.NONE);
+    }
+
+    /**
+     * Put complex types that extend others.
+     *
+     * @param complexBody Please put a siamese with id=2, name="Siameee", color=green, breed=persion, which hates 2
+     *     dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1 and
+     *     food="french fries".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putValidSync(Siamese complexBody, Context context) {
+        putValidSyncWithResponse(complexBody, context, Context.NONE);
     }
 
     private static final ClientLogger LOGGER = new ClientLogger(Inheritances.class);

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Polymorphicrecursives.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Polymorphicrecursives.java
@@ -207,7 +207,7 @@ public final class Polymorphicrecursives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Fish getValidSync(Context context) {
-        return getValidSyncWithResponse(context, Context.NONE).getValue();
+        return getValidSyncWithResponse(context).getValue();
     }
 
     /**
@@ -413,7 +413,7 @@ public final class Polymorphicrecursives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValidSync(Fish complexBody, Context context) {
-        putValidSyncWithResponse(complexBody, context, Context.NONE);
+        putValidSyncWithResponse(complexBody, context);
     }
 
     private static final ClientLogger LOGGER = new ClientLogger(Polymorphicrecursives.class);

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Polymorphicrecursives.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Polymorphicrecursives.java
@@ -103,6 +103,26 @@ public final class Polymorphicrecursives {
     /**
      * Get complex types that are polymorphic and have recursive references.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that are polymorphic and have recursive references along with {@link Response} on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Fish>> getValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types that are polymorphic and have recursive references.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types that are polymorphic and have recursive references on successful completion of {@link
@@ -111,6 +131,21 @@ public final class Polymorphicrecursives {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Fish> getValidAsync() {
         return getValidWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types that are polymorphic and have recursive references.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that are polymorphic and have recursive references on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Fish> getValidAsync(Context context) {
+        return getValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -133,13 +168,46 @@ public final class Polymorphicrecursives {
     /**
      * Get complex types that are polymorphic and have recursive references.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that are polymorphic and have recursive references along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Fish> getValidSyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getValidSync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types that are polymorphic and have recursive references.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types that are polymorphic and have recursive references.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Fish getValidSync() {
-        return getValidSyncWithResponse().getValue();
+        return getValidSyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get complex types that are polymorphic and have recursive references.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that are polymorphic and have recursive references.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Fish getValidSync(Context context) {
+        return getValidSyncWithResponse(context, Context.NONE).getValue();
     }
 
     /**
@@ -183,6 +251,38 @@ public final class Polymorphicrecursives {
      *     "length": 20, "age": 6 }, { "fishtype": "sawshark", "species": "dangerous", "length": 10, "age": 105 } ] }, {
      *     "fishtype": "sawshark", "species": "dangerous", "length": 10, "age": 105 } ] }, { "fishtype": "sawshark",
      *     "species": "dangerous", "length": 10, "age": 105 } ] }.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putValidWithResponseAsync(Fish complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putValid(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types that are polymorphic and have recursive references.
+     *
+     * @param complexBody Please put a salmon that looks like this: { "fishtype": "salmon", "species": "king", "length":
+     *     1, "age": 1, "location": "alaska", "iswild": true, "siblings": [ { "fishtype": "shark", "species":
+     *     "predator", "length": 20, "age": 6, "siblings": [ { "fishtype": "salmon", "species": "coho", "length": 2,
+     *     "age": 2, "location": "atlantic", "iswild": true, "siblings": [ { "fishtype": "shark", "species": "predator",
+     *     "length": 20, "age": 6 }, { "fishtype": "sawshark", "species": "dangerous", "length": 10, "age": 105 } ] }, {
+     *     "fishtype": "sawshark", "species": "dangerous", "length": 10, "age": 105 } ] }, { "fishtype": "sawshark",
+     *     "species": "dangerous", "length": 10, "age": 105 } ] }.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -191,6 +291,27 @@ public final class Polymorphicrecursives {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putValidAsync(Fish complexBody) {
         return putValidWithResponseAsync(complexBody).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types that are polymorphic and have recursive references.
+     *
+     * @param complexBody Please put a salmon that looks like this: { "fishtype": "salmon", "species": "king", "length":
+     *     1, "age": 1, "location": "alaska", "iswild": true, "siblings": [ { "fishtype": "shark", "species":
+     *     "predator", "length": 20, "age": 6, "siblings": [ { "fishtype": "salmon", "species": "coho", "length": 2,
+     *     "age": 2, "location": "atlantic", "iswild": true, "siblings": [ { "fishtype": "shark", "species": "predator",
+     *     "length": 20, "age": 6 }, { "fishtype": "sawshark", "species": "dangerous", "length": 10, "age": 105 } ] }, {
+     *     "fishtype": "sawshark", "species": "dangerous", "length": 10, "age": 105 } ] }, { "fishtype": "sawshark",
+     *     "species": "dangerous", "length": 10, "age": 105 } ] }.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putValidAsync(Fish complexBody, Context context) {
+        return putValidWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
     }
 
     /**
@@ -234,13 +355,65 @@ public final class Polymorphicrecursives {
      *     "length": 20, "age": 6 }, { "fishtype": "sawshark", "species": "dangerous", "length": 10, "age": 105 } ] }, {
      *     "fishtype": "sawshark", "species": "dangerous", "length": 10, "age": 105 } ] }, { "fishtype": "sawshark",
      *     "species": "dangerous", "length": 10, "age": 105 } ] }.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> putValidSyncWithResponse(Fish complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putValidSync(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types that are polymorphic and have recursive references.
+     *
+     * @param complexBody Please put a salmon that looks like this: { "fishtype": "salmon", "species": "king", "length":
+     *     1, "age": 1, "location": "alaska", "iswild": true, "siblings": [ { "fishtype": "shark", "species":
+     *     "predator", "length": 20, "age": 6, "siblings": [ { "fishtype": "salmon", "species": "coho", "length": 2,
+     *     "age": 2, "location": "atlantic", "iswild": true, "siblings": [ { "fishtype": "shark", "species": "predator",
+     *     "length": 20, "age": 6 }, { "fishtype": "sawshark", "species": "dangerous", "length": 10, "age": 105 } ] }, {
+     *     "fishtype": "sawshark", "species": "dangerous", "length": 10, "age": 105 } ] }, { "fishtype": "sawshark",
+     *     "species": "dangerous", "length": 10, "age": 105 } ] }.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValidSync(Fish complexBody) {
-        putValidSyncWithResponse(complexBody);
+        putValidSyncWithResponse(complexBody, Context.NONE);
+    }
+
+    /**
+     * Put complex types that are polymorphic and have recursive references.
+     *
+     * @param complexBody Please put a salmon that looks like this: { "fishtype": "salmon", "species": "king", "length":
+     *     1, "age": 1, "location": "alaska", "iswild": true, "siblings": [ { "fishtype": "shark", "species":
+     *     "predator", "length": 20, "age": 6, "siblings": [ { "fishtype": "salmon", "species": "coho", "length": 2,
+     *     "age": 2, "location": "atlantic", "iswild": true, "siblings": [ { "fishtype": "shark", "species": "predator",
+     *     "length": 20, "age": 6 }, { "fishtype": "sawshark", "species": "dangerous", "length": 10, "age": 105 } ] }, {
+     *     "fishtype": "sawshark", "species": "dangerous", "length": 10, "age": 105 } ] }, { "fishtype": "sawshark",
+     *     "species": "dangerous", "length": 10, "age": 105 } ] }.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putValidSync(Fish complexBody, Context context) {
+        putValidSyncWithResponse(complexBody, context, Context.NONE);
     }
 
     private static final ClientLogger LOGGER = new ClientLogger(Polymorphicrecursives.class);

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Polymorphisms.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Polymorphisms.java
@@ -307,7 +307,7 @@ public final class Polymorphisms {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Fish getValidSync(Context context) {
-        return getValidSyncWithResponse(context, Context.NONE).getValue();
+        return getValidSyncWithResponse(context).getValue();
     }
 
     /**
@@ -505,7 +505,7 @@ public final class Polymorphisms {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValidSync(Fish complexBody, Context context) {
-        putValidSyncWithResponse(complexBody, context, Context.NONE);
+        putValidSyncWithResponse(complexBody, context);
     }
 
     /**
@@ -631,7 +631,7 @@ public final class Polymorphisms {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DotFish getDotSyntaxSync(Context context) {
-        return getDotSyntaxSyncWithResponse(context, Context.NONE).getValue();
+        return getDotSyntaxSyncWithResponse(context).getValue();
     }
 
     /**
@@ -772,7 +772,7 @@ public final class Polymorphisms {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DotFishMarket getComposedWithDiscriminatorSync(Context context) {
-        return getComposedWithDiscriminatorSyncWithResponse(context, Context.NONE).getValue();
+        return getComposedWithDiscriminatorSyncWithResponse(context).getValue();
     }
 
     /**
@@ -914,7 +914,7 @@ public final class Polymorphisms {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DotFishMarket getComposedWithoutDiscriminatorSync(Context context) {
-        return getComposedWithoutDiscriminatorSyncWithResponse(context, Context.NONE).getValue();
+        return getComposedWithoutDiscriminatorSyncWithResponse(context).getValue();
     }
 
     /**
@@ -1046,7 +1046,7 @@ public final class Polymorphisms {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Salmon getComplicatedSync(Context context) {
-        return getComplicatedSyncWithResponse(context, Context.NONE).getValue();
+        return getComplicatedSyncWithResponse(context).getValue();
     }
 
     /**
@@ -1205,7 +1205,7 @@ public final class Polymorphisms {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putComplicatedSync(Salmon complexBody, Context context) {
-        putComplicatedSyncWithResponse(complexBody, context, Context.NONE);
+        putComplicatedSyncWithResponse(complexBody, context);
     }
 
     /**
@@ -1367,7 +1367,7 @@ public final class Polymorphisms {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Salmon putMissingDiscriminatorSync(Salmon complexBody, Context context) {
-        return putMissingDiscriminatorSyncWithResponse(complexBody, context, Context.NONE).getValue();
+        return putMissingDiscriminatorSyncWithResponse(complexBody, context).getValue();
     }
 
     /**
@@ -1566,7 +1566,7 @@ public final class Polymorphisms {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValidMissingRequiredSync(Fish complexBody, Context context) {
-        putValidMissingRequiredSyncWithResponse(complexBody, context, Context.NONE);
+        putValidMissingRequiredSyncWithResponse(complexBody, context);
     }
 
     private static final ClientLogger LOGGER = new ClientLogger(Polymorphisms.class);

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Polymorphisms.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Polymorphisms.java
@@ -206,6 +206,25 @@ public final class Polymorphisms {
     /**
      * Get complex types that are polymorphic.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that are polymorphic along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Fish>> getValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types that are polymorphic.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types that are polymorphic on successful completion of {@link Mono}.
@@ -213,6 +232,20 @@ public final class Polymorphisms {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Fish> getValidAsync() {
         return getValidWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types that are polymorphic.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that are polymorphic on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Fish> getValidAsync(Context context) {
+        return getValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -235,13 +268,46 @@ public final class Polymorphisms {
     /**
      * Get complex types that are polymorphic.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that are polymorphic along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Fish> getValidSyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getValidSync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types that are polymorphic.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types that are polymorphic.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Fish getValidSync() {
-        return getValidSyncWithResponse().getValue();
+        return getValidSyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get complex types that are polymorphic.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that are polymorphic.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Fish getValidSync(Context context) {
+        return getValidSyncWithResponse(context, Context.NONE).getValue();
     }
 
     /**
@@ -283,6 +349,37 @@ public final class Polymorphisms {
      *     'birthday': '1900-01-05T01:00:00Z', 'length':10.0, 'picture': new Buffer([255, 255, 255, 255,
      *     254]).toString('base64'), 'species':'dangerous', }, { 'fishtype': 'goblin', 'age': 1, 'birthday':
      *     '2015-08-08T00:00:00Z', 'length': 30.0, 'species': 'scary', 'jawsize': 5 } ] };.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putValidWithResponseAsync(Fish complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putValid(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types that are polymorphic.
+     *
+     * @param complexBody Please put a salmon that looks like this: { 'fishtype':'Salmon', 'location':'alaska',
+     *     'iswild':true, 'species':'king', 'length':1.0, 'siblings':[ { 'fishtype':'Shark', 'age':6, 'birthday':
+     *     '2012-01-05T01:00:00Z', 'length':20.0, 'species':'predator', }, { 'fishtype':'Sawshark', 'age':105,
+     *     'birthday': '1900-01-05T01:00:00Z', 'length':10.0, 'picture': new Buffer([255, 255, 255, 255,
+     *     254]).toString('base64'), 'species':'dangerous', }, { 'fishtype': 'goblin', 'age': 1, 'birthday':
+     *     '2015-08-08T00:00:00Z', 'length': 30.0, 'species': 'scary', 'jawsize': 5 } ] };.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -291,6 +388,26 @@ public final class Polymorphisms {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putValidAsync(Fish complexBody) {
         return putValidWithResponseAsync(complexBody).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types that are polymorphic.
+     *
+     * @param complexBody Please put a salmon that looks like this: { 'fishtype':'Salmon', 'location':'alaska',
+     *     'iswild':true, 'species':'king', 'length':1.0, 'siblings':[ { 'fishtype':'Shark', 'age':6, 'birthday':
+     *     '2012-01-05T01:00:00Z', 'length':20.0, 'species':'predator', }, { 'fishtype':'Sawshark', 'age':105,
+     *     'birthday': '1900-01-05T01:00:00Z', 'length':10.0, 'picture': new Buffer([255, 255, 255, 255,
+     *     254]).toString('base64'), 'species':'dangerous', }, { 'fishtype': 'goblin', 'age': 1, 'birthday':
+     *     '2015-08-08T00:00:00Z', 'length': 30.0, 'species': 'scary', 'jawsize': 5 } ] };.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putValidAsync(Fish complexBody, Context context) {
+        return putValidWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
     }
 
     /**
@@ -332,13 +449,63 @@ public final class Polymorphisms {
      *     'birthday': '1900-01-05T01:00:00Z', 'length':10.0, 'picture': new Buffer([255, 255, 255, 255,
      *     254]).toString('base64'), 'species':'dangerous', }, { 'fishtype': 'goblin', 'age': 1, 'birthday':
      *     '2015-08-08T00:00:00Z', 'length': 30.0, 'species': 'scary', 'jawsize': 5 } ] };.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> putValidSyncWithResponse(Fish complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putValidSync(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types that are polymorphic.
+     *
+     * @param complexBody Please put a salmon that looks like this: { 'fishtype':'Salmon', 'location':'alaska',
+     *     'iswild':true, 'species':'king', 'length':1.0, 'siblings':[ { 'fishtype':'Shark', 'age':6, 'birthday':
+     *     '2012-01-05T01:00:00Z', 'length':20.0, 'species':'predator', }, { 'fishtype':'Sawshark', 'age':105,
+     *     'birthday': '1900-01-05T01:00:00Z', 'length':10.0, 'picture': new Buffer([255, 255, 255, 255,
+     *     254]).toString('base64'), 'species':'dangerous', }, { 'fishtype': 'goblin', 'age': 1, 'birthday':
+     *     '2015-08-08T00:00:00Z', 'length': 30.0, 'species': 'scary', 'jawsize': 5 } ] };.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValidSync(Fish complexBody) {
-        putValidSyncWithResponse(complexBody);
+        putValidSyncWithResponse(complexBody, Context.NONE);
+    }
+
+    /**
+     * Put complex types that are polymorphic.
+     *
+     * @param complexBody Please put a salmon that looks like this: { 'fishtype':'Salmon', 'location':'alaska',
+     *     'iswild':true, 'species':'king', 'length':1.0, 'siblings':[ { 'fishtype':'Shark', 'age':6, 'birthday':
+     *     '2012-01-05T01:00:00Z', 'length':20.0, 'species':'predator', }, { 'fishtype':'Sawshark', 'age':105,
+     *     'birthday': '1900-01-05T01:00:00Z', 'length':10.0, 'picture': new Buffer([255, 255, 255, 255,
+     *     254]).toString('base64'), 'species':'dangerous', }, { 'fishtype': 'goblin', 'age': 1, 'birthday':
+     *     '2015-08-08T00:00:00Z', 'length': 30.0, 'species': 'scary', 'jawsize': 5 } ] };.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putValidSync(Fish complexBody, Context context) {
+        putValidSyncWithResponse(complexBody, context, Context.NONE);
     }
 
     /**
@@ -362,6 +529,26 @@ public final class Polymorphisms {
     /**
      * Get complex types that are polymorphic, JSON key contains a dot.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that are polymorphic, JSON key contains a dot along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<DotFish>> getDotSyntaxWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDotSyntax(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types that are polymorphic, JSON key contains a dot.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types that are polymorphic, JSON key contains a dot on successful completion of {@link Mono}.
@@ -369,6 +556,20 @@ public final class Polymorphisms {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<DotFish> getDotSyntaxAsync() {
         return getDotSyntaxWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types that are polymorphic, JSON key contains a dot.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that are polymorphic, JSON key contains a dot on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<DotFish> getDotSyntaxAsync(Context context) {
+        return getDotSyntaxWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -391,13 +592,46 @@ public final class Polymorphisms {
     /**
      * Get complex types that are polymorphic, JSON key contains a dot.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that are polymorphic, JSON key contains a dot along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<DotFish> getDotSyntaxSyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDotSyntaxSync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types that are polymorphic, JSON key contains a dot.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types that are polymorphic, JSON key contains a dot.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DotFish getDotSyntaxSync() {
-        return getDotSyntaxSyncWithResponse().getValue();
+        return getDotSyntaxSyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get complex types that are polymorphic, JSON key contains a dot.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that are polymorphic, JSON key contains a dot.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public DotFish getDotSyntaxSync(Context context) {
+        return getDotSyntaxSyncWithResponse(context, Context.NONE).getValue();
     }
 
     /**
@@ -424,6 +658,27 @@ public final class Polymorphisms {
      * Get complex object composing a polymorphic scalar property and array property with polymorphic element type, with
      * discriminator specified. Deserialization must NOT fail and use the discriminator type specified on the wire.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex object composing a polymorphic scalar property and array property with polymorphic element type,
+     *     with discriminator specified along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<DotFishMarket>> getComposedWithDiscriminatorWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getComposedWithDiscriminator(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex object composing a polymorphic scalar property and array property with polymorphic element type, with
+     * discriminator specified. Deserialization must NOT fail and use the discriminator type specified on the wire.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex object composing a polymorphic scalar property and array property with polymorphic element type,
@@ -432,6 +687,22 @@ public final class Polymorphisms {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<DotFishMarket> getComposedWithDiscriminatorAsync() {
         return getComposedWithDiscriminatorWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex object composing a polymorphic scalar property and array property with polymorphic element type, with
+     * discriminator specified. Deserialization must NOT fail and use the discriminator type specified on the wire.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex object composing a polymorphic scalar property and array property with polymorphic element type,
+     *     with discriminator specified on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<DotFishMarket> getComposedWithDiscriminatorAsync(Context context) {
+        return getComposedWithDiscriminatorWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -457,6 +728,27 @@ public final class Polymorphisms {
      * Get complex object composing a polymorphic scalar property and array property with polymorphic element type, with
      * discriminator specified. Deserialization must NOT fail and use the discriminator type specified on the wire.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex object composing a polymorphic scalar property and array property with polymorphic element type,
+     *     with discriminator specified along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<DotFishMarket> getComposedWithDiscriminatorSyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getComposedWithDiscriminatorSync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex object composing a polymorphic scalar property and array property with polymorphic element type, with
+     * discriminator specified. Deserialization must NOT fail and use the discriminator type specified on the wire.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex object composing a polymorphic scalar property and array property with polymorphic element type,
@@ -464,7 +756,23 @@ public final class Polymorphisms {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DotFishMarket getComposedWithDiscriminatorSync() {
-        return getComposedWithDiscriminatorSyncWithResponse().getValue();
+        return getComposedWithDiscriminatorSyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get complex object composing a polymorphic scalar property and array property with polymorphic element type, with
+     * discriminator specified. Deserialization must NOT fail and use the discriminator type specified on the wire.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex object composing a polymorphic scalar property and array property with polymorphic element type,
+     *     with discriminator specified.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public DotFishMarket getComposedWithDiscriminatorSync(Context context) {
+        return getComposedWithDiscriminatorSyncWithResponse(context, Context.NONE).getValue();
     }
 
     /**
@@ -491,6 +799,27 @@ public final class Polymorphisms {
      * Get complex object composing a polymorphic scalar property and array property with polymorphic element type,
      * without discriminator specified on wire. Deserialization must NOT fail and use the explicit type of the property.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex object composing a polymorphic scalar property and array property with polymorphic element type,
+     *     without discriminator specified on wire along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<DotFishMarket>> getComposedWithoutDiscriminatorWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getComposedWithoutDiscriminator(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex object composing a polymorphic scalar property and array property with polymorphic element type,
+     * without discriminator specified on wire. Deserialization must NOT fail and use the explicit type of the property.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex object composing a polymorphic scalar property and array property with polymorphic element type,
@@ -499,6 +828,23 @@ public final class Polymorphisms {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<DotFishMarket> getComposedWithoutDiscriminatorAsync() {
         return getComposedWithoutDiscriminatorWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex object composing a polymorphic scalar property and array property with polymorphic element type,
+     * without discriminator specified on wire. Deserialization must NOT fail and use the explicit type of the property.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex object composing a polymorphic scalar property and array property with polymorphic element type,
+     *     without discriminator specified on wire on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<DotFishMarket> getComposedWithoutDiscriminatorAsync(Context context) {
+        return getComposedWithoutDiscriminatorWithResponseAsync(context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -524,6 +870,27 @@ public final class Polymorphisms {
      * Get complex object composing a polymorphic scalar property and array property with polymorphic element type,
      * without discriminator specified on wire. Deserialization must NOT fail and use the explicit type of the property.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex object composing a polymorphic scalar property and array property with polymorphic element type,
+     *     without discriminator specified on wire along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<DotFishMarket> getComposedWithoutDiscriminatorSyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getComposedWithoutDiscriminatorSync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex object composing a polymorphic scalar property and array property with polymorphic element type,
+     * without discriminator specified on wire. Deserialization must NOT fail and use the explicit type of the property.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex object composing a polymorphic scalar property and array property with polymorphic element type,
@@ -531,7 +898,23 @@ public final class Polymorphisms {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DotFishMarket getComposedWithoutDiscriminatorSync() {
-        return getComposedWithoutDiscriminatorSyncWithResponse().getValue();
+        return getComposedWithoutDiscriminatorSyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get complex object composing a polymorphic scalar property and array property with polymorphic element type,
+     * without discriminator specified on wire. Deserialization must NOT fail and use the explicit type of the property.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex object composing a polymorphic scalar property and array property with polymorphic element type,
+     *     without discriminator specified on wire.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public DotFishMarket getComposedWithoutDiscriminatorSync(Context context) {
+        return getComposedWithoutDiscriminatorSyncWithResponse(context, Context.NONE).getValue();
     }
 
     /**
@@ -555,6 +938,26 @@ public final class Polymorphisms {
     /**
      * Get complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties
+     *     along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Salmon>> getComplicatedWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getComplicated(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties
@@ -563,6 +966,21 @@ public final class Polymorphisms {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Salmon> getComplicatedAsync() {
         return getComplicatedWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties
+     *     on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Salmon> getComplicatedAsync(Context context) {
+        return getComplicatedWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -586,6 +1004,26 @@ public final class Polymorphisms {
     /**
      * Get complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties
+     *     along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Salmon> getComplicatedSyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getComplicatedSync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types that are polymorphic, but not at the root of the hierarchy; also have additional
@@ -593,7 +1031,22 @@ public final class Polymorphisms {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Salmon getComplicatedSync() {
-        return getComplicatedSyncWithResponse().getValue();
+        return getComplicatedSyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that are polymorphic, but not at the root of the hierarchy; also have additional
+     *     properties.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Salmon getComplicatedSync(Context context) {
+        return getComplicatedSyncWithResponse(context, Context.NONE).getValue();
     }
 
     /**
@@ -626,6 +1079,32 @@ public final class Polymorphisms {
      * Put complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties.
      *
      * @param complexBody The complexBody parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putComplicatedWithResponseAsync(Salmon complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putComplicated(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties.
+     *
+     * @param complexBody The complexBody parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -634,6 +1113,21 @@ public final class Polymorphisms {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putComplicatedAsync(Salmon complexBody) {
         return putComplicatedWithResponseAsync(complexBody).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties.
+     *
+     * @param complexBody The complexBody parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putComplicatedAsync(Salmon complexBody, Context context) {
+        return putComplicatedWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
     }
 
     /**
@@ -665,13 +1159,53 @@ public final class Polymorphisms {
      * Put complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties.
      *
      * @param complexBody The complexBody parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> putComplicatedSyncWithResponse(Salmon complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putComplicatedSync(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties.
+     *
+     * @param complexBody The complexBody parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putComplicatedSync(Salmon complexBody) {
-        putComplicatedSyncWithResponse(complexBody);
+        putComplicatedSyncWithResponse(complexBody, Context.NONE);
+    }
+
+    /**
+     * Put complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties.
+     *
+     * @param complexBody The complexBody parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putComplicatedSync(Salmon complexBody, Context context) {
+        putComplicatedSyncWithResponse(complexBody, context, Context.NONE);
     }
 
     /**
@@ -704,6 +1238,32 @@ public final class Polymorphisms {
      * Put complex types that are polymorphic, omitting the discriminator.
      *
      * @param complexBody The complexBody parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Salmon>> putMissingDiscriminatorWithResponseAsync(Salmon complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putMissingDiscriminator(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types that are polymorphic, omitting the discriminator.
+     *
+     * @param complexBody The complexBody parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -712,6 +1272,22 @@ public final class Polymorphisms {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Salmon> putMissingDiscriminatorAsync(Salmon complexBody) {
         return putMissingDiscriminatorWithResponseAsync(complexBody).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Put complex types that are polymorphic, omitting the discriminator.
+     *
+     * @param complexBody The complexBody parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Salmon> putMissingDiscriminatorAsync(Salmon complexBody, Context context) {
+        return putMissingDiscriminatorWithResponseAsync(complexBody, context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -743,6 +1319,32 @@ public final class Polymorphisms {
      * Put complex types that are polymorphic, omitting the discriminator.
      *
      * @param complexBody The complexBody parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Salmon> putMissingDiscriminatorSyncWithResponse(Salmon complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putMissingDiscriminatorSync(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types that are polymorphic, omitting the discriminator.
+     *
+     * @param complexBody The complexBody parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -750,7 +1352,22 @@ public final class Polymorphisms {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Salmon putMissingDiscriminatorSync(Salmon complexBody) {
-        return putMissingDiscriminatorSyncWithResponse(complexBody).getValue();
+        return putMissingDiscriminatorSyncWithResponse(complexBody, Context.NONE).getValue();
+    }
+
+    /**
+     * Put complex types that are polymorphic, omitting the discriminator.
+     *
+     * @param complexBody The complexBody parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Salmon putMissingDiscriminatorSync(Salmon complexBody, Context context) {
+        return putMissingDiscriminatorSyncWithResponse(complexBody, context, Context.NONE).getValue();
     }
 
     /**
@@ -793,6 +1410,37 @@ public final class Polymorphisms {
      *     "2013-06-01T01:00:00Z", "location": "alaska", "picture": base64(FF FF FF FF FE), "siblings": [ { "fishtype":
      *     "shark", "species": "predator", "birthday": "2012-01-05T01:00:00Z", "length": 20, "age": 6 }, { "fishtype":
      *     "sawshark", "species": "dangerous", "picture": base64(FF FF FF FF FE), "length": 10, "age": 105 } ] }.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putValidMissingRequiredWithResponseAsync(Fish complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putValidMissingRequired(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request should not be
+     * allowed from the client.
+     *
+     * @param complexBody Please attempt put a sawshark that looks like this, the client should not allow this data to
+     *     be sent: { "fishtype": "sawshark", "species": "snaggle toothed", "length": 18.5, "age": 2, "birthday":
+     *     "2013-06-01T01:00:00Z", "location": "alaska", "picture": base64(FF FF FF FF FE), "siblings": [ { "fishtype":
+     *     "shark", "species": "predator", "birthday": "2012-01-05T01:00:00Z", "length": 20, "age": 6 }, { "fishtype":
+     *     "sawshark", "species": "dangerous", "picture": base64(FF FF FF FF FE), "length": 10, "age": 105 } ] }.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -801,6 +1449,26 @@ public final class Polymorphisms {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putValidMissingRequiredAsync(Fish complexBody) {
         return putValidMissingRequiredWithResponseAsync(complexBody).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request should not be
+     * allowed from the client.
+     *
+     * @param complexBody Please attempt put a sawshark that looks like this, the client should not allow this data to
+     *     be sent: { "fishtype": "sawshark", "species": "snaggle toothed", "length": 18.5, "age": 2, "birthday":
+     *     "2013-06-01T01:00:00Z", "location": "alaska", "picture": base64(FF FF FF FF FE), "siblings": [ { "fishtype":
+     *     "shark", "species": "predator", "birthday": "2012-01-05T01:00:00Z", "length": 20, "age": 6 }, { "fishtype":
+     *     "sawshark", "species": "dangerous", "picture": base64(FF FF FF FF FE), "length": 10, "age": 105 } ] }.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putValidMissingRequiredAsync(Fish complexBody, Context context) {
+        return putValidMissingRequiredWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
     }
 
     /**
@@ -842,13 +1510,63 @@ public final class Polymorphisms {
      *     "2013-06-01T01:00:00Z", "location": "alaska", "picture": base64(FF FF FF FF FE), "siblings": [ { "fishtype":
      *     "shark", "species": "predator", "birthday": "2012-01-05T01:00:00Z", "length": 20, "age": 6 }, { "fishtype":
      *     "sawshark", "species": "dangerous", "picture": base64(FF FF FF FF FE), "length": 10, "age": 105 } ] }.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> putValidMissingRequiredSyncWithResponse(Fish complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putValidMissingRequiredSync(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request should not be
+     * allowed from the client.
+     *
+     * @param complexBody Please attempt put a sawshark that looks like this, the client should not allow this data to
+     *     be sent: { "fishtype": "sawshark", "species": "snaggle toothed", "length": 18.5, "age": 2, "birthday":
+     *     "2013-06-01T01:00:00Z", "location": "alaska", "picture": base64(FF FF FF FF FE), "siblings": [ { "fishtype":
+     *     "shark", "species": "predator", "birthday": "2012-01-05T01:00:00Z", "length": 20, "age": 6 }, { "fishtype":
+     *     "sawshark", "species": "dangerous", "picture": base64(FF FF FF FF FE), "length": 10, "age": 105 } ] }.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValidMissingRequiredSync(Fish complexBody) {
-        putValidMissingRequiredSyncWithResponse(complexBody);
+        putValidMissingRequiredSyncWithResponse(complexBody, Context.NONE);
+    }
+
+    /**
+     * Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request should not be
+     * allowed from the client.
+     *
+     * @param complexBody Please attempt put a sawshark that looks like this, the client should not allow this data to
+     *     be sent: { "fishtype": "sawshark", "species": "snaggle toothed", "length": 18.5, "age": 2, "birthday":
+     *     "2013-06-01T01:00:00Z", "location": "alaska", "picture": base64(FF FF FF FF FE), "siblings": [ { "fishtype":
+     *     "shark", "species": "predator", "birthday": "2012-01-05T01:00:00Z", "length": 20, "age": 6 }, { "fishtype":
+     *     "sawshark", "species": "dangerous", "picture": base64(FF FF FF FF FE), "length": 10, "age": 105 } ] }.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putValidMissingRequiredSync(Fish complexBody, Context context) {
+        putValidMissingRequiredSyncWithResponse(complexBody, context, Context.NONE);
     }
 
     private static final ClientLogger LOGGER = new ClientLogger(Polymorphisms.class);

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Primitives.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Primitives.java
@@ -514,7 +514,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public IntWrapper getIntSync(Context context) {
-        return getIntSyncWithResponse(context, Context.NONE).getValue();
+        return getIntSyncWithResponse(context).getValue();
     }
 
     /**
@@ -672,7 +672,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putIntSync(IntWrapper complexBody, Context context) {
-        putIntSyncWithResponse(complexBody, context, Context.NONE);
+        putIntSyncWithResponse(complexBody, context);
     }
 
     /**
@@ -796,7 +796,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public LongWrapper getLongSync(Context context) {
-        return getLongSyncWithResponse(context, Context.NONE).getValue();
+        return getLongSyncWithResponse(context).getValue();
     }
 
     /**
@@ -954,7 +954,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putLongSync(LongWrapper complexBody, Context context) {
-        putLongSyncWithResponse(complexBody, context, Context.NONE);
+        putLongSyncWithResponse(complexBody, context);
     }
 
     /**
@@ -1078,7 +1078,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public FloatWrapper getFloatSync(Context context) {
-        return getFloatSyncWithResponse(context, Context.NONE).getValue();
+        return getFloatSyncWithResponse(context).getValue();
     }
 
     /**
@@ -1236,7 +1236,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putFloatSync(FloatWrapper complexBody, Context context) {
-        putFloatSyncWithResponse(complexBody, context, Context.NONE);
+        putFloatSyncWithResponse(complexBody, context);
     }
 
     /**
@@ -1362,7 +1362,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DoubleWrapper getDoubleSync(Context context) {
-        return getDoubleSyncWithResponse(context, Context.NONE).getValue();
+        return getDoubleSyncWithResponse(context).getValue();
     }
 
     /**
@@ -1520,7 +1520,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDoubleSync(DoubleWrapper complexBody, Context context) {
-        putDoubleSyncWithResponse(complexBody, context, Context.NONE);
+        putDoubleSyncWithResponse(complexBody, context);
     }
 
     /**
@@ -1644,7 +1644,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public BooleanWrapper getBoolSync(Context context) {
-        return getBoolSyncWithResponse(context, Context.NONE).getValue();
+        return getBoolSyncWithResponse(context).getValue();
     }
 
     /**
@@ -1802,7 +1802,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putBoolSync(BooleanWrapper complexBody, Context context) {
-        putBoolSyncWithResponse(complexBody, context, Context.NONE);
+        putBoolSyncWithResponse(complexBody, context);
     }
 
     /**
@@ -1928,7 +1928,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public StringWrapper getStringSync(Context context) {
-        return getStringSyncWithResponse(context, Context.NONE).getValue();
+        return getStringSyncWithResponse(context).getValue();
     }
 
     /**
@@ -2086,7 +2086,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putStringSync(StringWrapper complexBody, Context context) {
-        putStringSyncWithResponse(complexBody, context, Context.NONE);
+        putStringSyncWithResponse(complexBody, context);
     }
 
     /**
@@ -2210,7 +2210,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DateWrapper getDateSync(Context context) {
-        return getDateSyncWithResponse(context, Context.NONE).getValue();
+        return getDateSyncWithResponse(context).getValue();
     }
 
     /**
@@ -2368,7 +2368,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDateSync(DateWrapper complexBody, Context context) {
-        putDateSyncWithResponse(complexBody, context, Context.NONE);
+        putDateSyncWithResponse(complexBody, context);
     }
 
     /**
@@ -2494,7 +2494,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DatetimeWrapper getDateTimeSync(Context context) {
-        return getDateTimeSyncWithResponse(context, Context.NONE).getValue();
+        return getDateTimeSyncWithResponse(context).getValue();
     }
 
     /**
@@ -2653,7 +2653,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDateTimeSync(DatetimeWrapper complexBody, Context context) {
-        putDateTimeSyncWithResponse(complexBody, context, Context.NONE);
+        putDateTimeSyncWithResponse(complexBody, context);
     }
 
     /**
@@ -2779,7 +2779,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Datetimerfc1123Wrapper getDateTimeRfc1123Sync(Context context) {
-        return getDateTimeRfc1123SyncWithResponse(context, Context.NONE).getValue();
+        return getDateTimeRfc1123SyncWithResponse(context).getValue();
     }
 
     /**
@@ -2939,7 +2939,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDateTimeRfc1123Sync(Datetimerfc1123Wrapper complexBody, Context context) {
-        putDateTimeRfc1123SyncWithResponse(complexBody, context, Context.NONE);
+        putDateTimeRfc1123SyncWithResponse(complexBody, context);
     }
 
     /**
@@ -3065,7 +3065,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DurationWrapper getDurationSync(Context context) {
-        return getDurationSyncWithResponse(context, Context.NONE).getValue();
+        return getDurationSyncWithResponse(context).getValue();
     }
 
     /**
@@ -3224,7 +3224,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDurationSync(DurationWrapper complexBody, Context context) {
-        putDurationSyncWithResponse(complexBody, context, Context.NONE);
+        putDurationSyncWithResponse(complexBody, context);
     }
 
     /**
@@ -3348,7 +3348,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ByteWrapper getByteSync(Context context) {
-        return getByteSyncWithResponse(context, Context.NONE).getValue();
+        return getByteSyncWithResponse(context).getValue();
     }
 
     /**
@@ -3506,7 +3506,7 @@ public final class Primitives {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putByteSync(ByteWrapper complexBody, Context context) {
-        putByteSyncWithResponse(complexBody, context, Context.NONE);
+        putByteSyncWithResponse(complexBody, context);
     }
 
     private static final ClientLogger LOGGER = new ClientLogger(Primitives.class);

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Primitives.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Primitives.java
@@ -412,6 +412,26 @@ public final class Primitives {
     /**
      * Get complex types with integer properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with integer properties along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<IntWrapper>> getIntWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getInt(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with integer properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with integer properties on successful completion of {@link Mono}.
@@ -419,6 +439,20 @@ public final class Primitives {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<IntWrapper> getIntAsync() {
         return getIntWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with integer properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with integer properties on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<IntWrapper> getIntAsync(Context context) {
+        return getIntWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -441,13 +475,46 @@ public final class Primitives {
     /**
      * Get complex types with integer properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with integer properties along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<IntWrapper> getIntSyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getIntSync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with integer properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with integer properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public IntWrapper getIntSync() {
-        return getIntSyncWithResponse().getValue();
+        return getIntSyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get complex types with integer properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with integer properties.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public IntWrapper getIntSync(Context context) {
+        return getIntSyncWithResponse(context, Context.NONE).getValue();
     }
 
     /**
@@ -479,6 +546,32 @@ public final class Primitives {
      * Put complex types with integer properties.
      *
      * @param complexBody Please put -1 and 2.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putIntWithResponseAsync(IntWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putInt(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with integer properties.
+     *
+     * @param complexBody Please put -1 and 2.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -487,6 +580,21 @@ public final class Primitives {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putIntAsync(IntWrapper complexBody) {
         return putIntWithResponseAsync(complexBody).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with integer properties.
+     *
+     * @param complexBody Please put -1 and 2.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putIntAsync(IntWrapper complexBody, Context context) {
+        return putIntWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
     }
 
     /**
@@ -518,13 +626,53 @@ public final class Primitives {
      * Put complex types with integer properties.
      *
      * @param complexBody Please put -1 and 2.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> putIntSyncWithResponse(IntWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putIntSync(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with integer properties.
+     *
+     * @param complexBody Please put -1 and 2.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putIntSync(IntWrapper complexBody) {
-        putIntSyncWithResponse(complexBody);
+        putIntSyncWithResponse(complexBody, Context.NONE);
+    }
+
+    /**
+     * Put complex types with integer properties.
+     *
+     * @param complexBody Please put -1 and 2.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putIntSync(IntWrapper complexBody, Context context) {
+        putIntSyncWithResponse(complexBody, context, Context.NONE);
     }
 
     /**
@@ -547,6 +695,25 @@ public final class Primitives {
     /**
      * Get complex types with long properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with long properties along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<LongWrapper>> getLongWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getLong(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with long properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with long properties on successful completion of {@link Mono}.
@@ -554,6 +721,20 @@ public final class Primitives {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<LongWrapper> getLongAsync() {
         return getLongWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with long properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with long properties on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<LongWrapper> getLongAsync(Context context) {
+        return getLongWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -576,13 +757,46 @@ public final class Primitives {
     /**
      * Get complex types with long properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with long properties along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<LongWrapper> getLongSyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getLongSync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with long properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with long properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public LongWrapper getLongSync() {
-        return getLongSyncWithResponse().getValue();
+        return getLongSyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get complex types with long properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with long properties.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public LongWrapper getLongSync(Context context) {
+        return getLongSyncWithResponse(context, Context.NONE).getValue();
     }
 
     /**
@@ -614,6 +828,32 @@ public final class Primitives {
      * Put complex types with long properties.
      *
      * @param complexBody Please put 1099511627775 and -999511627788.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putLongWithResponseAsync(LongWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putLong(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with long properties.
+     *
+     * @param complexBody Please put 1099511627775 and -999511627788.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -622,6 +862,21 @@ public final class Primitives {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putLongAsync(LongWrapper complexBody) {
         return putLongWithResponseAsync(complexBody).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with long properties.
+     *
+     * @param complexBody Please put 1099511627775 and -999511627788.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putLongAsync(LongWrapper complexBody, Context context) {
+        return putLongWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
     }
 
     /**
@@ -653,13 +908,53 @@ public final class Primitives {
      * Put complex types with long properties.
      *
      * @param complexBody Please put 1099511627775 and -999511627788.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> putLongSyncWithResponse(LongWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putLongSync(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with long properties.
+     *
+     * @param complexBody Please put 1099511627775 and -999511627788.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putLongSync(LongWrapper complexBody) {
-        putLongSyncWithResponse(complexBody);
+        putLongSyncWithResponse(complexBody, Context.NONE);
+    }
+
+    /**
+     * Put complex types with long properties.
+     *
+     * @param complexBody Please put 1099511627775 and -999511627788.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putLongSync(LongWrapper complexBody, Context context) {
+        putLongSyncWithResponse(complexBody, context, Context.NONE);
     }
 
     /**
@@ -682,6 +977,25 @@ public final class Primitives {
     /**
      * Get complex types with float properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with float properties along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<FloatWrapper>> getFloatWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getFloat(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with float properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with float properties on successful completion of {@link Mono}.
@@ -689,6 +1003,20 @@ public final class Primitives {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<FloatWrapper> getFloatAsync() {
         return getFloatWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with float properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with float properties on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<FloatWrapper> getFloatAsync(Context context) {
+        return getFloatWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -711,13 +1039,46 @@ public final class Primitives {
     /**
      * Get complex types with float properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with float properties along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<FloatWrapper> getFloatSyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getFloatSync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with float properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with float properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public FloatWrapper getFloatSync() {
-        return getFloatSyncWithResponse().getValue();
+        return getFloatSyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get complex types with float properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with float properties.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public FloatWrapper getFloatSync(Context context) {
+        return getFloatSyncWithResponse(context, Context.NONE).getValue();
     }
 
     /**
@@ -749,6 +1110,32 @@ public final class Primitives {
      * Put complex types with float properties.
      *
      * @param complexBody Please put 1.05 and -0.003.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putFloatWithResponseAsync(FloatWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putFloat(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with float properties.
+     *
+     * @param complexBody Please put 1.05 and -0.003.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -757,6 +1144,21 @@ public final class Primitives {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putFloatAsync(FloatWrapper complexBody) {
         return putFloatWithResponseAsync(complexBody).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with float properties.
+     *
+     * @param complexBody Please put 1.05 and -0.003.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putFloatAsync(FloatWrapper complexBody, Context context) {
+        return putFloatWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
     }
 
     /**
@@ -788,13 +1190,53 @@ public final class Primitives {
      * Put complex types with float properties.
      *
      * @param complexBody Please put 1.05 and -0.003.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> putFloatSyncWithResponse(FloatWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putFloatSync(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with float properties.
+     *
+     * @param complexBody Please put 1.05 and -0.003.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putFloatSync(FloatWrapper complexBody) {
-        putFloatSyncWithResponse(complexBody);
+        putFloatSyncWithResponse(complexBody, Context.NONE);
+    }
+
+    /**
+     * Put complex types with float properties.
+     *
+     * @param complexBody Please put 1.05 and -0.003.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putFloatSync(FloatWrapper complexBody, Context context) {
+        putFloatSyncWithResponse(complexBody, context, Context.NONE);
     }
 
     /**
@@ -818,6 +1260,26 @@ public final class Primitives {
     /**
      * Get complex types with double properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with double properties along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<DoubleWrapper>> getDoubleWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDouble(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with double properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with double properties on successful completion of {@link Mono}.
@@ -825,6 +1287,20 @@ public final class Primitives {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<DoubleWrapper> getDoubleAsync() {
         return getDoubleWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with double properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with double properties on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<DoubleWrapper> getDoubleAsync(Context context) {
+        return getDoubleWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -847,13 +1323,46 @@ public final class Primitives {
     /**
      * Get complex types with double properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with double properties along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<DoubleWrapper> getDoubleSyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDoubleSync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with double properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with double properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DoubleWrapper getDoubleSync() {
-        return getDoubleSyncWithResponse().getValue();
+        return getDoubleSyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get complex types with double properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with double properties.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public DoubleWrapper getDoubleSync(Context context) {
+        return getDoubleSyncWithResponse(context, Context.NONE).getValue();
     }
 
     /**
@@ -885,6 +1394,32 @@ public final class Primitives {
      * Put complex types with double properties.
      *
      * @param complexBody Please put 3e-100 and -0.000000000000000000000000000000000000000000000000000000005.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putDoubleWithResponseAsync(DoubleWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putDouble(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with double properties.
+     *
+     * @param complexBody Please put 3e-100 and -0.000000000000000000000000000000000000000000000000000000005.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -893,6 +1428,21 @@ public final class Primitives {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putDoubleAsync(DoubleWrapper complexBody) {
         return putDoubleWithResponseAsync(complexBody).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with double properties.
+     *
+     * @param complexBody Please put 3e-100 and -0.000000000000000000000000000000000000000000000000000000005.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putDoubleAsync(DoubleWrapper complexBody, Context context) {
+        return putDoubleWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
     }
 
     /**
@@ -924,13 +1474,53 @@ public final class Primitives {
      * Put complex types with double properties.
      *
      * @param complexBody Please put 3e-100 and -0.000000000000000000000000000000000000000000000000000000005.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> putDoubleSyncWithResponse(DoubleWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putDoubleSync(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with double properties.
+     *
+     * @param complexBody Please put 3e-100 and -0.000000000000000000000000000000000000000000000000000000005.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDoubleSync(DoubleWrapper complexBody) {
-        putDoubleSyncWithResponse(complexBody);
+        putDoubleSyncWithResponse(complexBody, Context.NONE);
+    }
+
+    /**
+     * Put complex types with double properties.
+     *
+     * @param complexBody Please put 3e-100 and -0.000000000000000000000000000000000000000000000000000000005.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putDoubleSync(DoubleWrapper complexBody, Context context) {
+        putDoubleSyncWithResponse(complexBody, context, Context.NONE);
     }
 
     /**
@@ -953,6 +1543,25 @@ public final class Primitives {
     /**
      * Get complex types with bool properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with bool properties along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BooleanWrapper>> getBoolWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getBool(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with bool properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with bool properties on successful completion of {@link Mono}.
@@ -960,6 +1569,20 @@ public final class Primitives {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<BooleanWrapper> getBoolAsync() {
         return getBoolWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with bool properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with bool properties on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<BooleanWrapper> getBoolAsync(Context context) {
+        return getBoolWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -982,13 +1605,46 @@ public final class Primitives {
     /**
      * Get complex types with bool properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with bool properties along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<BooleanWrapper> getBoolSyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getBoolSync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with bool properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with bool properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public BooleanWrapper getBoolSync() {
-        return getBoolSyncWithResponse().getValue();
+        return getBoolSyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get complex types with bool properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with bool properties.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public BooleanWrapper getBoolSync(Context context) {
+        return getBoolSyncWithResponse(context, Context.NONE).getValue();
     }
 
     /**
@@ -1020,6 +1676,32 @@ public final class Primitives {
      * Put complex types with bool properties.
      *
      * @param complexBody Please put true and false.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putBoolWithResponseAsync(BooleanWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putBool(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with bool properties.
+     *
+     * @param complexBody Please put true and false.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1028,6 +1710,21 @@ public final class Primitives {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putBoolAsync(BooleanWrapper complexBody) {
         return putBoolWithResponseAsync(complexBody).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with bool properties.
+     *
+     * @param complexBody Please put true and false.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putBoolAsync(BooleanWrapper complexBody, Context context) {
+        return putBoolWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
     }
 
     /**
@@ -1059,13 +1756,53 @@ public final class Primitives {
      * Put complex types with bool properties.
      *
      * @param complexBody Please put true and false.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> putBoolSyncWithResponse(BooleanWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putBoolSync(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with bool properties.
+     *
+     * @param complexBody Please put true and false.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putBoolSync(BooleanWrapper complexBody) {
-        putBoolSyncWithResponse(complexBody);
+        putBoolSyncWithResponse(complexBody, Context.NONE);
+    }
+
+    /**
+     * Put complex types with bool properties.
+     *
+     * @param complexBody Please put true and false.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putBoolSync(BooleanWrapper complexBody, Context context) {
+        putBoolSyncWithResponse(complexBody, context, Context.NONE);
     }
 
     /**
@@ -1089,6 +1826,26 @@ public final class Primitives {
     /**
      * Get complex types with string properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with string properties along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<StringWrapper>> getStringWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getString(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with string properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with string properties on successful completion of {@link Mono}.
@@ -1096,6 +1853,20 @@ public final class Primitives {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<StringWrapper> getStringAsync() {
         return getStringWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with string properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with string properties on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<StringWrapper> getStringAsync(Context context) {
+        return getStringWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -1118,13 +1889,46 @@ public final class Primitives {
     /**
      * Get complex types with string properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with string properties along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<StringWrapper> getStringSyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getStringSync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with string properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with string properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public StringWrapper getStringSync() {
-        return getStringSyncWithResponse().getValue();
+        return getStringSyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get complex types with string properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with string properties.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public StringWrapper getStringSync(Context context) {
+        return getStringSyncWithResponse(context, Context.NONE).getValue();
     }
 
     /**
@@ -1156,6 +1960,32 @@ public final class Primitives {
      * Put complex types with string properties.
      *
      * @param complexBody Please put 'goodrequest', '', and null.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putStringWithResponseAsync(StringWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putString(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with string properties.
+     *
+     * @param complexBody Please put 'goodrequest', '', and null.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1164,6 +1994,21 @@ public final class Primitives {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putStringAsync(StringWrapper complexBody) {
         return putStringWithResponseAsync(complexBody).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with string properties.
+     *
+     * @param complexBody Please put 'goodrequest', '', and null.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putStringAsync(StringWrapper complexBody, Context context) {
+        return putStringWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
     }
 
     /**
@@ -1195,13 +2040,53 @@ public final class Primitives {
      * Put complex types with string properties.
      *
      * @param complexBody Please put 'goodrequest', '', and null.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> putStringSyncWithResponse(StringWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putStringSync(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with string properties.
+     *
+     * @param complexBody Please put 'goodrequest', '', and null.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putStringSync(StringWrapper complexBody) {
-        putStringSyncWithResponse(complexBody);
+        putStringSyncWithResponse(complexBody, Context.NONE);
+    }
+
+    /**
+     * Put complex types with string properties.
+     *
+     * @param complexBody Please put 'goodrequest', '', and null.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putStringSync(StringWrapper complexBody, Context context) {
+        putStringSyncWithResponse(complexBody, context, Context.NONE);
     }
 
     /**
@@ -1224,6 +2109,25 @@ public final class Primitives {
     /**
      * Get complex types with date properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with date properties along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<DateWrapper>> getDateWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDate(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with date properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with date properties on successful completion of {@link Mono}.
@@ -1231,6 +2135,20 @@ public final class Primitives {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<DateWrapper> getDateAsync() {
         return getDateWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with date properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with date properties on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<DateWrapper> getDateAsync(Context context) {
+        return getDateWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -1253,13 +2171,46 @@ public final class Primitives {
     /**
      * Get complex types with date properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with date properties along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<DateWrapper> getDateSyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDateSync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with date properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with date properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DateWrapper getDateSync() {
-        return getDateSyncWithResponse().getValue();
+        return getDateSyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get complex types with date properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with date properties.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public DateWrapper getDateSync(Context context) {
+        return getDateSyncWithResponse(context, Context.NONE).getValue();
     }
 
     /**
@@ -1291,6 +2242,32 @@ public final class Primitives {
      * Put complex types with date properties.
      *
      * @param complexBody Please put '0001-01-01' and '2016-02-29'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putDateWithResponseAsync(DateWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putDate(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with date properties.
+     *
+     * @param complexBody Please put '0001-01-01' and '2016-02-29'.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1299,6 +2276,21 @@ public final class Primitives {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putDateAsync(DateWrapper complexBody) {
         return putDateWithResponseAsync(complexBody).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with date properties.
+     *
+     * @param complexBody Please put '0001-01-01' and '2016-02-29'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putDateAsync(DateWrapper complexBody, Context context) {
+        return putDateWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
     }
 
     /**
@@ -1330,13 +2322,53 @@ public final class Primitives {
      * Put complex types with date properties.
      *
      * @param complexBody Please put '0001-01-01' and '2016-02-29'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> putDateSyncWithResponse(DateWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putDateSync(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with date properties.
+     *
+     * @param complexBody Please put '0001-01-01' and '2016-02-29'.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDateSync(DateWrapper complexBody) {
-        putDateSyncWithResponse(complexBody);
+        putDateSyncWithResponse(complexBody, Context.NONE);
+    }
+
+    /**
+     * Put complex types with date properties.
+     *
+     * @param complexBody Please put '0001-01-01' and '2016-02-29'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putDateSync(DateWrapper complexBody, Context context) {
+        putDateSyncWithResponse(complexBody, context, Context.NONE);
     }
 
     /**
@@ -1360,6 +2392,26 @@ public final class Primitives {
     /**
      * Get complex types with datetime properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with datetime properties along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<DatetimeWrapper>> getDateTimeWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDateTime(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with datetime properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with datetime properties on successful completion of {@link Mono}.
@@ -1367,6 +2419,20 @@ public final class Primitives {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<DatetimeWrapper> getDateTimeAsync() {
         return getDateTimeWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with datetime properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with datetime properties on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<DatetimeWrapper> getDateTimeAsync(Context context) {
+        return getDateTimeWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -1389,13 +2455,46 @@ public final class Primitives {
     /**
      * Get complex types with datetime properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with datetime properties along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<DatetimeWrapper> getDateTimeSyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDateTimeSync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with datetime properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with datetime properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DatetimeWrapper getDateTimeSync() {
-        return getDateTimeSyncWithResponse().getValue();
+        return getDateTimeSyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get complex types with datetime properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with datetime properties.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public DatetimeWrapper getDateTimeSync(Context context) {
+        return getDateTimeSyncWithResponse(context, Context.NONE).getValue();
     }
 
     /**
@@ -1428,6 +2527,32 @@ public final class Primitives {
      * Put complex types with datetime properties.
      *
      * @param complexBody Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putDateTimeWithResponseAsync(DatetimeWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putDateTime(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with datetime properties.
+     *
+     * @param complexBody Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1436,6 +2561,21 @@ public final class Primitives {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putDateTimeAsync(DatetimeWrapper complexBody) {
         return putDateTimeWithResponseAsync(complexBody).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with datetime properties.
+     *
+     * @param complexBody Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putDateTimeAsync(DatetimeWrapper complexBody, Context context) {
+        return putDateTimeWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
     }
 
     /**
@@ -1467,13 +2607,53 @@ public final class Primitives {
      * Put complex types with datetime properties.
      *
      * @param complexBody Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> putDateTimeSyncWithResponse(DatetimeWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putDateTimeSync(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with datetime properties.
+     *
+     * @param complexBody Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDateTimeSync(DatetimeWrapper complexBody) {
-        putDateTimeSyncWithResponse(complexBody);
+        putDateTimeSyncWithResponse(complexBody, Context.NONE);
+    }
+
+    /**
+     * Put complex types with datetime properties.
+     *
+     * @param complexBody Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putDateTimeSync(DatetimeWrapper complexBody, Context context) {
+        putDateTimeSyncWithResponse(complexBody, context, Context.NONE);
     }
 
     /**
@@ -1497,6 +2677,26 @@ public final class Primitives {
     /**
      * Get complex types with datetimeRfc1123 properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with datetimeRfc1123 properties along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Datetimerfc1123Wrapper>> getDateTimeRfc1123WithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDateTimeRfc1123(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with datetimeRfc1123 properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with datetimeRfc1123 properties on successful completion of {@link Mono}.
@@ -1504,6 +2704,20 @@ public final class Primitives {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Datetimerfc1123Wrapper> getDateTimeRfc1123Async() {
         return getDateTimeRfc1123WithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with datetimeRfc1123 properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with datetimeRfc1123 properties on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Datetimerfc1123Wrapper> getDateTimeRfc1123Async(Context context) {
+        return getDateTimeRfc1123WithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -1526,13 +2740,46 @@ public final class Primitives {
     /**
      * Get complex types with datetimeRfc1123 properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with datetimeRfc1123 properties along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Datetimerfc1123Wrapper> getDateTimeRfc1123SyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDateTimeRfc1123Sync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with datetimeRfc1123 properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with datetimeRfc1123 properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Datetimerfc1123Wrapper getDateTimeRfc1123Sync() {
-        return getDateTimeRfc1123SyncWithResponse().getValue();
+        return getDateTimeRfc1123SyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get complex types with datetimeRfc1123 properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with datetimeRfc1123 properties.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Datetimerfc1123Wrapper getDateTimeRfc1123Sync(Context context) {
+        return getDateTimeRfc1123SyncWithResponse(context, Context.NONE).getValue();
     }
 
     /**
@@ -1565,6 +2812,33 @@ public final class Primitives {
      * Put complex types with datetimeRfc1123 properties.
      *
      * @param complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00 GMT'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putDateTimeRfc1123WithResponseAsync(
+            Datetimerfc1123Wrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putDateTimeRfc1123(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with datetimeRfc1123 properties.
+     *
+     * @param complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00 GMT'.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1573,6 +2847,21 @@ public final class Primitives {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putDateTimeRfc1123Async(Datetimerfc1123Wrapper complexBody) {
         return putDateTimeRfc1123WithResponseAsync(complexBody).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with datetimeRfc1123 properties.
+     *
+     * @param complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00 GMT'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putDateTimeRfc1123Async(Datetimerfc1123Wrapper complexBody, Context context) {
+        return putDateTimeRfc1123WithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
     }
 
     /**
@@ -1604,13 +2893,53 @@ public final class Primitives {
      * Put complex types with datetimeRfc1123 properties.
      *
      * @param complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00 GMT'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> putDateTimeRfc1123SyncWithResponse(Datetimerfc1123Wrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putDateTimeRfc1123Sync(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with datetimeRfc1123 properties.
+     *
+     * @param complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00 GMT'.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDateTimeRfc1123Sync(Datetimerfc1123Wrapper complexBody) {
-        putDateTimeRfc1123SyncWithResponse(complexBody);
+        putDateTimeRfc1123SyncWithResponse(complexBody, Context.NONE);
+    }
+
+    /**
+     * Put complex types with datetimeRfc1123 properties.
+     *
+     * @param complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00 GMT'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putDateTimeRfc1123Sync(Datetimerfc1123Wrapper complexBody, Context context) {
+        putDateTimeRfc1123SyncWithResponse(complexBody, context, Context.NONE);
     }
 
     /**
@@ -1634,6 +2963,26 @@ public final class Primitives {
     /**
      * Get complex types with duration properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with duration properties along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<DurationWrapper>> getDurationWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDuration(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with duration properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with duration properties on successful completion of {@link Mono}.
@@ -1641,6 +2990,20 @@ public final class Primitives {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<DurationWrapper> getDurationAsync() {
         return getDurationWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with duration properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with duration properties on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<DurationWrapper> getDurationAsync(Context context) {
+        return getDurationWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -1663,13 +3026,46 @@ public final class Primitives {
     /**
      * Get complex types with duration properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with duration properties along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<DurationWrapper> getDurationSyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getDurationSync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with duration properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with duration properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DurationWrapper getDurationSync() {
-        return getDurationSyncWithResponse().getValue();
+        return getDurationSyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get complex types with duration properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with duration properties.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public DurationWrapper getDurationSync(Context context) {
+        return getDurationSyncWithResponse(context, Context.NONE).getValue();
     }
 
     /**
@@ -1702,6 +3098,32 @@ public final class Primitives {
      * Put complex types with duration properties.
      *
      * @param complexBody Please put 'P123DT22H14M12.011S'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putDurationWithResponseAsync(DurationWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putDuration(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with duration properties.
+     *
+     * @param complexBody Please put 'P123DT22H14M12.011S'.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1710,6 +3132,21 @@ public final class Primitives {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putDurationAsync(DurationWrapper complexBody) {
         return putDurationWithResponseAsync(complexBody).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with duration properties.
+     *
+     * @param complexBody Please put 'P123DT22H14M12.011S'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putDurationAsync(DurationWrapper complexBody, Context context) {
+        return putDurationWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
     }
 
     /**
@@ -1741,13 +3178,53 @@ public final class Primitives {
      * Put complex types with duration properties.
      *
      * @param complexBody Please put 'P123DT22H14M12.011S'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> putDurationSyncWithResponse(DurationWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putDurationSync(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with duration properties.
+     *
+     * @param complexBody Please put 'P123DT22H14M12.011S'.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDurationSync(DurationWrapper complexBody) {
-        putDurationSyncWithResponse(complexBody);
+        putDurationSyncWithResponse(complexBody, Context.NONE);
+    }
+
+    /**
+     * Put complex types with duration properties.
+     *
+     * @param complexBody Please put 'P123DT22H14M12.011S'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putDurationSync(DurationWrapper complexBody, Context context) {
+        putDurationSyncWithResponse(complexBody, context, Context.NONE);
     }
 
     /**
@@ -1770,6 +3247,25 @@ public final class Primitives {
     /**
      * Get complex types with byte properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with byte properties along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<ByteWrapper>> getByteWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getByte(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with byte properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with byte properties on successful completion of {@link Mono}.
@@ -1777,6 +3273,20 @@ public final class Primitives {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<ByteWrapper> getByteAsync() {
         return getByteWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types with byte properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with byte properties on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<ByteWrapper> getByteAsync(Context context) {
+        return getByteWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -1799,13 +3309,46 @@ public final class Primitives {
     /**
      * Get complex types with byte properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with byte properties along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<ByteWrapper> getByteSyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getByteSync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types with byte properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types with byte properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ByteWrapper getByteSync() {
-        return getByteSyncWithResponse().getValue();
+        return getByteSyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get complex types with byte properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types with byte properties.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public ByteWrapper getByteSync(Context context) {
+        return getByteSyncWithResponse(context, Context.NONE).getValue();
     }
 
     /**
@@ -1837,6 +3380,32 @@ public final class Primitives {
      * Put complex types with byte properties.
      *
      * @param complexBody Please put non-ascii byte string hex(FF FE FD FC 00 FA F9 F8 F7 F6).
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putByteWithResponseAsync(ByteWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putByte(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with byte properties.
+     *
+     * @param complexBody Please put non-ascii byte string hex(FF FE FD FC 00 FA F9 F8 F7 F6).
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1845,6 +3414,21 @@ public final class Primitives {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putByteAsync(ByteWrapper complexBody) {
         return putByteWithResponseAsync(complexBody).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types with byte properties.
+     *
+     * @param complexBody Please put non-ascii byte string hex(FF FE FD FC 00 FA F9 F8 F7 F6).
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putByteAsync(ByteWrapper complexBody, Context context) {
+        return putByteWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
     }
 
     /**
@@ -1876,13 +3460,53 @@ public final class Primitives {
      * Put complex types with byte properties.
      *
      * @param complexBody Please put non-ascii byte string hex(FF FE FD FC 00 FA F9 F8 F7 F6).
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> putByteSyncWithResponse(ByteWrapper complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putByteSync(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types with byte properties.
+     *
+     * @param complexBody Please put non-ascii byte string hex(FF FE FD FC 00 FA F9 F8 F7 F6).
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putByteSync(ByteWrapper complexBody) {
-        putByteSyncWithResponse(complexBody);
+        putByteSyncWithResponse(complexBody, Context.NONE);
+    }
+
+    /**
+     * Put complex types with byte properties.
+     *
+     * @param complexBody Please put non-ascii byte string hex(FF FE FD FC 00 FA F9 F8 F7 F6).
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putByteSync(ByteWrapper complexBody, Context context) {
+        putByteSyncWithResponse(complexBody, context, Context.NONE);
     }
 
     private static final ClientLogger LOGGER = new ClientLogger(Primitives.class);

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Readonlyproperties.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Readonlyproperties.java
@@ -103,6 +103,26 @@ public final class Readonlyproperties {
     /**
      * Get complex types that have readonly properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that have readonly properties along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<ReadonlyObj>> getValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getValid(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types that have readonly properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types that have readonly properties on successful completion of {@link Mono}.
@@ -110,6 +130,20 @@ public final class Readonlyproperties {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<ReadonlyObj> getValidAsync() {
         return getValidWithResponseAsync().flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get complex types that have readonly properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that have readonly properties on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<ReadonlyObj> getValidAsync(Context context) {
+        return getValidWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -132,13 +166,46 @@ public final class Readonlyproperties {
     /**
      * Get complex types that have readonly properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that have readonly properties along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<ReadonlyObj> getValidSyncWithResponse(Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getValidSync(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get complex types that have readonly properties.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return complex types that have readonly properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ReadonlyObj getValidSync() {
-        return getValidSyncWithResponse().getValue();
+        return getValidSyncWithResponse(Context.NONE).getValue();
+    }
+
+    /**
+     * Get complex types that have readonly properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return complex types that have readonly properties.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public ReadonlyObj getValidSync(Context context) {
+        return getValidSyncWithResponse(context, Context.NONE).getValue();
     }
 
     /**
@@ -170,6 +237,32 @@ public final class Readonlyproperties {
      * Put complex types that have readonly properties.
      *
      * @param complexBody The complexBody parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putValidWithResponseAsync(ReadonlyObj complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putValid(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types that have readonly properties.
+     *
+     * @param complexBody The complexBody parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -178,6 +271,21 @@ public final class Readonlyproperties {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putValidAsync(ReadonlyObj complexBody) {
         return putValidWithResponseAsync(complexBody).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put complex types that have readonly properties.
+     *
+     * @param complexBody The complexBody parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putValidAsync(ReadonlyObj complexBody, Context context) {
+        return putValidWithResponseAsync(complexBody, context).flatMap(ignored -> Mono.empty());
     }
 
     /**
@@ -209,13 +317,53 @@ public final class Readonlyproperties {
      * Put complex types that have readonly properties.
      *
      * @param complexBody The complexBody parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> putValidSyncWithResponse(ReadonlyObj complexBody, Context context) {
+        if (this.client.getHost() == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (complexBody == null) {
+            throw LOGGER.logExceptionAsError(
+                    new IllegalArgumentException("Parameter complexBody is required and cannot be null."));
+        } else {
+            complexBody.validate();
+        }
+        final String accept = "application/json";
+        return service.putValidSync(this.client.getHost(), complexBody, accept, context);
+    }
+
+    /**
+     * Put complex types that have readonly properties.
+     *
+     * @param complexBody The complexBody parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValidSync(ReadonlyObj complexBody) {
-        putValidSyncWithResponse(complexBody);
+        putValidSyncWithResponse(complexBody, Context.NONE);
+    }
+
+    /**
+     * Put complex types that have readonly properties.
+     *
+     * @param complexBody The complexBody parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putValidSync(ReadonlyObj complexBody, Context context) {
+        putValidSyncWithResponse(complexBody, context, Context.NONE);
     }
 
     private static final ClientLogger LOGGER = new ClientLogger(Readonlyproperties.class);

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Readonlyproperties.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/Readonlyproperties.java
@@ -205,7 +205,7 @@ public final class Readonlyproperties {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ReadonlyObj getValidSync(Context context) {
-        return getValidSyncWithResponse(context, Context.NONE).getValue();
+        return getValidSyncWithResponse(context).getValue();
     }
 
     /**
@@ -363,7 +363,7 @@ public final class Readonlyproperties {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValidSync(ReadonlyObj complexBody, Context context) {
-        putValidSyncWithResponse(complexBody, context, Context.NONE);
+        putValidSyncWithResponse(complexBody, context);
     }
 
     private static final ClientLogger LOGGER = new ClientLogger(Readonlyproperties.class);

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/Xmls.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/Xmls.java
@@ -333,6 +333,26 @@ public final class Xmls {
     /**
      * Get a complex type that has a ref to a complex type with no XML node.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a complex type that has a ref to a complex type with no XML node along with {@link Response} on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<RootWithRefAndNoMeta>> getComplexTypeRefNoMetaWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/xml";
+        return service.getComplexTypeRefNoMeta(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get a complex type that has a ref to a complex type with no XML node.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a complex type that has a ref to a complex type with no XML node on successful completion of {@link
@@ -346,13 +366,30 @@ public final class Xmls {
     /**
      * Get a complex type that has a ref to a complex type with no XML node.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a complex type that has a ref to a complex type with no XML node on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<RootWithRefAndNoMeta> getComplexTypeRefNoMetaAsync(Context context) {
+        return getComplexTypeRefNoMetaWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get a complex type that has a ref to a complex type with no XML node.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a complex type that has a ref to a complex type with no XML node along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<RootWithRefAndNoMeta> getComplexTypeRefNoMetaWithResponse() {
-        return getComplexTypeRefNoMetaWithResponseAsync().block();
+    public Response<RootWithRefAndNoMeta> getComplexTypeRefNoMetaWithResponse(Context context) {
+        return getComplexTypeRefNoMetaWithResponseAsync(context).block();
     }
 
     /**
@@ -364,7 +401,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public RootWithRefAndNoMeta getComplexTypeRefNoMeta() {
-        return getComplexTypeRefNoMetaWithResponse().getValue();
+        return getComplexTypeRefNoMetaWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -394,6 +431,30 @@ public final class Xmls {
      * Puts a complex type that has a ref to a complex type with no XML node.
      *
      * @param model I am root, and I ref a model with no meta.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putComplexTypeRefNoMetaWithResponseAsync(RootWithRefAndNoMeta model, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (model == null) {
+            return Mono.error(new IllegalArgumentException("Parameter model is required and cannot be null."));
+        } else {
+            model.validate();
+        }
+        return service.putComplexTypeRefNoMeta(this.client.getHost(), model, context);
+    }
+
+    /**
+     * Puts a complex type that has a ref to a complex type with no XML node.
+     *
+     * @param model I am root, and I ref a model with no meta.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -408,14 +469,30 @@ public final class Xmls {
      * Puts a complex type that has a ref to a complex type with no XML node.
      *
      * @param model I am root, and I ref a model with no meta.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putComplexTypeRefNoMetaAsync(RootWithRefAndNoMeta model, Context context) {
+        return putComplexTypeRefNoMetaWithResponseAsync(model, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts a complex type that has a ref to a complex type with no XML node.
+     *
+     * @param model I am root, and I ref a model with no meta.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putComplexTypeRefNoMetaWithResponse(RootWithRefAndNoMeta model) {
-        return putComplexTypeRefNoMetaWithResponseAsync(model).block();
+    public Response<Void> putComplexTypeRefNoMetaWithResponse(RootWithRefAndNoMeta model, Context context) {
+        return putComplexTypeRefNoMetaWithResponseAsync(model, context).block();
     }
 
     /**
@@ -428,7 +505,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putComplexTypeRefNoMeta(RootWithRefAndNoMeta model) {
-        putComplexTypeRefNoMetaWithResponse(model);
+        putComplexTypeRefNoMetaWithResponse(model, Context.NONE);
     }
 
     /**
@@ -453,6 +530,26 @@ public final class Xmls {
     /**
      * Get a complex type that has a ref to a complex type with XML node.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a complex type that has a ref to a complex type with XML node along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<RootWithRefAndMeta>> getComplexTypeRefWithMetaWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/xml";
+        return service.getComplexTypeRefWithMeta(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get a complex type that has a ref to a complex type with XML node.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a complex type that has a ref to a complex type with XML node on successful completion of {@link Mono}.
@@ -465,13 +562,29 @@ public final class Xmls {
     /**
      * Get a complex type that has a ref to a complex type with XML node.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a complex type that has a ref to a complex type with XML node on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<RootWithRefAndMeta> getComplexTypeRefWithMetaAsync(Context context) {
+        return getComplexTypeRefWithMetaWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get a complex type that has a ref to a complex type with XML node.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a complex type that has a ref to a complex type with XML node along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<RootWithRefAndMeta> getComplexTypeRefWithMetaWithResponse() {
-        return getComplexTypeRefWithMetaWithResponseAsync().block();
+    public Response<RootWithRefAndMeta> getComplexTypeRefWithMetaWithResponse(Context context) {
+        return getComplexTypeRefWithMetaWithResponseAsync(context).block();
     }
 
     /**
@@ -483,7 +596,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public RootWithRefAndMeta getComplexTypeRefWithMeta() {
-        return getComplexTypeRefWithMetaWithResponse().getValue();
+        return getComplexTypeRefWithMetaWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -514,6 +627,30 @@ public final class Xmls {
      * Puts a complex type that has a ref to a complex type with XML node.
      *
      * @param model I am root, and I ref a model WITH meta.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putComplexTypeRefWithMetaWithResponseAsync(RootWithRefAndMeta model, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (model == null) {
+            return Mono.error(new IllegalArgumentException("Parameter model is required and cannot be null."));
+        } else {
+            model.validate();
+        }
+        return service.putComplexTypeRefWithMeta(this.client.getHost(), model, context);
+    }
+
+    /**
+     * Puts a complex type that has a ref to a complex type with XML node.
+     *
+     * @param model I am root, and I ref a model WITH meta.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -528,14 +665,30 @@ public final class Xmls {
      * Puts a complex type that has a ref to a complex type with XML node.
      *
      * @param model I am root, and I ref a model WITH meta.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putComplexTypeRefWithMetaAsync(RootWithRefAndMeta model, Context context) {
+        return putComplexTypeRefWithMetaWithResponseAsync(model, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts a complex type that has a ref to a complex type with XML node.
+     *
+     * @param model I am root, and I ref a model WITH meta.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putComplexTypeRefWithMetaWithResponse(RootWithRefAndMeta model) {
-        return putComplexTypeRefWithMetaWithResponseAsync(model).block();
+    public Response<Void> putComplexTypeRefWithMetaWithResponse(RootWithRefAndMeta model, Context context) {
+        return putComplexTypeRefWithMetaWithResponseAsync(model, context).block();
     }
 
     /**
@@ -548,7 +701,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putComplexTypeRefWithMeta(RootWithRefAndMeta model) {
-        putComplexTypeRefWithMetaWithResponse(model);
+        putComplexTypeRefWithMetaWithResponse(model, Context.NONE);
     }
 
     /**
@@ -571,6 +724,25 @@ public final class Xmls {
     /**
      * Get a simple XML document.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a simple XML document along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Slideshow>> getSimpleWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/xml";
+        return service.getSimple(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get a simple XML document.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a simple XML document on successful completion of {@link Mono}.
@@ -583,13 +755,29 @@ public final class Xmls {
     /**
      * Get a simple XML document.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a simple XML document on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Slideshow> getSimpleAsync(Context context) {
+        return getSimpleWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get a simple XML document.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a simple XML document along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Slideshow> getSimpleWithResponse() {
-        return getSimpleWithResponseAsync().block();
+    public Response<Slideshow> getSimpleWithResponse(Context context) {
+        return getSimpleWithResponseAsync(context).block();
     }
 
     /**
@@ -601,7 +789,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Slideshow getSimple() {
-        return getSimpleWithResponse().getValue();
+        return getSimpleWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -632,6 +820,31 @@ public final class Xmls {
      * Put a simple XML document.
      *
      * @param slideshow Data about a slideshow.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putSimpleWithResponseAsync(Slideshow slideshow, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (slideshow == null) {
+            return Mono.error(new IllegalArgumentException("Parameter slideshow is required and cannot be null."));
+        } else {
+            slideshow.validate();
+        }
+        final String accept = "application/xml";
+        return service.putSimple(this.client.getHost(), slideshow, accept, context);
+    }
+
+    /**
+     * Put a simple XML document.
+     *
+     * @param slideshow Data about a slideshow.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -646,14 +859,30 @@ public final class Xmls {
      * Put a simple XML document.
      *
      * @param slideshow Data about a slideshow.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putSimpleAsync(Slideshow slideshow, Context context) {
+        return putSimpleWithResponseAsync(slideshow, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put a simple XML document.
+     *
+     * @param slideshow Data about a slideshow.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putSimpleWithResponse(Slideshow slideshow) {
-        return putSimpleWithResponseAsync(slideshow).block();
+    public Response<Void> putSimpleWithResponse(Slideshow slideshow, Context context) {
+        return putSimpleWithResponseAsync(slideshow, context).block();
     }
 
     /**
@@ -666,7 +895,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putSimple(Slideshow slideshow) {
-        putSimpleWithResponse(slideshow);
+        putSimpleWithResponse(slideshow, Context.NONE);
     }
 
     /**
@@ -690,6 +919,26 @@ public final class Xmls {
     /**
      * Get an XML document with multiple wrapped lists.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an XML document with multiple wrapped lists along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<AppleBarrel>> getWrappedListsWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/xml";
+        return service.getWrappedLists(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get an XML document with multiple wrapped lists.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an XML document with multiple wrapped lists on successful completion of {@link Mono}.
@@ -702,13 +951,29 @@ public final class Xmls {
     /**
      * Get an XML document with multiple wrapped lists.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an XML document with multiple wrapped lists on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<AppleBarrel> getWrappedListsAsync(Context context) {
+        return getWrappedListsWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get an XML document with multiple wrapped lists.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an XML document with multiple wrapped lists along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<AppleBarrel> getWrappedListsWithResponse() {
-        return getWrappedListsWithResponseAsync().block();
+    public Response<AppleBarrel> getWrappedListsWithResponse(Context context) {
+        return getWrappedListsWithResponseAsync(context).block();
     }
 
     /**
@@ -720,7 +985,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public AppleBarrel getWrappedLists() {
-        return getWrappedListsWithResponse().getValue();
+        return getWrappedListsWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -752,6 +1017,31 @@ public final class Xmls {
      * Put an XML document with multiple wrapped lists.
      *
      * @param wrappedLists A barrel of apples.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putWrappedListsWithResponseAsync(AppleBarrel wrappedLists, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (wrappedLists == null) {
+            return Mono.error(new IllegalArgumentException("Parameter wrappedLists is required and cannot be null."));
+        } else {
+            wrappedLists.validate();
+        }
+        final String accept = "application/xml";
+        return service.putWrappedLists(this.client.getHost(), wrappedLists, accept, context);
+    }
+
+    /**
+     * Put an XML document with multiple wrapped lists.
+     *
+     * @param wrappedLists A barrel of apples.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -766,14 +1056,30 @@ public final class Xmls {
      * Put an XML document with multiple wrapped lists.
      *
      * @param wrappedLists A barrel of apples.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putWrappedListsAsync(AppleBarrel wrappedLists, Context context) {
+        return putWrappedListsWithResponseAsync(wrappedLists, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put an XML document with multiple wrapped lists.
+     *
+     * @param wrappedLists A barrel of apples.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putWrappedListsWithResponse(AppleBarrel wrappedLists) {
-        return putWrappedListsWithResponseAsync(wrappedLists).block();
+    public Response<Void> putWrappedListsWithResponse(AppleBarrel wrappedLists, Context context) {
+        return putWrappedListsWithResponseAsync(wrappedLists, context).block();
     }
 
     /**
@@ -786,7 +1092,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putWrappedLists(AppleBarrel wrappedLists) {
-        putWrappedListsWithResponse(wrappedLists);
+        putWrappedListsWithResponse(wrappedLists, Context.NONE);
     }
 
     /**
@@ -808,6 +1114,24 @@ public final class Xmls {
     /**
      * Get strongly-typed response headers.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return strongly-typed response headers on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<XmlsGetHeadersResponse> getHeadersWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.getHeaders(this.client.getHost(), context);
+    }
+
+    /**
+     * Get strongly-typed response headers.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return strongly-typed response headers on successful completion of {@link Mono}.
@@ -820,13 +1144,29 @@ public final class Xmls {
     /**
      * Get strongly-typed response headers.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return strongly-typed response headers on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getHeadersAsync(Context context) {
+        return getHeadersWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get strongly-typed response headers.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return strongly-typed response headers.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public XmlsGetHeadersResponse getHeadersWithResponse() {
-        return getHeadersWithResponseAsync().block();
+    public XmlsGetHeadersResponse getHeadersWithResponse(Context context) {
+        return getHeadersWithResponseAsync(context).block();
     }
 
     /**
@@ -837,7 +1177,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getHeaders() {
-        getHeadersWithResponse();
+        getHeadersWithResponse(Context.NONE);
     }
 
     /**
@@ -860,6 +1200,25 @@ public final class Xmls {
     /**
      * Get an empty list.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an empty list along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Slideshow>> getEmptyListWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/xml";
+        return service.getEmptyList(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get an empty list.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an empty list on successful completion of {@link Mono}.
@@ -872,13 +1231,29 @@ public final class Xmls {
     /**
      * Get an empty list.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an empty list on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Slideshow> getEmptyListAsync(Context context) {
+        return getEmptyListWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get an empty list.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an empty list along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Slideshow> getEmptyListWithResponse() {
-        return getEmptyListWithResponseAsync().block();
+    public Response<Slideshow> getEmptyListWithResponse(Context context) {
+        return getEmptyListWithResponseAsync(context).block();
     }
 
     /**
@@ -890,7 +1265,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Slideshow getEmptyList() {
-        return getEmptyListWithResponse().getValue();
+        return getEmptyListWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -920,6 +1295,30 @@ public final class Xmls {
      * Puts an empty list.
      *
      * @param slideshow Data about a slideshow.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putEmptyListWithResponseAsync(Slideshow slideshow, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (slideshow == null) {
+            return Mono.error(new IllegalArgumentException("Parameter slideshow is required and cannot be null."));
+        } else {
+            slideshow.validate();
+        }
+        return service.putEmptyList(this.client.getHost(), slideshow, context);
+    }
+
+    /**
+     * Puts an empty list.
+     *
+     * @param slideshow Data about a slideshow.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -934,14 +1333,30 @@ public final class Xmls {
      * Puts an empty list.
      *
      * @param slideshow Data about a slideshow.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putEmptyListAsync(Slideshow slideshow, Context context) {
+        return putEmptyListWithResponseAsync(slideshow, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts an empty list.
+     *
+     * @param slideshow Data about a slideshow.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putEmptyListWithResponse(Slideshow slideshow) {
-        return putEmptyListWithResponseAsync(slideshow).block();
+    public Response<Void> putEmptyListWithResponse(Slideshow slideshow, Context context) {
+        return putEmptyListWithResponseAsync(slideshow, context).block();
     }
 
     /**
@@ -954,7 +1369,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putEmptyList(Slideshow slideshow) {
-        putEmptyListWithResponse(slideshow);
+        putEmptyListWithResponse(slideshow, Context.NONE);
     }
 
     /**
@@ -977,6 +1392,25 @@ public final class Xmls {
     /**
      * Gets some empty wrapped lists.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return some empty wrapped lists along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<AppleBarrel>> getEmptyWrappedListsWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/xml";
+        return service.getEmptyWrappedLists(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Gets some empty wrapped lists.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return some empty wrapped lists on successful completion of {@link Mono}.
@@ -989,13 +1423,29 @@ public final class Xmls {
     /**
      * Gets some empty wrapped lists.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return some empty wrapped lists on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<AppleBarrel> getEmptyWrappedListsAsync(Context context) {
+        return getEmptyWrappedListsWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Gets some empty wrapped lists.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return some empty wrapped lists along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<AppleBarrel> getEmptyWrappedListsWithResponse() {
-        return getEmptyWrappedListsWithResponseAsync().block();
+    public Response<AppleBarrel> getEmptyWrappedListsWithResponse(Context context) {
+        return getEmptyWrappedListsWithResponseAsync(context).block();
     }
 
     /**
@@ -1007,7 +1457,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public AppleBarrel getEmptyWrappedLists() {
-        return getEmptyWrappedListsWithResponse().getValue();
+        return getEmptyWrappedListsWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1038,6 +1488,30 @@ public final class Xmls {
      * Puts some empty wrapped lists.
      *
      * @param appleBarrel A barrel of apples.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putEmptyWrappedListsWithResponseAsync(AppleBarrel appleBarrel, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (appleBarrel == null) {
+            return Mono.error(new IllegalArgumentException("Parameter appleBarrel is required and cannot be null."));
+        } else {
+            appleBarrel.validate();
+        }
+        return service.putEmptyWrappedLists(this.client.getHost(), appleBarrel, context);
+    }
+
+    /**
+     * Puts some empty wrapped lists.
+     *
+     * @param appleBarrel A barrel of apples.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1052,14 +1526,30 @@ public final class Xmls {
      * Puts some empty wrapped lists.
      *
      * @param appleBarrel A barrel of apples.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putEmptyWrappedListsAsync(AppleBarrel appleBarrel, Context context) {
+        return putEmptyWrappedListsWithResponseAsync(appleBarrel, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts some empty wrapped lists.
+     *
+     * @param appleBarrel A barrel of apples.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putEmptyWrappedListsWithResponse(AppleBarrel appleBarrel) {
-        return putEmptyWrappedListsWithResponseAsync(appleBarrel).block();
+    public Response<Void> putEmptyWrappedListsWithResponse(AppleBarrel appleBarrel, Context context) {
+        return putEmptyWrappedListsWithResponseAsync(appleBarrel, context).block();
     }
 
     /**
@@ -1072,7 +1562,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putEmptyWrappedLists(AppleBarrel appleBarrel) {
-        putEmptyWrappedListsWithResponse(appleBarrel);
+        putEmptyWrappedListsWithResponse(appleBarrel, Context.NONE);
     }
 
     /**
@@ -1095,6 +1585,25 @@ public final class Xmls {
     /**
      * Gets a list as the root element.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a list as the root element along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Banana>>> getRootListWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/xml";
+        return service.getRootList(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Gets a list as the root element.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a list as the root element on successful completion of {@link Mono}.
@@ -1107,13 +1616,29 @@ public final class Xmls {
     /**
      * Gets a list as the root element.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a list as the root element on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Banana>> getRootListAsync(Context context) {
+        return getRootListWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Gets a list as the root element.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a list as the root element along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Banana>> getRootListWithResponse() {
-        return getRootListWithResponseAsync().block();
+    public Response<List<Banana>> getRootListWithResponse(Context context) {
+        return getRootListWithResponseAsync(context).block();
     }
 
     /**
@@ -1125,7 +1650,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Banana> getRootList() {
-        return getRootListWithResponse().getValue();
+        return getRootListWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1156,6 +1681,31 @@ public final class Xmls {
      * Puts a list as the root element.
      *
      * @param bananas Array of Banana.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putRootListWithResponseAsync(List<Banana> bananas, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (bananas == null) {
+            return Mono.error(new IllegalArgumentException("Parameter bananas is required and cannot be null."));
+        } else {
+            bananas.forEach(e -> e.validate());
+        }
+        BananasWrapper bananasConverted = new BananasWrapper(bananas);
+        return service.putRootList(this.client.getHost(), bananasConverted, context);
+    }
+
+    /**
+     * Puts a list as the root element.
+     *
+     * @param bananas Array of Banana.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1170,14 +1720,30 @@ public final class Xmls {
      * Puts a list as the root element.
      *
      * @param bananas Array of Banana.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putRootListAsync(List<Banana> bananas, Context context) {
+        return putRootListWithResponseAsync(bananas, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts a list as the root element.
+     *
+     * @param bananas Array of Banana.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putRootListWithResponse(List<Banana> bananas) {
-        return putRootListWithResponseAsync(bananas).block();
+    public Response<Void> putRootListWithResponse(List<Banana> bananas, Context context) {
+        return putRootListWithResponseAsync(bananas, context).block();
     }
 
     /**
@@ -1190,7 +1756,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putRootList(List<Banana> bananas) {
-        putRootListWithResponse(bananas);
+        putRootListWithResponse(bananas, Context.NONE);
     }
 
     /**
@@ -1213,6 +1779,25 @@ public final class Xmls {
     /**
      * Gets a list with a single item.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a list with a single item along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Banana>>> getRootListSingleItemWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/xml";
+        return service.getRootListSingleItem(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Gets a list with a single item.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a list with a single item on successful completion of {@link Mono}.
@@ -1225,13 +1810,29 @@ public final class Xmls {
     /**
      * Gets a list with a single item.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a list with a single item on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Banana>> getRootListSingleItemAsync(Context context) {
+        return getRootListSingleItemWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Gets a list with a single item.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a list with a single item along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Banana>> getRootListSingleItemWithResponse() {
-        return getRootListSingleItemWithResponseAsync().block();
+    public Response<List<Banana>> getRootListSingleItemWithResponse(Context context) {
+        return getRootListSingleItemWithResponseAsync(context).block();
     }
 
     /**
@@ -1243,7 +1844,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Banana> getRootListSingleItem() {
-        return getRootListSingleItemWithResponse().getValue();
+        return getRootListSingleItemWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1275,6 +1876,31 @@ public final class Xmls {
      * Puts a list with a single item.
      *
      * @param bananas Array of Banana.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putRootListSingleItemWithResponseAsync(List<Banana> bananas, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (bananas == null) {
+            return Mono.error(new IllegalArgumentException("Parameter bananas is required and cannot be null."));
+        } else {
+            bananas.forEach(e -> e.validate());
+        }
+        BananasWrapper bananasConverted = new BananasWrapper(bananas);
+        return service.putRootListSingleItem(this.client.getHost(), bananasConverted, context);
+    }
+
+    /**
+     * Puts a list with a single item.
+     *
+     * @param bananas Array of Banana.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1289,14 +1915,30 @@ public final class Xmls {
      * Puts a list with a single item.
      *
      * @param bananas Array of Banana.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putRootListSingleItemAsync(List<Banana> bananas, Context context) {
+        return putRootListSingleItemWithResponseAsync(bananas, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts a list with a single item.
+     *
+     * @param bananas Array of Banana.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putRootListSingleItemWithResponse(List<Banana> bananas) {
-        return putRootListSingleItemWithResponseAsync(bananas).block();
+    public Response<Void> putRootListSingleItemWithResponse(List<Banana> bananas, Context context) {
+        return putRootListSingleItemWithResponseAsync(bananas, context).block();
     }
 
     /**
@@ -1309,7 +1951,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putRootListSingleItem(List<Banana> bananas) {
-        putRootListSingleItemWithResponse(bananas);
+        putRootListSingleItemWithResponse(bananas, Context.NONE);
     }
 
     /**
@@ -1332,6 +1974,25 @@ public final class Xmls {
     /**
      * Gets an empty list as the root element.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an empty list as the root element along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Banana>>> getEmptyRootListWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/xml";
+        return service.getEmptyRootList(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Gets an empty list as the root element.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an empty list as the root element on successful completion of {@link Mono}.
@@ -1344,13 +2005,29 @@ public final class Xmls {
     /**
      * Gets an empty list as the root element.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an empty list as the root element on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Banana>> getEmptyRootListAsync(Context context) {
+        return getEmptyRootListWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Gets an empty list as the root element.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an empty list as the root element along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Banana>> getEmptyRootListWithResponse() {
-        return getEmptyRootListWithResponseAsync().block();
+    public Response<List<Banana>> getEmptyRootListWithResponse(Context context) {
+        return getEmptyRootListWithResponseAsync(context).block();
     }
 
     /**
@@ -1362,7 +2039,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Banana> getEmptyRootList() {
-        return getEmptyRootListWithResponse().getValue();
+        return getEmptyRootListWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1394,6 +2071,31 @@ public final class Xmls {
      * Puts an empty list as the root element.
      *
      * @param bananas Array of Banana.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putEmptyRootListWithResponseAsync(List<Banana> bananas, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (bananas == null) {
+            return Mono.error(new IllegalArgumentException("Parameter bananas is required and cannot be null."));
+        } else {
+            bananas.forEach(e -> e.validate());
+        }
+        BananasWrapper bananasConverted = new BananasWrapper(bananas);
+        return service.putEmptyRootList(this.client.getHost(), bananasConverted, context);
+    }
+
+    /**
+     * Puts an empty list as the root element.
+     *
+     * @param bananas Array of Banana.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1408,14 +2110,30 @@ public final class Xmls {
      * Puts an empty list as the root element.
      *
      * @param bananas Array of Banana.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putEmptyRootListAsync(List<Banana> bananas, Context context) {
+        return putEmptyRootListWithResponseAsync(bananas, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts an empty list as the root element.
+     *
+     * @param bananas Array of Banana.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putEmptyRootListWithResponse(List<Banana> bananas) {
-        return putEmptyRootListWithResponseAsync(bananas).block();
+    public Response<Void> putEmptyRootListWithResponse(List<Banana> bananas, Context context) {
+        return putEmptyRootListWithResponseAsync(bananas, context).block();
     }
 
     /**
@@ -1428,7 +2146,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putEmptyRootList(List<Banana> bananas) {
-        putEmptyRootListWithResponse(bananas);
+        putEmptyRootListWithResponse(bananas, Context.NONE);
     }
 
     /**
@@ -1452,6 +2170,26 @@ public final class Xmls {
     /**
      * Gets an XML document with an empty child element.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an XML document with an empty child element along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Banana>> getEmptyChildElementWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/xml";
+        return service.getEmptyChildElement(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Gets an XML document with an empty child element.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an XML document with an empty child element on successful completion of {@link Mono}.
@@ -1464,13 +2202,29 @@ public final class Xmls {
     /**
      * Gets an XML document with an empty child element.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an XML document with an empty child element on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Banana> getEmptyChildElementAsync(Context context) {
+        return getEmptyChildElementWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Gets an XML document with an empty child element.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an XML document with an empty child element along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Banana> getEmptyChildElementWithResponse() {
-        return getEmptyChildElementWithResponseAsync().block();
+    public Response<Banana> getEmptyChildElementWithResponse(Context context) {
+        return getEmptyChildElementWithResponseAsync(context).block();
     }
 
     /**
@@ -1482,7 +2236,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Banana getEmptyChildElement() {
-        return getEmptyChildElementWithResponse().getValue();
+        return getEmptyChildElementWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1512,6 +2266,30 @@ public final class Xmls {
      * Puts a value with an empty child element.
      *
      * @param banana A banana.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putEmptyChildElementWithResponseAsync(Banana banana, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (banana == null) {
+            return Mono.error(new IllegalArgumentException("Parameter banana is required and cannot be null."));
+        } else {
+            banana.validate();
+        }
+        return service.putEmptyChildElement(this.client.getHost(), banana, context);
+    }
+
+    /**
+     * Puts a value with an empty child element.
+     *
+     * @param banana A banana.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1526,14 +2304,30 @@ public final class Xmls {
      * Puts a value with an empty child element.
      *
      * @param banana A banana.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putEmptyChildElementAsync(Banana banana, Context context) {
+        return putEmptyChildElementWithResponseAsync(banana, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts a value with an empty child element.
+     *
+     * @param banana A banana.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putEmptyChildElementWithResponse(Banana banana) {
-        return putEmptyChildElementWithResponseAsync(banana).block();
+    public Response<Void> putEmptyChildElementWithResponse(Banana banana, Context context) {
+        return putEmptyChildElementWithResponseAsync(banana, context).block();
     }
 
     /**
@@ -1546,7 +2340,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putEmptyChildElement(Banana banana) {
-        putEmptyChildElementWithResponse(banana);
+        putEmptyChildElementWithResponse(banana, Context.NONE);
     }
 
     /**
@@ -1570,6 +2364,26 @@ public final class Xmls {
     /**
      * Lists containers in a storage account.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an enumeration of containers along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<ListContainersResponse>> listContainersWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String comp = "list";
+        final String accept = "application/xml";
+        return service.listContainers(this.client.getHost(), comp, accept, context);
+    }
+
+    /**
+     * Lists containers in a storage account.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an enumeration of containers on successful completion of {@link Mono}.
@@ -1582,13 +2396,29 @@ public final class Xmls {
     /**
      * Lists containers in a storage account.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an enumeration of containers on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<ListContainersResponse> listContainersAsync(Context context) {
+        return listContainersWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Lists containers in a storage account.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an enumeration of containers along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<ListContainersResponse> listContainersWithResponse() {
-        return listContainersWithResponseAsync().block();
+    public Response<ListContainersResponse> listContainersWithResponse(Context context) {
+        return listContainersWithResponseAsync(context).block();
     }
 
     /**
@@ -1600,7 +2430,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ListContainersResponse listContainers() {
-        return listContainersWithResponse().getValue();
+        return listContainersWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1626,6 +2456,27 @@ public final class Xmls {
     /**
      * Gets storage service properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return storage service properties along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<StorageServiceProperties>> getServicePropertiesWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String comp = "properties";
+        final String restype = "service";
+        final String accept = "application/xml";
+        return service.getServiceProperties(this.client.getHost(), comp, restype, accept, context);
+    }
+
+    /**
+     * Gets storage service properties.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return storage service properties on successful completion of {@link Mono}.
@@ -1638,13 +2489,29 @@ public final class Xmls {
     /**
      * Gets storage service properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return storage service properties on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<StorageServiceProperties> getServicePropertiesAsync(Context context) {
+        return getServicePropertiesWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Gets storage service properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return storage service properties along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<StorageServiceProperties> getServicePropertiesWithResponse() {
-        return getServicePropertiesWithResponseAsync().block();
+    public Response<StorageServiceProperties> getServicePropertiesWithResponse(Context context) {
+        return getServicePropertiesWithResponseAsync(context).block();
     }
 
     /**
@@ -1656,7 +2523,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public StorageServiceProperties getServiceProperties() {
-        return getServicePropertiesWithResponse().getValue();
+        return getServicePropertiesWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1689,6 +2556,33 @@ public final class Xmls {
      * Puts storage service properties.
      *
      * @param properties Storage Service Properties.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putServicePropertiesWithResponseAsync(
+            StorageServiceProperties properties, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (properties == null) {
+            return Mono.error(new IllegalArgumentException("Parameter properties is required and cannot be null."));
+        } else {
+            properties.validate();
+        }
+        final String comp = "properties";
+        final String restype = "service";
+        return service.putServiceProperties(this.client.getHost(), comp, restype, properties, context);
+    }
+
+    /**
+     * Puts storage service properties.
+     *
+     * @param properties Storage Service Properties.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1703,14 +2597,30 @@ public final class Xmls {
      * Puts storage service properties.
      *
      * @param properties Storage Service Properties.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putServicePropertiesAsync(StorageServiceProperties properties, Context context) {
+        return putServicePropertiesWithResponseAsync(properties, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts storage service properties.
+     *
+     * @param properties Storage Service Properties.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putServicePropertiesWithResponse(StorageServiceProperties properties) {
-        return putServicePropertiesWithResponseAsync(properties).block();
+    public Response<Void> putServicePropertiesWithResponse(StorageServiceProperties properties, Context context) {
+        return putServicePropertiesWithResponseAsync(properties, context).block();
     }
 
     /**
@@ -1723,7 +2633,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putServiceProperties(StorageServiceProperties properties) {
-        putServicePropertiesWithResponse(properties);
+        putServicePropertiesWithResponse(properties, Context.NONE);
     }
 
     /**
@@ -1748,6 +2658,27 @@ public final class Xmls {
     /**
      * Gets storage ACLs for a container.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return storage ACLs for a container along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<SignedIdentifier>>> getAclsWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String comp = "acl";
+        final String restype = "container";
+        final String accept = "application/xml";
+        return service.getAcls(this.client.getHost(), comp, restype, accept, context);
+    }
+
+    /**
+     * Gets storage ACLs for a container.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return storage ACLs for a container on successful completion of {@link Mono}.
@@ -1760,13 +2691,29 @@ public final class Xmls {
     /**
      * Gets storage ACLs for a container.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return storage ACLs for a container on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<SignedIdentifier>> getAclsAsync(Context context) {
+        return getAclsWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Gets storage ACLs for a container.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return storage ACLs for a container along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<SignedIdentifier>> getAclsWithResponse() {
-        return getAclsWithResponseAsync().block();
+    public Response<List<SignedIdentifier>> getAclsWithResponse(Context context) {
+        return getAclsWithResponseAsync(context).block();
     }
 
     /**
@@ -1778,7 +2725,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<SignedIdentifier> getAcls() {
-        return getAclsWithResponse().getValue();
+        return getAclsWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1812,6 +2759,33 @@ public final class Xmls {
      * Puts storage ACLs for a container.
      *
      * @param properties a collection of signed identifiers.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putAclsWithResponseAsync(List<SignedIdentifier> properties, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (properties == null) {
+            return Mono.error(new IllegalArgumentException("Parameter properties is required and cannot be null."));
+        } else {
+            properties.forEach(e -> e.validate());
+        }
+        final String comp = "acl";
+        final String restype = "container";
+        SignedIdentifiersWrapper propertiesConverted = new SignedIdentifiersWrapper(properties);
+        return service.putAcls(this.client.getHost(), comp, restype, propertiesConverted, context);
+    }
+
+    /**
+     * Puts storage ACLs for a container.
+     *
+     * @param properties a collection of signed identifiers.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1826,14 +2800,30 @@ public final class Xmls {
      * Puts storage ACLs for a container.
      *
      * @param properties a collection of signed identifiers.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putAclsAsync(List<SignedIdentifier> properties, Context context) {
+        return putAclsWithResponseAsync(properties, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts storage ACLs for a container.
+     *
+     * @param properties a collection of signed identifiers.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putAclsWithResponse(List<SignedIdentifier> properties) {
-        return putAclsWithResponseAsync(properties).block();
+    public Response<Void> putAclsWithResponse(List<SignedIdentifier> properties, Context context) {
+        return putAclsWithResponseAsync(properties, context).block();
     }
 
     /**
@@ -1846,7 +2836,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putAcls(List<SignedIdentifier> properties) {
-        putAclsWithResponse(properties);
+        putAclsWithResponse(properties, Context.NONE);
     }
 
     /**
@@ -1872,6 +2862,27 @@ public final class Xmls {
     /**
      * Lists blobs in a storage container.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an enumeration of blobs along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<ListBlobsResponse>> listBlobsWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String comp = "list";
+        final String restype = "container";
+        final String accept = "application/xml";
+        return service.listBlobs(this.client.getHost(), comp, restype, accept, context);
+    }
+
+    /**
+     * Lists blobs in a storage container.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an enumeration of blobs on successful completion of {@link Mono}.
@@ -1884,13 +2895,29 @@ public final class Xmls {
     /**
      * Lists blobs in a storage container.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an enumeration of blobs on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<ListBlobsResponse> listBlobsAsync(Context context) {
+        return listBlobsWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Lists blobs in a storage container.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an enumeration of blobs along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<ListBlobsResponse> listBlobsWithResponse() {
-        return listBlobsWithResponseAsync().block();
+    public Response<ListBlobsResponse> listBlobsWithResponse(Context context) {
+        return listBlobsWithResponseAsync(context).block();
     }
 
     /**
@@ -1902,7 +2929,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ListBlobsResponse listBlobs() {
-        return listBlobsWithResponse().getValue();
+        return listBlobsWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1932,6 +2959,30 @@ public final class Xmls {
      * A Swagger with XML that has one operation that takes JSON as input. You need to send the ID number 42.
      *
      * @param properties The properties parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> jsonInputWithResponseAsync(JsonInput properties, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (properties == null) {
+            return Mono.error(new IllegalArgumentException("Parameter properties is required and cannot be null."));
+        } else {
+            properties.validate();
+        }
+        return service.jsonInput(this.client.getHost(), properties, context);
+    }
+
+    /**
+     * A Swagger with XML that has one operation that takes JSON as input. You need to send the ID number 42.
+     *
+     * @param properties The properties parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1946,14 +2997,30 @@ public final class Xmls {
      * A Swagger with XML that has one operation that takes JSON as input. You need to send the ID number 42.
      *
      * @param properties The properties parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> jsonInputAsync(JsonInput properties, Context context) {
+        return jsonInputWithResponseAsync(properties, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * A Swagger with XML that has one operation that takes JSON as input. You need to send the ID number 42.
+     *
+     * @param properties The properties parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> jsonInputWithResponse(JsonInput properties) {
-        return jsonInputWithResponseAsync(properties).block();
+    public Response<Void> jsonInputWithResponse(JsonInput properties, Context context) {
+        return jsonInputWithResponseAsync(properties, context).block();
     }
 
     /**
@@ -1966,7 +3033,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void jsonInput(JsonInput properties) {
-        jsonInputWithResponse(properties);
+        jsonInputWithResponse(properties, Context.NONE);
     }
 
     /**
@@ -1989,6 +3056,25 @@ public final class Xmls {
     /**
      * A Swagger with XML that has one operation that returns JSON. ID number 42.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<JsonOutput>> jsonOutputWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.jsonOutput(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * A Swagger with XML that has one operation that returns JSON. ID number 42.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body on successful completion of {@link Mono}.
@@ -2001,13 +3087,29 @@ public final class Xmls {
     /**
      * A Swagger with XML that has one operation that returns JSON. ID number 42.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<JsonOutput> jsonOutputAsync(Context context) {
+        return jsonOutputWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * A Swagger with XML that has one operation that returns JSON. ID number 42.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<JsonOutput> jsonOutputWithResponse() {
-        return jsonOutputWithResponseAsync().block();
+    public Response<JsonOutput> jsonOutputWithResponse(Context context) {
+        return jsonOutputWithResponseAsync(context).block();
     }
 
     /**
@@ -2019,7 +3121,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public JsonOutput jsonOutput() {
-        return jsonOutputWithResponse().getValue();
+        return jsonOutputWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2046,6 +3148,28 @@ public final class Xmls {
      * Get back an XML object with an x-ms-text property, which should translate to the returned object's 'language'
      * property being 'english' and its 'content' property being 'I am text'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return back an XML object with an x-ms-text property, which should translate to the returned object's 'language'
+     *     property being 'english' and its 'content' property being 'I am text' along with {@link Response} on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<ObjectWithXMsTextProperty>> getXMsTextWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/xml";
+        return service.getXMsText(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get back an XML object with an x-ms-text property, which should translate to the returned object's 'language'
+     * property being 'english' and its 'content' property being 'I am text'.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return back an XML object with an x-ms-text property, which should translate to the returned object's 'language'
@@ -2061,14 +3185,33 @@ public final class Xmls {
      * Get back an XML object with an x-ms-text property, which should translate to the returned object's 'language'
      * property being 'english' and its 'content' property being 'I am text'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return back an XML object with an x-ms-text property, which should translate to the returned object's 'language'
+     *     property being 'english' and its 'content' property being 'I am text' on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<ObjectWithXMsTextProperty> getXMsTextAsync(Context context) {
+        return getXMsTextWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get back an XML object with an x-ms-text property, which should translate to the returned object's 'language'
+     * property being 'english' and its 'content' property being 'I am text'.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return back an XML object with an x-ms-text property, which should translate to the returned object's 'language'
      *     property being 'english' and its 'content' property being 'I am text' along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<ObjectWithXMsTextProperty> getXMsTextWithResponse() {
-        return getXMsTextWithResponseAsync().block();
+    public Response<ObjectWithXMsTextProperty> getXMsTextWithResponse(Context context) {
+        return getXMsTextWithResponseAsync(context).block();
     }
 
     /**
@@ -2082,7 +3225,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ObjectWithXMsTextProperty getXMsText() {
-        return getXMsTextWithResponse().getValue();
+        return getXMsTextWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2106,6 +3249,26 @@ public final class Xmls {
     /**
      * Get an XML document with binary property.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an XML document with binary property along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<ModelWithByteProperty>> getBytesWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/xml";
+        return service.getBytes(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get an XML document with binary property.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an XML document with binary property on successful completion of {@link Mono}.
@@ -2118,13 +3281,29 @@ public final class Xmls {
     /**
      * Get an XML document with binary property.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an XML document with binary property on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<ModelWithByteProperty> getBytesAsync(Context context) {
+        return getBytesWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get an XML document with binary property.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an XML document with binary property along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<ModelWithByteProperty> getBytesWithResponse() {
-        return getBytesWithResponseAsync().block();
+    public Response<ModelWithByteProperty> getBytesWithResponse(Context context) {
+        return getBytesWithResponseAsync(context).block();
     }
 
     /**
@@ -2136,7 +3315,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ModelWithByteProperty getBytes() {
-        return getBytesWithResponse().getValue();
+        return getBytesWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2167,6 +3346,31 @@ public final class Xmls {
      * Put an XML document with binary property.
      *
      * @param slideshow The slideshow parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putBinaryWithResponseAsync(ModelWithByteProperty slideshow, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (slideshow == null) {
+            return Mono.error(new IllegalArgumentException("Parameter slideshow is required and cannot be null."));
+        } else {
+            slideshow.validate();
+        }
+        final String accept = "application/xml";
+        return service.putBinary(this.client.getHost(), slideshow, accept, context);
+    }
+
+    /**
+     * Put an XML document with binary property.
+     *
+     * @param slideshow The slideshow parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -2181,14 +3385,30 @@ public final class Xmls {
      * Put an XML document with binary property.
      *
      * @param slideshow The slideshow parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putBinaryAsync(ModelWithByteProperty slideshow, Context context) {
+        return putBinaryWithResponseAsync(slideshow, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put an XML document with binary property.
+     *
+     * @param slideshow The slideshow parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putBinaryWithResponse(ModelWithByteProperty slideshow) {
-        return putBinaryWithResponseAsync(slideshow).block();
+    public Response<Void> putBinaryWithResponse(ModelWithByteProperty slideshow, Context context) {
+        return putBinaryWithResponseAsync(slideshow, context).block();
     }
 
     /**
@@ -2201,7 +3421,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putBinary(ModelWithByteProperty slideshow) {
-        putBinaryWithResponse(slideshow);
+        putBinaryWithResponse(slideshow, Context.NONE);
     }
 
     /**
@@ -2224,6 +3444,25 @@ public final class Xmls {
     /**
      * Get an XML document with uri property.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an XML document with uri property along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<ModelWithUrlProperty>> getUriWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/xml";
+        return service.getUri(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get an XML document with uri property.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an XML document with uri property on successful completion of {@link Mono}.
@@ -2236,13 +3475,29 @@ public final class Xmls {
     /**
      * Get an XML document with uri property.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an XML document with uri property on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<ModelWithUrlProperty> getUriAsync(Context context) {
+        return getUriWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get an XML document with uri property.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an XML document with uri property along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<ModelWithUrlProperty> getUriWithResponse() {
-        return getUriWithResponseAsync().block();
+    public Response<ModelWithUrlProperty> getUriWithResponse(Context context) {
+        return getUriWithResponseAsync(context).block();
     }
 
     /**
@@ -2254,7 +3509,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ModelWithUrlProperty getUri() {
-        return getUriWithResponse().getValue();
+        return getUriWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2285,6 +3540,31 @@ public final class Xmls {
      * Put an XML document with uri property.
      *
      * @param model The model parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putUriWithResponseAsync(ModelWithUrlProperty model, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (model == null) {
+            return Mono.error(new IllegalArgumentException("Parameter model is required and cannot be null."));
+        } else {
+            model.validate();
+        }
+        final String accept = "application/xml";
+        return service.putUri(this.client.getHost(), model, accept, context);
+    }
+
+    /**
+     * Put an XML document with uri property.
+     *
+     * @param model The model parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -2299,14 +3579,30 @@ public final class Xmls {
      * Put an XML document with uri property.
      *
      * @param model The model parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putUriAsync(ModelWithUrlProperty model, Context context) {
+        return putUriWithResponseAsync(model, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put an XML document with uri property.
+     *
+     * @param model The model parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putUriWithResponse(ModelWithUrlProperty model) {
-        return putUriWithResponseAsync(model).block();
+    public Response<Void> putUriWithResponse(ModelWithUrlProperty model, Context context) {
+        return putUriWithResponseAsync(model, context).block();
     }
 
     /**
@@ -2319,6 +3615,6 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putUri(ModelWithUrlProperty model) {
-        putUriWithResponse(model);
+        putUriWithResponse(model, Context.NONE);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/url/PathItems.java
+++ b/vanilla-tests/src/main/java/fixtures/url/PathItems.java
@@ -167,6 +167,58 @@ public final class PathItems {
      * @param localStringPath should contain value 'localStringPath'.
      * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter.
      * @param localStringQuery should contain value 'localStringQuery'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getAllWithValuesWithResponseAsync(
+            String pathItemStringPath,
+            String localStringPath,
+            String pathItemStringQuery,
+            String localStringQuery,
+            Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (pathItemStringPath == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter pathItemStringPath is required and cannot be null."));
+        }
+        if (this.client.getGlobalStringPath() == null) {
+            return Mono.error(
+                    new IllegalArgumentException(
+                            "Parameter this.client.getGlobalStringPath() is required and cannot be null."));
+        }
+        if (localStringPath == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter localStringPath is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getAllWithValues(
+                this.client.getHost(),
+                pathItemStringPath,
+                pathItemStringQuery,
+                this.client.getGlobalStringPath(),
+                this.client.getGlobalStringQuery(),
+                localStringPath,
+                localStringQuery,
+                accept,
+                context);
+    }
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath',
+     * localStringPath='localStringPath', globalStringQuery='globalStringQuery',
+     * pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
+     *
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path.
+     * @param localStringPath should contain value 'localStringPath'.
+     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter.
+     * @param localStringQuery should contain value 'localStringQuery'.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -210,6 +262,34 @@ public final class PathItems {
      * @param localStringPath should contain value 'localStringPath'.
      * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter.
      * @param localStringQuery should contain value 'localStringQuery'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getAllWithValuesAsync(
+            String pathItemStringPath,
+            String localStringPath,
+            String pathItemStringQuery,
+            String localStringQuery,
+            Context context) {
+        return getAllWithValuesWithResponseAsync(
+                        pathItemStringPath, localStringPath, pathItemStringQuery, localStringQuery, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath',
+     * localStringPath='localStringPath', globalStringQuery='globalStringQuery',
+     * pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
+     *
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path.
+     * @param localStringPath should contain value 'localStringPath'.
+     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter.
+     * @param localStringQuery should contain value 'localStringQuery'.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -217,9 +297,13 @@ public final class PathItems {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> getAllWithValuesWithResponse(
-            String pathItemStringPath, String localStringPath, String pathItemStringQuery, String localStringQuery) {
+            String pathItemStringPath,
+            String localStringPath,
+            String pathItemStringQuery,
+            String localStringQuery,
+            Context context) {
         return getAllWithValuesWithResponseAsync(
-                        pathItemStringPath, localStringPath, pathItemStringQuery, localStringQuery)
+                        pathItemStringPath, localStringPath, pathItemStringQuery, localStringQuery, context)
                 .block();
     }
 
@@ -239,7 +323,8 @@ public final class PathItems {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getAllWithValues(
             String pathItemStringPath, String localStringPath, String pathItemStringQuery, String localStringQuery) {
-        getAllWithValuesWithResponse(pathItemStringPath, localStringPath, pathItemStringQuery, localStringQuery);
+        getAllWithValuesWithResponse(
+                pathItemStringPath, localStringPath, pathItemStringQuery, localStringQuery, Context.NONE);
     }
 
     /**
@@ -257,7 +342,8 @@ public final class PathItems {
     public void getAllWithValues(String pathItemStringPath, String localStringPath) {
         final String pathItemStringQuery = null;
         final String localStringQuery = null;
-        getAllWithValuesWithResponse(pathItemStringPath, localStringPath, pathItemStringQuery, localStringQuery);
+        getAllWithValuesWithResponse(
+                pathItemStringPath, localStringPath, pathItemStringQuery, localStringQuery, Context.NONE);
     }
 
     /**
@@ -318,6 +404,58 @@ public final class PathItems {
      * @param localStringPath should contain value 'localStringPath'.
      * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter.
      * @param localStringQuery should contain value 'localStringQuery'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getGlobalQueryNullWithResponseAsync(
+            String pathItemStringPath,
+            String localStringPath,
+            String pathItemStringQuery,
+            String localStringQuery,
+            Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (pathItemStringPath == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter pathItemStringPath is required and cannot be null."));
+        }
+        if (this.client.getGlobalStringPath() == null) {
+            return Mono.error(
+                    new IllegalArgumentException(
+                            "Parameter this.client.getGlobalStringPath() is required and cannot be null."));
+        }
+        if (localStringPath == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter localStringPath is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getGlobalQueryNull(
+                this.client.getHost(),
+                pathItemStringPath,
+                pathItemStringQuery,
+                this.client.getGlobalStringPath(),
+                this.client.getGlobalStringQuery(),
+                localStringPath,
+                localStringQuery,
+                accept,
+                context);
+    }
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath',
+     * localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery',
+     * localStringQuery='localStringQuery'.
+     *
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path.
+     * @param localStringPath should contain value 'localStringPath'.
+     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter.
+     * @param localStringQuery should contain value 'localStringQuery'.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -361,6 +499,34 @@ public final class PathItems {
      * @param localStringPath should contain value 'localStringPath'.
      * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter.
      * @param localStringQuery should contain value 'localStringQuery'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getGlobalQueryNullAsync(
+            String pathItemStringPath,
+            String localStringPath,
+            String pathItemStringQuery,
+            String localStringQuery,
+            Context context) {
+        return getGlobalQueryNullWithResponseAsync(
+                        pathItemStringPath, localStringPath, pathItemStringQuery, localStringQuery, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath',
+     * localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery',
+     * localStringQuery='localStringQuery'.
+     *
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path.
+     * @param localStringPath should contain value 'localStringPath'.
+     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter.
+     * @param localStringQuery should contain value 'localStringQuery'.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -368,9 +534,13 @@ public final class PathItems {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> getGlobalQueryNullWithResponse(
-            String pathItemStringPath, String localStringPath, String pathItemStringQuery, String localStringQuery) {
+            String pathItemStringPath,
+            String localStringPath,
+            String pathItemStringQuery,
+            String localStringQuery,
+            Context context) {
         return getGlobalQueryNullWithResponseAsync(
-                        pathItemStringPath, localStringPath, pathItemStringQuery, localStringQuery)
+                        pathItemStringPath, localStringPath, pathItemStringQuery, localStringQuery, context)
                 .block();
     }
 
@@ -390,7 +560,8 @@ public final class PathItems {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getGlobalQueryNull(
             String pathItemStringPath, String localStringPath, String pathItemStringQuery, String localStringQuery) {
-        getGlobalQueryNullWithResponse(pathItemStringPath, localStringPath, pathItemStringQuery, localStringQuery);
+        getGlobalQueryNullWithResponse(
+                pathItemStringPath, localStringPath, pathItemStringQuery, localStringQuery, Context.NONE);
     }
 
     /**
@@ -408,7 +579,8 @@ public final class PathItems {
     public void getGlobalQueryNull(String pathItemStringPath, String localStringPath) {
         final String pathItemStringQuery = null;
         final String localStringQuery = null;
-        getGlobalQueryNullWithResponse(pathItemStringPath, localStringPath, pathItemStringQuery, localStringQuery);
+        getGlobalQueryNullWithResponse(
+                pathItemStringPath, localStringPath, pathItemStringQuery, localStringQuery, Context.NONE);
     }
 
     /**
@@ -469,6 +641,58 @@ public final class PathItems {
      * @param localStringPath should contain value 'localStringPath'.
      * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter.
      * @param localStringQuery should contain null value.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getGlobalAndLocalQueryNullWithResponseAsync(
+            String pathItemStringPath,
+            String localStringPath,
+            String pathItemStringQuery,
+            String localStringQuery,
+            Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (pathItemStringPath == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter pathItemStringPath is required and cannot be null."));
+        }
+        if (this.client.getGlobalStringPath() == null) {
+            return Mono.error(
+                    new IllegalArgumentException(
+                            "Parameter this.client.getGlobalStringPath() is required and cannot be null."));
+        }
+        if (localStringPath == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter localStringPath is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getGlobalAndLocalQueryNull(
+                this.client.getHost(),
+                pathItemStringPath,
+                pathItemStringQuery,
+                this.client.getGlobalStringPath(),
+                this.client.getGlobalStringQuery(),
+                localStringPath,
+                localStringQuery,
+                accept,
+                context);
+    }
+
+    /**
+     * send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath',
+     * localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery',
+     * localStringQuery=null.
+     *
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path.
+     * @param localStringPath should contain value 'localStringPath'.
+     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter.
+     * @param localStringQuery should contain null value.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -512,6 +736,34 @@ public final class PathItems {
      * @param localStringPath should contain value 'localStringPath'.
      * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter.
      * @param localStringQuery should contain null value.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getGlobalAndLocalQueryNullAsync(
+            String pathItemStringPath,
+            String localStringPath,
+            String pathItemStringQuery,
+            String localStringQuery,
+            Context context) {
+        return getGlobalAndLocalQueryNullWithResponseAsync(
+                        pathItemStringPath, localStringPath, pathItemStringQuery, localStringQuery, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath',
+     * localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery',
+     * localStringQuery=null.
+     *
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path.
+     * @param localStringPath should contain value 'localStringPath'.
+     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter.
+     * @param localStringQuery should contain null value.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -519,9 +771,13 @@ public final class PathItems {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> getGlobalAndLocalQueryNullWithResponse(
-            String pathItemStringPath, String localStringPath, String pathItemStringQuery, String localStringQuery) {
+            String pathItemStringPath,
+            String localStringPath,
+            String pathItemStringQuery,
+            String localStringQuery,
+            Context context) {
         return getGlobalAndLocalQueryNullWithResponseAsync(
-                        pathItemStringPath, localStringPath, pathItemStringQuery, localStringQuery)
+                        pathItemStringPath, localStringPath, pathItemStringQuery, localStringQuery, context)
                 .block();
     }
 
@@ -542,7 +798,7 @@ public final class PathItems {
     public void getGlobalAndLocalQueryNull(
             String pathItemStringPath, String localStringPath, String pathItemStringQuery, String localStringQuery) {
         getGlobalAndLocalQueryNullWithResponse(
-                pathItemStringPath, localStringPath, pathItemStringQuery, localStringQuery);
+                pathItemStringPath, localStringPath, pathItemStringQuery, localStringQuery, Context.NONE);
     }
 
     /**
@@ -561,7 +817,7 @@ public final class PathItems {
         final String pathItemStringQuery = null;
         final String localStringQuery = null;
         getGlobalAndLocalQueryNullWithResponse(
-                pathItemStringPath, localStringPath, pathItemStringQuery, localStringQuery);
+                pathItemStringPath, localStringPath, pathItemStringQuery, localStringQuery, Context.NONE);
     }
 
     /**
@@ -622,6 +878,58 @@ public final class PathItems {
      * @param localStringPath should contain value 'localStringPath'.
      * @param pathItemStringQuery should contain value null.
      * @param localStringQuery should contain value null.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getLocalPathItemQueryNullWithResponseAsync(
+            String pathItemStringPath,
+            String localStringPath,
+            String pathItemStringQuery,
+            String localStringQuery,
+            Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (pathItemStringPath == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter pathItemStringPath is required and cannot be null."));
+        }
+        if (this.client.getGlobalStringPath() == null) {
+            return Mono.error(
+                    new IllegalArgumentException(
+                            "Parameter this.client.getGlobalStringPath() is required and cannot be null."));
+        }
+        if (localStringPath == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter localStringPath is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getLocalPathItemQueryNull(
+                this.client.getHost(),
+                pathItemStringPath,
+                pathItemStringQuery,
+                this.client.getGlobalStringPath(),
+                this.client.getGlobalStringQuery(),
+                localStringPath,
+                localStringQuery,
+                accept,
+                context);
+    }
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath',
+     * localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null,
+     * localStringQuery=null.
+     *
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path.
+     * @param localStringPath should contain value 'localStringPath'.
+     * @param pathItemStringQuery should contain value null.
+     * @param localStringQuery should contain value null.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -665,6 +973,34 @@ public final class PathItems {
      * @param localStringPath should contain value 'localStringPath'.
      * @param pathItemStringQuery should contain value null.
      * @param localStringQuery should contain value null.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getLocalPathItemQueryNullAsync(
+            String pathItemStringPath,
+            String localStringPath,
+            String pathItemStringQuery,
+            String localStringQuery,
+            Context context) {
+        return getLocalPathItemQueryNullWithResponseAsync(
+                        pathItemStringPath, localStringPath, pathItemStringQuery, localStringQuery, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath',
+     * localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null,
+     * localStringQuery=null.
+     *
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path.
+     * @param localStringPath should contain value 'localStringPath'.
+     * @param pathItemStringQuery should contain value null.
+     * @param localStringQuery should contain value null.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -672,9 +1008,13 @@ public final class PathItems {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> getLocalPathItemQueryNullWithResponse(
-            String pathItemStringPath, String localStringPath, String pathItemStringQuery, String localStringQuery) {
+            String pathItemStringPath,
+            String localStringPath,
+            String pathItemStringQuery,
+            String localStringQuery,
+            Context context) {
         return getLocalPathItemQueryNullWithResponseAsync(
-                        pathItemStringPath, localStringPath, pathItemStringQuery, localStringQuery)
+                        pathItemStringPath, localStringPath, pathItemStringQuery, localStringQuery, context)
                 .block();
     }
 
@@ -695,7 +1035,7 @@ public final class PathItems {
     public void getLocalPathItemQueryNull(
             String pathItemStringPath, String localStringPath, String pathItemStringQuery, String localStringQuery) {
         getLocalPathItemQueryNullWithResponse(
-                pathItemStringPath, localStringPath, pathItemStringQuery, localStringQuery);
+                pathItemStringPath, localStringPath, pathItemStringQuery, localStringQuery, Context.NONE);
     }
 
     /**
@@ -714,6 +1054,6 @@ public final class PathItems {
         final String pathItemStringQuery = null;
         final String localStringQuery = null;
         getLocalPathItemQueryNullWithResponse(
-                pathItemStringPath, localStringPath, pathItemStringQuery, localStringQuery);
+                pathItemStringPath, localStringPath, pathItemStringQuery, localStringQuery, Context.NONE);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/url/Paths.java
+++ b/vanilla-tests/src/main/java/fixtures/url/Paths.java
@@ -321,6 +321,26 @@ public final class Paths {
     /**
      * Get true Boolean value on path.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return true Boolean value on path along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getBooleanTrueWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final boolean boolPath = true;
+        final String accept = "application/json";
+        return service.getBooleanTrue(this.client.getHost(), boolPath, accept, context);
+    }
+
+    /**
+     * Get true Boolean value on path.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return true Boolean value on path on successful completion of {@link Mono}.
@@ -333,13 +353,29 @@ public final class Paths {
     /**
      * Get true Boolean value on path.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return true Boolean value on path on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getBooleanTrueAsync(Context context) {
+        return getBooleanTrueWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get true Boolean value on path.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return true Boolean value on path along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getBooleanTrueWithResponse() {
-        return getBooleanTrueWithResponseAsync().block();
+    public Response<Void> getBooleanTrueWithResponse(Context context) {
+        return getBooleanTrueWithResponseAsync(context).block();
     }
 
     /**
@@ -350,7 +386,7 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getBooleanTrue() {
-        getBooleanTrueWithResponse();
+        getBooleanTrueWithResponse(Context.NONE);
     }
 
     /**
@@ -375,6 +411,26 @@ public final class Paths {
     /**
      * Get false Boolean value on path.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return false Boolean value on path along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getBooleanFalseWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final boolean boolPath = false;
+        final String accept = "application/json";
+        return service.getBooleanFalse(this.client.getHost(), boolPath, accept, context);
+    }
+
+    /**
+     * Get false Boolean value on path.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return false Boolean value on path on successful completion of {@link Mono}.
@@ -387,13 +443,29 @@ public final class Paths {
     /**
      * Get false Boolean value on path.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return false Boolean value on path on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getBooleanFalseAsync(Context context) {
+        return getBooleanFalseWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get false Boolean value on path.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return false Boolean value on path along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getBooleanFalseWithResponse() {
-        return getBooleanFalseWithResponseAsync().block();
+    public Response<Void> getBooleanFalseWithResponse(Context context) {
+        return getBooleanFalseWithResponseAsync(context).block();
     }
 
     /**
@@ -404,7 +476,7 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getBooleanFalse() {
-        getBooleanFalseWithResponse();
+        getBooleanFalseWithResponse(Context.NONE);
     }
 
     /**
@@ -429,6 +501,26 @@ public final class Paths {
     /**
      * Get '1000000' integer value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '1000000' integer value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getIntOneMillionWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final int intPath = 1000000;
+        final String accept = "application/json";
+        return service.getIntOneMillion(this.client.getHost(), intPath, accept, context);
+    }
+
+    /**
+     * Get '1000000' integer value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '1000000' integer value on successful completion of {@link Mono}.
@@ -441,13 +533,29 @@ public final class Paths {
     /**
      * Get '1000000' integer value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '1000000' integer value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getIntOneMillionAsync(Context context) {
+        return getIntOneMillionWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get '1000000' integer value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '1000000' integer value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getIntOneMillionWithResponse() {
-        return getIntOneMillionWithResponseAsync().block();
+    public Response<Void> getIntOneMillionWithResponse(Context context) {
+        return getIntOneMillionWithResponseAsync(context).block();
     }
 
     /**
@@ -458,7 +566,7 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getIntOneMillion() {
-        getIntOneMillionWithResponse();
+        getIntOneMillionWithResponse(Context.NONE);
     }
 
     /**
@@ -483,6 +591,26 @@ public final class Paths {
     /**
      * Get '-1000000' integer value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '-1000000' integer value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getIntNegativeOneMillionWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final int intPath = -1000000;
+        final String accept = "application/json";
+        return service.getIntNegativeOneMillion(this.client.getHost(), intPath, accept, context);
+    }
+
+    /**
+     * Get '-1000000' integer value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '-1000000' integer value on successful completion of {@link Mono}.
@@ -495,13 +623,29 @@ public final class Paths {
     /**
      * Get '-1000000' integer value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '-1000000' integer value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getIntNegativeOneMillionAsync(Context context) {
+        return getIntNegativeOneMillionWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get '-1000000' integer value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '-1000000' integer value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getIntNegativeOneMillionWithResponse() {
-        return getIntNegativeOneMillionWithResponseAsync().block();
+    public Response<Void> getIntNegativeOneMillionWithResponse(Context context) {
+        return getIntNegativeOneMillionWithResponseAsync(context).block();
     }
 
     /**
@@ -512,7 +656,7 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getIntNegativeOneMillion() {
-        getIntNegativeOneMillionWithResponse();
+        getIntNegativeOneMillionWithResponse(Context.NONE);
     }
 
     /**
@@ -536,6 +680,26 @@ public final class Paths {
     /**
      * Get '10000000000' 64 bit integer value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '10000000000' 64 bit integer value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getTenBillionWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final long longPath = 10000000000L;
+        final String accept = "application/json";
+        return service.getTenBillion(this.client.getHost(), longPath, accept, context);
+    }
+
+    /**
+     * Get '10000000000' 64 bit integer value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '10000000000' 64 bit integer value on successful completion of {@link Mono}.
@@ -548,13 +712,29 @@ public final class Paths {
     /**
      * Get '10000000000' 64 bit integer value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '10000000000' 64 bit integer value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getTenBillionAsync(Context context) {
+        return getTenBillionWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get '10000000000' 64 bit integer value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '10000000000' 64 bit integer value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getTenBillionWithResponse() {
-        return getTenBillionWithResponseAsync().block();
+    public Response<Void> getTenBillionWithResponse(Context context) {
+        return getTenBillionWithResponseAsync(context).block();
     }
 
     /**
@@ -565,7 +745,7 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getTenBillion() {
-        getTenBillionWithResponse();
+        getTenBillionWithResponse(Context.NONE);
     }
 
     /**
@@ -590,6 +770,26 @@ public final class Paths {
     /**
      * Get '-10000000000' 64 bit integer value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '-10000000000' 64 bit integer value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getNegativeTenBillionWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final long longPath = -10000000000L;
+        final String accept = "application/json";
+        return service.getNegativeTenBillion(this.client.getHost(), longPath, accept, context);
+    }
+
+    /**
+     * Get '-10000000000' 64 bit integer value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '-10000000000' 64 bit integer value on successful completion of {@link Mono}.
@@ -602,13 +802,29 @@ public final class Paths {
     /**
      * Get '-10000000000' 64 bit integer value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '-10000000000' 64 bit integer value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getNegativeTenBillionAsync(Context context) {
+        return getNegativeTenBillionWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get '-10000000000' 64 bit integer value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '-10000000000' 64 bit integer value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getNegativeTenBillionWithResponse() {
-        return getNegativeTenBillionWithResponseAsync().block();
+    public Response<Void> getNegativeTenBillionWithResponse(Context context) {
+        return getNegativeTenBillionWithResponseAsync(context).block();
     }
 
     /**
@@ -619,7 +835,7 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getNegativeTenBillion() {
-        getNegativeTenBillionWithResponse();
+        getNegativeTenBillionWithResponse(Context.NONE);
     }
 
     /**
@@ -644,6 +860,26 @@ public final class Paths {
     /**
      * Get '1.034E+20' numeric value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '1.034E+20' numeric value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> floatScientificPositiveWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final float floatPath = 103400000000000000000f;
+        final String accept = "application/json";
+        return service.floatScientificPositive(this.client.getHost(), floatPath, accept, context);
+    }
+
+    /**
+     * Get '1.034E+20' numeric value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '1.034E+20' numeric value on successful completion of {@link Mono}.
@@ -656,13 +892,29 @@ public final class Paths {
     /**
      * Get '1.034E+20' numeric value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '1.034E+20' numeric value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> floatScientificPositiveAsync(Context context) {
+        return floatScientificPositiveWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get '1.034E+20' numeric value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '1.034E+20' numeric value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> floatScientificPositiveWithResponse() {
-        return floatScientificPositiveWithResponseAsync().block();
+    public Response<Void> floatScientificPositiveWithResponse(Context context) {
+        return floatScientificPositiveWithResponseAsync(context).block();
     }
 
     /**
@@ -673,7 +925,7 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void floatScientificPositive() {
-        floatScientificPositiveWithResponse();
+        floatScientificPositiveWithResponse(Context.NONE);
     }
 
     /**
@@ -698,6 +950,26 @@ public final class Paths {
     /**
      * Get '-1.034E-20' numeric value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '-1.034E-20' numeric value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> floatScientificNegativeWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final float floatPath = -1.034E-20f;
+        final String accept = "application/json";
+        return service.floatScientificNegative(this.client.getHost(), floatPath, accept, context);
+    }
+
+    /**
+     * Get '-1.034E-20' numeric value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '-1.034E-20' numeric value on successful completion of {@link Mono}.
@@ -710,13 +982,29 @@ public final class Paths {
     /**
      * Get '-1.034E-20' numeric value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '-1.034E-20' numeric value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> floatScientificNegativeAsync(Context context) {
+        return floatScientificNegativeWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get '-1.034E-20' numeric value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '-1.034E-20' numeric value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> floatScientificNegativeWithResponse() {
-        return floatScientificNegativeWithResponseAsync().block();
+    public Response<Void> floatScientificNegativeWithResponse(Context context) {
+        return floatScientificNegativeWithResponseAsync(context).block();
     }
 
     /**
@@ -727,7 +1015,7 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void floatScientificNegative() {
-        floatScientificNegativeWithResponse();
+        floatScientificNegativeWithResponse(Context.NONE);
     }
 
     /**
@@ -752,6 +1040,26 @@ public final class Paths {
     /**
      * Get '9999999.999' numeric value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '9999999.999' numeric value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> doubleDecimalPositiveWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final double doublePath = 9999999.999;
+        final String accept = "application/json";
+        return service.doubleDecimalPositive(this.client.getHost(), doublePath, accept, context);
+    }
+
+    /**
+     * Get '9999999.999' numeric value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '9999999.999' numeric value on successful completion of {@link Mono}.
@@ -764,13 +1072,29 @@ public final class Paths {
     /**
      * Get '9999999.999' numeric value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '9999999.999' numeric value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> doubleDecimalPositiveAsync(Context context) {
+        return doubleDecimalPositiveWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get '9999999.999' numeric value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '9999999.999' numeric value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> doubleDecimalPositiveWithResponse() {
-        return doubleDecimalPositiveWithResponseAsync().block();
+    public Response<Void> doubleDecimalPositiveWithResponse(Context context) {
+        return doubleDecimalPositiveWithResponseAsync(context).block();
     }
 
     /**
@@ -781,7 +1105,7 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void doubleDecimalPositive() {
-        doubleDecimalPositiveWithResponse();
+        doubleDecimalPositiveWithResponse(Context.NONE);
     }
 
     /**
@@ -806,6 +1130,26 @@ public final class Paths {
     /**
      * Get '-9999999.999' numeric value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '-9999999.999' numeric value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> doubleDecimalNegativeWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final double doublePath = -9999999.999;
+        final String accept = "application/json";
+        return service.doubleDecimalNegative(this.client.getHost(), doublePath, accept, context);
+    }
+
+    /**
+     * Get '-9999999.999' numeric value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '-9999999.999' numeric value on successful completion of {@link Mono}.
@@ -818,13 +1162,29 @@ public final class Paths {
     /**
      * Get '-9999999.999' numeric value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '-9999999.999' numeric value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> doubleDecimalNegativeAsync(Context context) {
+        return doubleDecimalNegativeWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get '-9999999.999' numeric value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '-9999999.999' numeric value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> doubleDecimalNegativeWithResponse() {
-        return doubleDecimalNegativeWithResponseAsync().block();
+    public Response<Void> doubleDecimalNegativeWithResponse(Context context) {
+        return doubleDecimalNegativeWithResponseAsync(context).block();
     }
 
     /**
@@ -835,7 +1195,7 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void doubleDecimalNegative() {
-        doubleDecimalNegativeWithResponse();
+        doubleDecimalNegativeWithResponse(Context.NONE);
     }
 
     /**
@@ -861,6 +1221,27 @@ public final class Paths {
     /**
      * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> stringUnicodeWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String stringPath = "啊齄丂狛狜隣郎隣兀﨩";
+        final String accept = "application/json";
+        return service.stringUnicode(this.client.getHost(), stringPath, accept, context);
+    }
+
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value on successful completion of {@link Mono}.
@@ -873,13 +1254,29 @@ public final class Paths {
     /**
      * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> stringUnicodeAsync(Context context) {
+        return stringUnicodeWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> stringUnicodeWithResponse() {
-        return stringUnicodeWithResponseAsync().block();
+    public Response<Void> stringUnicodeWithResponse(Context context) {
+        return stringUnicodeWithResponseAsync(context).block();
     }
 
     /**
@@ -890,7 +1287,7 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void stringUnicode() {
-        stringUnicodeWithResponse();
+        stringUnicodeWithResponse(Context.NONE);
     }
 
     /**
@@ -915,6 +1312,26 @@ public final class Paths {
     /**
      * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return 'begin!*'();:@ &amp;=+$,/?#[]end along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> stringUrlEncodedWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String stringPath = "begin!*'();:@ &=+$,/?#[]end";
+        final String accept = "application/json";
+        return service.stringUrlEncoded(this.client.getHost(), stringPath, accept, context);
+    }
+
+    /**
+     * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return 'begin!*'();:@ &amp;=+$,/?#[]end on successful completion of {@link Mono}.
@@ -927,13 +1344,29 @@ public final class Paths {
     /**
      * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return 'begin!*'();:@ &amp;=+$,/?#[]end on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> stringUrlEncodedAsync(Context context) {
+        return stringUrlEncodedWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return 'begin!*'();:@ &amp;=+$,/?#[]end along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> stringUrlEncodedWithResponse() {
-        return stringUrlEncodedWithResponseAsync().block();
+    public Response<Void> stringUrlEncodedWithResponse(Context context) {
+        return stringUrlEncodedWithResponseAsync(context).block();
     }
 
     /**
@@ -944,7 +1377,7 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void stringUrlEncoded() {
-        stringUrlEncodedWithResponse();
+        stringUrlEncodedWithResponse(Context.NONE);
     }
 
     /**
@@ -973,6 +1406,28 @@ public final class Paths {
      *
      * <p>https://tools.ietf.org/html/rfc3986#appendix-A 'path' accept any 'pchar' not encoded.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> stringUrlNonEncodedWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String stringPath = "begin!*'();:@&=+$,end";
+        final String accept = "application/json";
+        return service.stringUrlNonEncoded(this.client.getHost(), stringPath, accept, context);
+    }
+
+    /**
+     * Get 'begin!*'();:@&amp;=+$,end
+     *
+     * <p>https://tools.ietf.org/html/rfc3986#appendix-A 'path' accept any 'pchar' not encoded.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -987,13 +1442,31 @@ public final class Paths {
      *
      * <p>https://tools.ietf.org/html/rfc3986#appendix-A 'path' accept any 'pchar' not encoded.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> stringUrlNonEncodedAsync(Context context) {
+        return stringUrlNonEncodedWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get 'begin!*'();:@&amp;=+$,end
+     *
+     * <p>https://tools.ietf.org/html/rfc3986#appendix-A 'path' accept any 'pchar' not encoded.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> stringUrlNonEncodedWithResponse() {
-        return stringUrlNonEncodedWithResponseAsync().block();
+    public Response<Void> stringUrlNonEncodedWithResponse(Context context) {
+        return stringUrlNonEncodedWithResponseAsync(context).block();
     }
 
     /**
@@ -1006,7 +1479,7 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void stringUrlNonEncoded() {
-        stringUrlNonEncodedWithResponse();
+        stringUrlNonEncodedWithResponse(Context.NONE);
     }
 
     /**
@@ -1030,6 +1503,26 @@ public final class Paths {
     /**
      * Get ''.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '' along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> stringEmptyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String stringPath = "";
+        final String accept = "application/json";
+        return service.stringEmpty(this.client.getHost(), stringPath, accept, context);
+    }
+
+    /**
+     * Get ''.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '' on successful completion of {@link Mono}.
@@ -1042,13 +1535,29 @@ public final class Paths {
     /**
      * Get ''.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '' on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> stringEmptyAsync(Context context) {
+        return stringEmptyWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get ''.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '' along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> stringEmptyWithResponse() {
-        return stringEmptyWithResponseAsync().block();
+    public Response<Void> stringEmptyWithResponse(Context context) {
+        return stringEmptyWithResponseAsync(context).block();
     }
 
     /**
@@ -1059,7 +1568,7 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void stringEmpty() {
-        stringEmptyWithResponse();
+        stringEmptyWithResponse(Context.NONE);
     }
 
     /**
@@ -1088,6 +1597,29 @@ public final class Paths {
      * Get null (should throw).
      *
      * @param stringPath null string value.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null (should throw) along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> stringNullWithResponseAsync(String stringPath, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (stringPath == null) {
+            return Mono.error(new IllegalArgumentException("Parameter stringPath is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.stringNull(this.client.getHost(), stringPath, accept, context);
+    }
+
+    /**
+     * Get null (should throw).
+     *
+     * @param stringPath null string value.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1102,14 +1634,30 @@ public final class Paths {
      * Get null (should throw).
      *
      * @param stringPath null string value.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null (should throw) on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> stringNullAsync(String stringPath, Context context) {
+        return stringNullWithResponseAsync(stringPath, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get null (should throw).
+     *
+     * @param stringPath null string value.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null (should throw) along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> stringNullWithResponse(String stringPath) {
-        return stringNullWithResponseAsync(stringPath).block();
+    public Response<Void> stringNullWithResponse(String stringPath, Context context) {
+        return stringNullWithResponseAsync(stringPath, context).block();
     }
 
     /**
@@ -1122,7 +1670,7 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void stringNull(String stringPath) {
-        stringNullWithResponse(stringPath);
+        stringNullWithResponse(stringPath, Context.NONE);
     }
 
     /**
@@ -1152,6 +1700,30 @@ public final class Paths {
      * Get using uri with 'green color' in path parameter.
      *
      * @param enumPath send the value green.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return using uri with 'green color' in path parameter along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> enumValidWithResponseAsync(UriColor enumPath, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (enumPath == null) {
+            return Mono.error(new IllegalArgumentException("Parameter enumPath is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.enumValid(this.client.getHost(), enumPath, accept, context);
+    }
+
+    /**
+     * Get using uri with 'green color' in path parameter.
+     *
+     * @param enumPath send the value green.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1166,14 +1738,30 @@ public final class Paths {
      * Get using uri with 'green color' in path parameter.
      *
      * @param enumPath send the value green.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return using uri with 'green color' in path parameter on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> enumValidAsync(UriColor enumPath, Context context) {
+        return enumValidWithResponseAsync(enumPath, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get using uri with 'green color' in path parameter.
+     *
+     * @param enumPath send the value green.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return using uri with 'green color' in path parameter along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> enumValidWithResponse(UriColor enumPath) {
-        return enumValidWithResponseAsync(enumPath).block();
+    public Response<Void> enumValidWithResponse(UriColor enumPath, Context context) {
+        return enumValidWithResponseAsync(enumPath, context).block();
     }
 
     /**
@@ -1186,7 +1774,7 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void enumValid(UriColor enumPath) {
-        enumValidWithResponse(enumPath);
+        enumValidWithResponse(enumPath, Context.NONE);
     }
 
     /**
@@ -1216,6 +1804,30 @@ public final class Paths {
      * Get null (should throw on the client before the request is sent on wire).
      *
      * @param enumPath send null should throw.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null (should throw on the client before the request is sent on wire) along with {@link Response} on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> enumNullWithResponseAsync(UriColor enumPath, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (enumPath == null) {
+            return Mono.error(new IllegalArgumentException("Parameter enumPath is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.enumNull(this.client.getHost(), enumPath, accept, context);
+    }
+
+    /**
+     * Get null (should throw on the client before the request is sent on wire).
+     *
+     * @param enumPath send null should throw.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1231,14 +1843,31 @@ public final class Paths {
      * Get null (should throw on the client before the request is sent on wire).
      *
      * @param enumPath send null should throw.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null (should throw on the client before the request is sent on wire) on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> enumNullAsync(UriColor enumPath, Context context) {
+        return enumNullWithResponseAsync(enumPath, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get null (should throw on the client before the request is sent on wire).
+     *
+     * @param enumPath send null should throw.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null (should throw on the client before the request is sent on wire) along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> enumNullWithResponse(UriColor enumPath) {
-        return enumNullWithResponseAsync(enumPath).block();
+    public Response<Void> enumNullWithResponse(UriColor enumPath, Context context) {
+        return enumNullWithResponseAsync(enumPath, context).block();
     }
 
     /**
@@ -1251,7 +1880,7 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void enumNull(UriColor enumPath) {
-        enumNullWithResponse(enumPath);
+        enumNullWithResponse(enumPath, Context.NONE);
     }
 
     /**
@@ -1283,6 +1912,31 @@ public final class Paths {
      * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
      *
      * @param bytePath '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> byteMultiByteWithResponseAsync(byte[] bytePath, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (bytePath == null) {
+            return Mono.error(new IllegalArgumentException("Parameter bytePath is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        String bytePathConverted = Base64Util.encodeToString(bytePath);
+        return service.byteMultiByte(this.client.getHost(), bytePathConverted, accept, context);
+    }
+
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     *
+     * @param bytePath '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1297,14 +1951,30 @@ public final class Paths {
      * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
      *
      * @param bytePath '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> byteMultiByteAsync(byte[] bytePath, Context context) {
+        return byteMultiByteWithResponseAsync(bytePath, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     *
+     * @param bytePath '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> byteMultiByteWithResponse(byte[] bytePath) {
-        return byteMultiByteWithResponseAsync(bytePath).block();
+    public Response<Void> byteMultiByteWithResponse(byte[] bytePath, Context context) {
+        return byteMultiByteWithResponseAsync(bytePath, context).block();
     }
 
     /**
@@ -1317,7 +1987,7 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void byteMultiByte(byte[] bytePath) {
-        byteMultiByteWithResponse(bytePath);
+        byteMultiByteWithResponse(bytePath, Context.NONE);
     }
 
     /**
@@ -1343,6 +2013,27 @@ public final class Paths {
     /**
      * Get '' as byte array.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '' as byte array along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> byteEmptyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final byte[] bytePath = "".getBytes();
+        final String accept = "application/json";
+        String bytePathConverted = Base64Util.encodeToString(bytePath);
+        return service.byteEmpty(this.client.getHost(), bytePathConverted, accept, context);
+    }
+
+    /**
+     * Get '' as byte array.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '' as byte array on successful completion of {@link Mono}.
@@ -1355,13 +2046,29 @@ public final class Paths {
     /**
      * Get '' as byte array.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '' as byte array on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> byteEmptyAsync(Context context) {
+        return byteEmptyWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get '' as byte array.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '' as byte array along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> byteEmptyWithResponse() {
-        return byteEmptyWithResponseAsync().block();
+    public Response<Void> byteEmptyWithResponse(Context context) {
+        return byteEmptyWithResponseAsync(context).block();
     }
 
     /**
@@ -1372,7 +2079,7 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void byteEmpty() {
-        byteEmptyWithResponse();
+        byteEmptyWithResponse(Context.NONE);
     }
 
     /**
@@ -1403,6 +2110,30 @@ public final class Paths {
      * Get null as byte array (should throw).
      *
      * @param bytePath null as byte array (should throw).
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null as byte array (should throw) along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> byteNullWithResponseAsync(byte[] bytePath, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (bytePath == null) {
+            return Mono.error(new IllegalArgumentException("Parameter bytePath is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        String bytePathConverted = Base64Util.encodeToString(bytePath);
+        return service.byteNull(this.client.getHost(), bytePathConverted, accept, context);
+    }
+
+    /**
+     * Get null as byte array (should throw).
+     *
+     * @param bytePath null as byte array (should throw).
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1417,14 +2148,30 @@ public final class Paths {
      * Get null as byte array (should throw).
      *
      * @param bytePath null as byte array (should throw).
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null as byte array (should throw) on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> byteNullAsync(byte[] bytePath, Context context) {
+        return byteNullWithResponseAsync(bytePath, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get null as byte array (should throw).
+     *
+     * @param bytePath null as byte array (should throw).
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null as byte array (should throw) along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> byteNullWithResponse(byte[] bytePath) {
-        return byteNullWithResponseAsync(bytePath).block();
+    public Response<Void> byteNullWithResponse(byte[] bytePath, Context context) {
+        return byteNullWithResponseAsync(bytePath, context).block();
     }
 
     /**
@@ -1437,7 +2184,7 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void byteNull(byte[] bytePath) {
-        byteNullWithResponse(bytePath);
+        byteNullWithResponse(bytePath, Context.NONE);
     }
 
     /**
@@ -1461,6 +2208,26 @@ public final class Paths {
     /**
      * Get '2012-01-01' as date.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '2012-01-01' as date along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> dateValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final LocalDate datePath = LocalDate.parse("2012-01-01");
+        final String accept = "application/json";
+        return service.dateValid(this.client.getHost(), datePath, accept, context);
+    }
+
+    /**
+     * Get '2012-01-01' as date.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '2012-01-01' as date on successful completion of {@link Mono}.
@@ -1473,13 +2240,29 @@ public final class Paths {
     /**
      * Get '2012-01-01' as date.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '2012-01-01' as date on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> dateValidAsync(Context context) {
+        return dateValidWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get '2012-01-01' as date.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '2012-01-01' as date along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> dateValidWithResponse() {
-        return dateValidWithResponseAsync().block();
+    public Response<Void> dateValidWithResponse(Context context) {
+        return dateValidWithResponseAsync(context).block();
     }
 
     /**
@@ -1490,7 +2273,7 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void dateValid() {
-        dateValidWithResponse();
+        dateValidWithResponse(Context.NONE);
     }
 
     /**
@@ -1520,6 +2303,30 @@ public final class Paths {
      * Get null as date - this should throw or be unusable on the client side, depending on date representation.
      *
      * @param datePath null as date (should throw).
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null as date - this should throw or be unusable on the client side, depending on date representation
+     *     along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> dateNullWithResponseAsync(LocalDate datePath, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (datePath == null) {
+            return Mono.error(new IllegalArgumentException("Parameter datePath is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.dateNull(this.client.getHost(), datePath, accept, context);
+    }
+
+    /**
+     * Get null as date - this should throw or be unusable on the client side, depending on date representation.
+     *
+     * @param datePath null as date (should throw).
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1535,6 +2342,23 @@ public final class Paths {
      * Get null as date - this should throw or be unusable on the client side, depending on date representation.
      *
      * @param datePath null as date (should throw).
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null as date - this should throw or be unusable on the client side, depending on date representation on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> dateNullAsync(LocalDate datePath, Context context) {
+        return dateNullWithResponseAsync(datePath, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get null as date - this should throw or be unusable on the client side, depending on date representation.
+     *
+     * @param datePath null as date (should throw).
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1542,8 +2366,8 @@ public final class Paths {
      *     along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> dateNullWithResponse(LocalDate datePath) {
-        return dateNullWithResponseAsync(datePath).block();
+    public Response<Void> dateNullWithResponse(LocalDate datePath, Context context) {
+        return dateNullWithResponseAsync(datePath, context).block();
     }
 
     /**
@@ -1556,7 +2380,7 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void dateNull(LocalDate datePath) {
-        dateNullWithResponse(datePath);
+        dateNullWithResponse(datePath, Context.NONE);
     }
 
     /**
@@ -1581,6 +2405,26 @@ public final class Paths {
     /**
      * Get '2012-01-01T01:01:01Z' as date-time.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '2012-01-01T01:01:01Z' as date-time along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> dateTimeValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final OffsetDateTime dateTimePath = OffsetDateTime.parse("2012-01-01T01:01:01Z");
+        final String accept = "application/json";
+        return service.dateTimeValid(this.client.getHost(), dateTimePath, accept, context);
+    }
+
+    /**
+     * Get '2012-01-01T01:01:01Z' as date-time.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '2012-01-01T01:01:01Z' as date-time on successful completion of {@link Mono}.
@@ -1593,13 +2437,29 @@ public final class Paths {
     /**
      * Get '2012-01-01T01:01:01Z' as date-time.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '2012-01-01T01:01:01Z' as date-time on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> dateTimeValidAsync(Context context) {
+        return dateTimeValidWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get '2012-01-01T01:01:01Z' as date-time.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '2012-01-01T01:01:01Z' as date-time along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> dateTimeValidWithResponse() {
-        return dateTimeValidWithResponseAsync().block();
+    public Response<Void> dateTimeValidWithResponse(Context context) {
+        return dateTimeValidWithResponseAsync(context).block();
     }
 
     /**
@@ -1610,7 +2470,7 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void dateTimeValid() {
-        dateTimeValidWithResponse();
+        dateTimeValidWithResponse(Context.NONE);
     }
 
     /**
@@ -1641,6 +2501,30 @@ public final class Paths {
      * Get null as date-time, should be disallowed or throw depending on representation of date-time.
      *
      * @param dateTimePath null as date-time.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null as date-time, should be disallowed or throw depending on representation of date-time along with
+     *     {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> dateTimeNullWithResponseAsync(OffsetDateTime dateTimePath, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (dateTimePath == null) {
+            return Mono.error(new IllegalArgumentException("Parameter dateTimePath is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.dateTimeNull(this.client.getHost(), dateTimePath, accept, context);
+    }
+
+    /**
+     * Get null as date-time, should be disallowed or throw depending on representation of date-time.
+     *
+     * @param dateTimePath null as date-time.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1656,6 +2540,23 @@ public final class Paths {
      * Get null as date-time, should be disallowed or throw depending on representation of date-time.
      *
      * @param dateTimePath null as date-time.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null as date-time, should be disallowed or throw depending on representation of date-time on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> dateTimeNullAsync(OffsetDateTime dateTimePath, Context context) {
+        return dateTimeNullWithResponseAsync(dateTimePath, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get null as date-time, should be disallowed or throw depending on representation of date-time.
+     *
+     * @param dateTimePath null as date-time.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1663,8 +2564,8 @@ public final class Paths {
      *     {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> dateTimeNullWithResponse(OffsetDateTime dateTimePath) {
-        return dateTimeNullWithResponseAsync(dateTimePath).block();
+    public Response<Void> dateTimeNullWithResponse(OffsetDateTime dateTimePath, Context context) {
+        return dateTimeNullWithResponseAsync(dateTimePath, context).block();
     }
 
     /**
@@ -1677,7 +2578,7 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void dateTimeNull(OffsetDateTime dateTimePath) {
-        dateTimeNullWithResponse(dateTimePath);
+        dateTimeNullWithResponse(dateTimePath, Context.NONE);
     }
 
     /**
@@ -1709,6 +2610,31 @@ public final class Paths {
      * Get 'lorem' encoded value as 'bG9yZW0' (base64url).
      *
      * @param base64UrlPath base64url encoded value.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return 'lorem' encoded value as 'bG9yZW0' (base64url) along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> base64UrlWithResponseAsync(byte[] base64UrlPath, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (base64UrlPath == null) {
+            return Mono.error(new IllegalArgumentException("Parameter base64UrlPath is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        Base64Url base64UrlPathConverted = Base64Url.encode(base64UrlPath);
+        return service.base64Url(this.client.getHost(), base64UrlPathConverted, accept, context);
+    }
+
+    /**
+     * Get 'lorem' encoded value as 'bG9yZW0' (base64url).
+     *
+     * @param base64UrlPath base64url encoded value.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1723,14 +2649,30 @@ public final class Paths {
      * Get 'lorem' encoded value as 'bG9yZW0' (base64url).
      *
      * @param base64UrlPath base64url encoded value.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return 'lorem' encoded value as 'bG9yZW0' (base64url) on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> base64UrlAsync(byte[] base64UrlPath, Context context) {
+        return base64UrlWithResponseAsync(base64UrlPath, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get 'lorem' encoded value as 'bG9yZW0' (base64url).
+     *
+     * @param base64UrlPath base64url encoded value.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return 'lorem' encoded value as 'bG9yZW0' (base64url) along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> base64UrlWithResponse(byte[] base64UrlPath) {
-        return base64UrlWithResponseAsync(base64UrlPath).block();
+    public Response<Void> base64UrlWithResponse(byte[] base64UrlPath, Context context) {
+        return base64UrlWithResponseAsync(base64UrlPath, context).block();
     }
 
     /**
@@ -1743,7 +2685,7 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void base64Url(byte[] base64UrlPath) {
-        base64UrlWithResponse(base64UrlPath);
+        base64UrlWithResponse(base64UrlPath, Context.NONE);
     }
 
     /**
@@ -1778,6 +2720,33 @@ public final class Paths {
      *
      * @param arrayPath an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the
      *     csv-array format.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array
+     *     format along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> arrayCsvInPathWithResponseAsync(List<String> arrayPath, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (arrayPath == null) {
+            return Mono.error(new IllegalArgumentException("Parameter arrayPath is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        String arrayPathConverted =
+                arrayPath.stream().map(value -> Objects.toString(value, "")).collect(Collectors.joining(","));
+        return service.arrayCsvInPath(this.client.getHost(), arrayPathConverted, accept, context);
+    }
+
+    /**
+     * Get an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
+     *
+     * @param arrayPath an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the
+     *     csv-array format.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1794,6 +2763,24 @@ public final class Paths {
      *
      * @param arrayPath an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the
      *     csv-array format.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array
+     *     format on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> arrayCsvInPathAsync(List<String> arrayPath, Context context) {
+        return arrayCsvInPathWithResponseAsync(arrayPath, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
+     *
+     * @param arrayPath an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the
+     *     csv-array format.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1801,8 +2788,8 @@ public final class Paths {
      *     format along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> arrayCsvInPathWithResponse(List<String> arrayPath) {
-        return arrayCsvInPathWithResponseAsync(arrayPath).block();
+    public Response<Void> arrayCsvInPathWithResponse(List<String> arrayPath, Context context) {
+        return arrayCsvInPathWithResponseAsync(arrayPath, context).block();
     }
 
     /**
@@ -1816,7 +2803,7 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void arrayCsvInPath(List<String> arrayPath) {
-        arrayCsvInPathWithResponse(arrayPath);
+        arrayCsvInPathWithResponse(arrayPath, Context.NONE);
     }
 
     /**
@@ -1849,6 +2836,32 @@ public final class Paths {
      * Get the date 2016-04-13 encoded value as '1460505600' (Unix time).
      *
      * @param unixTimeUrlPath Unix time encoded value.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the date 2016-04-13 encoded value as '1460505600' (Unix time) along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> unixTimeUrlWithResponseAsync(OffsetDateTime unixTimeUrlPath, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (unixTimeUrlPath == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter unixTimeUrlPath is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        long unixTimeUrlPathConverted = unixTimeUrlPath.toEpochSecond();
+        return service.unixTimeUrl(this.client.getHost(), unixTimeUrlPathConverted, accept, context);
+    }
+
+    /**
+     * Get the date 2016-04-13 encoded value as '1460505600' (Unix time).
+     *
+     * @param unixTimeUrlPath Unix time encoded value.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1863,14 +2876,30 @@ public final class Paths {
      * Get the date 2016-04-13 encoded value as '1460505600' (Unix time).
      *
      * @param unixTimeUrlPath Unix time encoded value.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the date 2016-04-13 encoded value as '1460505600' (Unix time) on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> unixTimeUrlAsync(OffsetDateTime unixTimeUrlPath, Context context) {
+        return unixTimeUrlWithResponseAsync(unixTimeUrlPath, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get the date 2016-04-13 encoded value as '1460505600' (Unix time).
+     *
+     * @param unixTimeUrlPath Unix time encoded value.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the date 2016-04-13 encoded value as '1460505600' (Unix time) along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> unixTimeUrlWithResponse(OffsetDateTime unixTimeUrlPath) {
-        return unixTimeUrlWithResponseAsync(unixTimeUrlPath).block();
+    public Response<Void> unixTimeUrlWithResponse(OffsetDateTime unixTimeUrlPath, Context context) {
+        return unixTimeUrlWithResponseAsync(unixTimeUrlPath, context).block();
     }
 
     /**
@@ -1883,6 +2912,6 @@ public final class Paths {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void unixTimeUrl(OffsetDateTime unixTimeUrlPath) {
-        unixTimeUrlWithResponse(unixTimeUrlPath);
+        unixTimeUrlWithResponse(unixTimeUrlPath, Context.NONE);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/url/Queries.java
+++ b/vanilla-tests/src/main/java/fixtures/url/Queries.java
@@ -391,6 +391,26 @@ public final class Queries {
     /**
      * Get true Boolean value on path.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return true Boolean value on path along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getBooleanTrueWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final boolean boolQuery = true;
+        final String accept = "application/json";
+        return service.getBooleanTrue(this.client.getHost(), boolQuery, accept, context);
+    }
+
+    /**
+     * Get true Boolean value on path.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return true Boolean value on path on successful completion of {@link Mono}.
@@ -403,13 +423,29 @@ public final class Queries {
     /**
      * Get true Boolean value on path.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return true Boolean value on path on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getBooleanTrueAsync(Context context) {
+        return getBooleanTrueWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get true Boolean value on path.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return true Boolean value on path along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getBooleanTrueWithResponse() {
-        return getBooleanTrueWithResponseAsync().block();
+    public Response<Void> getBooleanTrueWithResponse(Context context) {
+        return getBooleanTrueWithResponseAsync(context).block();
     }
 
     /**
@@ -420,7 +456,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getBooleanTrue() {
-        getBooleanTrueWithResponse();
+        getBooleanTrueWithResponse(Context.NONE);
     }
 
     /**
@@ -445,6 +481,26 @@ public final class Queries {
     /**
      * Get false Boolean value on path.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return false Boolean value on path along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getBooleanFalseWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final boolean boolQuery = false;
+        final String accept = "application/json";
+        return service.getBooleanFalse(this.client.getHost(), boolQuery, accept, context);
+    }
+
+    /**
+     * Get false Boolean value on path.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return false Boolean value on path on successful completion of {@link Mono}.
@@ -457,13 +513,29 @@ public final class Queries {
     /**
      * Get false Boolean value on path.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return false Boolean value on path on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getBooleanFalseAsync(Context context) {
+        return getBooleanFalseWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get false Boolean value on path.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return false Boolean value on path along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getBooleanFalseWithResponse() {
-        return getBooleanFalseWithResponseAsync().block();
+    public Response<Void> getBooleanFalseWithResponse(Context context) {
+        return getBooleanFalseWithResponseAsync(context).block();
     }
 
     /**
@@ -474,7 +546,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getBooleanFalse() {
-        getBooleanFalseWithResponse();
+        getBooleanFalseWithResponse(Context.NONE);
     }
 
     /**
@@ -496,6 +568,27 @@ public final class Queries {
         final String accept = "application/json";
         return FluxUtil.withContext(
                 context -> service.getBooleanNull(this.client.getHost(), boolQuery, accept, context));
+    }
+
+    /**
+     * Get null Boolean value on query (query string should be absent).
+     *
+     * @param boolQuery null boolean value.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null Boolean value on query (query string should be absent) along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getBooleanNullWithResponseAsync(Boolean boolQuery, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getBooleanNull(this.client.getHost(), boolQuery, accept, context);
     }
 
     /**
@@ -529,14 +622,30 @@ public final class Queries {
      * Get null Boolean value on query (query string should be absent).
      *
      * @param boolQuery null boolean value.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null Boolean value on query (query string should be absent) on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getBooleanNullAsync(Boolean boolQuery, Context context) {
+        return getBooleanNullWithResponseAsync(boolQuery, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get null Boolean value on query (query string should be absent).
+     *
+     * @param boolQuery null boolean value.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null Boolean value on query (query string should be absent) along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getBooleanNullWithResponse(Boolean boolQuery) {
-        return getBooleanNullWithResponseAsync(boolQuery).block();
+    public Response<Void> getBooleanNullWithResponse(Boolean boolQuery, Context context) {
+        return getBooleanNullWithResponseAsync(boolQuery, context).block();
     }
 
     /**
@@ -549,7 +658,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getBooleanNull(Boolean boolQuery) {
-        getBooleanNullWithResponse(boolQuery);
+        getBooleanNullWithResponse(boolQuery, Context.NONE);
     }
 
     /**
@@ -561,7 +670,7 @@ public final class Queries {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getBooleanNull() {
         final Boolean boolQuery = null;
-        getBooleanNullWithResponse(boolQuery);
+        getBooleanNullWithResponse(boolQuery, Context.NONE);
     }
 
     /**
@@ -586,6 +695,26 @@ public final class Queries {
     /**
      * Get '1000000' integer value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '1000000' integer value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getIntOneMillionWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final int intQuery = 1000000;
+        final String accept = "application/json";
+        return service.getIntOneMillion(this.client.getHost(), intQuery, accept, context);
+    }
+
+    /**
+     * Get '1000000' integer value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '1000000' integer value on successful completion of {@link Mono}.
@@ -598,13 +727,29 @@ public final class Queries {
     /**
      * Get '1000000' integer value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '1000000' integer value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getIntOneMillionAsync(Context context) {
+        return getIntOneMillionWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get '1000000' integer value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '1000000' integer value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getIntOneMillionWithResponse() {
-        return getIntOneMillionWithResponseAsync().block();
+    public Response<Void> getIntOneMillionWithResponse(Context context) {
+        return getIntOneMillionWithResponseAsync(context).block();
     }
 
     /**
@@ -615,7 +760,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getIntOneMillion() {
-        getIntOneMillionWithResponse();
+        getIntOneMillionWithResponse(Context.NONE);
     }
 
     /**
@@ -640,6 +785,26 @@ public final class Queries {
     /**
      * Get '-1000000' integer value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '-1000000' integer value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getIntNegativeOneMillionWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final int intQuery = -1000000;
+        final String accept = "application/json";
+        return service.getIntNegativeOneMillion(this.client.getHost(), intQuery, accept, context);
+    }
+
+    /**
+     * Get '-1000000' integer value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '-1000000' integer value on successful completion of {@link Mono}.
@@ -652,13 +817,29 @@ public final class Queries {
     /**
      * Get '-1000000' integer value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '-1000000' integer value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getIntNegativeOneMillionAsync(Context context) {
+        return getIntNegativeOneMillionWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get '-1000000' integer value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '-1000000' integer value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getIntNegativeOneMillionWithResponse() {
-        return getIntNegativeOneMillionWithResponseAsync().block();
+    public Response<Void> getIntNegativeOneMillionWithResponse(Context context) {
+        return getIntNegativeOneMillionWithResponseAsync(context).block();
     }
 
     /**
@@ -669,7 +850,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getIntNegativeOneMillion() {
-        getIntNegativeOneMillionWithResponse();
+        getIntNegativeOneMillionWithResponse(Context.NONE);
     }
 
     /**
@@ -690,6 +871,27 @@ public final class Queries {
         }
         final String accept = "application/json";
         return FluxUtil.withContext(context -> service.getIntNull(this.client.getHost(), intQuery, accept, context));
+    }
+
+    /**
+     * Get null integer value (no query parameter).
+     *
+     * @param intQuery null integer value.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null integer value (no query parameter) along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getIntNullWithResponseAsync(Integer intQuery, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getIntNull(this.client.getHost(), intQuery, accept, context);
     }
 
     /**
@@ -723,14 +925,30 @@ public final class Queries {
      * Get null integer value (no query parameter).
      *
      * @param intQuery null integer value.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null integer value (no query parameter) on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getIntNullAsync(Integer intQuery, Context context) {
+        return getIntNullWithResponseAsync(intQuery, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get null integer value (no query parameter).
+     *
+     * @param intQuery null integer value.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null integer value (no query parameter) along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getIntNullWithResponse(Integer intQuery) {
-        return getIntNullWithResponseAsync(intQuery).block();
+    public Response<Void> getIntNullWithResponse(Integer intQuery, Context context) {
+        return getIntNullWithResponseAsync(intQuery, context).block();
     }
 
     /**
@@ -743,7 +961,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getIntNull(Integer intQuery) {
-        getIntNullWithResponse(intQuery);
+        getIntNullWithResponse(intQuery, Context.NONE);
     }
 
     /**
@@ -755,7 +973,7 @@ public final class Queries {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getIntNull() {
         final Integer intQuery = null;
-        getIntNullWithResponse(intQuery);
+        getIntNullWithResponse(intQuery, Context.NONE);
     }
 
     /**
@@ -780,6 +998,26 @@ public final class Queries {
     /**
      * Get '10000000000' 64 bit integer value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '10000000000' 64 bit integer value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getTenBillionWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final long longQuery = 10000000000L;
+        final String accept = "application/json";
+        return service.getTenBillion(this.client.getHost(), longQuery, accept, context);
+    }
+
+    /**
+     * Get '10000000000' 64 bit integer value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '10000000000' 64 bit integer value on successful completion of {@link Mono}.
@@ -792,13 +1030,29 @@ public final class Queries {
     /**
      * Get '10000000000' 64 bit integer value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '10000000000' 64 bit integer value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getTenBillionAsync(Context context) {
+        return getTenBillionWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get '10000000000' 64 bit integer value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '10000000000' 64 bit integer value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getTenBillionWithResponse() {
-        return getTenBillionWithResponseAsync().block();
+    public Response<Void> getTenBillionWithResponse(Context context) {
+        return getTenBillionWithResponseAsync(context).block();
     }
 
     /**
@@ -809,7 +1063,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getTenBillion() {
-        getTenBillionWithResponse();
+        getTenBillionWithResponse(Context.NONE);
     }
 
     /**
@@ -834,6 +1088,26 @@ public final class Queries {
     /**
      * Get '-10000000000' 64 bit integer value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '-10000000000' 64 bit integer value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getNegativeTenBillionWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final long longQuery = -10000000000L;
+        final String accept = "application/json";
+        return service.getNegativeTenBillion(this.client.getHost(), longQuery, accept, context);
+    }
+
+    /**
+     * Get '-10000000000' 64 bit integer value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '-10000000000' 64 bit integer value on successful completion of {@link Mono}.
@@ -846,13 +1120,29 @@ public final class Queries {
     /**
      * Get '-10000000000' 64 bit integer value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '-10000000000' 64 bit integer value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getNegativeTenBillionAsync(Context context) {
+        return getNegativeTenBillionWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get '-10000000000' 64 bit integer value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '-10000000000' 64 bit integer value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getNegativeTenBillionWithResponse() {
-        return getNegativeTenBillionWithResponseAsync().block();
+    public Response<Void> getNegativeTenBillionWithResponse(Context context) {
+        return getNegativeTenBillionWithResponseAsync(context).block();
     }
 
     /**
@@ -863,7 +1153,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getNegativeTenBillion() {
-        getNegativeTenBillionWithResponse();
+        getNegativeTenBillionWithResponse(Context.NONE);
     }
 
     /**
@@ -884,6 +1174,27 @@ public final class Queries {
         }
         final String accept = "application/json";
         return FluxUtil.withContext(context -> service.getLongNull(this.client.getHost(), longQuery, accept, context));
+    }
+
+    /**
+     * Get 'null 64 bit integer value (no query param in uri).
+     *
+     * @param longQuery null 64 bit integer value.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return 'null 64 bit integer value (no query param in uri) along with {@link Response} on successful completion
+     *     of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getLongNullWithResponseAsync(Long longQuery, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getLongNull(this.client.getHost(), longQuery, accept, context);
     }
 
     /**
@@ -917,14 +1228,30 @@ public final class Queries {
      * Get 'null 64 bit integer value (no query param in uri).
      *
      * @param longQuery null 64 bit integer value.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return 'null 64 bit integer value (no query param in uri) on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getLongNullAsync(Long longQuery, Context context) {
+        return getLongNullWithResponseAsync(longQuery, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get 'null 64 bit integer value (no query param in uri).
+     *
+     * @param longQuery null 64 bit integer value.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return 'null 64 bit integer value (no query param in uri) along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getLongNullWithResponse(Long longQuery) {
-        return getLongNullWithResponseAsync(longQuery).block();
+    public Response<Void> getLongNullWithResponse(Long longQuery, Context context) {
+        return getLongNullWithResponseAsync(longQuery, context).block();
     }
 
     /**
@@ -937,7 +1264,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getLongNull(Long longQuery) {
-        getLongNullWithResponse(longQuery);
+        getLongNullWithResponse(longQuery, Context.NONE);
     }
 
     /**
@@ -949,7 +1276,7 @@ public final class Queries {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getLongNull() {
         final Long longQuery = null;
-        getLongNullWithResponse(longQuery);
+        getLongNullWithResponse(longQuery, Context.NONE);
     }
 
     /**
@@ -974,6 +1301,26 @@ public final class Queries {
     /**
      * Get '1.034E+20' numeric value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '1.034E+20' numeric value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> floatScientificPositiveWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final float floatQuery = 103400000000000000000f;
+        final String accept = "application/json";
+        return service.floatScientificPositive(this.client.getHost(), floatQuery, accept, context);
+    }
+
+    /**
+     * Get '1.034E+20' numeric value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '1.034E+20' numeric value on successful completion of {@link Mono}.
@@ -986,13 +1333,29 @@ public final class Queries {
     /**
      * Get '1.034E+20' numeric value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '1.034E+20' numeric value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> floatScientificPositiveAsync(Context context) {
+        return floatScientificPositiveWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get '1.034E+20' numeric value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '1.034E+20' numeric value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> floatScientificPositiveWithResponse() {
-        return floatScientificPositiveWithResponseAsync().block();
+    public Response<Void> floatScientificPositiveWithResponse(Context context) {
+        return floatScientificPositiveWithResponseAsync(context).block();
     }
 
     /**
@@ -1003,7 +1366,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void floatScientificPositive() {
-        floatScientificPositiveWithResponse();
+        floatScientificPositiveWithResponse(Context.NONE);
     }
 
     /**
@@ -1028,6 +1391,26 @@ public final class Queries {
     /**
      * Get '-1.034E-20' numeric value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '-1.034E-20' numeric value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> floatScientificNegativeWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final float floatQuery = -1.034E-20f;
+        final String accept = "application/json";
+        return service.floatScientificNegative(this.client.getHost(), floatQuery, accept, context);
+    }
+
+    /**
+     * Get '-1.034E-20' numeric value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '-1.034E-20' numeric value on successful completion of {@link Mono}.
@@ -1040,13 +1423,29 @@ public final class Queries {
     /**
      * Get '-1.034E-20' numeric value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '-1.034E-20' numeric value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> floatScientificNegativeAsync(Context context) {
+        return floatScientificNegativeWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get '-1.034E-20' numeric value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '-1.034E-20' numeric value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> floatScientificNegativeWithResponse() {
-        return floatScientificNegativeWithResponseAsync().block();
+    public Response<Void> floatScientificNegativeWithResponse(Context context) {
+        return floatScientificNegativeWithResponseAsync(context).block();
     }
 
     /**
@@ -1057,7 +1456,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void floatScientificNegative() {
-        floatScientificNegativeWithResponse();
+        floatScientificNegativeWithResponse(Context.NONE);
     }
 
     /**
@@ -1078,6 +1477,27 @@ public final class Queries {
         }
         final String accept = "application/json";
         return FluxUtil.withContext(context -> service.floatNull(this.client.getHost(), floatQuery, accept, context));
+    }
+
+    /**
+     * Get null numeric value (no query parameter).
+     *
+     * @param floatQuery null numeric value.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null numeric value (no query parameter) along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> floatNullWithResponseAsync(Float floatQuery, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.floatNull(this.client.getHost(), floatQuery, accept, context);
     }
 
     /**
@@ -1111,14 +1531,30 @@ public final class Queries {
      * Get null numeric value (no query parameter).
      *
      * @param floatQuery null numeric value.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null numeric value (no query parameter) on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> floatNullAsync(Float floatQuery, Context context) {
+        return floatNullWithResponseAsync(floatQuery, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get null numeric value (no query parameter).
+     *
+     * @param floatQuery null numeric value.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null numeric value (no query parameter) along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> floatNullWithResponse(Float floatQuery) {
-        return floatNullWithResponseAsync(floatQuery).block();
+    public Response<Void> floatNullWithResponse(Float floatQuery, Context context) {
+        return floatNullWithResponseAsync(floatQuery, context).block();
     }
 
     /**
@@ -1131,7 +1567,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void floatNull(Float floatQuery) {
-        floatNullWithResponse(floatQuery);
+        floatNullWithResponse(floatQuery, Context.NONE);
     }
 
     /**
@@ -1143,7 +1579,7 @@ public final class Queries {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void floatNull() {
         final Float floatQuery = null;
-        floatNullWithResponse(floatQuery);
+        floatNullWithResponse(floatQuery, Context.NONE);
     }
 
     /**
@@ -1168,6 +1604,26 @@ public final class Queries {
     /**
      * Get '9999999.999' numeric value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '9999999.999' numeric value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> doubleDecimalPositiveWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final double doubleQuery = 9999999.999;
+        final String accept = "application/json";
+        return service.doubleDecimalPositive(this.client.getHost(), doubleQuery, accept, context);
+    }
+
+    /**
+     * Get '9999999.999' numeric value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '9999999.999' numeric value on successful completion of {@link Mono}.
@@ -1180,13 +1636,29 @@ public final class Queries {
     /**
      * Get '9999999.999' numeric value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '9999999.999' numeric value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> doubleDecimalPositiveAsync(Context context) {
+        return doubleDecimalPositiveWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get '9999999.999' numeric value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '9999999.999' numeric value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> doubleDecimalPositiveWithResponse() {
-        return doubleDecimalPositiveWithResponseAsync().block();
+    public Response<Void> doubleDecimalPositiveWithResponse(Context context) {
+        return doubleDecimalPositiveWithResponseAsync(context).block();
     }
 
     /**
@@ -1197,7 +1669,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void doubleDecimalPositive() {
-        doubleDecimalPositiveWithResponse();
+        doubleDecimalPositiveWithResponse(Context.NONE);
     }
 
     /**
@@ -1222,6 +1694,26 @@ public final class Queries {
     /**
      * Get '-9999999.999' numeric value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '-9999999.999' numeric value along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> doubleDecimalNegativeWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final double doubleQuery = -9999999.999;
+        final String accept = "application/json";
+        return service.doubleDecimalNegative(this.client.getHost(), doubleQuery, accept, context);
+    }
+
+    /**
+     * Get '-9999999.999' numeric value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '-9999999.999' numeric value on successful completion of {@link Mono}.
@@ -1234,13 +1726,29 @@ public final class Queries {
     /**
      * Get '-9999999.999' numeric value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '-9999999.999' numeric value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> doubleDecimalNegativeAsync(Context context) {
+        return doubleDecimalNegativeWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get '-9999999.999' numeric value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '-9999999.999' numeric value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> doubleDecimalNegativeWithResponse() {
-        return doubleDecimalNegativeWithResponseAsync().block();
+    public Response<Void> doubleDecimalNegativeWithResponse(Context context) {
+        return doubleDecimalNegativeWithResponseAsync(context).block();
     }
 
     /**
@@ -1251,7 +1759,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void doubleDecimalNegative() {
-        doubleDecimalNegativeWithResponse();
+        doubleDecimalNegativeWithResponse(Context.NONE);
     }
 
     /**
@@ -1272,6 +1780,27 @@ public final class Queries {
         }
         final String accept = "application/json";
         return FluxUtil.withContext(context -> service.doubleNull(this.client.getHost(), doubleQuery, accept, context));
+    }
+
+    /**
+     * Get null numeric value (no query parameter).
+     *
+     * @param doubleQuery null numeric value.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null numeric value (no query parameter) along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> doubleNullWithResponseAsync(Double doubleQuery, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.doubleNull(this.client.getHost(), doubleQuery, accept, context);
     }
 
     /**
@@ -1305,14 +1834,30 @@ public final class Queries {
      * Get null numeric value (no query parameter).
      *
      * @param doubleQuery null numeric value.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null numeric value (no query parameter) on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> doubleNullAsync(Double doubleQuery, Context context) {
+        return doubleNullWithResponseAsync(doubleQuery, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get null numeric value (no query parameter).
+     *
+     * @param doubleQuery null numeric value.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null numeric value (no query parameter) along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> doubleNullWithResponse(Double doubleQuery) {
-        return doubleNullWithResponseAsync(doubleQuery).block();
+    public Response<Void> doubleNullWithResponse(Double doubleQuery, Context context) {
+        return doubleNullWithResponseAsync(doubleQuery, context).block();
     }
 
     /**
@@ -1325,7 +1870,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void doubleNull(Double doubleQuery) {
-        doubleNullWithResponse(doubleQuery);
+        doubleNullWithResponse(doubleQuery, Context.NONE);
     }
 
     /**
@@ -1337,7 +1882,7 @@ public final class Queries {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void doubleNull() {
         final Double doubleQuery = null;
-        doubleNullWithResponse(doubleQuery);
+        doubleNullWithResponse(doubleQuery, Context.NONE);
     }
 
     /**
@@ -1363,6 +1908,27 @@ public final class Queries {
     /**
      * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> stringUnicodeWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String stringQuery = "啊齄丂狛狜隣郎隣兀﨩";
+        final String accept = "application/json";
+        return service.stringUnicode(this.client.getHost(), stringQuery, accept, context);
+    }
+
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value on successful completion of {@link Mono}.
@@ -1375,13 +1941,29 @@ public final class Queries {
     /**
      * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> stringUnicodeAsync(Context context) {
+        return stringUnicodeWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> stringUnicodeWithResponse() {
-        return stringUnicodeWithResponseAsync().block();
+    public Response<Void> stringUnicodeWithResponse(Context context) {
+        return stringUnicodeWithResponseAsync(context).block();
     }
 
     /**
@@ -1392,7 +1974,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void stringUnicode() {
-        stringUnicodeWithResponse();
+        stringUnicodeWithResponse(Context.NONE);
     }
 
     /**
@@ -1417,6 +1999,26 @@ public final class Queries {
     /**
      * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return 'begin!*'();:@ &amp;=+$,/?#[]end along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> stringUrlEncodedWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String stringQuery = "begin!*'();:@ &=+$,/?#[]end";
+        final String accept = "application/json";
+        return service.stringUrlEncoded(this.client.getHost(), stringQuery, accept, context);
+    }
+
+    /**
+     * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return 'begin!*'();:@ &amp;=+$,/?#[]end on successful completion of {@link Mono}.
@@ -1429,13 +2031,29 @@ public final class Queries {
     /**
      * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return 'begin!*'();:@ &amp;=+$,/?#[]end on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> stringUrlEncodedAsync(Context context) {
+        return stringUrlEncodedWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return 'begin!*'();:@ &amp;=+$,/?#[]end along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> stringUrlEncodedWithResponse() {
-        return stringUrlEncodedWithResponseAsync().block();
+    public Response<Void> stringUrlEncodedWithResponse(Context context) {
+        return stringUrlEncodedWithResponseAsync(context).block();
     }
 
     /**
@@ -1446,7 +2064,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void stringUrlEncoded() {
-        stringUrlEncodedWithResponse();
+        stringUrlEncodedWithResponse(Context.NONE);
     }
 
     /**
@@ -1471,6 +2089,26 @@ public final class Queries {
     /**
      * Get ''.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '' along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> stringEmptyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String stringQuery = "";
+        final String accept = "application/json";
+        return service.stringEmpty(this.client.getHost(), stringQuery, accept, context);
+    }
+
+    /**
+     * Get ''.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '' on successful completion of {@link Mono}.
@@ -1483,13 +2121,29 @@ public final class Queries {
     /**
      * Get ''.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '' on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> stringEmptyAsync(Context context) {
+        return stringEmptyWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get ''.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '' along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> stringEmptyWithResponse() {
-        return stringEmptyWithResponseAsync().block();
+    public Response<Void> stringEmptyWithResponse(Context context) {
+        return stringEmptyWithResponseAsync(context).block();
     }
 
     /**
@@ -1500,7 +2154,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void stringEmpty() {
-        stringEmptyWithResponse();
+        stringEmptyWithResponse(Context.NONE);
     }
 
     /**
@@ -1520,6 +2174,26 @@ public final class Queries {
         }
         final String accept = "application/json";
         return FluxUtil.withContext(context -> service.stringNull(this.client.getHost(), stringQuery, accept, context));
+    }
+
+    /**
+     * Get null (no query parameter in url).
+     *
+     * @param stringQuery null string value.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null (no query parameter in url) along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> stringNullWithResponseAsync(String stringQuery, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.stringNull(this.client.getHost(), stringQuery, accept, context);
     }
 
     /**
@@ -1553,14 +2227,30 @@ public final class Queries {
      * Get null (no query parameter in url).
      *
      * @param stringQuery null string value.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null (no query parameter in url) on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> stringNullAsync(String stringQuery, Context context) {
+        return stringNullWithResponseAsync(stringQuery, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get null (no query parameter in url).
+     *
+     * @param stringQuery null string value.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null (no query parameter in url) along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> stringNullWithResponse(String stringQuery) {
-        return stringNullWithResponseAsync(stringQuery).block();
+    public Response<Void> stringNullWithResponse(String stringQuery, Context context) {
+        return stringNullWithResponseAsync(stringQuery, context).block();
     }
 
     /**
@@ -1573,7 +2263,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void stringNull(String stringQuery) {
-        stringNullWithResponse(stringQuery);
+        stringNullWithResponse(stringQuery, Context.NONE);
     }
 
     /**
@@ -1585,7 +2275,7 @@ public final class Queries {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void stringNull() {
         final String stringQuery = null;
-        stringNullWithResponse(stringQuery);
+        stringNullWithResponse(stringQuery, Context.NONE);
     }
 
     /**
@@ -1606,6 +2296,27 @@ public final class Queries {
         }
         final String accept = "application/json";
         return FluxUtil.withContext(context -> service.enumValid(this.client.getHost(), enumQuery, accept, context));
+    }
+
+    /**
+     * Get using uri with query parameter 'green color'.
+     *
+     * @param enumQuery 'green color' enum value.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return using uri with query parameter 'green color' along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> enumValidWithResponseAsync(UriColor enumQuery, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.enumValid(this.client.getHost(), enumQuery, accept, context);
     }
 
     /**
@@ -1639,14 +2350,30 @@ public final class Queries {
      * Get using uri with query parameter 'green color'.
      *
      * @param enumQuery 'green color' enum value.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return using uri with query parameter 'green color' on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> enumValidAsync(UriColor enumQuery, Context context) {
+        return enumValidWithResponseAsync(enumQuery, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get using uri with query parameter 'green color'.
+     *
+     * @param enumQuery 'green color' enum value.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return using uri with query parameter 'green color' along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> enumValidWithResponse(UriColor enumQuery) {
-        return enumValidWithResponseAsync(enumQuery).block();
+    public Response<Void> enumValidWithResponse(UriColor enumQuery, Context context) {
+        return enumValidWithResponseAsync(enumQuery, context).block();
     }
 
     /**
@@ -1659,7 +2386,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void enumValid(UriColor enumQuery) {
-        enumValidWithResponse(enumQuery);
+        enumValidWithResponse(enumQuery, Context.NONE);
     }
 
     /**
@@ -1671,7 +2398,7 @@ public final class Queries {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void enumValid() {
         final UriColor enumQuery = null;
-        enumValidWithResponse(enumQuery);
+        enumValidWithResponse(enumQuery, Context.NONE);
     }
 
     /**
@@ -1691,6 +2418,26 @@ public final class Queries {
         }
         final String accept = "application/json";
         return FluxUtil.withContext(context -> service.enumNull(this.client.getHost(), enumQuery, accept, context));
+    }
+
+    /**
+     * Get null (no query parameter in url).
+     *
+     * @param enumQuery null string value.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null (no query parameter in url) along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> enumNullWithResponseAsync(UriColor enumQuery, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.enumNull(this.client.getHost(), enumQuery, accept, context);
     }
 
     /**
@@ -1724,14 +2471,30 @@ public final class Queries {
      * Get null (no query parameter in url).
      *
      * @param enumQuery null string value.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null (no query parameter in url) on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> enumNullAsync(UriColor enumQuery, Context context) {
+        return enumNullWithResponseAsync(enumQuery, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get null (no query parameter in url).
+     *
+     * @param enumQuery null string value.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null (no query parameter in url) along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> enumNullWithResponse(UriColor enumQuery) {
-        return enumNullWithResponseAsync(enumQuery).block();
+    public Response<Void> enumNullWithResponse(UriColor enumQuery, Context context) {
+        return enumNullWithResponseAsync(enumQuery, context).block();
     }
 
     /**
@@ -1744,7 +2507,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void enumNull(UriColor enumQuery) {
-        enumNullWithResponse(enumQuery);
+        enumNullWithResponse(enumQuery, Context.NONE);
     }
 
     /**
@@ -1756,7 +2519,7 @@ public final class Queries {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void enumNull() {
         final UriColor enumQuery = null;
-        enumNullWithResponse(enumQuery);
+        enumNullWithResponse(enumQuery, Context.NONE);
     }
 
     /**
@@ -1779,6 +2542,28 @@ public final class Queries {
         String byteQueryConverted = Base64Util.encodeToString(byteQuery);
         return FluxUtil.withContext(
                 context -> service.byteMultiByte(this.client.getHost(), byteQueryConverted, accept, context));
+    }
+
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     *
+     * @param byteQuery '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> byteMultiByteWithResponseAsync(byte[] byteQuery, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        String byteQueryConverted = Base64Util.encodeToString(byteQuery);
+        return service.byteMultiByte(this.client.getHost(), byteQueryConverted, accept, context);
     }
 
     /**
@@ -1812,14 +2597,30 @@ public final class Queries {
      * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
      *
      * @param byteQuery '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> byteMultiByteAsync(byte[] byteQuery, Context context) {
+        return byteMultiByteWithResponseAsync(byteQuery, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     *
+     * @param byteQuery '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> byteMultiByteWithResponse(byte[] byteQuery) {
-        return byteMultiByteWithResponseAsync(byteQuery).block();
+    public Response<Void> byteMultiByteWithResponse(byte[] byteQuery, Context context) {
+        return byteMultiByteWithResponseAsync(byteQuery, context).block();
     }
 
     /**
@@ -1832,7 +2633,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void byteMultiByte(byte[] byteQuery) {
-        byteMultiByteWithResponse(byteQuery);
+        byteMultiByteWithResponse(byteQuery, Context.NONE);
     }
 
     /**
@@ -1844,7 +2645,7 @@ public final class Queries {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void byteMultiByte() {
         final byte[] byteQuery = new byte[0];
-        byteMultiByteWithResponse(byteQuery);
+        byteMultiByteWithResponse(byteQuery, Context.NONE);
     }
 
     /**
@@ -1870,6 +2671,27 @@ public final class Queries {
     /**
      * Get '' as byte array.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '' as byte array along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> byteEmptyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final byte[] byteQuery = "".getBytes();
+        final String accept = "application/json";
+        String byteQueryConverted = Base64Util.encodeToString(byteQuery);
+        return service.byteEmpty(this.client.getHost(), byteQueryConverted, accept, context);
+    }
+
+    /**
+     * Get '' as byte array.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '' as byte array on successful completion of {@link Mono}.
@@ -1882,13 +2704,29 @@ public final class Queries {
     /**
      * Get '' as byte array.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '' as byte array on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> byteEmptyAsync(Context context) {
+        return byteEmptyWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get '' as byte array.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '' as byte array along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> byteEmptyWithResponse() {
-        return byteEmptyWithResponseAsync().block();
+    public Response<Void> byteEmptyWithResponse(Context context) {
+        return byteEmptyWithResponseAsync(context).block();
     }
 
     /**
@@ -1899,7 +2737,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void byteEmpty() {
-        byteEmptyWithResponse();
+        byteEmptyWithResponse(Context.NONE);
     }
 
     /**
@@ -1922,6 +2760,28 @@ public final class Queries {
         String byteQueryConverted = Base64Util.encodeToString(byteQuery);
         return FluxUtil.withContext(
                 context -> service.byteNull(this.client.getHost(), byteQueryConverted, accept, context));
+    }
+
+    /**
+     * Get null as byte array (no query parameters in uri).
+     *
+     * @param byteQuery null as byte array (no query parameters in uri).
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null as byte array (no query parameters in uri) along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> byteNullWithResponseAsync(byte[] byteQuery, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        String byteQueryConverted = Base64Util.encodeToString(byteQuery);
+        return service.byteNull(this.client.getHost(), byteQueryConverted, accept, context);
     }
 
     /**
@@ -1955,14 +2815,30 @@ public final class Queries {
      * Get null as byte array (no query parameters in uri).
      *
      * @param byteQuery null as byte array (no query parameters in uri).
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null as byte array (no query parameters in uri) on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> byteNullAsync(byte[] byteQuery, Context context) {
+        return byteNullWithResponseAsync(byteQuery, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get null as byte array (no query parameters in uri).
+     *
+     * @param byteQuery null as byte array (no query parameters in uri).
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null as byte array (no query parameters in uri) along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> byteNullWithResponse(byte[] byteQuery) {
-        return byteNullWithResponseAsync(byteQuery).block();
+    public Response<Void> byteNullWithResponse(byte[] byteQuery, Context context) {
+        return byteNullWithResponseAsync(byteQuery, context).block();
     }
 
     /**
@@ -1975,7 +2851,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void byteNull(byte[] byteQuery) {
-        byteNullWithResponse(byteQuery);
+        byteNullWithResponse(byteQuery, Context.NONE);
     }
 
     /**
@@ -1987,7 +2863,7 @@ public final class Queries {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void byteNull() {
         final byte[] byteQuery = new byte[0];
-        byteNullWithResponse(byteQuery);
+        byteNullWithResponse(byteQuery, Context.NONE);
     }
 
     /**
@@ -2011,6 +2887,26 @@ public final class Queries {
     /**
      * Get '2012-01-01' as date.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '2012-01-01' as date along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> dateValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final LocalDate dateQuery = LocalDate.parse("2012-01-01");
+        final String accept = "application/json";
+        return service.dateValid(this.client.getHost(), dateQuery, accept, context);
+    }
+
+    /**
+     * Get '2012-01-01' as date.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '2012-01-01' as date on successful completion of {@link Mono}.
@@ -2023,13 +2919,29 @@ public final class Queries {
     /**
      * Get '2012-01-01' as date.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '2012-01-01' as date on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> dateValidAsync(Context context) {
+        return dateValidWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get '2012-01-01' as date.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '2012-01-01' as date along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> dateValidWithResponse() {
-        return dateValidWithResponseAsync().block();
+    public Response<Void> dateValidWithResponse(Context context) {
+        return dateValidWithResponseAsync(context).block();
     }
 
     /**
@@ -2040,7 +2952,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void dateValid() {
-        dateValidWithResponse();
+        dateValidWithResponse(Context.NONE);
     }
 
     /**
@@ -2061,6 +2973,27 @@ public final class Queries {
         }
         final String accept = "application/json";
         return FluxUtil.withContext(context -> service.dateNull(this.client.getHost(), dateQuery, accept, context));
+    }
+
+    /**
+     * Get null as date - this should result in no query parameters in uri.
+     *
+     * @param dateQuery null as date (no query parameters in uri).
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null as date - this should result in no query parameters in uri along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> dateNullWithResponseAsync(LocalDate dateQuery, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.dateNull(this.client.getHost(), dateQuery, accept, context);
     }
 
     /**
@@ -2094,14 +3027,30 @@ public final class Queries {
      * Get null as date - this should result in no query parameters in uri.
      *
      * @param dateQuery null as date (no query parameters in uri).
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null as date - this should result in no query parameters in uri on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> dateNullAsync(LocalDate dateQuery, Context context) {
+        return dateNullWithResponseAsync(dateQuery, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get null as date - this should result in no query parameters in uri.
+     *
+     * @param dateQuery null as date (no query parameters in uri).
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null as date - this should result in no query parameters in uri along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> dateNullWithResponse(LocalDate dateQuery) {
-        return dateNullWithResponseAsync(dateQuery).block();
+    public Response<Void> dateNullWithResponse(LocalDate dateQuery, Context context) {
+        return dateNullWithResponseAsync(dateQuery, context).block();
     }
 
     /**
@@ -2114,7 +3063,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void dateNull(LocalDate dateQuery) {
-        dateNullWithResponse(dateQuery);
+        dateNullWithResponse(dateQuery, Context.NONE);
     }
 
     /**
@@ -2126,7 +3075,7 @@ public final class Queries {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void dateNull() {
         final LocalDate dateQuery = null;
-        dateNullWithResponse(dateQuery);
+        dateNullWithResponse(dateQuery, Context.NONE);
     }
 
     /**
@@ -2151,6 +3100,26 @@ public final class Queries {
     /**
      * Get '2012-01-01T01:01:01Z' as date-time.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '2012-01-01T01:01:01Z' as date-time along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> dateTimeValidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final OffsetDateTime dateTimeQuery = OffsetDateTime.parse("2012-01-01T01:01:01Z");
+        final String accept = "application/json";
+        return service.dateTimeValid(this.client.getHost(), dateTimeQuery, accept, context);
+    }
+
+    /**
+     * Get '2012-01-01T01:01:01Z' as date-time.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '2012-01-01T01:01:01Z' as date-time on successful completion of {@link Mono}.
@@ -2163,13 +3132,29 @@ public final class Queries {
     /**
      * Get '2012-01-01T01:01:01Z' as date-time.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return '2012-01-01T01:01:01Z' as date-time on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> dateTimeValidAsync(Context context) {
+        return dateTimeValidWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get '2012-01-01T01:01:01Z' as date-time.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return '2012-01-01T01:01:01Z' as date-time along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> dateTimeValidWithResponse() {
-        return dateTimeValidWithResponseAsync().block();
+    public Response<Void> dateTimeValidWithResponse(Context context) {
+        return dateTimeValidWithResponseAsync(context).block();
     }
 
     /**
@@ -2180,7 +3165,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void dateTimeValid() {
-        dateTimeValidWithResponse();
+        dateTimeValidWithResponse(Context.NONE);
     }
 
     /**
@@ -2202,6 +3187,27 @@ public final class Queries {
         final String accept = "application/json";
         return FluxUtil.withContext(
                 context -> service.dateTimeNull(this.client.getHost(), dateTimeQuery, accept, context));
+    }
+
+    /**
+     * Get null as date-time, should result in no query parameters in uri.
+     *
+     * @param dateTimeQuery null as date-time (no query parameters).
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null as date-time, should result in no query parameters in uri along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> dateTimeNullWithResponseAsync(OffsetDateTime dateTimeQuery, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.dateTimeNull(this.client.getHost(), dateTimeQuery, accept, context);
     }
 
     /**
@@ -2235,14 +3241,30 @@ public final class Queries {
      * Get null as date-time, should result in no query parameters in uri.
      *
      * @param dateTimeQuery null as date-time (no query parameters).
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null as date-time, should result in no query parameters in uri on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> dateTimeNullAsync(OffsetDateTime dateTimeQuery, Context context) {
+        return dateTimeNullWithResponseAsync(dateTimeQuery, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get null as date-time, should result in no query parameters in uri.
+     *
+     * @param dateTimeQuery null as date-time (no query parameters).
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null as date-time, should result in no query parameters in uri along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> dateTimeNullWithResponse(OffsetDateTime dateTimeQuery) {
-        return dateTimeNullWithResponseAsync(dateTimeQuery).block();
+    public Response<Void> dateTimeNullWithResponse(OffsetDateTime dateTimeQuery, Context context) {
+        return dateTimeNullWithResponseAsync(dateTimeQuery, context).block();
     }
 
     /**
@@ -2255,7 +3277,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void dateTimeNull(OffsetDateTime dateTimeQuery) {
-        dateTimeNullWithResponse(dateTimeQuery);
+        dateTimeNullWithResponse(dateTimeQuery, Context.NONE);
     }
 
     /**
@@ -2267,7 +3289,7 @@ public final class Queries {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void dateTimeNull() {
         final OffsetDateTime dateTimeQuery = null;
-        dateTimeNullWithResponse(dateTimeQuery);
+        dateTimeNullWithResponse(dateTimeQuery, Context.NONE);
     }
 
     /**
@@ -2296,6 +3318,34 @@ public final class Queries {
                                 .collect(Collectors.joining(","));
         return FluxUtil.withContext(
                 context -> service.arrayStringCsvValid(this.client.getHost(), arrayQueryConverted, accept, context));
+    }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the
+     *     csv-array format.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array
+     *     format along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> arrayStringCsvValidWithResponseAsync(List<String> arrayQuery, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        String arrayQueryConverted =
+                (arrayQuery == null)
+                        ? null
+                        : arrayQuery.stream()
+                                .map(value -> Objects.toString(value, ""))
+                                .collect(Collectors.joining(","));
+        return service.arrayStringCsvValid(this.client.getHost(), arrayQueryConverted, accept, context);
     }
 
     /**
@@ -2333,6 +3383,24 @@ public final class Queries {
      *
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the
      *     csv-array format.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array
+     *     format on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> arrayStringCsvValidAsync(List<String> arrayQuery, Context context) {
+        return arrayStringCsvValidWithResponseAsync(arrayQuery, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the
+     *     csv-array format.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -2340,8 +3408,8 @@ public final class Queries {
      *     format along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> arrayStringCsvValidWithResponse(List<String> arrayQuery) {
-        return arrayStringCsvValidWithResponseAsync(arrayQuery).block();
+    public Response<Void> arrayStringCsvValidWithResponse(List<String> arrayQuery, Context context) {
+        return arrayStringCsvValidWithResponseAsync(arrayQuery, context).block();
     }
 
     /**
@@ -2355,7 +3423,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void arrayStringCsvValid(List<String> arrayQuery) {
-        arrayStringCsvValidWithResponse(arrayQuery);
+        arrayStringCsvValidWithResponse(arrayQuery, Context.NONE);
     }
 
     /**
@@ -2367,7 +3435,7 @@ public final class Queries {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void arrayStringCsvValid() {
         final List<String> arrayQuery = null;
-        arrayStringCsvValidWithResponse(arrayQuery);
+        arrayStringCsvValidWithResponse(arrayQuery, Context.NONE);
     }
 
     /**
@@ -2401,6 +3469,33 @@ public final class Queries {
      * Get a null array of string using the csv-array format.
      *
      * @param arrayQuery a null array of string using the csv-array format.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a null array of string using the csv-array format along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> arrayStringCsvNullWithResponseAsync(List<String> arrayQuery, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        String arrayQueryConverted =
+                (arrayQuery == null)
+                        ? null
+                        : arrayQuery.stream()
+                                .map(value -> Objects.toString(value, ""))
+                                .collect(Collectors.joining(","));
+        return service.arrayStringCsvNull(this.client.getHost(), arrayQueryConverted, accept, context);
+    }
+
+    /**
+     * Get a null array of string using the csv-array format.
+     *
+     * @param arrayQuery a null array of string using the csv-array format.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -2428,14 +3523,30 @@ public final class Queries {
      * Get a null array of string using the csv-array format.
      *
      * @param arrayQuery a null array of string using the csv-array format.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a null array of string using the csv-array format on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> arrayStringCsvNullAsync(List<String> arrayQuery, Context context) {
+        return arrayStringCsvNullWithResponseAsync(arrayQuery, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get a null array of string using the csv-array format.
+     *
+     * @param arrayQuery a null array of string using the csv-array format.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a null array of string using the csv-array format along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> arrayStringCsvNullWithResponse(List<String> arrayQuery) {
-        return arrayStringCsvNullWithResponseAsync(arrayQuery).block();
+    public Response<Void> arrayStringCsvNullWithResponse(List<String> arrayQuery, Context context) {
+        return arrayStringCsvNullWithResponseAsync(arrayQuery, context).block();
     }
 
     /**
@@ -2448,7 +3559,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void arrayStringCsvNull(List<String> arrayQuery) {
-        arrayStringCsvNullWithResponse(arrayQuery);
+        arrayStringCsvNullWithResponse(arrayQuery, Context.NONE);
     }
 
     /**
@@ -2460,7 +3571,7 @@ public final class Queries {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void arrayStringCsvNull() {
         final List<String> arrayQuery = null;
-        arrayStringCsvNullWithResponse(arrayQuery);
+        arrayStringCsvNullWithResponse(arrayQuery, Context.NONE);
     }
 
     /**
@@ -2494,6 +3605,33 @@ public final class Queries {
      * Get an empty array [] of string using the csv-array format.
      *
      * @param arrayQuery an empty array [] of string using the csv-array format.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an empty array [] of string using the csv-array format along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> arrayStringCsvEmptyWithResponseAsync(List<String> arrayQuery, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        String arrayQueryConverted =
+                (arrayQuery == null)
+                        ? null
+                        : arrayQuery.stream()
+                                .map(value -> Objects.toString(value, ""))
+                                .collect(Collectors.joining(","));
+        return service.arrayStringCsvEmpty(this.client.getHost(), arrayQueryConverted, accept, context);
+    }
+
+    /**
+     * Get an empty array [] of string using the csv-array format.
+     *
+     * @param arrayQuery an empty array [] of string using the csv-array format.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -2521,14 +3659,30 @@ public final class Queries {
      * Get an empty array [] of string using the csv-array format.
      *
      * @param arrayQuery an empty array [] of string using the csv-array format.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an empty array [] of string using the csv-array format on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> arrayStringCsvEmptyAsync(List<String> arrayQuery, Context context) {
+        return arrayStringCsvEmptyWithResponseAsync(arrayQuery, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get an empty array [] of string using the csv-array format.
+     *
+     * @param arrayQuery an empty array [] of string using the csv-array format.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an empty array [] of string using the csv-array format along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> arrayStringCsvEmptyWithResponse(List<String> arrayQuery) {
-        return arrayStringCsvEmptyWithResponseAsync(arrayQuery).block();
+    public Response<Void> arrayStringCsvEmptyWithResponse(List<String> arrayQuery, Context context) {
+        return arrayStringCsvEmptyWithResponseAsync(arrayQuery, context).block();
     }
 
     /**
@@ -2541,7 +3695,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void arrayStringCsvEmpty(List<String> arrayQuery) {
-        arrayStringCsvEmptyWithResponse(arrayQuery);
+        arrayStringCsvEmptyWithResponse(arrayQuery, Context.NONE);
     }
 
     /**
@@ -2553,7 +3707,7 @@ public final class Queries {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void arrayStringCsvEmpty() {
         final List<String> arrayQuery = null;
-        arrayStringCsvEmptyWithResponse(arrayQuery);
+        arrayStringCsvEmptyWithResponse(arrayQuery, Context.NONE);
     }
 
     /**
@@ -2590,6 +3744,34 @@ public final class Queries {
      * the 'arrayQuery' parameter to the service.
      *
      * @param arrayQuery Array-typed query parameter. Pass in ['hello', 'nihao', 'bonjour'].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> arrayStringNoCollectionFormatEmptyWithResponseAsync(
+            List<String> arrayQuery, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        String arrayQueryConverted =
+                (arrayQuery == null)
+                        ? null
+                        : arrayQuery.stream()
+                                .map(value -> Objects.toString(value, ""))
+                                .collect(Collectors.joining(","));
+        return service.arrayStringNoCollectionFormatEmpty(this.client.getHost(), arrayQueryConverted, accept, context);
+    }
+
+    /**
+     * Array query has no defined collection format, should default to csv. Pass in ['hello', 'nihao', 'bonjour'] for
+     * the 'arrayQuery' parameter to the service.
+     *
+     * @param arrayQuery Array-typed query parameter. Pass in ['hello', 'nihao', 'bonjour'].
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -2619,14 +3801,32 @@ public final class Queries {
      * the 'arrayQuery' parameter to the service.
      *
      * @param arrayQuery Array-typed query parameter. Pass in ['hello', 'nihao', 'bonjour'].
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> arrayStringNoCollectionFormatEmptyAsync(List<String> arrayQuery, Context context) {
+        return arrayStringNoCollectionFormatEmptyWithResponseAsync(arrayQuery, context)
+                .flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Array query has no defined collection format, should default to csv. Pass in ['hello', 'nihao', 'bonjour'] for
+     * the 'arrayQuery' parameter to the service.
+     *
+     * @param arrayQuery Array-typed query parameter. Pass in ['hello', 'nihao', 'bonjour'].
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> arrayStringNoCollectionFormatEmptyWithResponse(List<String> arrayQuery) {
-        return arrayStringNoCollectionFormatEmptyWithResponseAsync(arrayQuery).block();
+    public Response<Void> arrayStringNoCollectionFormatEmptyWithResponse(List<String> arrayQuery, Context context) {
+        return arrayStringNoCollectionFormatEmptyWithResponseAsync(arrayQuery, context).block();
     }
 
     /**
@@ -2640,7 +3840,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void arrayStringNoCollectionFormatEmpty(List<String> arrayQuery) {
-        arrayStringNoCollectionFormatEmptyWithResponse(arrayQuery);
+        arrayStringNoCollectionFormatEmptyWithResponse(arrayQuery, Context.NONE);
     }
 
     /**
@@ -2653,7 +3853,7 @@ public final class Queries {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void arrayStringNoCollectionFormatEmpty() {
         final List<String> arrayQuery = null;
-        arrayStringNoCollectionFormatEmptyWithResponse(arrayQuery);
+        arrayStringNoCollectionFormatEmptyWithResponse(arrayQuery, Context.NONE);
     }
 
     /**
@@ -2682,6 +3882,34 @@ public final class Queries {
                                 .collect(Collectors.joining(" "));
         return FluxUtil.withContext(
                 context -> service.arrayStringSsvValid(this.client.getHost(), arrayQueryConverted, accept, context));
+    }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the
+     *     ssv-array format.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array
+     *     format along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> arrayStringSsvValidWithResponseAsync(List<String> arrayQuery, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        String arrayQueryConverted =
+                (arrayQuery == null)
+                        ? null
+                        : arrayQuery.stream()
+                                .map(value -> Objects.toString(value, ""))
+                                .collect(Collectors.joining(" "));
+        return service.arrayStringSsvValid(this.client.getHost(), arrayQueryConverted, accept, context);
     }
 
     /**
@@ -2719,6 +3947,24 @@ public final class Queries {
      *
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the
      *     ssv-array format.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array
+     *     format on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> arrayStringSsvValidAsync(List<String> arrayQuery, Context context) {
+        return arrayStringSsvValidWithResponseAsync(arrayQuery, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the
+     *     ssv-array format.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -2726,8 +3972,8 @@ public final class Queries {
      *     format along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> arrayStringSsvValidWithResponse(List<String> arrayQuery) {
-        return arrayStringSsvValidWithResponseAsync(arrayQuery).block();
+    public Response<Void> arrayStringSsvValidWithResponse(List<String> arrayQuery, Context context) {
+        return arrayStringSsvValidWithResponseAsync(arrayQuery, context).block();
     }
 
     /**
@@ -2741,7 +3987,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void arrayStringSsvValid(List<String> arrayQuery) {
-        arrayStringSsvValidWithResponse(arrayQuery);
+        arrayStringSsvValidWithResponse(arrayQuery, Context.NONE);
     }
 
     /**
@@ -2753,7 +3999,7 @@ public final class Queries {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void arrayStringSsvValid() {
         final List<String> arrayQuery = null;
-        arrayStringSsvValidWithResponse(arrayQuery);
+        arrayStringSsvValidWithResponse(arrayQuery, Context.NONE);
     }
 
     /**
@@ -2782,6 +4028,34 @@ public final class Queries {
                                 .collect(Collectors.joining("	"));
         return FluxUtil.withContext(
                 context -> service.arrayStringTsvValid(this.client.getHost(), arrayQueryConverted, accept, context));
+    }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the
+     *     tsv-array format.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array
+     *     format along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> arrayStringTsvValidWithResponseAsync(List<String> arrayQuery, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        String arrayQueryConverted =
+                (arrayQuery == null)
+                        ? null
+                        : arrayQuery.stream()
+                                .map(value -> Objects.toString(value, ""))
+                                .collect(Collectors.joining("	"));
+        return service.arrayStringTsvValid(this.client.getHost(), arrayQueryConverted, accept, context);
     }
 
     /**
@@ -2819,6 +4093,24 @@ public final class Queries {
      *
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the
      *     tsv-array format.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array
+     *     format on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> arrayStringTsvValidAsync(List<String> arrayQuery, Context context) {
+        return arrayStringTsvValidWithResponseAsync(arrayQuery, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the
+     *     tsv-array format.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -2826,8 +4118,8 @@ public final class Queries {
      *     format along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> arrayStringTsvValidWithResponse(List<String> arrayQuery) {
-        return arrayStringTsvValidWithResponseAsync(arrayQuery).block();
+    public Response<Void> arrayStringTsvValidWithResponse(List<String> arrayQuery, Context context) {
+        return arrayStringTsvValidWithResponseAsync(arrayQuery, context).block();
     }
 
     /**
@@ -2841,7 +4133,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void arrayStringTsvValid(List<String> arrayQuery) {
-        arrayStringTsvValidWithResponse(arrayQuery);
+        arrayStringTsvValidWithResponse(arrayQuery, Context.NONE);
     }
 
     /**
@@ -2853,7 +4145,7 @@ public final class Queries {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void arrayStringTsvValid() {
         final List<String> arrayQuery = null;
-        arrayStringTsvValidWithResponse(arrayQuery);
+        arrayStringTsvValidWithResponse(arrayQuery, Context.NONE);
     }
 
     /**
@@ -2883,6 +4175,35 @@ public final class Queries {
                                 .collect(Collectors.joining("|"));
         return FluxUtil.withContext(
                 context -> service.arrayStringPipesValid(this.client.getHost(), arrayQueryConverted, accept, context));
+    }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array
+     * format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the
+     *     pipes-array format.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array
+     *     format along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> arrayStringPipesValidWithResponseAsync(List<String> arrayQuery, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        String arrayQueryConverted =
+                (arrayQuery == null)
+                        ? null
+                        : arrayQuery.stream()
+                                .map(value -> Objects.toString(value, ""))
+                                .collect(Collectors.joining("|"));
+        return service.arrayStringPipesValid(this.client.getHost(), arrayQueryConverted, accept, context);
     }
 
     /**
@@ -2923,6 +4244,25 @@ public final class Queries {
      *
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the
      *     pipes-array format.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array
+     *     format on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> arrayStringPipesValidAsync(List<String> arrayQuery, Context context) {
+        return arrayStringPipesValidWithResponseAsync(arrayQuery, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array
+     * format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the
+     *     pipes-array format.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -2930,8 +4270,8 @@ public final class Queries {
      *     format along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> arrayStringPipesValidWithResponse(List<String> arrayQuery) {
-        return arrayStringPipesValidWithResponseAsync(arrayQuery).block();
+    public Response<Void> arrayStringPipesValidWithResponse(List<String> arrayQuery, Context context) {
+        return arrayStringPipesValidWithResponseAsync(arrayQuery, context).block();
     }
 
     /**
@@ -2946,7 +4286,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void arrayStringPipesValid(List<String> arrayQuery) {
-        arrayStringPipesValidWithResponse(arrayQuery);
+        arrayStringPipesValidWithResponse(arrayQuery, Context.NONE);
     }
 
     /**
@@ -2959,6 +4299,6 @@ public final class Queries {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void arrayStringPipesValid() {
         final List<String> arrayQuery = null;
-        arrayStringPipesValidWithResponse(arrayQuery);
+        arrayStringPipesValidWithResponse(arrayQuery, Context.NONE);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/url/multi/Queries.java
+++ b/vanilla-tests/src/main/java/fixtures/url/multi/Queries.java
@@ -107,6 +107,31 @@ public final class Queries {
      * Get a null array of string using the multi-array format.
      *
      * @param arrayQuery a null array of string using the multi-array format.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a null array of string using the multi-array format along with {@link Response} on successful completion
+     *     of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> arrayStringMultiNullWithResponseAsync(List<String> arrayQuery, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        List<String> arrayQueryConverted =
+                (arrayQuery == null)
+                        ? new ArrayList<>()
+                        : arrayQuery.stream().map(item -> Objects.toString(item, "")).collect(Collectors.toList());
+        return service.arrayStringMultiNull(this.client.getHost(), arrayQueryConverted, accept, context);
+    }
+
+    /**
+     * Get a null array of string using the multi-array format.
+     *
+     * @param arrayQuery a null array of string using the multi-array format.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -134,14 +159,30 @@ public final class Queries {
      * Get a null array of string using the multi-array format.
      *
      * @param arrayQuery a null array of string using the multi-array format.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a null array of string using the multi-array format on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> arrayStringMultiNullAsync(List<String> arrayQuery, Context context) {
+        return arrayStringMultiNullWithResponseAsync(arrayQuery, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get a null array of string using the multi-array format.
+     *
+     * @param arrayQuery a null array of string using the multi-array format.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a null array of string using the multi-array format along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> arrayStringMultiNullWithResponse(List<String> arrayQuery) {
-        return arrayStringMultiNullWithResponseAsync(arrayQuery).block();
+    public Response<Void> arrayStringMultiNullWithResponse(List<String> arrayQuery, Context context) {
+        return arrayStringMultiNullWithResponseAsync(arrayQuery, context).block();
     }
 
     /**
@@ -154,7 +195,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void arrayStringMultiNull(List<String> arrayQuery) {
-        arrayStringMultiNullWithResponse(arrayQuery);
+        arrayStringMultiNullWithResponse(arrayQuery, Context.NONE);
     }
 
     /**
@@ -166,7 +207,7 @@ public final class Queries {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void arrayStringMultiNull() {
         final List<String> arrayQuery = null;
-        arrayStringMultiNullWithResponse(arrayQuery);
+        arrayStringMultiNullWithResponse(arrayQuery, Context.NONE);
     }
 
     /**
@@ -192,6 +233,31 @@ public final class Queries {
                         : arrayQuery.stream().map(item -> Objects.toString(item, "")).collect(Collectors.toList());
         return FluxUtil.withContext(
                 context -> service.arrayStringMultiEmpty(this.client.getHost(), arrayQueryConverted, accept, context));
+    }
+
+    /**
+     * Get an empty array [] of string using the multi-array format.
+     *
+     * @param arrayQuery an empty array [] of string using the multi-array format.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an empty array [] of string using the multi-array format along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> arrayStringMultiEmptyWithResponseAsync(List<String> arrayQuery, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        List<String> arrayQueryConverted =
+                (arrayQuery == null)
+                        ? new ArrayList<>()
+                        : arrayQuery.stream().map(item -> Objects.toString(item, "")).collect(Collectors.toList());
+        return service.arrayStringMultiEmpty(this.client.getHost(), arrayQueryConverted, accept, context);
     }
 
     /**
@@ -225,14 +291,30 @@ public final class Queries {
      * Get an empty array [] of string using the multi-array format.
      *
      * @param arrayQuery an empty array [] of string using the multi-array format.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an empty array [] of string using the multi-array format on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> arrayStringMultiEmptyAsync(List<String> arrayQuery, Context context) {
+        return arrayStringMultiEmptyWithResponseAsync(arrayQuery, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get an empty array [] of string using the multi-array format.
+     *
+     * @param arrayQuery an empty array [] of string using the multi-array format.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an empty array [] of string using the multi-array format along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> arrayStringMultiEmptyWithResponse(List<String> arrayQuery) {
-        return arrayStringMultiEmptyWithResponseAsync(arrayQuery).block();
+    public Response<Void> arrayStringMultiEmptyWithResponse(List<String> arrayQuery, Context context) {
+        return arrayStringMultiEmptyWithResponseAsync(arrayQuery, context).block();
     }
 
     /**
@@ -245,7 +327,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void arrayStringMultiEmpty(List<String> arrayQuery) {
-        arrayStringMultiEmptyWithResponse(arrayQuery);
+        arrayStringMultiEmptyWithResponse(arrayQuery, Context.NONE);
     }
 
     /**
@@ -257,7 +339,7 @@ public final class Queries {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void arrayStringMultiEmpty() {
         final List<String> arrayQuery = null;
-        arrayStringMultiEmptyWithResponse(arrayQuery);
+        arrayStringMultiEmptyWithResponse(arrayQuery, Context.NONE);
     }
 
     /**
@@ -284,6 +366,32 @@ public final class Queries {
                         : arrayQuery.stream().map(item -> Objects.toString(item, "")).collect(Collectors.toList());
         return FluxUtil.withContext(
                 context -> service.arrayStringMultiValid(this.client.getHost(), arrayQueryConverted, accept, context));
+    }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the mult-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the
+     *     mult-array format.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the mult-array
+     *     format along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> arrayStringMultiValidWithResponseAsync(List<String> arrayQuery, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        List<String> arrayQueryConverted =
+                (arrayQuery == null)
+                        ? new ArrayList<>()
+                        : arrayQuery.stream().map(item -> Objects.toString(item, "")).collect(Collectors.toList());
+        return service.arrayStringMultiValid(this.client.getHost(), arrayQueryConverted, accept, context);
     }
 
     /**
@@ -321,6 +429,24 @@ public final class Queries {
      *
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the
      *     mult-array format.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the mult-array
+     *     format on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> arrayStringMultiValidAsync(List<String> arrayQuery, Context context) {
+        return arrayStringMultiValidWithResponseAsync(arrayQuery, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the mult-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the
+     *     mult-array format.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -328,8 +454,8 @@ public final class Queries {
      *     format along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> arrayStringMultiValidWithResponse(List<String> arrayQuery) {
-        return arrayStringMultiValidWithResponseAsync(arrayQuery).block();
+    public Response<Void> arrayStringMultiValidWithResponse(List<String> arrayQuery, Context context) {
+        return arrayStringMultiValidWithResponseAsync(arrayQuery, context).block();
     }
 
     /**
@@ -343,7 +469,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void arrayStringMultiValid(List<String> arrayQuery) {
-        arrayStringMultiValidWithResponse(arrayQuery);
+        arrayStringMultiValidWithResponse(arrayQuery, Context.NONE);
     }
 
     /**
@@ -355,6 +481,6 @@ public final class Queries {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void arrayStringMultiValid() {
         final List<String> arrayQuery = null;
-        arrayStringMultiValidWithResponse(arrayQuery);
+        arrayStringMultiValidWithResponse(arrayQuery, Context.NONE);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/validation/AutoRestValidationTest.java
+++ b/vanilla-tests/src/main/java/fixtures/validation/AutoRestValidationTest.java
@@ -243,6 +243,36 @@ public final class AutoRestValidationTest {
      *
      * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
      * @param id Required int multiple of 10 from 100 to 1000.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the product documentation along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Product>> validationOfMethodParametersWithResponseAsync(
+            String resourceGroupName, int id, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (this.getSubscriptionId() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.getSubscriptionId() is required and cannot be null."));
+        }
+        if (resourceGroupName == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter resourceGroupName is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.validationOfMethodParameters(
+                this.getHost(), this.getSubscriptionId(), resourceGroupName, id, this.getApiVersion(), accept, context);
+    }
+
+    /**
+     * Validates input parameters on the method. See swagger for details.
+     *
+     * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
+     * @param id Required int multiple of 10 from 100 to 1000.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -259,14 +289,33 @@ public final class AutoRestValidationTest {
      *
      * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
      * @param id Required int multiple of 10 from 100 to 1000.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the product documentation on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Product> validationOfMethodParametersAsync(String resourceGroupName, int id, Context context) {
+        return validationOfMethodParametersWithResponseAsync(resourceGroupName, id, context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Validates input parameters on the method. See swagger for details.
+     *
+     * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
+     * @param id Required int multiple of 10 from 100 to 1000.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the product documentation along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Product> validationOfMethodParametersWithResponse(String resourceGroupName, int id) {
-        return validationOfMethodParametersWithResponseAsync(resourceGroupName, id).block();
+    public Response<Product> validationOfMethodParametersWithResponse(
+            String resourceGroupName, int id, Context context) {
+        return validationOfMethodParametersWithResponseAsync(resourceGroupName, id, context).block();
     }
 
     /**
@@ -281,7 +330,7 @@ public final class AutoRestValidationTest {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Product validationOfMethodParameters(String resourceGroupName, int id) {
-        return validationOfMethodParametersWithResponse(resourceGroupName, id).getValue();
+        return validationOfMethodParametersWithResponse(resourceGroupName, id, Context.NONE).getValue();
     }
 
     /**
@@ -331,6 +380,47 @@ public final class AutoRestValidationTest {
      * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
      * @param id Required int multiple of 10 from 100 to 1000.
      * @param body The product documentation.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the product documentation along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Product>> validationOfBodyWithResponseAsync(
+            String resourceGroupName, int id, Product body, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (this.getSubscriptionId() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.getSubscriptionId() is required and cannot be null."));
+        }
+        if (resourceGroupName == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter resourceGroupName is required and cannot be null."));
+        }
+        if (body != null) {
+            body.validate();
+        }
+        final String accept = "application/json";
+        return service.validationOfBody(
+                this.getHost(),
+                this.getSubscriptionId(),
+                resourceGroupName,
+                id,
+                this.getApiVersion(),
+                body,
+                accept,
+                context);
+    }
+
+    /**
+     * Validates body parameters on the method. See swagger for details.
+     *
+     * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
+     * @param id Required int multiple of 10 from 100 to 1000.
+     * @param body The product documentation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -365,14 +455,34 @@ public final class AutoRestValidationTest {
      * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
      * @param id Required int multiple of 10 from 100 to 1000.
      * @param body The product documentation.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the product documentation on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Product> validationOfBodyAsync(String resourceGroupName, int id, Product body, Context context) {
+        return validationOfBodyWithResponseAsync(resourceGroupName, id, body, context)
+                .flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Validates body parameters on the method. See swagger for details.
+     *
+     * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
+     * @param id Required int multiple of 10 from 100 to 1000.
+     * @param body The product documentation.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the product documentation along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Product> validationOfBodyWithResponse(String resourceGroupName, int id, Product body) {
-        return validationOfBodyWithResponseAsync(resourceGroupName, id, body).block();
+    public Response<Product> validationOfBodyWithResponse(
+            String resourceGroupName, int id, Product body, Context context) {
+        return validationOfBodyWithResponseAsync(resourceGroupName, id, body, context).block();
     }
 
     /**
@@ -388,7 +498,7 @@ public final class AutoRestValidationTest {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Product validationOfBody(String resourceGroupName, int id, Product body) {
-        return validationOfBodyWithResponse(resourceGroupName, id, body).getValue();
+        return validationOfBodyWithResponse(resourceGroupName, id, body, Context.NONE).getValue();
     }
 
     /**
@@ -404,7 +514,7 @@ public final class AutoRestValidationTest {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Product validationOfBody(String resourceGroupName, int id) {
         final Product body = null;
-        return validationOfBodyWithResponse(resourceGroupName, id, body).getValue();
+        return validationOfBodyWithResponse(resourceGroupName, id, body, Context.NONE).getValue();
     }
 
     /**
@@ -426,6 +536,24 @@ public final class AutoRestValidationTest {
     /**
      * The getWithConstantInPath operation.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> getWithConstantInPathWithResponseAsync(Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        final String constantParam = "constant";
+        return service.getWithConstantInPath(this.getHost(), constantParam, context);
+    }
+
+    /**
+     * The getWithConstantInPath operation.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return A {@link Mono} that completes when a successful response is received.
@@ -438,13 +566,29 @@ public final class AutoRestValidationTest {
     /**
      * The getWithConstantInPath operation.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getWithConstantInPathAsync(Context context) {
+        return getWithConstantInPathWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * The getWithConstantInPath operation.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getWithConstantInPathWithResponse() {
-        return getWithConstantInPathWithResponseAsync().block();
+    public Response<Void> getWithConstantInPathWithResponse(Context context) {
+        return getWithConstantInPathWithResponseAsync(context).block();
     }
 
     /**
@@ -455,7 +599,7 @@ public final class AutoRestValidationTest {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getWithConstantInPath() {
-        getWithConstantInPathWithResponse();
+        getWithConstantInPathWithResponse(Context.NONE);
     }
 
     /**
@@ -479,6 +623,29 @@ public final class AutoRestValidationTest {
         final String accept = "application/json";
         return FluxUtil.withContext(
                 context -> service.postWithConstantInBody(this.getHost(), constantParam, body, accept, context));
+    }
+
+    /**
+     * The postWithConstantInBody operation.
+     *
+     * @param body The product documentation.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the product documentation along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Product>> postWithConstantInBodyWithResponseAsync(Product body, Context context) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (body != null) {
+            body.validate();
+        }
+        final String constantParam = "constant";
+        final String accept = "application/json";
+        return service.postWithConstantInBody(this.getHost(), constantParam, body, accept, context);
     }
 
     /**
@@ -512,14 +679,30 @@ public final class AutoRestValidationTest {
      * The postWithConstantInBody operation.
      *
      * @param body The product documentation.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the product documentation on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Product> postWithConstantInBodyAsync(Product body, Context context) {
+        return postWithConstantInBodyWithResponseAsync(body, context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * The postWithConstantInBody operation.
+     *
+     * @param body The product documentation.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the product documentation along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Product> postWithConstantInBodyWithResponse(Product body) {
-        return postWithConstantInBodyWithResponseAsync(body).block();
+    public Response<Product> postWithConstantInBodyWithResponse(Product body, Context context) {
+        return postWithConstantInBodyWithResponseAsync(body, context).block();
     }
 
     /**
@@ -533,7 +716,7 @@ public final class AutoRestValidationTest {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Product postWithConstantInBody(Product body) {
-        return postWithConstantInBodyWithResponse(body).getValue();
+        return postWithConstantInBodyWithResponse(body, Context.NONE).getValue();
     }
 
     /**
@@ -546,6 +729,6 @@ public final class AutoRestValidationTest {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Product postWithConstantInBody() {
         final Product body = null;
-        return postWithConstantInBodyWithResponse(body).getValue();
+        return postWithConstantInBodyWithResponse(body, Context.NONE).getValue();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/Xmls.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/Xmls.java
@@ -333,6 +333,26 @@ public final class Xmls {
     /**
      * Get a complex type that has a ref to a complex type with no XML node.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a complex type that has a ref to a complex type with no XML node along with {@link Response} on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<RootWithRefAndNoMeta>> getComplexTypeRefNoMetaWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/xml";
+        return service.getComplexTypeRefNoMeta(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get a complex type that has a ref to a complex type with no XML node.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a complex type that has a ref to a complex type with no XML node on successful completion of {@link
@@ -346,13 +366,30 @@ public final class Xmls {
     /**
      * Get a complex type that has a ref to a complex type with no XML node.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a complex type that has a ref to a complex type with no XML node on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<RootWithRefAndNoMeta> getComplexTypeRefNoMetaAsync(Context context) {
+        return getComplexTypeRefNoMetaWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get a complex type that has a ref to a complex type with no XML node.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a complex type that has a ref to a complex type with no XML node along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<RootWithRefAndNoMeta> getComplexTypeRefNoMetaWithResponse() {
-        return getComplexTypeRefNoMetaWithResponseAsync().block();
+    public Response<RootWithRefAndNoMeta> getComplexTypeRefNoMetaWithResponse(Context context) {
+        return getComplexTypeRefNoMetaWithResponseAsync(context).block();
     }
 
     /**
@@ -364,7 +401,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public RootWithRefAndNoMeta getComplexTypeRefNoMeta() {
-        return getComplexTypeRefNoMetaWithResponse().getValue();
+        return getComplexTypeRefNoMetaWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -394,6 +431,30 @@ public final class Xmls {
      * Puts a complex type that has a ref to a complex type with no XML node.
      *
      * @param model I am root, and I ref a model with no meta.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putComplexTypeRefNoMetaWithResponseAsync(RootWithRefAndNoMeta model, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (model == null) {
+            return Mono.error(new IllegalArgumentException("Parameter model is required and cannot be null."));
+        } else {
+            model.validate();
+        }
+        return service.putComplexTypeRefNoMeta(this.client.getHost(), model, context);
+    }
+
+    /**
+     * Puts a complex type that has a ref to a complex type with no XML node.
+     *
+     * @param model I am root, and I ref a model with no meta.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -408,14 +469,30 @@ public final class Xmls {
      * Puts a complex type that has a ref to a complex type with no XML node.
      *
      * @param model I am root, and I ref a model with no meta.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putComplexTypeRefNoMetaAsync(RootWithRefAndNoMeta model, Context context) {
+        return putComplexTypeRefNoMetaWithResponseAsync(model, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts a complex type that has a ref to a complex type with no XML node.
+     *
+     * @param model I am root, and I ref a model with no meta.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putComplexTypeRefNoMetaWithResponse(RootWithRefAndNoMeta model) {
-        return putComplexTypeRefNoMetaWithResponseAsync(model).block();
+    public Response<Void> putComplexTypeRefNoMetaWithResponse(RootWithRefAndNoMeta model, Context context) {
+        return putComplexTypeRefNoMetaWithResponseAsync(model, context).block();
     }
 
     /**
@@ -428,7 +505,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putComplexTypeRefNoMeta(RootWithRefAndNoMeta model) {
-        putComplexTypeRefNoMetaWithResponse(model);
+        putComplexTypeRefNoMetaWithResponse(model, Context.NONE);
     }
 
     /**
@@ -453,6 +530,26 @@ public final class Xmls {
     /**
      * Get a complex type that has a ref to a complex type with XML node.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a complex type that has a ref to a complex type with XML node along with {@link Response} on successful
+     *     completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<RootWithRefAndMeta>> getComplexTypeRefWithMetaWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/xml";
+        return service.getComplexTypeRefWithMeta(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get a complex type that has a ref to a complex type with XML node.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a complex type that has a ref to a complex type with XML node on successful completion of {@link Mono}.
@@ -465,13 +562,29 @@ public final class Xmls {
     /**
      * Get a complex type that has a ref to a complex type with XML node.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a complex type that has a ref to a complex type with XML node on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<RootWithRefAndMeta> getComplexTypeRefWithMetaAsync(Context context) {
+        return getComplexTypeRefWithMetaWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get a complex type that has a ref to a complex type with XML node.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a complex type that has a ref to a complex type with XML node along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<RootWithRefAndMeta> getComplexTypeRefWithMetaWithResponse() {
-        return getComplexTypeRefWithMetaWithResponseAsync().block();
+    public Response<RootWithRefAndMeta> getComplexTypeRefWithMetaWithResponse(Context context) {
+        return getComplexTypeRefWithMetaWithResponseAsync(context).block();
     }
 
     /**
@@ -483,7 +596,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public RootWithRefAndMeta getComplexTypeRefWithMeta() {
-        return getComplexTypeRefWithMetaWithResponse().getValue();
+        return getComplexTypeRefWithMetaWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -514,6 +627,30 @@ public final class Xmls {
      * Puts a complex type that has a ref to a complex type with XML node.
      *
      * @param model I am root, and I ref a model WITH meta.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putComplexTypeRefWithMetaWithResponseAsync(RootWithRefAndMeta model, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (model == null) {
+            return Mono.error(new IllegalArgumentException("Parameter model is required and cannot be null."));
+        } else {
+            model.validate();
+        }
+        return service.putComplexTypeRefWithMeta(this.client.getHost(), model, context);
+    }
+
+    /**
+     * Puts a complex type that has a ref to a complex type with XML node.
+     *
+     * @param model I am root, and I ref a model WITH meta.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -528,14 +665,30 @@ public final class Xmls {
      * Puts a complex type that has a ref to a complex type with XML node.
      *
      * @param model I am root, and I ref a model WITH meta.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putComplexTypeRefWithMetaAsync(RootWithRefAndMeta model, Context context) {
+        return putComplexTypeRefWithMetaWithResponseAsync(model, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts a complex type that has a ref to a complex type with XML node.
+     *
+     * @param model I am root, and I ref a model WITH meta.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putComplexTypeRefWithMetaWithResponse(RootWithRefAndMeta model) {
-        return putComplexTypeRefWithMetaWithResponseAsync(model).block();
+    public Response<Void> putComplexTypeRefWithMetaWithResponse(RootWithRefAndMeta model, Context context) {
+        return putComplexTypeRefWithMetaWithResponseAsync(model, context).block();
     }
 
     /**
@@ -548,7 +701,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putComplexTypeRefWithMeta(RootWithRefAndMeta model) {
-        putComplexTypeRefWithMetaWithResponse(model);
+        putComplexTypeRefWithMetaWithResponse(model, Context.NONE);
     }
 
     /**
@@ -571,6 +724,25 @@ public final class Xmls {
     /**
      * Get a simple XML document.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a simple XML document along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Slideshow>> getSimpleWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/xml";
+        return service.getSimple(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get a simple XML document.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a simple XML document on successful completion of {@link Mono}.
@@ -583,13 +755,29 @@ public final class Xmls {
     /**
      * Get a simple XML document.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a simple XML document on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Slideshow> getSimpleAsync(Context context) {
+        return getSimpleWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get a simple XML document.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a simple XML document along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Slideshow> getSimpleWithResponse() {
-        return getSimpleWithResponseAsync().block();
+    public Response<Slideshow> getSimpleWithResponse(Context context) {
+        return getSimpleWithResponseAsync(context).block();
     }
 
     /**
@@ -601,7 +789,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Slideshow getSimple() {
-        return getSimpleWithResponse().getValue();
+        return getSimpleWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -632,6 +820,31 @@ public final class Xmls {
      * Put a simple XML document.
      *
      * @param slideshow Data about a slideshow.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putSimpleWithResponseAsync(Slideshow slideshow, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (slideshow == null) {
+            return Mono.error(new IllegalArgumentException("Parameter slideshow is required and cannot be null."));
+        } else {
+            slideshow.validate();
+        }
+        final String accept = "application/xml";
+        return service.putSimple(this.client.getHost(), slideshow, accept, context);
+    }
+
+    /**
+     * Put a simple XML document.
+     *
+     * @param slideshow Data about a slideshow.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -646,14 +859,30 @@ public final class Xmls {
      * Put a simple XML document.
      *
      * @param slideshow Data about a slideshow.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putSimpleAsync(Slideshow slideshow, Context context) {
+        return putSimpleWithResponseAsync(slideshow, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put a simple XML document.
+     *
+     * @param slideshow Data about a slideshow.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putSimpleWithResponse(Slideshow slideshow) {
-        return putSimpleWithResponseAsync(slideshow).block();
+    public Response<Void> putSimpleWithResponse(Slideshow slideshow, Context context) {
+        return putSimpleWithResponseAsync(slideshow, context).block();
     }
 
     /**
@@ -666,7 +895,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putSimple(Slideshow slideshow) {
-        putSimpleWithResponse(slideshow);
+        putSimpleWithResponse(slideshow, Context.NONE);
     }
 
     /**
@@ -690,6 +919,26 @@ public final class Xmls {
     /**
      * Get an XML document with multiple wrapped lists.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an XML document with multiple wrapped lists along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<AppleBarrel>> getWrappedListsWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/xml";
+        return service.getWrappedLists(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get an XML document with multiple wrapped lists.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an XML document with multiple wrapped lists on successful completion of {@link Mono}.
@@ -702,13 +951,29 @@ public final class Xmls {
     /**
      * Get an XML document with multiple wrapped lists.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an XML document with multiple wrapped lists on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<AppleBarrel> getWrappedListsAsync(Context context) {
+        return getWrappedListsWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get an XML document with multiple wrapped lists.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an XML document with multiple wrapped lists along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<AppleBarrel> getWrappedListsWithResponse() {
-        return getWrappedListsWithResponseAsync().block();
+    public Response<AppleBarrel> getWrappedListsWithResponse(Context context) {
+        return getWrappedListsWithResponseAsync(context).block();
     }
 
     /**
@@ -720,7 +985,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public AppleBarrel getWrappedLists() {
-        return getWrappedListsWithResponse().getValue();
+        return getWrappedListsWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -752,6 +1017,31 @@ public final class Xmls {
      * Put an XML document with multiple wrapped lists.
      *
      * @param wrappedLists A barrel of apples.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putWrappedListsWithResponseAsync(AppleBarrel wrappedLists, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (wrappedLists == null) {
+            return Mono.error(new IllegalArgumentException("Parameter wrappedLists is required and cannot be null."));
+        } else {
+            wrappedLists.validate();
+        }
+        final String accept = "application/xml";
+        return service.putWrappedLists(this.client.getHost(), wrappedLists, accept, context);
+    }
+
+    /**
+     * Put an XML document with multiple wrapped lists.
+     *
+     * @param wrappedLists A barrel of apples.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -766,14 +1056,30 @@ public final class Xmls {
      * Put an XML document with multiple wrapped lists.
      *
      * @param wrappedLists A barrel of apples.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putWrappedListsAsync(AppleBarrel wrappedLists, Context context) {
+        return putWrappedListsWithResponseAsync(wrappedLists, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put an XML document with multiple wrapped lists.
+     *
+     * @param wrappedLists A barrel of apples.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putWrappedListsWithResponse(AppleBarrel wrappedLists) {
-        return putWrappedListsWithResponseAsync(wrappedLists).block();
+    public Response<Void> putWrappedListsWithResponse(AppleBarrel wrappedLists, Context context) {
+        return putWrappedListsWithResponseAsync(wrappedLists, context).block();
     }
 
     /**
@@ -786,7 +1092,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putWrappedLists(AppleBarrel wrappedLists) {
-        putWrappedListsWithResponse(wrappedLists);
+        putWrappedListsWithResponse(wrappedLists, Context.NONE);
     }
 
     /**
@@ -808,6 +1114,24 @@ public final class Xmls {
     /**
      * Get strongly-typed response headers.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return strongly-typed response headers on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<XmlsGetHeadersResponse> getHeadersWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.getHeaders(this.client.getHost(), context);
+    }
+
+    /**
+     * Get strongly-typed response headers.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return strongly-typed response headers on successful completion of {@link Mono}.
@@ -820,13 +1144,29 @@ public final class Xmls {
     /**
      * Get strongly-typed response headers.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return strongly-typed response headers on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> getHeadersAsync(Context context) {
+        return getHeadersWithResponseAsync(context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Get strongly-typed response headers.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return strongly-typed response headers.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public XmlsGetHeadersResponse getHeadersWithResponse() {
-        return getHeadersWithResponseAsync().block();
+    public XmlsGetHeadersResponse getHeadersWithResponse(Context context) {
+        return getHeadersWithResponseAsync(context).block();
     }
 
     /**
@@ -837,7 +1177,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getHeaders() {
-        getHeadersWithResponse();
+        getHeadersWithResponse(Context.NONE);
     }
 
     /**
@@ -860,6 +1200,25 @@ public final class Xmls {
     /**
      * Get an empty list.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an empty list along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Slideshow>> getEmptyListWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/xml";
+        return service.getEmptyList(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get an empty list.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an empty list on successful completion of {@link Mono}.
@@ -872,13 +1231,29 @@ public final class Xmls {
     /**
      * Get an empty list.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an empty list on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Slideshow> getEmptyListAsync(Context context) {
+        return getEmptyListWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get an empty list.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an empty list along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Slideshow> getEmptyListWithResponse() {
-        return getEmptyListWithResponseAsync().block();
+    public Response<Slideshow> getEmptyListWithResponse(Context context) {
+        return getEmptyListWithResponseAsync(context).block();
     }
 
     /**
@@ -890,7 +1265,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Slideshow getEmptyList() {
-        return getEmptyListWithResponse().getValue();
+        return getEmptyListWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -920,6 +1295,30 @@ public final class Xmls {
      * Puts an empty list.
      *
      * @param slideshow Data about a slideshow.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putEmptyListWithResponseAsync(Slideshow slideshow, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (slideshow == null) {
+            return Mono.error(new IllegalArgumentException("Parameter slideshow is required and cannot be null."));
+        } else {
+            slideshow.validate();
+        }
+        return service.putEmptyList(this.client.getHost(), slideshow, context);
+    }
+
+    /**
+     * Puts an empty list.
+     *
+     * @param slideshow Data about a slideshow.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -934,14 +1333,30 @@ public final class Xmls {
      * Puts an empty list.
      *
      * @param slideshow Data about a slideshow.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putEmptyListAsync(Slideshow slideshow, Context context) {
+        return putEmptyListWithResponseAsync(slideshow, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts an empty list.
+     *
+     * @param slideshow Data about a slideshow.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putEmptyListWithResponse(Slideshow slideshow) {
-        return putEmptyListWithResponseAsync(slideshow).block();
+    public Response<Void> putEmptyListWithResponse(Slideshow slideshow, Context context) {
+        return putEmptyListWithResponseAsync(slideshow, context).block();
     }
 
     /**
@@ -954,7 +1369,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putEmptyList(Slideshow slideshow) {
-        putEmptyListWithResponse(slideshow);
+        putEmptyListWithResponse(slideshow, Context.NONE);
     }
 
     /**
@@ -977,6 +1392,25 @@ public final class Xmls {
     /**
      * Gets some empty wrapped lists.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return some empty wrapped lists along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<AppleBarrel>> getEmptyWrappedListsWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/xml";
+        return service.getEmptyWrappedLists(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Gets some empty wrapped lists.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return some empty wrapped lists on successful completion of {@link Mono}.
@@ -989,13 +1423,29 @@ public final class Xmls {
     /**
      * Gets some empty wrapped lists.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return some empty wrapped lists on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<AppleBarrel> getEmptyWrappedListsAsync(Context context) {
+        return getEmptyWrappedListsWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Gets some empty wrapped lists.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return some empty wrapped lists along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<AppleBarrel> getEmptyWrappedListsWithResponse() {
-        return getEmptyWrappedListsWithResponseAsync().block();
+    public Response<AppleBarrel> getEmptyWrappedListsWithResponse(Context context) {
+        return getEmptyWrappedListsWithResponseAsync(context).block();
     }
 
     /**
@@ -1007,7 +1457,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public AppleBarrel getEmptyWrappedLists() {
-        return getEmptyWrappedListsWithResponse().getValue();
+        return getEmptyWrappedListsWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1038,6 +1488,30 @@ public final class Xmls {
      * Puts some empty wrapped lists.
      *
      * @param appleBarrel A barrel of apples.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putEmptyWrappedListsWithResponseAsync(AppleBarrel appleBarrel, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (appleBarrel == null) {
+            return Mono.error(new IllegalArgumentException("Parameter appleBarrel is required and cannot be null."));
+        } else {
+            appleBarrel.validate();
+        }
+        return service.putEmptyWrappedLists(this.client.getHost(), appleBarrel, context);
+    }
+
+    /**
+     * Puts some empty wrapped lists.
+     *
+     * @param appleBarrel A barrel of apples.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1052,14 +1526,30 @@ public final class Xmls {
      * Puts some empty wrapped lists.
      *
      * @param appleBarrel A barrel of apples.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putEmptyWrappedListsAsync(AppleBarrel appleBarrel, Context context) {
+        return putEmptyWrappedListsWithResponseAsync(appleBarrel, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts some empty wrapped lists.
+     *
+     * @param appleBarrel A barrel of apples.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putEmptyWrappedListsWithResponse(AppleBarrel appleBarrel) {
-        return putEmptyWrappedListsWithResponseAsync(appleBarrel).block();
+    public Response<Void> putEmptyWrappedListsWithResponse(AppleBarrel appleBarrel, Context context) {
+        return putEmptyWrappedListsWithResponseAsync(appleBarrel, context).block();
     }
 
     /**
@@ -1072,7 +1562,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putEmptyWrappedLists(AppleBarrel appleBarrel) {
-        putEmptyWrappedListsWithResponse(appleBarrel);
+        putEmptyWrappedListsWithResponse(appleBarrel, Context.NONE);
     }
 
     /**
@@ -1095,6 +1585,25 @@ public final class Xmls {
     /**
      * Gets a list as the root element.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a list as the root element along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Banana>>> getRootListWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/xml";
+        return service.getRootList(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Gets a list as the root element.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a list as the root element on successful completion of {@link Mono}.
@@ -1107,13 +1616,29 @@ public final class Xmls {
     /**
      * Gets a list as the root element.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a list as the root element on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Banana>> getRootListAsync(Context context) {
+        return getRootListWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Gets a list as the root element.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a list as the root element along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Banana>> getRootListWithResponse() {
-        return getRootListWithResponseAsync().block();
+    public Response<List<Banana>> getRootListWithResponse(Context context) {
+        return getRootListWithResponseAsync(context).block();
     }
 
     /**
@@ -1125,7 +1650,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Banana> getRootList() {
-        return getRootListWithResponse().getValue();
+        return getRootListWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1156,6 +1681,31 @@ public final class Xmls {
      * Puts a list as the root element.
      *
      * @param bananas Array of Banana.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putRootListWithResponseAsync(List<Banana> bananas, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (bananas == null) {
+            return Mono.error(new IllegalArgumentException("Parameter bananas is required and cannot be null."));
+        } else {
+            bananas.forEach(e -> e.validate());
+        }
+        BananasWrapper bananasConverted = new BananasWrapper(bananas);
+        return service.putRootList(this.client.getHost(), bananasConverted, context);
+    }
+
+    /**
+     * Puts a list as the root element.
+     *
+     * @param bananas Array of Banana.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1170,14 +1720,30 @@ public final class Xmls {
      * Puts a list as the root element.
      *
      * @param bananas Array of Banana.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putRootListAsync(List<Banana> bananas, Context context) {
+        return putRootListWithResponseAsync(bananas, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts a list as the root element.
+     *
+     * @param bananas Array of Banana.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putRootListWithResponse(List<Banana> bananas) {
-        return putRootListWithResponseAsync(bananas).block();
+    public Response<Void> putRootListWithResponse(List<Banana> bananas, Context context) {
+        return putRootListWithResponseAsync(bananas, context).block();
     }
 
     /**
@@ -1190,7 +1756,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putRootList(List<Banana> bananas) {
-        putRootListWithResponse(bananas);
+        putRootListWithResponse(bananas, Context.NONE);
     }
 
     /**
@@ -1213,6 +1779,25 @@ public final class Xmls {
     /**
      * Gets a list with a single item.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a list with a single item along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Banana>>> getRootListSingleItemWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/xml";
+        return service.getRootListSingleItem(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Gets a list with a single item.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a list with a single item on successful completion of {@link Mono}.
@@ -1225,13 +1810,29 @@ public final class Xmls {
     /**
      * Gets a list with a single item.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a list with a single item on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Banana>> getRootListSingleItemAsync(Context context) {
+        return getRootListSingleItemWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Gets a list with a single item.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return a list with a single item along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Banana>> getRootListSingleItemWithResponse() {
-        return getRootListSingleItemWithResponseAsync().block();
+    public Response<List<Banana>> getRootListSingleItemWithResponse(Context context) {
+        return getRootListSingleItemWithResponseAsync(context).block();
     }
 
     /**
@@ -1243,7 +1844,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Banana> getRootListSingleItem() {
-        return getRootListSingleItemWithResponse().getValue();
+        return getRootListSingleItemWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1275,6 +1876,31 @@ public final class Xmls {
      * Puts a list with a single item.
      *
      * @param bananas Array of Banana.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putRootListSingleItemWithResponseAsync(List<Banana> bananas, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (bananas == null) {
+            return Mono.error(new IllegalArgumentException("Parameter bananas is required and cannot be null."));
+        } else {
+            bananas.forEach(e -> e.validate());
+        }
+        BananasWrapper bananasConverted = new BananasWrapper(bananas);
+        return service.putRootListSingleItem(this.client.getHost(), bananasConverted, context);
+    }
+
+    /**
+     * Puts a list with a single item.
+     *
+     * @param bananas Array of Banana.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1289,14 +1915,30 @@ public final class Xmls {
      * Puts a list with a single item.
      *
      * @param bananas Array of Banana.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putRootListSingleItemAsync(List<Banana> bananas, Context context) {
+        return putRootListSingleItemWithResponseAsync(bananas, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts a list with a single item.
+     *
+     * @param bananas Array of Banana.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putRootListSingleItemWithResponse(List<Banana> bananas) {
-        return putRootListSingleItemWithResponseAsync(bananas).block();
+    public Response<Void> putRootListSingleItemWithResponse(List<Banana> bananas, Context context) {
+        return putRootListSingleItemWithResponseAsync(bananas, context).block();
     }
 
     /**
@@ -1309,7 +1951,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putRootListSingleItem(List<Banana> bananas) {
-        putRootListSingleItemWithResponse(bananas);
+        putRootListSingleItemWithResponse(bananas, Context.NONE);
     }
 
     /**
@@ -1332,6 +1974,25 @@ public final class Xmls {
     /**
      * Gets an empty list as the root element.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an empty list as the root element along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<Banana>>> getEmptyRootListWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/xml";
+        return service.getEmptyRootList(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Gets an empty list as the root element.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an empty list as the root element on successful completion of {@link Mono}.
@@ -1344,13 +2005,29 @@ public final class Xmls {
     /**
      * Gets an empty list as the root element.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an empty list as the root element on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<Banana>> getEmptyRootListAsync(Context context) {
+        return getEmptyRootListWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Gets an empty list as the root element.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an empty list as the root element along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<Banana>> getEmptyRootListWithResponse() {
-        return getEmptyRootListWithResponseAsync().block();
+    public Response<List<Banana>> getEmptyRootListWithResponse(Context context) {
+        return getEmptyRootListWithResponseAsync(context).block();
     }
 
     /**
@@ -1362,7 +2039,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Banana> getEmptyRootList() {
-        return getEmptyRootListWithResponse().getValue();
+        return getEmptyRootListWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1394,6 +2071,31 @@ public final class Xmls {
      * Puts an empty list as the root element.
      *
      * @param bananas Array of Banana.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putEmptyRootListWithResponseAsync(List<Banana> bananas, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (bananas == null) {
+            return Mono.error(new IllegalArgumentException("Parameter bananas is required and cannot be null."));
+        } else {
+            bananas.forEach(e -> e.validate());
+        }
+        BananasWrapper bananasConverted = new BananasWrapper(bananas);
+        return service.putEmptyRootList(this.client.getHost(), bananasConverted, context);
+    }
+
+    /**
+     * Puts an empty list as the root element.
+     *
+     * @param bananas Array of Banana.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1408,14 +2110,30 @@ public final class Xmls {
      * Puts an empty list as the root element.
      *
      * @param bananas Array of Banana.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putEmptyRootListAsync(List<Banana> bananas, Context context) {
+        return putEmptyRootListWithResponseAsync(bananas, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts an empty list as the root element.
+     *
+     * @param bananas Array of Banana.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putEmptyRootListWithResponse(List<Banana> bananas) {
-        return putEmptyRootListWithResponseAsync(bananas).block();
+    public Response<Void> putEmptyRootListWithResponse(List<Banana> bananas, Context context) {
+        return putEmptyRootListWithResponseAsync(bananas, context).block();
     }
 
     /**
@@ -1428,7 +2146,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putEmptyRootList(List<Banana> bananas) {
-        putEmptyRootListWithResponse(bananas);
+        putEmptyRootListWithResponse(bananas, Context.NONE);
     }
 
     /**
@@ -1452,6 +2170,26 @@ public final class Xmls {
     /**
      * Gets an XML document with an empty child element.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an XML document with an empty child element along with {@link Response} on successful completion of
+     *     {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Banana>> getEmptyChildElementWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/xml";
+        return service.getEmptyChildElement(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Gets an XML document with an empty child element.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an XML document with an empty child element on successful completion of {@link Mono}.
@@ -1464,13 +2202,29 @@ public final class Xmls {
     /**
      * Gets an XML document with an empty child element.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an XML document with an empty child element on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Banana> getEmptyChildElementAsync(Context context) {
+        return getEmptyChildElementWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Gets an XML document with an empty child element.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an XML document with an empty child element along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Banana> getEmptyChildElementWithResponse() {
-        return getEmptyChildElementWithResponseAsync().block();
+    public Response<Banana> getEmptyChildElementWithResponse(Context context) {
+        return getEmptyChildElementWithResponseAsync(context).block();
     }
 
     /**
@@ -1482,7 +2236,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Banana getEmptyChildElement() {
-        return getEmptyChildElementWithResponse().getValue();
+        return getEmptyChildElementWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1512,6 +2266,30 @@ public final class Xmls {
      * Puts a value with an empty child element.
      *
      * @param banana A banana.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putEmptyChildElementWithResponseAsync(Banana banana, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (banana == null) {
+            return Mono.error(new IllegalArgumentException("Parameter banana is required and cannot be null."));
+        } else {
+            banana.validate();
+        }
+        return service.putEmptyChildElement(this.client.getHost(), banana, context);
+    }
+
+    /**
+     * Puts a value with an empty child element.
+     *
+     * @param banana A banana.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1526,14 +2304,30 @@ public final class Xmls {
      * Puts a value with an empty child element.
      *
      * @param banana A banana.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putEmptyChildElementAsync(Banana banana, Context context) {
+        return putEmptyChildElementWithResponseAsync(banana, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts a value with an empty child element.
+     *
+     * @param banana A banana.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putEmptyChildElementWithResponse(Banana banana) {
-        return putEmptyChildElementWithResponseAsync(banana).block();
+    public Response<Void> putEmptyChildElementWithResponse(Banana banana, Context context) {
+        return putEmptyChildElementWithResponseAsync(banana, context).block();
     }
 
     /**
@@ -1546,7 +2340,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putEmptyChildElement(Banana banana) {
-        putEmptyChildElementWithResponse(banana);
+        putEmptyChildElementWithResponse(banana, Context.NONE);
     }
 
     /**
@@ -1570,6 +2364,26 @@ public final class Xmls {
     /**
      * Lists containers in a storage account.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an enumeration of containers along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<ListContainersResponse>> listContainersWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String comp = "list";
+        final String accept = "application/xml";
+        return service.listContainers(this.client.getHost(), comp, accept, context);
+    }
+
+    /**
+     * Lists containers in a storage account.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an enumeration of containers on successful completion of {@link Mono}.
@@ -1582,13 +2396,29 @@ public final class Xmls {
     /**
      * Lists containers in a storage account.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an enumeration of containers on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<ListContainersResponse> listContainersAsync(Context context) {
+        return listContainersWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Lists containers in a storage account.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an enumeration of containers along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<ListContainersResponse> listContainersWithResponse() {
-        return listContainersWithResponseAsync().block();
+    public Response<ListContainersResponse> listContainersWithResponse(Context context) {
+        return listContainersWithResponseAsync(context).block();
     }
 
     /**
@@ -1600,7 +2430,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ListContainersResponse listContainers() {
-        return listContainersWithResponse().getValue();
+        return listContainersWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1626,6 +2456,27 @@ public final class Xmls {
     /**
      * Gets storage service properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return storage service properties along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<StorageServiceProperties>> getServicePropertiesWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String comp = "properties";
+        final String restype = "service";
+        final String accept = "application/xml";
+        return service.getServiceProperties(this.client.getHost(), comp, restype, accept, context);
+    }
+
+    /**
+     * Gets storage service properties.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return storage service properties on successful completion of {@link Mono}.
@@ -1638,13 +2489,29 @@ public final class Xmls {
     /**
      * Gets storage service properties.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return storage service properties on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<StorageServiceProperties> getServicePropertiesAsync(Context context) {
+        return getServicePropertiesWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Gets storage service properties.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return storage service properties along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<StorageServiceProperties> getServicePropertiesWithResponse() {
-        return getServicePropertiesWithResponseAsync().block();
+    public Response<StorageServiceProperties> getServicePropertiesWithResponse(Context context) {
+        return getServicePropertiesWithResponseAsync(context).block();
     }
 
     /**
@@ -1656,7 +2523,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public StorageServiceProperties getServiceProperties() {
-        return getServicePropertiesWithResponse().getValue();
+        return getServicePropertiesWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1689,6 +2556,33 @@ public final class Xmls {
      * Puts storage service properties.
      *
      * @param properties Storage Service Properties.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putServicePropertiesWithResponseAsync(
+            StorageServiceProperties properties, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (properties == null) {
+            return Mono.error(new IllegalArgumentException("Parameter properties is required and cannot be null."));
+        } else {
+            properties.validate();
+        }
+        final String comp = "properties";
+        final String restype = "service";
+        return service.putServiceProperties(this.client.getHost(), comp, restype, properties, context);
+    }
+
+    /**
+     * Puts storage service properties.
+     *
+     * @param properties Storage Service Properties.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1703,14 +2597,30 @@ public final class Xmls {
      * Puts storage service properties.
      *
      * @param properties Storage Service Properties.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putServicePropertiesAsync(StorageServiceProperties properties, Context context) {
+        return putServicePropertiesWithResponseAsync(properties, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts storage service properties.
+     *
+     * @param properties Storage Service Properties.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putServicePropertiesWithResponse(StorageServiceProperties properties) {
-        return putServicePropertiesWithResponseAsync(properties).block();
+    public Response<Void> putServicePropertiesWithResponse(StorageServiceProperties properties, Context context) {
+        return putServicePropertiesWithResponseAsync(properties, context).block();
     }
 
     /**
@@ -1723,7 +2633,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putServiceProperties(StorageServiceProperties properties) {
-        putServicePropertiesWithResponse(properties);
+        putServicePropertiesWithResponse(properties, Context.NONE);
     }
 
     /**
@@ -1748,6 +2658,27 @@ public final class Xmls {
     /**
      * Gets storage ACLs for a container.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return storage ACLs for a container along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<List<SignedIdentifier>>> getAclsWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String comp = "acl";
+        final String restype = "container";
+        final String accept = "application/xml";
+        return service.getAcls(this.client.getHost(), comp, restype, accept, context);
+    }
+
+    /**
+     * Gets storage ACLs for a container.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return storage ACLs for a container on successful completion of {@link Mono}.
@@ -1760,13 +2691,29 @@ public final class Xmls {
     /**
      * Gets storage ACLs for a container.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return storage ACLs for a container on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<List<SignedIdentifier>> getAclsAsync(Context context) {
+        return getAclsWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Gets storage ACLs for a container.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return storage ACLs for a container along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<List<SignedIdentifier>> getAclsWithResponse() {
-        return getAclsWithResponseAsync().block();
+    public Response<List<SignedIdentifier>> getAclsWithResponse(Context context) {
+        return getAclsWithResponseAsync(context).block();
     }
 
     /**
@@ -1778,7 +2725,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<SignedIdentifier> getAcls() {
-        return getAclsWithResponse().getValue();
+        return getAclsWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1812,6 +2759,33 @@ public final class Xmls {
      * Puts storage ACLs for a container.
      *
      * @param properties a collection of signed identifiers.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putAclsWithResponseAsync(List<SignedIdentifier> properties, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (properties == null) {
+            return Mono.error(new IllegalArgumentException("Parameter properties is required and cannot be null."));
+        } else {
+            properties.forEach(e -> e.validate());
+        }
+        final String comp = "acl";
+        final String restype = "container";
+        SignedIdentifiersWrapper propertiesConverted = new SignedIdentifiersWrapper(properties);
+        return service.putAcls(this.client.getHost(), comp, restype, propertiesConverted, context);
+    }
+
+    /**
+     * Puts storage ACLs for a container.
+     *
+     * @param properties a collection of signed identifiers.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1826,14 +2800,30 @@ public final class Xmls {
      * Puts storage ACLs for a container.
      *
      * @param properties a collection of signed identifiers.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putAclsAsync(List<SignedIdentifier> properties, Context context) {
+        return putAclsWithResponseAsync(properties, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Puts storage ACLs for a container.
+     *
+     * @param properties a collection of signed identifiers.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putAclsWithResponse(List<SignedIdentifier> properties) {
-        return putAclsWithResponseAsync(properties).block();
+    public Response<Void> putAclsWithResponse(List<SignedIdentifier> properties, Context context) {
+        return putAclsWithResponseAsync(properties, context).block();
     }
 
     /**
@@ -1846,7 +2836,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putAcls(List<SignedIdentifier> properties) {
-        putAclsWithResponse(properties);
+        putAclsWithResponse(properties, Context.NONE);
     }
 
     /**
@@ -1872,6 +2862,27 @@ public final class Xmls {
     /**
      * Lists blobs in a storage container.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an enumeration of blobs along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<ListBlobsResponse>> listBlobsWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String comp = "list";
+        final String restype = "container";
+        final String accept = "application/xml";
+        return service.listBlobs(this.client.getHost(), comp, restype, accept, context);
+    }
+
+    /**
+     * Lists blobs in a storage container.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an enumeration of blobs on successful completion of {@link Mono}.
@@ -1884,13 +2895,29 @@ public final class Xmls {
     /**
      * Lists blobs in a storage container.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an enumeration of blobs on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<ListBlobsResponse> listBlobsAsync(Context context) {
+        return listBlobsWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Lists blobs in a storage container.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an enumeration of blobs along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<ListBlobsResponse> listBlobsWithResponse() {
-        return listBlobsWithResponseAsync().block();
+    public Response<ListBlobsResponse> listBlobsWithResponse(Context context) {
+        return listBlobsWithResponseAsync(context).block();
     }
 
     /**
@@ -1902,7 +2929,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ListBlobsResponse listBlobs() {
-        return listBlobsWithResponse().getValue();
+        return listBlobsWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -1932,6 +2959,30 @@ public final class Xmls {
      * A Swagger with XML that has one operation that takes JSON as input. You need to send the ID number 42.
      *
      * @param properties The properties parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> jsonInputWithResponseAsync(JsonInput properties, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (properties == null) {
+            return Mono.error(new IllegalArgumentException("Parameter properties is required and cannot be null."));
+        } else {
+            properties.validate();
+        }
+        return service.jsonInput(this.client.getHost(), properties, context);
+    }
+
+    /**
+     * A Swagger with XML that has one operation that takes JSON as input. You need to send the ID number 42.
+     *
+     * @param properties The properties parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1946,14 +2997,30 @@ public final class Xmls {
      * A Swagger with XML that has one operation that takes JSON as input. You need to send the ID number 42.
      *
      * @param properties The properties parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> jsonInputAsync(JsonInput properties, Context context) {
+        return jsonInputWithResponseAsync(properties, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * A Swagger with XML that has one operation that takes JSON as input. You need to send the ID number 42.
+     *
+     * @param properties The properties parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> jsonInputWithResponse(JsonInput properties) {
-        return jsonInputWithResponseAsync(properties).block();
+    public Response<Void> jsonInputWithResponse(JsonInput properties, Context context) {
+        return jsonInputWithResponseAsync(properties, context).block();
     }
 
     /**
@@ -1966,7 +3033,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void jsonInput(JsonInput properties) {
-        jsonInputWithResponse(properties);
+        jsonInputWithResponse(properties, Context.NONE);
     }
 
     /**
@@ -1989,6 +3056,25 @@ public final class Xmls {
     /**
      * A Swagger with XML that has one operation that returns JSON. ID number 42.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<JsonOutput>> jsonOutputWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.jsonOutput(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * A Swagger with XML that has one operation that returns JSON. ID number 42.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body on successful completion of {@link Mono}.
@@ -2001,13 +3087,29 @@ public final class Xmls {
     /**
      * A Swagger with XML that has one operation that returns JSON. ID number 42.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<JsonOutput> jsonOutputAsync(Context context) {
+        return jsonOutputWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * A Swagger with XML that has one operation that returns JSON. ID number 42.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<JsonOutput> jsonOutputWithResponse() {
-        return jsonOutputWithResponseAsync().block();
+    public Response<JsonOutput> jsonOutputWithResponse(Context context) {
+        return jsonOutputWithResponseAsync(context).block();
     }
 
     /**
@@ -2019,7 +3121,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public JsonOutput jsonOutput() {
-        return jsonOutputWithResponse().getValue();
+        return jsonOutputWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2046,6 +3148,28 @@ public final class Xmls {
      * Get back an XML object with an x-ms-text property, which should translate to the returned object's 'language'
      * property being 'english' and its 'content' property being 'I am text'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return back an XML object with an x-ms-text property, which should translate to the returned object's 'language'
+     *     property being 'english' and its 'content' property being 'I am text' along with {@link Response} on
+     *     successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<ObjectWithXMsTextProperty>> getXMsTextWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/xml";
+        return service.getXMsText(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get back an XML object with an x-ms-text property, which should translate to the returned object's 'language'
+     * property being 'english' and its 'content' property being 'I am text'.
+     *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return back an XML object with an x-ms-text property, which should translate to the returned object's 'language'
@@ -2061,14 +3185,33 @@ public final class Xmls {
      * Get back an XML object with an x-ms-text property, which should translate to the returned object's 'language'
      * property being 'english' and its 'content' property being 'I am text'.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return back an XML object with an x-ms-text property, which should translate to the returned object's 'language'
+     *     property being 'english' and its 'content' property being 'I am text' on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<ObjectWithXMsTextProperty> getXMsTextAsync(Context context) {
+        return getXMsTextWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get back an XML object with an x-ms-text property, which should translate to the returned object's 'language'
+     * property being 'english' and its 'content' property being 'I am text'.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return back an XML object with an x-ms-text property, which should translate to the returned object's 'language'
      *     property being 'english' and its 'content' property being 'I am text' along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<ObjectWithXMsTextProperty> getXMsTextWithResponse() {
-        return getXMsTextWithResponseAsync().block();
+    public Response<ObjectWithXMsTextProperty> getXMsTextWithResponse(Context context) {
+        return getXMsTextWithResponseAsync(context).block();
     }
 
     /**
@@ -2082,7 +3225,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ObjectWithXMsTextProperty getXMsText() {
-        return getXMsTextWithResponse().getValue();
+        return getXMsTextWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2106,6 +3249,26 @@ public final class Xmls {
     /**
      * Get an XML document with binary property.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an XML document with binary property along with {@link Response} on successful completion of {@link
+     *     Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<ModelWithByteProperty>> getBytesWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/xml";
+        return service.getBytes(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get an XML document with binary property.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an XML document with binary property on successful completion of {@link Mono}.
@@ -2118,13 +3281,29 @@ public final class Xmls {
     /**
      * Get an XML document with binary property.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an XML document with binary property on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<ModelWithByteProperty> getBytesAsync(Context context) {
+        return getBytesWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get an XML document with binary property.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an XML document with binary property along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<ModelWithByteProperty> getBytesWithResponse() {
-        return getBytesWithResponseAsync().block();
+    public Response<ModelWithByteProperty> getBytesWithResponse(Context context) {
+        return getBytesWithResponseAsync(context).block();
     }
 
     /**
@@ -2136,7 +3315,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ModelWithByteProperty getBytes() {
-        return getBytesWithResponse().getValue();
+        return getBytesWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2167,6 +3346,31 @@ public final class Xmls {
      * Put an XML document with binary property.
      *
      * @param slideshow The slideshow parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putBinaryWithResponseAsync(ModelWithByteProperty slideshow, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (slideshow == null) {
+            return Mono.error(new IllegalArgumentException("Parameter slideshow is required and cannot be null."));
+        } else {
+            slideshow.validate();
+        }
+        final String accept = "application/xml";
+        return service.putBinary(this.client.getHost(), slideshow, accept, context);
+    }
+
+    /**
+     * Put an XML document with binary property.
+     *
+     * @param slideshow The slideshow parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -2181,14 +3385,30 @@ public final class Xmls {
      * Put an XML document with binary property.
      *
      * @param slideshow The slideshow parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putBinaryAsync(ModelWithByteProperty slideshow, Context context) {
+        return putBinaryWithResponseAsync(slideshow, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put an XML document with binary property.
+     *
+     * @param slideshow The slideshow parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putBinaryWithResponse(ModelWithByteProperty slideshow) {
-        return putBinaryWithResponseAsync(slideshow).block();
+    public Response<Void> putBinaryWithResponse(ModelWithByteProperty slideshow, Context context) {
+        return putBinaryWithResponseAsync(slideshow, context).block();
     }
 
     /**
@@ -2201,7 +3421,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putBinary(ModelWithByteProperty slideshow) {
-        putBinaryWithResponse(slideshow);
+        putBinaryWithResponse(slideshow, Context.NONE);
     }
 
     /**
@@ -2224,6 +3444,25 @@ public final class Xmls {
     /**
      * Get an XML document with uri property.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an XML document with uri property along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<ModelWithUrlProperty>> getUriWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/xml";
+        return service.getUri(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get an XML document with uri property.
+     *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an XML document with uri property on successful completion of {@link Mono}.
@@ -2236,13 +3475,29 @@ public final class Xmls {
     /**
      * Get an XML document with uri property.
      *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return an XML document with uri property on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<ModelWithUrlProperty> getUriAsync(Context context) {
+        return getUriWithResponseAsync(context).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Get an XML document with uri property.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return an XML document with uri property along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<ModelWithUrlProperty> getUriWithResponse() {
-        return getUriWithResponseAsync().block();
+    public Response<ModelWithUrlProperty> getUriWithResponse(Context context) {
+        return getUriWithResponseAsync(context).block();
     }
 
     /**
@@ -2254,7 +3509,7 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ModelWithUrlProperty getUri() {
-        return getUriWithResponse().getValue();
+        return getUriWithResponse(Context.NONE).getValue();
     }
 
     /**
@@ -2285,6 +3540,31 @@ public final class Xmls {
      * Put an XML document with uri property.
      *
      * @param model The model parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putUriWithResponseAsync(ModelWithUrlProperty model, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (model == null) {
+            return Mono.error(new IllegalArgumentException("Parameter model is required and cannot be null."));
+        } else {
+            model.validate();
+        }
+        final String accept = "application/xml";
+        return service.putUri(this.client.getHost(), model, accept, context);
+    }
+
+    /**
+     * Put an XML document with uri property.
+     *
+     * @param model The model parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -2299,14 +3579,30 @@ public final class Xmls {
      * Put an XML document with uri property.
      *
      * @param model The model parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return A {@link Mono} that completes when a successful response is received.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putUriAsync(ModelWithUrlProperty model, Context context) {
+        return putUriWithResponseAsync(model, context).flatMap(ignored -> Mono.empty());
+    }
+
+    /**
+     * Put an XML document with uri property.
+     *
+     * @param model The model parameter.
+     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putUriWithResponse(ModelWithUrlProperty model) {
-        return putUriWithResponseAsync(model).block();
+    public Response<Void> putUriWithResponse(ModelWithUrlProperty model, Context context) {
+        return putUriWithResponseAsync(model, context).block();
     }
 
     /**
@@ -2319,6 +3615,6 @@ public final class Xmls {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putUri(ModelWithUrlProperty model) {
-        putUriWithResponse(model);
+        putUriWithResponse(model, Context.NONE);
     }
 }

--- a/vanilla-tests/swagger/custom-http-exception-mapping.md
+++ b/vanilla-tests/swagger/custom-http-exception-mapping.md
@@ -9,7 +9,6 @@ license-header: MICROSOFT_MIT_SMALL
 required-parameter-client-methods: true
 sync-methods: all
 client-side-validations: true
-add-context-parameter: true
 service-interface-as-public: true
 default-http-exception-type: com.azure.core.exception.ResourceNotFoundException
 http-status-code-to-exception-type-mapping:

--- a/vanilla-tests/swagger/lro.md
+++ b/vanilla-tests/swagger/lro.md
@@ -9,8 +9,6 @@ license-header: MICROSOFT_MIT_SMALL
 required-parameter-client-methods: true
 sync-methods: all
 client-side-validations: true
-add-context-parameter: true
-context-client-method-parameter: true
 polling:
   default:
     strategy: >-


### PR DESCRIPTION
After removal, code behaves as if they be `true`.

Checked SDK repo. All readme.md sets "context-client-method-parameter".

DPG and mgmt always configure them as `true`.