### PR TITLE
fix default value converter for unixtimelong

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
@@ -177,7 +177,10 @@ public class ClassType implements IType {
         .packageName("org.threeten.bp").name("OffsetDateTime")
         .build();
 
-    public static final ClassType UnixTimeLong = new ClassType.Builder(false).knownClass(java.lang.Long.class).build();
+    public static final ClassType UnixTimeLong = new ClassType.Builder(false)
+            .knownClass(java.lang.Long.class)
+            .defaultValueExpressionConverter(defaultValueExpression -> defaultValueExpression + 'L')
+            .build();
 
     public static final ClassType HttpPipeline = new ClassType.Builder(false)
         .knownClass(com.azure.core.http.HttpPipeline.class)

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/PrimitiveType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/PrimitiveType.java
@@ -38,7 +38,7 @@ public class PrimitiveType implements IType {
         defaultValueExpression -> Integer.toString(defaultValueExpression.charAt(0)), "\u0000", "writeString",
         true, "getString().charAt(0)", "getStringAttribute(%s, %s).charAt(0)", "getStringElement().charAt(0)");
 
-    public static final PrimitiveType UnixTimeLong = new PrimitiveType("long", ClassType.UnixTimeLong, null, null,
+    public static final PrimitiveType UnixTimeLong = new PrimitiveType("long", ClassType.UnixTimeLong, defaultValueExpression -> defaultValueExpression + 'L', null,
         "writeString", true, "getNullable(nonNullReader -> new UnixTime(nonNullReader.getLong()))",
         "getNullableAttribute(%s, %s, UnixTime::new)", "getNullableElement(UnixTime::new)");
 


### PR DESCRIPTION
link https://github.com/Azure/autorest.java/issues/1861
fix generate-tests for keyvault

generated code before: 
```java
Assertions.assertEquals(new Long(), model.properties().attributes().notBefore())
```

after:
```java
Assertions.assertEquals(598622795111508954L, model.properties().attributes().notBefore())
```