### PR TITLE
disambiguate context in example

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
@@ -237,7 +237,7 @@ public class ClassType implements IType {
         .build();
 
     public static final ClassType Context = new Builder(false).knownClass(com.azure.core.util.Context.class)
-        .defaultValueExpressionConverter(epr -> "Context.NONE")
+        .defaultValueExpressionConverter(epr -> "com.azure.core.util.Context.NONE")
         .build();
 
     public static final ClassType AndroidContext = new ClassType.Builder(false)

--- a/javagen/src/main/java/com/azure/autorest/template/example/ModelExampleWriter.java
+++ b/javagen/src/main/java/com/azure/autorest/template/example/ModelExampleWriter.java
@@ -183,7 +183,9 @@ public class ModelExampleWriter {
 
         public String accept(ExampleNode node) {
             if (node instanceof LiteralNode) {
-                node.getClientType().addImportsTo(imports, false);
+                if (node.getClientType() != ClassType.Context) {
+                    node.getClientType().addImportsTo(imports, false);
+                }
 
                 if (node.getClientType() == ClassType.URL) {
                     helperFeatures.add(ExampleHelperFeature.ThrowsIOException); // MalformedURLException from URL ctor

--- a/javagen/src/main/java/com/azure/autorest/util/ModelTestCaseUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/ModelTestCaseUtil.java
@@ -177,7 +177,7 @@ public class ModelTestCaseUtil {
                 }
             } // else abort
             return map;
-        } else if (type instanceof ClassType) {
+        } else if (type instanceof ClassType && type != ClassType.Context) {
             ClientModel model = ClientModelUtil.getClientModel(((ClassType) type).getName());
             if (model != null) {
                 return jsonFromModel(depth + 1, model);


### PR DESCRIPTION
fix monitor generate-test error
link: https://github.com/Azure/autorest.java/issues/1861

before:
```java
manager.actionGroups().deleteByResourceGroupWithResponse("ktjtgra", "aqo", new Context().withContextType("asers").withNotificationSource("sdewwrew"));
```

after: 
```java
manager.actionGroups().deleteByResourceGroupWithResponse("ktjtgra", "aqo", com.azure.core.util.Context.NONE);
```