### PR TITLE
Cadl, improve async convenience api

### DIFF
--- a/cadl-tests/src/main/java/com/arrays/itemtypes/BooleanValueAsyncClient.java
+++ b/cadl-tests/src/main/java/com/arrays/itemtypes/BooleanValueAsyncClient.java
@@ -16,6 +16,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.azure.core.util.serializer.TypeReference;
 import java.util.List;
 import reactor.core.publisher.Mono;
@@ -100,7 +101,7 @@ public final class BooleanValueAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(new TypeReference<List<Boolean>>() {}));
     }
 
@@ -121,6 +122,6 @@ public final class BooleanValueAsyncClient {
     public Mono<Void> put(List<Boolean> body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/arrays/itemtypes/DatetimeValueAsyncClient.java
+++ b/cadl-tests/src/main/java/com/arrays/itemtypes/DatetimeValueAsyncClient.java
@@ -16,6 +16,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.azure.core.util.serializer.TypeReference;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -101,7 +102,7 @@ public final class DatetimeValueAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(new TypeReference<List<OffsetDateTime>>() {}));
     }
 
@@ -122,6 +123,6 @@ public final class DatetimeValueAsyncClient {
     public Mono<Void> put(List<OffsetDateTime> body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/arrays/itemtypes/DurationValueAsyncClient.java
+++ b/cadl-tests/src/main/java/com/arrays/itemtypes/DurationValueAsyncClient.java
@@ -16,6 +16,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.azure.core.util.serializer.TypeReference;
 import java.time.Duration;
 import java.util.List;
@@ -101,7 +102,7 @@ public final class DurationValueAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(new TypeReference<List<Duration>>() {}));
     }
 
@@ -122,6 +123,6 @@ public final class DurationValueAsyncClient {
     public Mono<Void> put(List<Duration> body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/arrays/itemtypes/Float32ValueAsyncClient.java
+++ b/cadl-tests/src/main/java/com/arrays/itemtypes/Float32ValueAsyncClient.java
@@ -16,6 +16,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.azure.core.util.serializer.TypeReference;
 import java.util.List;
 import reactor.core.publisher.Mono;
@@ -100,7 +101,7 @@ public final class Float32ValueAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(new TypeReference<List<Double>>() {}));
     }
 
@@ -121,6 +122,6 @@ public final class Float32ValueAsyncClient {
     public Mono<Void> put(List<Double> body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/arrays/itemtypes/Int32ValueAsyncClient.java
+++ b/cadl-tests/src/main/java/com/arrays/itemtypes/Int32ValueAsyncClient.java
@@ -16,6 +16,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.azure.core.util.serializer.TypeReference;
 import java.util.List;
 import reactor.core.publisher.Mono;
@@ -100,7 +101,7 @@ public final class Int32ValueAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(new TypeReference<List<Integer>>() {}));
     }
 
@@ -121,6 +122,6 @@ public final class Int32ValueAsyncClient {
     public Mono<Void> put(List<Integer> body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/arrays/itemtypes/Int64ValueAsyncClient.java
+++ b/cadl-tests/src/main/java/com/arrays/itemtypes/Int64ValueAsyncClient.java
@@ -16,6 +16,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.azure.core.util.serializer.TypeReference;
 import java.util.List;
 import reactor.core.publisher.Mono;
@@ -100,7 +101,7 @@ public final class Int64ValueAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(new TypeReference<List<Long>>() {}));
     }
 
@@ -121,6 +122,6 @@ public final class Int64ValueAsyncClient {
     public Mono<Void> put(List<Long> body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/arrays/itemtypes/ModelValueAsyncClient.java
+++ b/cadl-tests/src/main/java/com/arrays/itemtypes/ModelValueAsyncClient.java
@@ -17,6 +17,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.azure.core.util.serializer.TypeReference;
 import java.util.List;
 import reactor.core.publisher.Mono;
@@ -111,7 +112,7 @@ public final class ModelValueAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(new TypeReference<List<InnerModel>>() {}));
     }
 
@@ -132,6 +133,6 @@ public final class ModelValueAsyncClient {
     public Mono<Void> put(List<InnerModel> body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/arrays/itemtypes/StringValueAsyncClient.java
+++ b/cadl-tests/src/main/java/com/arrays/itemtypes/StringValueAsyncClient.java
@@ -16,6 +16,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.azure.core.util.serializer.TypeReference;
 import java.util.List;
 import reactor.core.publisher.Mono;
@@ -100,7 +101,7 @@ public final class StringValueAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(new TypeReference<List<String>>() {}));
     }
 
@@ -121,6 +122,6 @@ public final class StringValueAsyncClient {
     public Mono<Void> put(List<String> body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/arrays/itemtypes/UnknownValueAsyncClient.java
+++ b/cadl-tests/src/main/java/com/arrays/itemtypes/UnknownValueAsyncClient.java
@@ -16,6 +16,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.azure.core.util.serializer.TypeReference;
 import java.util.List;
 import reactor.core.publisher.Mono;
@@ -100,7 +101,7 @@ public final class UnknownValueAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(new TypeReference<List<Object>>() {}));
     }
 
@@ -121,6 +122,6 @@ public final class UnknownValueAsyncClient {
     public Mono<Void> put(List<Object> body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/authentication/apikey/ApiKeyAsyncClient.java
+++ b/cadl-tests/src/main/java/com/authentication/apikey/ApiKeyAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
+import com.azure.core.util.FluxUtil;
 import reactor.core.publisher.Mono;
 
 /** Initializes a new instance of the asynchronous ApiKeyClient type. */
@@ -79,7 +80,7 @@ public final class ApiKeyAsyncClient {
     public Mono<Void> valid() {
         // Generated convenience method for validWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return validWithResponse(requestOptions).then();
+        return validWithResponse(requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**
@@ -97,6 +98,6 @@ public final class ApiKeyAsyncClient {
     public Mono<Void> invalid() {
         // Generated convenience method for invalidWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return invalidWithResponse(requestOptions).then();
+        return invalidWithResponse(requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/authentication/oauth2/OAuth2AsyncClient.java
+++ b/cadl-tests/src/main/java/com/authentication/oauth2/OAuth2AsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
+import com.azure.core.util.FluxUtil;
 import reactor.core.publisher.Mono;
 
 /** Initializes a new instance of the asynchronous OAuth2Client type. */
@@ -79,7 +80,7 @@ public final class OAuth2AsyncClient {
     public Mono<Void> valid() {
         // Generated convenience method for validWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return validWithResponse(requestOptions).then();
+        return validWithResponse(requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**
@@ -97,6 +98,6 @@ public final class OAuth2AsyncClient {
     public Mono<Void> invalid() {
         // Generated convenience method for invalidWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return invalidWithResponse(requestOptions).then();
+        return invalidWithResponse(requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/azure/lro/LroAsyncClient.java
+++ b/cadl-tests/src/main/java/com/azure/lro/LroAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.azure.core.util.polling.PollerFlux;
 import com.azure.lro.implementation.LroClientImpl;
 import reactor.core.publisher.Mono;
@@ -116,7 +117,7 @@ public final class LroAsyncClient {
         // Generated convenience method for pollingWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return pollingWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(String.class));
     }
 
@@ -136,7 +137,7 @@ public final class LroAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(String.class));
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/auth/AuthAsyncClient.java
+++ b/cadl-tests/src/main/java/com/cadl/auth/AuthAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.cadl.auth.implementation.AuthClientImpl;
 import reactor.core.publisher.Mono;
 
@@ -71,7 +72,7 @@ public final class AuthAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(String.class));
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/builtin/BuiltinAsyncClient.java
+++ b/cadl-tests/src/main/java/com/cadl/builtin/BuiltinAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.cadl.builtin.implementation.BuiltinClientImpl;
 import com.cadl.builtin.models.Builtin;
 import reactor.core.publisher.Mono;
@@ -98,7 +99,7 @@ public final class BuiltinAsyncClient {
         // Generated convenience method for readWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return readWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Builtin.class));
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/enumservice/EnumServiceAsyncClient.java
+++ b/cadl-tests/src/main/java/com/cadl/enumservice/EnumServiceAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.azure.core.util.serializer.CollectionFormat;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.cadl.enumservice.implementation.EnumServiceClientImpl;
@@ -352,7 +353,7 @@ public final class EnumServiceAsyncClient {
     public Mono<Color> getColor() {
         // Generated convenience method for getColorWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return getColorWithResponse(requestOptions).map(Response::getValue).map(Color::fromString);
+        return getColorWithResponse(requestOptions).flatMap(FluxUtil::toMono).map(Color::fromString);
     }
 
     /**
@@ -370,7 +371,7 @@ public final class EnumServiceAsyncClient {
     public Mono<ColorModel> getColorModel() {
         // Generated convenience method for getColorModelWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return getColorModelWithResponse(requestOptions).map(Response::getValue).map(ColorModel::fromString);
+        return getColorModelWithResponse(requestOptions).flatMap(FluxUtil::toMono).map(ColorModel::fromString);
     }
 
     /**
@@ -391,7 +392,7 @@ public final class EnumServiceAsyncClient {
         // Generated convenience method for setColorModelWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return setColorModelWithResponse(color.toString(), requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Operation.class));
     }
 
@@ -413,7 +414,7 @@ public final class EnumServiceAsyncClient {
         // Generated convenience method for setPriorityWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return setPriorityWithResponse(String.valueOf(priority.toLong()), requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Operation.class));
     }
 
@@ -433,7 +434,7 @@ public final class EnumServiceAsyncClient {
         // Generated convenience method for getRunningOperationWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getRunningOperationWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Operation.class));
     }
 
@@ -455,7 +456,7 @@ public final class EnumServiceAsyncClient {
         // Generated convenience method for getOperationWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getOperationWithResponse(state.toString(), requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Operation.class));
     }
 
@@ -488,7 +489,7 @@ public final class EnumServiceAsyncClient {
                                 .map(paramItemValue -> Objects.toString(paramItemValue, ""))
                                 .collect(Collectors.toList()),
                         requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(String.class));
     }
 
@@ -514,7 +515,7 @@ public final class EnumServiceAsyncClient {
                                 .map(paramItemValue -> Objects.toString(paramItemValue, ""))
                                 .collect(Collectors.toList()),
                         requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(String.class));
     }
 
@@ -549,7 +550,7 @@ public final class EnumServiceAsyncClient {
                                                 paramItemValue == null ? "" : String.valueOf(paramItemValue.toLong()))
                                 .collect(Collectors.toList()),
                         requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(String.class));
     }
 
@@ -577,7 +578,7 @@ public final class EnumServiceAsyncClient {
                                                 paramItemValue == null ? "" : String.valueOf(paramItemValue.toLong()))
                                 .collect(Collectors.toList()),
                         requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(String.class));
     }
 
@@ -607,7 +608,7 @@ public final class EnumServiceAsyncClient {
                             .collect(Collectors.joining(",")));
         }
         return setStringArrayWithResponse(stringArray, requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(String.class));
     }
 
@@ -629,7 +630,7 @@ public final class EnumServiceAsyncClient {
         // Generated convenience method for setStringArrayWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return setStringArrayWithResponse(stringArray, requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(String.class));
     }
 
@@ -658,7 +659,7 @@ public final class EnumServiceAsyncClient {
                             .serializeIterable(intArrayOpt, CollectionFormat.CSV));
         }
         return setIntArrayWithResponse(intArray, requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(String.class));
     }
 
@@ -680,7 +681,7 @@ public final class EnumServiceAsyncClient {
         // Generated convenience method for setIntArrayWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return setIntArrayWithResponse(intArray, requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(String.class));
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/errormodel/ErrorModelAsyncClient.java
+++ b/cadl-tests/src/main/java/com/cadl/errormodel/ErrorModelAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.cadl.errormodel.implementation.ErrorModelClientImpl;
 import com.cadl.errormodel.models.Diagnostic;
 import reactor.core.publisher.Mono;
@@ -75,7 +76,7 @@ public final class ErrorModelAsyncClient {
         // Generated convenience method for readWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return readWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Diagnostic.class));
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/longrunning/LongRunningAsyncClient.java
+++ b/cadl-tests/src/main/java/com/cadl/longrunning/LongRunningAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.azure.core.util.polling.PollerFlux;
 import com.cadl.longrunning.implementation.LongRunningClientImpl;
 import com.cadl.longrunning.models.ExportedResource;
@@ -231,7 +232,7 @@ public final class LongRunningAsyncClient {
         // Generated convenience method for statusMonitorWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return statusMonitorWithResponse(name, operationId, requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(OperationStatusResource.class));
     }
 
@@ -253,7 +254,7 @@ public final class LongRunningAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(name, requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Resource.class));
     }
 

--- a/cadl-tests/src/main/java/com/cadl/naming/NamingAsyncClient.java
+++ b/cadl-tests/src/main/java/com/cadl/naming/NamingAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.cadl.naming.implementation.NamingClientImpl;
 import com.cadl.naming.models.DataResponse;
 import reactor.core.publisher.Mono;
@@ -105,7 +106,7 @@ public final class NamingAsyncClient {
             requestOptions.setHeader("etag", etag);
         }
         return postWithResponse(name, requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(DataResponse.class));
     }
 
@@ -130,7 +131,7 @@ public final class NamingAsyncClient {
         // Generated convenience method for postWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return postWithResponse(name, requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(DataResponse.class));
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/optional/OptionalAsyncClient.java
+++ b/cadl-tests/src/main/java/com/cadl/optional/OptionalAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.cadl.optional.implementation.OptionalClientImpl;
 import com.cadl.optional.models.AllPropertiesOptional;
 import com.cadl.optional.models.Optional;
@@ -208,7 +209,7 @@ public final class OptionalAsyncClient {
                         stringRequired,
                         stringRequiredNullable,
                         requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(AllPropertiesOptional.class));
     }
 
@@ -245,7 +246,7 @@ public final class OptionalAsyncClient {
                         stringRequired,
                         stringRequiredNullable,
                         requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(AllPropertiesOptional.class));
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/partialupdate/PartialUpdateAsyncClient.java
+++ b/cadl-tests/src/main/java/com/cadl/partialupdate/PartialUpdateAsyncClient.java
@@ -14,6 +14,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.cadl.partialupdate.implementation.PartialUpdateClientImpl;
 import com.cadl.partialupdate.models.PartialUpdateModel;
 import reactor.core.publisher.Mono;
@@ -76,7 +77,7 @@ public final class PartialUpdateAsyncClient {
         // Generated convenience method for readWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return readWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(PartialUpdateModel.class));
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/polymorphism/PolymorphismAsyncClient.java
+++ b/cadl-tests/src/main/java/com/cadl/polymorphism/PolymorphismAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.cadl.polymorphism.implementation.PolymorphismClientImpl;
 import com.cadl.polymorphism.models.BaseType;
 import com.cadl.polymorphism.models.Pet;
@@ -141,7 +142,7 @@ public final class PolymorphismAsyncClient {
         // Generated convenience method for readWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return readWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Pet.class));
     }
 
@@ -163,7 +164,7 @@ public final class PolymorphismAsyncClient {
         // Generated convenience method for writeWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return writeWithResponse(BinaryData.fromObject(body), requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(BaseType.class));
     }
 
@@ -185,7 +186,7 @@ public final class PolymorphismAsyncClient {
         // Generated convenience method for taskWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return taskWithResponse(BinaryData.fromObject(body), requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Task.class));
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/response/CoreAsyncClient.java
+++ b/cadl-tests/src/main/java/com/cadl/response/CoreAsyncClient.java
@@ -18,6 +18,7 @@ import com.azure.core.http.rest.PagedResponseBase;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.cadl.response.implementation.CoreClientImpl;
 import com.cadl.response.models.Resource;
 import java.util.stream.Collectors;
@@ -171,7 +172,7 @@ public final class CoreAsyncClient {
         // Generated convenience method for createOrUpdateWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return createOrUpdateWithResponse(name, BinaryData.fromObject(resource), requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Resource.class));
     }
 
@@ -193,7 +194,7 @@ public final class CoreAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(name, requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Resource.class));
     }
 
@@ -214,7 +215,7 @@ public final class CoreAsyncClient {
     public Mono<Void> delete(String name) {
         // Generated convenience method for deleteWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return deleteWithResponse(name, requestOptions).then();
+        return deleteWithResponse(name, requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**

--- a/cadl-tests/src/main/java/com/cadl/response/ResponseAsyncClient.java
+++ b/cadl-tests/src/main/java/com/cadl/response/ResponseAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.azure.core.util.serializer.TypeReference;
 import com.cadl.response.implementation.ResponseClientImpl;
 import com.cadl.response.models.Resource;
@@ -145,7 +146,7 @@ public final class ResponseAsyncClient {
     public Mono<BinaryData> getBinary() {
         // Generated convenience method for getBinaryWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return getBinaryWithResponse(requestOptions).map(Response::getValue);
+        return getBinaryWithResponse(requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**
@@ -164,7 +165,7 @@ public final class ResponseAsyncClient {
         // Generated convenience method for getArrayWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getArrayWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(new TypeReference<List<Resource>>() {}));
     }
 
@@ -184,7 +185,7 @@ public final class ResponseAsyncClient {
         // Generated convenience method for createWithHeadersWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return createWithHeadersWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Resource.class));
     }
 
@@ -203,6 +204,6 @@ public final class ResponseAsyncClient {
     public Mono<Void> deleteWithHeaders() {
         // Generated convenience method for deleteWithHeadersWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return deleteWithHeadersWithResponse(requestOptions).then();
+        return deleteWithHeadersWithResponse(requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/server/ServerAsyncClient.java
+++ b/cadl-tests/src/main/java/com/cadl/server/ServerAsyncClient.java
@@ -14,6 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
+import com.azure.core.util.FluxUtil;
 import com.cadl.server.implementation.ServerClientImpl;
 import reactor.core.publisher.Mono;
 
@@ -66,6 +67,6 @@ public final class ServerAsyncClient {
     public Mono<Void> status(int code) {
         // Generated convenience method for statusWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return statusWithResponse(code, requestOptions).then();
+        return statusWithResponse(code, requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/specialheaders/SpecialHeadersAsyncClient.java
+++ b/cadl-tests/src/main/java/com/cadl/specialheaders/SpecialHeadersAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.azure.core.util.polling.PollerFlux;
 import com.cadl.specialheaders.implementation.SpecialHeadersClientImpl;
 import com.cadl.specialheaders.models.Resource;
@@ -235,7 +236,7 @@ public final class SpecialHeadersAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(name, requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Resource.class));
     }
 
@@ -258,7 +259,7 @@ public final class SpecialHeadersAsyncClient {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return putWithResponse(name, BinaryData.fromObject(body), requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Resource.class));
     }
 
@@ -281,7 +282,7 @@ public final class SpecialHeadersAsyncClient {
         // Generated convenience method for postWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return postWithResponse(name, BinaryData.fromObject(body), requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Resource.class));
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/visibility/VisibilityAsyncClient.java
+++ b/cadl-tests/src/main/java/com/cadl/visibility/VisibilityAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.cadl.visibility.implementation.VisibilityClientImpl;
 import com.cadl.visibility.models.Dog;
 import com.cadl.visibility.models.ReadDog;
@@ -150,7 +151,7 @@ public final class VisibilityAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Dog.class));
     }
 
@@ -172,7 +173,7 @@ public final class VisibilityAsyncClient {
         // Generated convenience method for createWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return createWithResponse(BinaryData.fromObject(dog), requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Dog.class));
     }
 
@@ -194,7 +195,7 @@ public final class VisibilityAsyncClient {
         // Generated convenience method for queryWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return queryWithResponse(BinaryData.fromObject(dog), requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Dog.class));
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/visibility/VisibilityReadAsyncClient.java
+++ b/cadl-tests/src/main/java/com/cadl/visibility/VisibilityReadAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.cadl.visibility.implementation.VisibilityReadsImpl;
 import com.cadl.visibility.models.Dog;
 import reactor.core.publisher.Mono;
@@ -76,7 +77,7 @@ public final class VisibilityReadAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Dog.class));
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/visibility/VisibilityWriteAsyncClient.java
+++ b/cadl-tests/src/main/java/com/cadl/visibility/VisibilityWriteAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.cadl.visibility.implementation.VisibilityWritesImpl;
 import com.cadl.visibility.models.Dog;
 import com.cadl.visibility.models.WriteDog;
@@ -89,7 +90,7 @@ public final class VisibilityWriteAsyncClient {
         // Generated convenience method for createWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return createWithResponse(BinaryData.fromObject(dog), requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Dog.class));
     }
 }

--- a/cadl-tests/src/main/java/com/dictionary/BooleanValueAsyncClient.java
+++ b/cadl-tests/src/main/java/com/dictionary/BooleanValueAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.azure.core.util.serializer.TypeReference;
 import com.dictionary.implementation.BooleanValuesImpl;
 import java.util.Map;
@@ -100,7 +101,7 @@ public final class BooleanValueAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(new TypeReference<Map<String, Boolean>>() {}));
     }
 
@@ -121,6 +122,6 @@ public final class BooleanValueAsyncClient {
     public Mono<Void> put(Map<String, Boolean> body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/dictionary/DatetimeValueAsyncClient.java
+++ b/cadl-tests/src/main/java/com/dictionary/DatetimeValueAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.azure.core.util.serializer.TypeReference;
 import com.dictionary.implementation.DatetimeValuesImpl;
 import java.time.OffsetDateTime;
@@ -101,7 +102,7 @@ public final class DatetimeValueAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(
                         protocolMethodData ->
                                 protocolMethodData.toObject(new TypeReference<Map<String, OffsetDateTime>>() {}));
@@ -124,6 +125,6 @@ public final class DatetimeValueAsyncClient {
     public Mono<Void> put(Map<String, OffsetDateTime> body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/dictionary/DurationValueAsyncClient.java
+++ b/cadl-tests/src/main/java/com/dictionary/DurationValueAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.azure.core.util.serializer.TypeReference;
 import com.dictionary.implementation.DurationValuesImpl;
 import java.time.Duration;
@@ -101,7 +102,7 @@ public final class DurationValueAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(new TypeReference<Map<String, Duration>>() {}));
     }
 
@@ -122,6 +123,6 @@ public final class DurationValueAsyncClient {
     public Mono<Void> put(Map<String, Duration> body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/dictionary/Float32ValueAsyncClient.java
+++ b/cadl-tests/src/main/java/com/dictionary/Float32ValueAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.azure.core.util.serializer.TypeReference;
 import com.dictionary.implementation.Float32ValuesImpl;
 import java.util.Map;
@@ -100,7 +101,7 @@ public final class Float32ValueAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(new TypeReference<Map<String, Double>>() {}));
     }
 
@@ -121,6 +122,6 @@ public final class Float32ValueAsyncClient {
     public Mono<Void> put(Map<String, Double> body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/dictionary/Int32ValueAsyncClient.java
+++ b/cadl-tests/src/main/java/com/dictionary/Int32ValueAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.azure.core.util.serializer.TypeReference;
 import com.dictionary.implementation.Int32ValuesImpl;
 import java.util.Map;
@@ -100,7 +101,7 @@ public final class Int32ValueAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(new TypeReference<Map<String, Integer>>() {}));
     }
 
@@ -121,6 +122,6 @@ public final class Int32ValueAsyncClient {
     public Mono<Void> put(Map<String, Integer> body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/dictionary/Int64ValueAsyncClient.java
+++ b/cadl-tests/src/main/java/com/dictionary/Int64ValueAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.azure.core.util.serializer.TypeReference;
 import com.dictionary.implementation.Int64ValuesImpl;
 import java.util.Map;
@@ -100,7 +101,7 @@ public final class Int64ValueAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(new TypeReference<Map<String, Long>>() {}));
     }
 
@@ -121,6 +122,6 @@ public final class Int64ValueAsyncClient {
     public Mono<Void> put(Map<String, Long> body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/dictionary/ModelValueAsyncClient.java
+++ b/cadl-tests/src/main/java/com/dictionary/ModelValueAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.azure.core.util.serializer.TypeReference;
 import com.dictionary.implementation.ModelValuesImpl;
 import com.dictionary.models.InnerModel;
@@ -111,7 +112,7 @@ public final class ModelValueAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(
                         protocolMethodData ->
                                 protocolMethodData.toObject(new TypeReference<Map<String, InnerModel>>() {}));
@@ -134,6 +135,6 @@ public final class ModelValueAsyncClient {
     public Mono<Void> put(Map<String, InnerModel> body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/dictionary/RecursiveModelValueAsyncClient.java
+++ b/cadl-tests/src/main/java/com/dictionary/RecursiveModelValueAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.azure.core.util.serializer.TypeReference;
 import com.dictionary.implementation.RecursiveModelValuesImpl;
 import com.dictionary.models.InnerModel;
@@ -111,7 +112,7 @@ public final class RecursiveModelValueAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(
                         protocolMethodData ->
                                 protocolMethodData.toObject(new TypeReference<Map<String, InnerModel>>() {}));
@@ -134,6 +135,6 @@ public final class RecursiveModelValueAsyncClient {
     public Mono<Void> put(Map<String, InnerModel> body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/dictionary/StringValueAsyncClient.java
+++ b/cadl-tests/src/main/java/com/dictionary/StringValueAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.azure.core.util.serializer.TypeReference;
 import com.dictionary.implementation.StringValuesImpl;
 import java.util.Map;
@@ -100,7 +101,7 @@ public final class StringValueAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(new TypeReference<Map<String, String>>() {}));
     }
 
@@ -121,6 +122,6 @@ public final class StringValueAsyncClient {
     public Mono<Void> put(Map<String, String> body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/dictionary/UnknownValueAsyncClient.java
+++ b/cadl-tests/src/main/java/com/dictionary/UnknownValueAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.azure.core.util.serializer.TypeReference;
 import com.dictionary.implementation.UnknownValuesImpl;
 import java.util.Map;
@@ -100,7 +101,7 @@ public final class UnknownValueAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(new TypeReference<Map<String, Object>>() {}));
     }
 
@@ -121,6 +122,6 @@ public final class UnknownValueAsyncClient {
     public Mono<Void> put(Map<String, Object> body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/extensibleenums/ExtensibleEnumsAsyncClient.java
+++ b/cadl-tests/src/main/java/com/extensibleenums/ExtensibleEnumsAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.extensibleenums.implementation.ExtensibleEnumsClientImpl;
 import com.extensibleenums.models.DaysOfWeekExtensibleEnum;
 import reactor.core.publisher.Mono;
@@ -140,7 +141,7 @@ public final class ExtensibleEnumsAsyncClient {
         // Generated convenience method for getKnownValueWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getKnownValueWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(DaysOfWeekExtensibleEnum::fromString);
     }
 
@@ -160,7 +161,7 @@ public final class ExtensibleEnumsAsyncClient {
         // Generated convenience method for getUnknownValueWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getUnknownValueWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(DaysOfWeekExtensibleEnum::fromString);
     }
 
@@ -181,7 +182,7 @@ public final class ExtensibleEnumsAsyncClient {
     public Mono<Void> putKnownValue(DaysOfWeekExtensibleEnum body) {
         // Generated convenience method for putKnownValueWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putKnownValueWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putKnownValueWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**
@@ -201,6 +202,6 @@ public final class ExtensibleEnumsAsyncClient {
     public Mono<Void> putUnknownValue(DaysOfWeekExtensibleEnum body) {
         // Generated convenience method for putUnknownValueWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putUnknownValueWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putUnknownValueWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/hello/HelloAsyncClient.java
+++ b/cadl-tests/src/main/java/com/hello/HelloAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.hello.implementation.HelloClientImpl;
 import reactor.core.publisher.Mono;
 
@@ -71,7 +72,7 @@ public final class HelloAsyncClient {
         // Generated convenience method for worldWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return worldWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(String.class));
     }
 }

--- a/cadl-tests/src/main/java/com/models/inheritance/InheritanceAsyncClient.java
+++ b/cadl-tests/src/main/java/com/models/inheritance/InheritanceAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.models.inheritance.implementation.InheritanceClientImpl;
 import com.models.inheritance.models.Fish;
 import com.models.inheritance.models.Siamese;
@@ -294,7 +295,7 @@ public final class InheritanceAsyncClient {
     public Mono<Void> postValid(Siamese input) {
         // Generated convenience method for postValidWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return postValidWithResponse(BinaryData.fromObject(input), requestOptions).then();
+        return postValidWithResponse(BinaryData.fromObject(input), requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**
@@ -313,7 +314,7 @@ public final class InheritanceAsyncClient {
         // Generated convenience method for getValidWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getValidWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Siamese.class));
     }
 
@@ -335,7 +336,7 @@ public final class InheritanceAsyncClient {
         // Generated convenience method for putValidWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return putValidWithResponse(BinaryData.fromObject(input), requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Siamese.class));
     }
 
@@ -356,7 +357,7 @@ public final class InheritanceAsyncClient {
         // Generated convenience method for getModelWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getModelWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Fish.class));
     }
 
@@ -377,7 +378,7 @@ public final class InheritanceAsyncClient {
     public Mono<Void> putModel(Fish input) {
         // Generated convenience method for putModelWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putModelWithResponse(BinaryData.fromObject(input), requestOptions).then();
+        return putModelWithResponse(BinaryData.fromObject(input), requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**
@@ -397,7 +398,7 @@ public final class InheritanceAsyncClient {
         // Generated convenience method for getRecursiveModelWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getRecursiveModelWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Fish.class));
     }
 
@@ -418,7 +419,7 @@ public final class InheritanceAsyncClient {
     public Mono<Void> putRecursiveModel(Fish input) {
         // Generated convenience method for putRecursiveModelWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putRecursiveModelWithResponse(BinaryData.fromObject(input), requestOptions).then();
+        return putRecursiveModelWithResponse(BinaryData.fromObject(input), requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**
@@ -438,7 +439,7 @@ public final class InheritanceAsyncClient {
         // Generated convenience method for getMissingDiscriminatorWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getMissingDiscriminatorWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Fish.class));
     }
 
@@ -459,7 +460,7 @@ public final class InheritanceAsyncClient {
         // Generated convenience method for getWrongDiscriminatorWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWrongDiscriminatorWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Fish.class));
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/optional/BytesAsyncClient.java
+++ b/cadl-tests/src/main/java/com/models/property/optional/BytesAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.models.property.optional.implementation.BytesImpl;
 import com.models.property.optional.models.BytesProperty;
 import reactor.core.publisher.Mono;
@@ -152,7 +153,7 @@ public final class BytesAsyncClient {
         // Generated convenience method for getAllWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getAllWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(BytesProperty.class));
     }
 
@@ -172,7 +173,7 @@ public final class BytesAsyncClient {
         // Generated convenience method for getDefaultWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getDefaultWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(BytesProperty.class));
     }
 
@@ -194,7 +195,7 @@ public final class BytesAsyncClient {
     public Mono<Void> putAll(BytesProperty body) {
         // Generated convenience method for putAllWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putAllWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putAllWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**
@@ -215,6 +216,6 @@ public final class BytesAsyncClient {
     public Mono<Void> putDefault(BytesProperty body) {
         // Generated convenience method for putDefaultWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putDefaultWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putDefaultWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/optional/CollectionsByteAsyncClient.java
+++ b/cadl-tests/src/main/java/com/models/property/optional/CollectionsByteAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.models.property.optional.implementation.CollectionsBytesImpl;
 import com.models.property.optional.models.CollectionsByteProperty;
 import reactor.core.publisher.Mono;
@@ -158,7 +159,7 @@ public final class CollectionsByteAsyncClient {
         // Generated convenience method for getAllWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getAllWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(CollectionsByteProperty.class));
     }
 
@@ -178,7 +179,7 @@ public final class CollectionsByteAsyncClient {
         // Generated convenience method for getDefaultWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getDefaultWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(CollectionsByteProperty.class));
     }
 
@@ -199,7 +200,7 @@ public final class CollectionsByteAsyncClient {
     public Mono<Void> putAll(CollectionsByteProperty body) {
         // Generated convenience method for putAllWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putAllWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putAllWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**
@@ -219,6 +220,6 @@ public final class CollectionsByteAsyncClient {
     public Mono<Void> putDefault(CollectionsByteProperty body) {
         // Generated convenience method for putDefaultWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putDefaultWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putDefaultWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/optional/CollectionsModelAsyncClient.java
+++ b/cadl-tests/src/main/java/com/models/property/optional/CollectionsModelAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.models.property.optional.implementation.CollectionsModelsImpl;
 import com.models.property.optional.models.CollectionsModelProperty;
 import reactor.core.publisher.Mono;
@@ -166,7 +167,7 @@ public final class CollectionsModelAsyncClient {
         // Generated convenience method for getAllWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getAllWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(CollectionsModelProperty.class));
     }
 
@@ -186,7 +187,7 @@ public final class CollectionsModelAsyncClient {
         // Generated convenience method for getDefaultWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getDefaultWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(CollectionsModelProperty.class));
     }
 
@@ -207,7 +208,7 @@ public final class CollectionsModelAsyncClient {
     public Mono<Void> putAll(CollectionsModelProperty body) {
         // Generated convenience method for putAllWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putAllWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putAllWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**
@@ -227,6 +228,6 @@ public final class CollectionsModelAsyncClient {
     public Mono<Void> putDefault(CollectionsModelProperty body) {
         // Generated convenience method for putDefaultWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putDefaultWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putDefaultWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/optional/DatetimeOperationAsyncClient.java
+++ b/cadl-tests/src/main/java/com/models/property/optional/DatetimeOperationAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.models.property.optional.implementation.DatetimeOperationsImpl;
 import com.models.property.optional.models.DatetimeProperty;
 import reactor.core.publisher.Mono;
@@ -150,7 +151,7 @@ public final class DatetimeOperationAsyncClient {
         // Generated convenience method for getAllWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getAllWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(DatetimeProperty.class));
     }
 
@@ -170,7 +171,7 @@ public final class DatetimeOperationAsyncClient {
         // Generated convenience method for getDefaultWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getDefaultWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(DatetimeProperty.class));
     }
 
@@ -191,7 +192,7 @@ public final class DatetimeOperationAsyncClient {
     public Mono<Void> putAll(DatetimeProperty body) {
         // Generated convenience method for putAllWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putAllWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putAllWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**
@@ -211,6 +212,6 @@ public final class DatetimeOperationAsyncClient {
     public Mono<Void> putDefault(DatetimeProperty body) {
         // Generated convenience method for putDefaultWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putDefaultWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putDefaultWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/optional/DurationOperationAsyncClient.java
+++ b/cadl-tests/src/main/java/com/models/property/optional/DurationOperationAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.models.property.optional.implementation.DurationOperationsImpl;
 import com.models.property.optional.models.DurationProperty;
 import reactor.core.publisher.Mono;
@@ -150,7 +151,7 @@ public final class DurationOperationAsyncClient {
         // Generated convenience method for getAllWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getAllWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(DurationProperty.class));
     }
 
@@ -170,7 +171,7 @@ public final class DurationOperationAsyncClient {
         // Generated convenience method for getDefaultWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getDefaultWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(DurationProperty.class));
     }
 
@@ -191,7 +192,7 @@ public final class DurationOperationAsyncClient {
     public Mono<Void> putAll(DurationProperty body) {
         // Generated convenience method for putAllWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putAllWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putAllWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**
@@ -211,6 +212,6 @@ public final class DurationOperationAsyncClient {
     public Mono<Void> putDefault(DurationProperty body) {
         // Generated convenience method for putDefaultWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putDefaultWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putDefaultWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/optional/RequiredAndOptionalAsyncClient.java
+++ b/cadl-tests/src/main/java/com/models/property/optional/RequiredAndOptionalAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.models.property.optional.implementation.RequiredAndOptionalsImpl;
 import com.models.property.optional.models.RequiredAndOptionalProperty;
 import reactor.core.publisher.Mono;
@@ -154,7 +155,7 @@ public final class RequiredAndOptionalAsyncClient {
         // Generated convenience method for getAllWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getAllWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(RequiredAndOptionalProperty.class));
     }
 
@@ -174,7 +175,7 @@ public final class RequiredAndOptionalAsyncClient {
         // Generated convenience method for getRequiredOnlyWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getRequiredOnlyWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(RequiredAndOptionalProperty.class));
     }
 
@@ -195,7 +196,7 @@ public final class RequiredAndOptionalAsyncClient {
     public Mono<Void> putAll(RequiredAndOptionalProperty body) {
         // Generated convenience method for putAllWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putAllWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putAllWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**
@@ -215,6 +216,6 @@ public final class RequiredAndOptionalAsyncClient {
     public Mono<Void> putRequiredOnly(RequiredAndOptionalProperty body) {
         // Generated convenience method for putRequiredOnlyWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putRequiredOnlyWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putRequiredOnlyWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/optional/StringOperationAsyncClient.java
+++ b/cadl-tests/src/main/java/com/models/property/optional/StringOperationAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.models.property.optional.implementation.StringOperationsImpl;
 import com.models.property.optional.models.StringProperty;
 import reactor.core.publisher.Mono;
@@ -152,7 +153,7 @@ public final class StringOperationAsyncClient {
         // Generated convenience method for getAllWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getAllWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(StringProperty.class));
     }
 
@@ -172,7 +173,7 @@ public final class StringOperationAsyncClient {
         // Generated convenience method for getDefaultWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getDefaultWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(StringProperty.class));
     }
 
@@ -194,7 +195,7 @@ public final class StringOperationAsyncClient {
     public Mono<Void> putAll(StringProperty body) {
         // Generated convenience method for putAllWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putAllWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putAllWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**
@@ -215,6 +216,6 @@ public final class StringOperationAsyncClient {
     public Mono<Void> putDefault(StringProperty body) {
         // Generated convenience method for putDefaultWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putDefaultWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putDefaultWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/types/BooleanOperationAsyncClient.java
+++ b/cadl-tests/src/main/java/com/models/property/types/BooleanOperationAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.models.property.types.implementation.BooleanOperationsImpl;
 import com.models.property.types.models.BooleanProperty;
 import reactor.core.publisher.Mono;
@@ -99,7 +100,7 @@ public final class BooleanOperationAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(BooleanProperty.class));
     }
 
@@ -120,6 +121,6 @@ public final class BooleanOperationAsyncClient {
     public Mono<Void> put(BooleanProperty body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/types/BytesAsyncClient.java
+++ b/cadl-tests/src/main/java/com/models/property/types/BytesAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.models.property.types.implementation.BytesImpl;
 import com.models.property.types.models.BytesProperty;
 import reactor.core.publisher.Mono;
@@ -99,7 +100,7 @@ public final class BytesAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(BytesProperty.class));
     }
 
@@ -120,6 +121,6 @@ public final class BytesAsyncClient {
     public Mono<Void> put(BytesProperty body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/types/CollectionsIntAsyncClient.java
+++ b/cadl-tests/src/main/java/com/models/property/types/CollectionsIntAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.models.property.types.implementation.CollectionsIntsImpl;
 import com.models.property.types.models.CollectionsIntProperty;
 import reactor.core.publisher.Mono;
@@ -104,7 +105,7 @@ public final class CollectionsIntAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(CollectionsIntProperty.class));
     }
 
@@ -125,6 +126,6 @@ public final class CollectionsIntAsyncClient {
     public Mono<Void> put(CollectionsIntProperty body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/types/CollectionsModelAsyncClient.java
+++ b/cadl-tests/src/main/java/com/models/property/types/CollectionsModelAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.models.property.types.implementation.CollectionsModelsImpl;
 import com.models.property.types.models.CollectionsModelProperty;
 import reactor.core.publisher.Mono;
@@ -108,7 +109,7 @@ public final class CollectionsModelAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(CollectionsModelProperty.class));
     }
 
@@ -129,6 +130,6 @@ public final class CollectionsModelAsyncClient {
     public Mono<Void> put(CollectionsModelProperty body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/types/CollectionsStringAsyncClient.java
+++ b/cadl-tests/src/main/java/com/models/property/types/CollectionsStringAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.models.property.types.implementation.CollectionsStringsImpl;
 import com.models.property.types.models.CollectionsStringProperty;
 import reactor.core.publisher.Mono;
@@ -104,7 +105,7 @@ public final class CollectionsStringAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(CollectionsStringProperty.class));
     }
 
@@ -125,6 +126,6 @@ public final class CollectionsStringAsyncClient {
     public Mono<Void> put(CollectionsStringProperty body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/types/DatetimeOperationAsyncClient.java
+++ b/cadl-tests/src/main/java/com/models/property/types/DatetimeOperationAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.models.property.types.implementation.DatetimeOperationsImpl;
 import com.models.property.types.models.DatetimeProperty;
 import reactor.core.publisher.Mono;
@@ -99,7 +100,7 @@ public final class DatetimeOperationAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(DatetimeProperty.class));
     }
 
@@ -120,6 +121,6 @@ public final class DatetimeOperationAsyncClient {
     public Mono<Void> put(DatetimeProperty body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/types/DictionaryStringAsyncClient.java
+++ b/cadl-tests/src/main/java/com/models/property/types/DictionaryStringAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.models.property.types.implementation.DictionaryStringsImpl;
 import com.models.property.types.models.DictionaryStringProperty;
 import reactor.core.publisher.Mono;
@@ -104,7 +105,7 @@ public final class DictionaryStringAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(DictionaryStringProperty.class));
     }
 
@@ -125,6 +126,6 @@ public final class DictionaryStringAsyncClient {
     public Mono<Void> put(DictionaryStringProperty body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/types/DurationOperationAsyncClient.java
+++ b/cadl-tests/src/main/java/com/models/property/types/DurationOperationAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.models.property.types.implementation.DurationOperationsImpl;
 import com.models.property.types.models.DurationProperty;
 import reactor.core.publisher.Mono;
@@ -99,7 +100,7 @@ public final class DurationOperationAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(DurationProperty.class));
     }
 
@@ -120,6 +121,6 @@ public final class DurationOperationAsyncClient {
     public Mono<Void> put(DurationProperty body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/types/EnumAsyncClient.java
+++ b/cadl-tests/src/main/java/com/models/property/types/EnumAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.models.property.types.implementation.EnumsImpl;
 import com.models.property.types.models.EnumProperty;
 import reactor.core.publisher.Mono;
@@ -99,7 +100,7 @@ public final class EnumAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(EnumProperty.class));
     }
 
@@ -120,6 +121,6 @@ public final class EnumAsyncClient {
     public Mono<Void> put(EnumProperty body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/types/ExtensibleEnumAsyncClient.java
+++ b/cadl-tests/src/main/java/com/models/property/types/ExtensibleEnumAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.models.property.types.implementation.ExtensibleEnumsImpl;
 import com.models.property.types.models.ExtensibleEnumProperty;
 import reactor.core.publisher.Mono;
@@ -100,7 +101,7 @@ public final class ExtensibleEnumAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(ExtensibleEnumProperty.class));
     }
 
@@ -121,6 +122,6 @@ public final class ExtensibleEnumAsyncClient {
     public Mono<Void> put(ExtensibleEnumProperty body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/types/FloatOperationAsyncClient.java
+++ b/cadl-tests/src/main/java/com/models/property/types/FloatOperationAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.models.property.types.implementation.FloatOperationsImpl;
 import com.models.property.types.models.FloatProperty;
 import reactor.core.publisher.Mono;
@@ -99,7 +100,7 @@ public final class FloatOperationAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(FloatProperty.class));
     }
 
@@ -120,6 +121,6 @@ public final class FloatOperationAsyncClient {
     public Mono<Void> put(FloatProperty body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/types/IntAsyncClient.java
+++ b/cadl-tests/src/main/java/com/models/property/types/IntAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.models.property.types.implementation.IntsImpl;
 import com.models.property.types.models.IntProperty;
 import reactor.core.publisher.Mono;
@@ -99,7 +100,7 @@ public final class IntAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(IntProperty.class));
     }
 
@@ -120,6 +121,6 @@ public final class IntAsyncClient {
     public Mono<Void> put(IntProperty body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/types/ModelAsyncClient.java
+++ b/cadl-tests/src/main/java/com/models/property/types/ModelAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.models.property.types.implementation.ModelsImpl;
 import com.models.property.types.models.ModelProperty;
 import reactor.core.publisher.Mono;
@@ -103,7 +104,7 @@ public final class ModelAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(ModelProperty.class));
     }
 
@@ -124,6 +125,6 @@ public final class ModelAsyncClient {
     public Mono<Void> put(ModelProperty body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/types/NeverAsyncClient.java
+++ b/cadl-tests/src/main/java/com/models/property/types/NeverAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.models.property.types.implementation.NeversImpl;
 import reactor.core.publisher.Mono;
 
@@ -93,7 +94,7 @@ public final class NeverAsyncClient {
     public Mono<Object> get() {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return getWithResponse(requestOptions).map(Response::getValue);
+        return getWithResponse(requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**
@@ -113,6 +114,6 @@ public final class NeverAsyncClient {
     public Mono<Void> put(Object body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/types/StringOperationAsyncClient.java
+++ b/cadl-tests/src/main/java/com/models/property/types/StringOperationAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.models.property.types.implementation.StringOperationsImpl;
 import com.models.property.types.models.StringProperty;
 import reactor.core.publisher.Mono;
@@ -99,7 +100,7 @@ public final class StringOperationAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(StringProperty.class));
     }
 
@@ -120,6 +121,6 @@ public final class StringOperationAsyncClient {
     public Mono<Void> put(StringProperty body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/models/usage/UsageAsyncClient.java
+++ b/cadl-tests/src/main/java/com/models/usage/UsageAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.models.usage.implementation.UsageClientImpl;
 import com.models.usage.models.InputOutputRecord;
 import com.models.usage.models.InputRecord;
@@ -137,7 +138,7 @@ public final class UsageAsyncClient {
     public Mono<Void> input(InputRecord input) {
         // Generated convenience method for inputWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return inputWithResponse(BinaryData.fromObject(input), requestOptions).then();
+        return inputWithResponse(BinaryData.fromObject(input), requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**
@@ -156,7 +157,7 @@ public final class UsageAsyncClient {
         // Generated convenience method for outputWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return outputWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(OutputRecord.class));
     }
 
@@ -178,7 +179,7 @@ public final class UsageAsyncClient {
         // Generated convenience method for inputAndOutputWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return inputAndOutputWithResponse(BinaryData.fromObject(body), requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(InputOutputRecord.class));
     }
 }

--- a/cadl-tests/src/main/java/com/readonlyproperties/ReadonlyPropertiesAsyncClient.java
+++ b/cadl-tests/src/main/java/com/readonlyproperties/ReadonlyPropertiesAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.readonlyproperties.implementation.ReadonlyPropertiesClientImpl;
 import com.readonlyproperties.models.OutputModel;
 import com.readonlyproperties.models.RoundTripModel;
@@ -168,7 +169,7 @@ public final class ReadonlyPropertiesAsyncClient {
         // Generated convenience method for getOptionalPropertyModelWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getOptionalPropertyModelWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(OutputModel.class));
     }
 
@@ -190,7 +191,7 @@ public final class ReadonlyPropertiesAsyncClient {
         // Generated convenience method for setOptionalPropertyModelWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return setOptionalPropertyModelWithResponse(BinaryData.fromObject(input), requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(RoundTripModel.class));
     }
 }

--- a/cadl-tests/src/main/java/com/resiliency/devdriven/DevDrivenAsyncClient.java
+++ b/cadl-tests/src/main/java/com/resiliency/devdriven/DevDrivenAsyncClient.java
@@ -18,6 +18,7 @@ import com.azure.core.http.rest.PagedResponseBase;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.resiliency.devdriven.implementation.DevDrivenClientImpl;
 import com.resiliency.devdriven.models.Input;
 import com.resiliency.devdriven.models.LroProduct;
@@ -186,7 +187,7 @@ public final class DevDrivenAsyncClient {
         // Generated convenience method for getModelWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getModelWithResponse(mode.toString(), requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Product.class));
     }
 
@@ -211,7 +212,7 @@ public final class DevDrivenAsyncClient {
         // Generated convenience method for postModelWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return postModelWithResponse(mode.toString(), BinaryData.fromObject(input), requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Product.class));
     }
 
@@ -275,7 +276,7 @@ public final class DevDrivenAsyncClient {
         // Generated convenience method for lroWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return lroWithResponse(mode.toString(), requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(LroProduct.class));
     }
 }

--- a/cadl-tests/src/main/java/com/resiliency/servicedriven1/ServiceDriven1AsyncClient.java
+++ b/cadl-tests/src/main/java/com/resiliency/servicedriven1/ServiceDriven1AsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.resiliency.servicedriven1.implementation.ServiceDriven1ClientImpl;
 import com.resiliency.servicedriven1.models.Message;
 import com.resiliency.servicedriven1.models.PostInput;
@@ -201,7 +202,7 @@ public final class ServiceDriven1AsyncClient {
     public Mono<Void> headNoParams() {
         // Generated convenience method for headNoParamsWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return headNoParamsWithResponse(requestOptions).then();
+        return headNoParamsWithResponse(requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**
@@ -224,7 +225,7 @@ public final class ServiceDriven1AsyncClient {
         // Generated convenience method for getRequiredWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getRequiredWithResponse(parameter, requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Message.class));
     }
 
@@ -251,7 +252,7 @@ public final class ServiceDriven1AsyncClient {
             requestOptions.addQueryParam("optionalParam", optionalParam);
         }
         return putRequiredOptionalWithResponse(requiredParam, requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Message.class));
     }
 
@@ -274,7 +275,7 @@ public final class ServiceDriven1AsyncClient {
         // Generated convenience method for putRequiredOptionalWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return putRequiredOptionalWithResponse(requiredParam, requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Message.class));
     }
 
@@ -296,7 +297,7 @@ public final class ServiceDriven1AsyncClient {
         // Generated convenience method for postParametersWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return postParametersWithResponse(BinaryData.fromObject(parameter), requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Message.class));
     }
 
@@ -323,7 +324,7 @@ public final class ServiceDriven1AsyncClient {
             requestOptions.addQueryParam("optionalParam", optionalParam);
         }
         return getOptionalWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Message.class));
     }
 
@@ -345,7 +346,7 @@ public final class ServiceDriven1AsyncClient {
         // Generated convenience method for getOptionalWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getOptionalWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Message.class));
     }
 }

--- a/cadl-tests/src/main/java/com/resiliency/servicedriven2/ServiceDriven2AsyncClient.java
+++ b/cadl-tests/src/main/java/com/resiliency/servicedriven2/ServiceDriven2AsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.resiliency.servicedriven2.implementation.ServiceDriven2ClientImpl;
 import com.resiliency.servicedriven2.models.ContentTypePath;
 import com.resiliency.servicedriven2.models.Message;
@@ -273,7 +274,7 @@ public final class ServiceDriven2AsyncClient {
         if (newParameter != null) {
             requestOptions.addQueryParam("new_parameter", newParameter);
         }
-        return headNoParamsWithResponse(requestOptions).then();
+        return headNoParamsWithResponse(requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**
@@ -292,7 +293,7 @@ public final class ServiceDriven2AsyncClient {
     public Mono<Void> headNoParams() {
         // Generated convenience method for headNoParamsWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return headNoParamsWithResponse(requestOptions).then();
+        return headNoParamsWithResponse(requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**
@@ -319,7 +320,7 @@ public final class ServiceDriven2AsyncClient {
             requestOptions.addQueryParam("new_parameter", newParameter);
         }
         return getRequiredWithResponse(parameter, requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Message.class));
     }
 
@@ -343,7 +344,7 @@ public final class ServiceDriven2AsyncClient {
         // Generated convenience method for getRequiredWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getRequiredWithResponse(parameter, requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Message.class));
     }
 
@@ -374,7 +375,7 @@ public final class ServiceDriven2AsyncClient {
             requestOptions.addQueryParam("new_parameter", newParameter);
         }
         return putRequiredOptionalWithResponse(requiredParam, requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Message.class));
     }
 
@@ -397,7 +398,7 @@ public final class ServiceDriven2AsyncClient {
         // Generated convenience method for putRequiredOptionalWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return putRequiredOptionalWithResponse(requiredParam, requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Message.class));
     }
 
@@ -420,7 +421,7 @@ public final class ServiceDriven2AsyncClient {
         // Generated convenience method for postParametersWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return postParametersWithResponse(contentTypePath.toString(), BinaryData.fromObject(parameter), requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Message.class));
     }
 
@@ -440,7 +441,7 @@ public final class ServiceDriven2AsyncClient {
     public Mono<Void> deleteParameters() {
         // Generated convenience method for deleteParametersWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return deleteParametersWithResponse(requestOptions).then();
+        return deleteParametersWithResponse(requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**
@@ -470,7 +471,7 @@ public final class ServiceDriven2AsyncClient {
             requestOptions.addQueryParam("new_parameter", newParameter);
         }
         return getOptionalWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Message.class));
     }
 
@@ -492,7 +493,7 @@ public final class ServiceDriven2AsyncClient {
         // Generated convenience method for getOptionalWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getOptionalWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Message.class));
     }
 
@@ -513,7 +514,7 @@ public final class ServiceDriven2AsyncClient {
         // Generated convenience method for getNewOperationWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getNewOperationWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(Message.class));
     }
 }

--- a/cadl-tests/src/main/java/com/specialwords/ModelAsyncClient.java
+++ b/cadl-tests/src/main/java/com/specialwords/ModelAsyncClient.java
@@ -15,6 +15,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
 import com.specialwords.implementation.ModelsImpl;
 import com.specialwords.models.BaseModel;
 import reactor.core.publisher.Mono;
@@ -98,7 +99,7 @@ public final class ModelAsyncClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions)
-                .map(Response::getValue)
+                .flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(BaseModel.class));
     }
 
@@ -119,6 +120,6 @@ public final class ModelAsyncClient {
     public Mono<Void> put(BaseModel body) {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return putWithResponse(BinaryData.fromObject(body), requestOptions).then();
+        return putWithResponse(BinaryData.fromObject(body), requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/specialwords/OperationAsyncClient.java
+++ b/cadl-tests/src/main/java/com/specialwords/OperationAsyncClient.java
@@ -14,6 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
+import com.azure.core.util.FluxUtil;
 import com.specialwords.implementation.OperationsImpl;
 import reactor.core.publisher.Mono;
 
@@ -63,6 +64,6 @@ public final class OperationAsyncClient {
     public Mono<Void> forMethod() {
         // Generated convenience method for forMethodWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return forMethodWithResponse(requestOptions).then();
+        return forMethodWithResponse(requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/cadl-tests/src/main/java/com/specialwords/ParameterAsyncClient.java
+++ b/cadl-tests/src/main/java/com/specialwords/ParameterAsyncClient.java
@@ -14,6 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
+import com.azure.core.util.FluxUtil;
 import com.specialwords.implementation.ParametersImpl;
 import reactor.core.publisher.Mono;
 
@@ -83,7 +84,7 @@ public final class ParameterAsyncClient {
     public Mono<Void> getWithIf(String ifParameter) {
         // Generated convenience method for getWithIfWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return getWithIfWithResponse(ifParameter, requestOptions).then();
+        return getWithIfWithResponse(ifParameter, requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**
@@ -103,6 +104,6 @@ public final class ParameterAsyncClient {
     public Mono<Void> getWithFilter(String filter) {
         // Generated convenience method for getWithFilterWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return getWithFilterWithResponse(filter, requestOptions).then();
+        return getWithFilterWithResponse(filter, requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/template/ConvenienceSyncMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ConvenienceSyncMethodTemplate.java
@@ -3,6 +3,7 @@
 
 package com.azure.autorest.template;
 
+import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.model.clientmodel.ClassType;
 import com.azure.autorest.model.clientmodel.ClientMethod;
 import com.azure.autorest.model.clientmodel.ClientMethodParameter;
@@ -14,8 +15,15 @@ import com.azure.autorest.model.clientmodel.IType;
 import com.azure.autorest.model.javamodel.JavaBlock;
 import com.azure.core.http.rest.Response;
 import com.azure.core.http.rest.ResponseBase;
+import com.azure.core.http.rest.SimpleResponse;
+import com.azure.core.util.CoreUtils;
+import com.azure.core.util.serializer.CollectionFormat;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.TypeReference;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class ConvenienceSyncMethodTemplate extends ConvenienceMethodTemplateBase {
@@ -29,6 +37,23 @@ public class ConvenienceSyncMethodTemplate extends ConvenienceMethodTemplateBase
 
     public static ConvenienceSyncMethodTemplate getInstance() {
         return INSTANCE;
+    }
+
+    public void addImports(Set<String> imports, List<ConvenienceMethod> convenienceMethods) {
+        if (!CoreUtils.isNullOrEmpty(convenienceMethods)) {
+            JavaSettings settings = JavaSettings.getInstance();
+            convenienceMethods.stream().flatMap(m -> m.getConvenienceMethods().stream())
+                    .forEach(m -> m.addImportsTo(imports, false, settings));
+
+            ClassType.BinaryData.addImportsTo(imports, false);
+            ClassType.RequestOptions.addImportsTo(imports, false);
+            imports.add(SimpleResponse.class.getName());
+            imports.add(Collectors.class.getName());
+            imports.add(Objects.class.getName());
+            imports.add(JacksonAdapter.class.getName());
+            imports.add(CollectionFormat.class.getName());
+            imports.add(TypeReference.class.getName());
+        }
     }
 
     @Override

--- a/javagen/src/main/java/com/azure/autorest/template/ServiceSyncClientTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceSyncClientTemplate.java
@@ -5,7 +5,6 @@ package com.azure.autorest.template;
 
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.model.clientmodel.AsyncSyncClient;
-import com.azure.autorest.model.clientmodel.ClassType;
 import com.azure.autorest.model.clientmodel.ClientMethod;
 import com.azure.autorest.model.clientmodel.ConvenienceMethod;
 import com.azure.autorest.model.clientmodel.MethodGroupClient;
@@ -15,16 +14,10 @@ import com.azure.autorest.model.javamodel.JavaContext;
 import com.azure.autorest.model.javamodel.JavaFile;
 import com.azure.autorest.model.javamodel.JavaVisibility;
 import com.azure.autorest.util.ClientModelUtil;
-import com.azure.core.http.rest.SimpleResponse;
-import com.azure.core.util.serializer.CollectionFormat;
-import com.azure.core.util.serializer.JacksonAdapter;
-import com.azure.core.util.serializer.TypeReference;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Template to create a synchronous client.
@@ -64,7 +57,7 @@ public class ServiceSyncClientTemplate implements IJavaTemplate<AsyncSyncClient,
     imports.add(builderPackageName + "." + builderClassName);
     addServiceClientAnnotationImport(imports);
 
-    addImportsToConvenienceMethods(imports, syncClient.getConvenienceMethods());
+    Templates.getConvenienceSyncMethodTemplate().addImports(imports, syncClient.getConvenienceMethods());
 
     javaFile.declareImport(imports);
     javaFile.javadocComment(comment ->
@@ -175,21 +168,6 @@ public class ServiceSyncClientTemplate implements IJavaTemplate<AsyncSyncClient,
 
   protected void addGeneratedAnnotation(JavaContext classBlock) {
     classBlock.annotation("Generated");
-  }
-
-  private static void addImportsToConvenienceMethods(Set<String> imports, List<ConvenienceMethod> convenienceMethods) {
-    JavaSettings settings = JavaSettings.getInstance();
-    convenienceMethods.stream().flatMap(m -> m.getConvenienceMethods().stream())
-        .forEach(m -> m.addImportsTo(imports, false, settings));
-
-    ClassType.BinaryData.addImportsTo(imports, false);
-    ClassType.RequestOptions.addImportsTo(imports, false);
-    imports.add(SimpleResponse.class.getName());
-    imports.add(Collectors.class.getName());
-    imports.add(Objects.class.getName());
-    imports.add(JacksonAdapter.class.getName());
-    imports.add(CollectionFormat.class.getName());
-    imports.add(TypeReference.class.getName());
   }
 
   private static void writeConvenienceMethods(ConvenienceMethod convenienceMethod, JavaClass classBlock) {


### PR DESCRIPTION
use `.flatMap(FluxUtil::toMono)` instead of `.map(Response::getValue)` (to handle null in response value)