### PR TITLE
Cadl, emitter for multi-client

### DIFF
--- a/cadl-extension/src/code-model-builder.ts
+++ b/cadl-extension/src/code-model-builder.ts
@@ -63,7 +63,6 @@ import {
   BooleanSchema,
   ByteArraySchema,
   ChoiceValue,
-  CodeModel,
   ConstantSchema,
   ConstantValue,
   DateTimeSchema,
@@ -91,6 +90,7 @@ import {
   OAuth2SecurityScheme,
   KeySecurityScheme,
 } from "@autorest/codemodel";
+import { CodeModel } from "./common/code-model.js";
 import { ConvenienceApi, Operation as CodeModelOperation, OperationLink, Request } from "./common/operation.js";
 import { SchemaContext, SchemaUsage } from "./common/schemas/usage.js";
 import { ChoiceSchema, SealedChoiceSchema } from "./common/schemas/choice.js";
@@ -288,7 +288,7 @@ export class CodeModelBuilder {
     }
   }
 
-  private processRoute(groupName: string, operation: Operation) {
+  private processRoute(groupName: string, operation: Operation): CodeModelOperation {
     const op = ignoreDiagnostics(getHttpOperation(this.program, operation));
 
     const operationGroup = this.codeModel.getOperationGroup(groupName);
@@ -362,6 +362,8 @@ export class CodeModelBuilder {
     this.processRouteForLongRunning(codeModelOperation, operation, op.responses);
 
     operationGroup.addOperation(codeModelOperation);
+
+    return codeModelOperation;
   }
 
   private processRouteForPaged(op: CodeModelOperation, responses: HttpOperationResponse[]) {

--- a/cadl-extension/src/code-model-builder.ts
+++ b/cadl-extension/src/code-model-builder.ts
@@ -279,6 +279,9 @@ export class CodeModelBuilder {
     for (const client of clients) {
       const codeModelClient = new CodeModelClient(client.name, this.getDoc(client.type), {
         summary: this.getSummary(client.type),
+
+        // at present, use global security definition
+        security: this.codeModel.security,
       });
 
       const operationGroups = listOperationGroups(this.program, client);

--- a/cadl-extension/src/code-model-builder.ts
+++ b/cadl-extension/src/code-model-builder.ts
@@ -296,8 +296,7 @@ export class CodeModelBuilder {
         const operations = listOperationsInOperationGroup(this.program, operationGroup);
         codeModelGroup = new OperationGroup(operationGroup.type.name);
         for (const operation of operations) {
-          this.processRoute(operationGroup.type.name, operation);
-          codeModelGroup.addOperation(this.processRoute("", operation));
+          codeModelGroup.addOperation(this.processRoute(operationGroup.type.name, operation));
         }
         codeModelClient.operationGroups.push(codeModelGroup);
       }

--- a/cadl-extension/src/common/client.ts
+++ b/cadl-extension/src/common/client.ts
@@ -1,9 +1,11 @@
 import { DeepPartial } from "@azure-tools/codegen";
-import { Aspect, OperationGroup } from "@autorest/codemodel";
+import { Aspect, OperationGroup, Security } from "@autorest/codemodel";
 
 export interface Client extends Aspect {
   /** All operations  */
   operationGroups: Array<OperationGroup>;
+
+  security: Security;
 }
 
 export class Client extends Aspect implements Client {
@@ -11,6 +13,7 @@ export class Client extends Aspect implements Client {
     super(name, description, objectInitializer);
 
     this.operationGroups = [];
+    this.security = new Security(false);
 
     this.applyTo(this, objectInitializer);
   }

--- a/cadl-extension/src/common/client.ts
+++ b/cadl-extension/src/common/client.ts
@@ -1,0 +1,17 @@
+import { DeepPartial } from "@azure-tools/codegen";
+import { Aspect, OperationGroup } from "@autorest/codemodel";
+
+export interface Client extends Aspect {
+  /** All operations  */
+  operationGroups: Array<OperationGroup>;
+}
+
+export class Client extends Aspect implements Client {
+  constructor(name: string, description: string, objectInitializer?: DeepPartial<Client>) {
+    super(name, description, objectInitializer);
+
+    this.operationGroups = [];
+
+    this.applyTo(this, objectInitializer);
+  }
+}

--- a/cadl-extension/src/common/code-model.ts
+++ b/cadl-extension/src/common/code-model.ts
@@ -1,0 +1,94 @@
+import { DeepPartial, enableSourceTracking } from "@azure-tools/codegen";
+import { Info, Metadata, OperationGroup, Parameter, Schemas, Security } from "@autorest/codemodel";
+import { Client } from "./client.js";
+
+/** the model that contains all the information required to generate a service api */
+export interface CodeModel extends Metadata {
+  /** Code model information */
+  info: Info;
+
+  /** All schemas for the model */
+  schemas: Schemas;
+
+  /** All operations  */
+  operationGroups: Array<OperationGroup>;
+
+  /** all global parameters (ie, ImplementationLocation = client ) */
+  globalParameters?: Array<Parameter>;
+
+  security: Security;
+
+  clients: Array<Client>;
+}
+
+export class CodeModel extends Metadata implements CodeModel {
+  constructor(title: string, sourceTracking = false, objectInitializer?: DeepPartial<CodeModel>) {
+    super();
+    // if we are enabling source tracking, then we have to use a proxied version of this
+    const $this = sourceTracking ? enableSourceTracking(this) : this;
+
+    $this.info = new Info(title);
+    $this.schemas = new Schemas();
+    $this.operationGroups = [];
+    $this.security = new Security(false);
+    $this.clients = [];
+
+    this.applyTo($this, objectInitializer);
+  }
+
+  private get globals(): Array<Parameter> {
+    return this.globalParameters || (this.globalParameters = []);
+  }
+
+  getOperationGroup(group: string) {
+    let result = this.operationGroups.find((each) => group.toLowerCase() === each.$key.toLowerCase());
+    if (!result) {
+      result = new OperationGroup(group);
+      this.operationGroups.push(result);
+    }
+    return result;
+  }
+
+  findGlobalParameter(predicate: (value: Parameter) => boolean) {
+    return this.globals.find(predicate);
+  }
+
+  addGlobalParameter(parameter: Parameter): Parameter;
+  addGlobalParameter(find: (value: Parameter) => boolean, create: () => Parameter): Parameter;
+  addGlobalParameter(
+    predicateOrParameter: Parameter | ((value: Parameter) => boolean),
+    create: ValueOrFactory<Parameter> = <any>undefined,
+  ): Parameter {
+    try {
+      if (typeof predicateOrParameter !== "function") {
+        // overload : parameter passed
+        this.globals.push(predicateOrParameter);
+
+        return predicateOrParameter;
+      }
+
+      // overload : predicate, parameter passed
+      let p = this.findGlobalParameter(predicateOrParameter);
+      if (!p) {
+        this.globals.push((p = realize(create)));
+      }
+      return p;
+    } finally {
+      this.globalParameters = sortAscendingInvalidLast(this.globals, (each) => each.extensions?.["x-ms-priority"]);
+    }
+  }
+}
+
+export type ValueOrFactory<T> = T | (() => T);
+
+function realize<T>(f: ValueOrFactory<T>): T {
+  return f instanceof Function ? f() : f;
+}
+
+function sortAscendingInvalidLast<T>(input: Array<T>, accessor: (each: T) => number | undefined): Array<T> {
+  return input.sort((a, b) => {
+    const pA = accessor(a) ?? Number.MAX_VALUE;
+    const pB = accessor(b) ?? Number.MAX_VALUE;
+    return pA - pB;
+  });
+}

--- a/cadl-tests/cadl/response.cadl
+++ b/cadl-tests/cadl/response.cadl
@@ -27,7 +27,9 @@ model Resource {
 model ResourceArray is Resource[];
 
 // operation using Azure.Core
+@Azure.DPG.client({name: "CoreClient", service: Cadl.Response})
 @route("/cadl-core")
+@doc("Cadl Core")
 interface CadlCoreOp {
   @doc("Creates a new resource or updates an existing one.")
   createOrUpdate is ResourceCreateOrReplace<Resource>;
@@ -42,7 +44,9 @@ interface CadlCoreOp {
   list is ResourceList<Resource>;
 }
 
+@Azure.DPG.client({name: "ResponseClient", service: Cadl.Response})
 @operationGroup
+@doc("Response")
 @route("/response")
 interface ResponseOp {
   // binary

--- a/cadl-tests/cadl/response.cadl
+++ b/cadl-tests/cadl/response.cadl
@@ -27,7 +27,10 @@ model Resource {
 model ResourceArray is Resource[];
 
 // operation using Azure.Core
-@Azure.DPG.client({name: "CoreClient", service: Cadl.Response})
+@Azure.DPG.client({
+  name: "CoreClient",
+  service: Cadl.Response,
+})
 @route("/cadl-core")
 @doc("Cadl Core")
 interface CadlCoreOp {
@@ -44,7 +47,10 @@ interface CadlCoreOp {
   list is ResourceList<Resource>;
 }
 
-@Azure.DPG.client({name: "ResponseClient", service: Cadl.Response})
+@Azure.DPG.client({
+  name: "ResponseClient",
+  service: Cadl.Response,
+})
 @operationGroup
 @doc("Response")
 @route("/response")


### PR DESCRIPTION
link https://github.com/Azure/autorest.java/pull/1815

sample yaml

```yaml
clients:
  - language:
      default:
        name: CoreClient
        description: Cadl Core
    protocol: {}
    operationGroups:
      - language:
          default:
            name: ''
            description: ''
        protocol: {}
        $key: ''
        operations:
          - *ref_20
          - *ref_21
          - *ref_22
          - *ref_23
  - language:
      default:
        name: ResponseClient
        description: Response
    protocol: {}
    operationGroups:
      - language:
          default:
            name: ResponseOp
            description: ''
        protocol: {}
        $key: ResponseOp
        operations:
          - *ref_24
          - *ref_25
          - *ref_26
          - *ref_27
```

Java part will be much more complex. It should switch to process this "clients", instead of from codemodel.