### PR TITLE
dpg, bug fix, extra V when version is v1.1

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/template/ServiceVersionTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceVersionTemplate.java
@@ -64,6 +64,10 @@ public class ServiceVersionTemplate implements IJavaTemplate<ServiceVersion, Jav
     }
 
     private String getVersionIdentifier(String version) {
-        return "V" + VERSION_TO_ENUM.matcher(version).replaceAll("_").toUpperCase();
+        String versionInEnum = VERSION_TO_ENUM.matcher(version).replaceAll("_").toUpperCase();
+        if (!versionInEnum.startsWith("V")) {
+            versionInEnum = "V" + versionInEnum;
+        }
+        return versionInEnum;
     }
 }


### PR DESCRIPTION
`v1.1` previous gets enum value `VV1_1`