### PR TITLE
fetch operation and add to operationCache if not hit

### DIFF
--- a/cadl-extension/src/code-model-builder.ts
+++ b/cadl-extension/src/code-model-builder.ts
@@ -433,7 +433,7 @@ export class CodeModelBuilder {
     op.responses.map((it) => this.processResponse(codeModelOperation, it));
 
     this.processRouteForPaged(codeModelOperation, op.responses);
-    this.processRouteForLongRunning(codeModelOperation, operation, op.responses);
+    this.processRouteForLongRunning(codeModelOperation, operation, op.responses, groupName);
 
     operationGroup.addOperation(codeModelOperation);
 
@@ -467,7 +467,7 @@ export class CodeModelBuilder {
     }
   }
 
-  private processRouteForLongRunning(op: CodeModelOperation, operation: Operation, responses: HttpOperationResponse[]) {
+  private processRouteForLongRunning(op: CodeModelOperation, operation: Operation, responses: HttpOperationResponse[], groupName: string) {
     let pollingFoundInOperationLinks = false;
     const operationLinks = getOperationLinks(this.program, operation);
     if (operationLinks) {
@@ -480,6 +480,9 @@ export class CodeModelBuilder {
 
         if (linkOperation.linkedOperation) {
           // Cadl requires linked operation written before
+          if (!this.operationCache.get(linkOperation.linkedOperation)) {
+            this.processRoute(groupName, linkOperation.linkedOperation);
+          }
           const opLink = new OperationLink(this.operationCache.get(linkOperation.linkedOperation)!);
           // parameters of operation link
           if (linkOperation.parameters) {

--- a/cadl-extension/src/code-model-builder.ts
+++ b/cadl-extension/src/code-model-builder.ts
@@ -433,7 +433,7 @@ export class CodeModelBuilder {
     op.responses.map((it) => this.processResponse(codeModelOperation, it));
 
     this.processRouteForPaged(codeModelOperation, op.responses);
-    this.processRouteForLongRunning(codeModelOperation, operation, op.responses, groupName);
+    this.processRouteForLongRunning(codeModelOperation, groupName, operation, op.responses);
 
     operationGroup.addOperation(codeModelOperation);
 
@@ -467,7 +467,12 @@ export class CodeModelBuilder {
     }
   }
 
-  private processRouteForLongRunning(op: CodeModelOperation, operation: Operation, responses: HttpOperationResponse[], groupName: string) {
+  private processRouteForLongRunning(
+    op: CodeModelOperation,
+    groupName: string,
+    operation: Operation,
+    responses: HttpOperationResponse[],
+  ) {
     let pollingFoundInOperationLinks = false;
     const operationLinks = getOperationLinks(this.program, operation);
     if (operationLinks) {


### PR DESCRIPTION
Fix the bug mentioned for ADP: https://github.com/Azure/autorest.java/issues/1800#issuecomment-1348125787

ADP API view: https://apiview.dev/Assemblies/Review/3b77bee6b3b940ad9c85df75cee51df1#com.adp.datamanagement.DataManagementClient

ADP generated code: https://github.com/haolingdong-msft/autorest.java/blob/adp-new-codegen/cadl-tests/cadl/adp/DataManagement/cadl-output/src/main/java/com/adp/datamanagement/DataManagementClient.java