### PR TITLE
Guard Paging ClientMethod Creation with Check

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -628,7 +628,10 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
             .type(pageMethodType)
             .groupedParameterRequired(false)
             .methodVisibility(visibilityFunction.methodVisibility(false, defaultOverloadType, false));
-        methods.add(builder.build());
+
+        if (settings.getSyncMethods() != SyncMethodsGeneration.NONE) {
+            methods.add(builder.build());
+        }
 
         if (generateClientMethodWithOnlyRequiredParameters) {
             methods.add(builder


### PR DESCRIPTION
Guards the creation of the basic paging `ClientMethod` with a check against `SyncMethodsGeneration` similar to what is done for the first page retrieval `ClientMethod`. This resolves an issue where a paging overload without `Context` would be generated and attempt to call the get page APIs with `Context` required.