### PR TITLE
client, (deprecated) ctor for subclass of ExpandableStringEnum

### DIFF
--- a/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/ApiVersion.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/ApiVersion.java
@@ -14,6 +14,14 @@ public final class ApiVersion extends ExpandableStringEnum<ApiVersion> {
     public static final ApiVersion TWO_THOUSAND_TWENTY_TWO0831 = fromString("2022-08-31");
 
     /**
+     * Creates a new instance of ApiVersion value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public ApiVersion() {}
+
+    /**
      * Creates or finds a ApiVersion from its string representation.
      *
      * @param name a name to look for.

--- a/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/DocumentBuildMode.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/DocumentBuildMode.java
@@ -17,6 +17,14 @@ public final class DocumentBuildMode extends ExpandableStringEnum<DocumentBuildM
     public static final DocumentBuildMode NEURAL = fromString("neural");
 
     /**
+     * Creates a new instance of DocumentBuildMode value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public DocumentBuildMode() {}
+
+    /**
      * Creates or finds a DocumentBuildMode from its string representation.
      *
      * @param name a name to look for.

--- a/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/DocumentFieldType.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/DocumentFieldType.java
@@ -50,6 +50,14 @@ public final class DocumentFieldType extends ExpandableStringEnum<DocumentFieldT
     public static final DocumentFieldType ADDRESS = fromString("address");
 
     /**
+     * Creates a new instance of DocumentFieldType value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public DocumentFieldType() {}
+
+    /**
      * Creates or finds a DocumentFieldType from its string representation.
      *
      * @param name a name to look for.

--- a/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/DocumentSignatureType.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/DocumentSignatureType.java
@@ -17,6 +17,14 @@ public final class DocumentSignatureType extends ExpandableStringEnum<DocumentSi
     public static final DocumentSignatureType UNSIGNED = fromString("unsigned");
 
     /**
+     * Creates a new instance of DocumentSignatureType value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public DocumentSignatureType() {}
+
+    /**
      * Creates or finds a DocumentSignatureType from its string representation.
      *
      * @param name a name to look for.

--- a/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/DocumentTableCellKind.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/DocumentTableCellKind.java
@@ -26,6 +26,14 @@ public final class DocumentTableCellKind extends ExpandableStringEnum<DocumentTa
     public static final DocumentTableCellKind DESCRIPTION = fromString("description");
 
     /**
+     * Creates a new instance of DocumentTableCellKind value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public DocumentTableCellKind() {}
+
+    /**
      * Creates or finds a DocumentTableCellKind from its string representation.
      *
      * @param name a name to look for.

--- a/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/LengthUnit.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/LengthUnit.java
@@ -20,6 +20,14 @@ public final class LengthUnit extends ExpandableStringEnum<LengthUnit> {
     public static final LengthUnit INCH = fromString("inch");
 
     /**
+     * Creates a new instance of LengthUnit value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public LengthUnit() {}
+
+    /**
      * Creates or finds a LengthUnit from its string representation.
      *
      * @param name a name to look for.

--- a/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/OperationKind.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/OperationKind.java
@@ -20,6 +20,14 @@ public final class OperationKind extends ExpandableStringEnum<OperationKind> {
     public static final OperationKind DOCUMENT_MODEL_COPY_TO = fromString("documentModelCopyTo");
 
     /**
+     * Creates a new instance of OperationKind value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public OperationKind() {}
+
+    /**
      * Creates or finds a OperationKind from its string representation.
      *
      * @param name a name to look for.

--- a/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/ParagraphRole.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/ParagraphRole.java
@@ -29,6 +29,14 @@ public final class ParagraphRole extends ExpandableStringEnum<ParagraphRole> {
     public static final ParagraphRole FOOTNOTE = fromString("footnote");
 
     /**
+     * Creates a new instance of ParagraphRole value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public ParagraphRole() {}
+
+    /**
      * Creates or finds a ParagraphRole from its string representation.
      *
      * @param name a name to look for.

--- a/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/SelectionMarkState.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/SelectionMarkState.java
@@ -17,6 +17,14 @@ public final class SelectionMarkState extends ExpandableStringEnum<SelectionMark
     public static final SelectionMarkState UNSELECTED = fromString("unselected");
 
     /**
+     * Creates a new instance of SelectionMarkState value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public SelectionMarkState() {}
+
+    /**
      * Creates or finds a SelectionMarkState from its string representation.
      *
      * @param name a name to look for.

--- a/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/StringIndexType.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/StringIndexType.java
@@ -20,6 +20,14 @@ public final class StringIndexType extends ExpandableStringEnum<StringIndexType>
     public static final StringIndexType UTF16CODE_UNIT = fromString("utf16CodeUnit");
 
     /**
+     * Creates a new instance of StringIndexType value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public StringIndexType() {}
+
+    /**
      * Creates or finds a StringIndexType from its string representation.
      *
      * @param name a name to look for.

--- a/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/PostContentSchemaGrantType.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/PostContentSchemaGrantType.java
@@ -21,6 +21,14 @@ public final class PostContentSchemaGrantType extends ExpandableStringEnum<PostC
     public static final PostContentSchemaGrantType REFRESH_TOKEN = fromString("refresh_token");
 
     /**
+     * Creates a new instance of PostContentSchemaGrantType value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public PostContentSchemaGrantType() {}
+
+    /**
      * Creates or finds a PostContentSchemaGrantType from its string representation.
      *
      * @param name a name to look for.

--- a/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/models/ArtifactArchitecture.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/models/ArtifactArchitecture.java
@@ -50,6 +50,14 @@ public final class ArtifactArchitecture extends ExpandableStringEnum<ArtifactArc
     public static final ArtifactArchitecture WASM = fromString("wasm");
 
     /**
+     * Creates a new instance of ArtifactArchitecture value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public ArtifactArchitecture() {}
+
+    /**
      * Creates or finds a ArtifactArchitecture from its string representation.
      *
      * @param name a name to look for.

--- a/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/models/ArtifactManifestOrder.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/models/ArtifactManifestOrder.java
@@ -20,6 +20,14 @@ public final class ArtifactManifestOrder extends ExpandableStringEnum<ArtifactMa
     public static final ArtifactManifestOrder LAST_UPDATED_ON_ASCENDING = fromString("timeasc");
 
     /**
+     * Creates a new instance of ArtifactManifestOrder value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public ArtifactManifestOrder() {}
+
+    /**
      * Creates or finds a ArtifactManifestOrder from its string representation.
      *
      * @param name a name to look for.

--- a/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/models/ArtifactOperatingSystem.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/models/ArtifactOperatingSystem.java
@@ -53,6 +53,14 @@ public final class ArtifactOperatingSystem extends ExpandableStringEnum<Artifact
     public static final ArtifactOperatingSystem WINDOWS = fromString("windows");
 
     /**
+     * Creates a new instance of ArtifactOperatingSystem value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public ArtifactOperatingSystem() {}
+
+    /**
      * Creates or finds a ArtifactOperatingSystem from its string representation.
      *
      * @param name a name to look for.

--- a/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/models/ArtifactTagOrder.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/models/ArtifactTagOrder.java
@@ -20,6 +20,14 @@ public final class ArtifactTagOrder extends ExpandableStringEnum<ArtifactTagOrde
     public static final ArtifactTagOrder LAST_UPDATED_ON_ASCENDING = fromString("timeasc");
 
     /**
+     * Creates a new instance of ArtifactTagOrder value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public ArtifactTagOrder() {}
+
+    /**
      * Creates or finds a ArtifactTagOrder from its string representation.
      *
      * @param name a name to look for.

--- a/azure-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceAsyncClient.java
+++ b/azure-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceAsyncClient.java
@@ -47,19 +47,6 @@ public final class AutoRestPagingTestServiceAsyncClient {
     }
 
     /**
-     * A paging operation that gets an empty next link and should stop after page 1.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getEmptyNextLinkNamePages() {
-        return this.serviceClient.getEmptyNextLinkNamePagesAsync();
-    }
-
-    /**
      * A paging operation that must ignore any kind of nextLink, and stop after page 1.
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
@@ -83,34 +70,6 @@ public final class AutoRestPagingTestServiceAsyncClient {
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedFlux<Product> getSinglePages() {
         return this.serviceClient.getSinglePagesAsync();
-    }
-
-    /**
-     * A paging operation that finishes on the first call with body params without a nextlink.
-     *
-     * @param name The name parameter.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getSinglePagesWithBodyParams(String name) {
-        return this.serviceClient.getSinglePagesWithBodyParamsAsync(name);
-    }
-
-    /**
-     * A paging operation that finishes on the first call with body params without a nextlink.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getSinglePagesWithBodyParams() {
-        return this.serviceClient.getSinglePagesWithBodyParamsAsync();
     }
 
     /**

--- a/azure-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceAsyncClient.java
+++ b/azure-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceAsyncClient.java
@@ -47,6 +47,19 @@ public final class AutoRestPagingTestServiceAsyncClient {
     }
 
     /**
+     * A paging operation that gets an empty next link and should stop after page 1.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getEmptyNextLinkNamePages() {
+        return this.serviceClient.getEmptyNextLinkNamePagesAsync();
+    }
+
+    /**
      * A paging operation that must ignore any kind of nextLink, and stop after page 1.
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
@@ -70,6 +83,34 @@ public final class AutoRestPagingTestServiceAsyncClient {
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedFlux<Product> getSinglePages() {
         return this.serviceClient.getSinglePagesAsync();
+    }
+
+    /**
+     * A paging operation that finishes on the first call with body params without a nextlink.
+     *
+     * @param name The name parameter.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getSinglePagesWithBodyParams(String name) {
+        return this.serviceClient.getSinglePagesWithBodyParamsAsync(name);
+    }
+
+    /**
+     * A paging operation that finishes on the first call with body params without a nextlink.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getSinglePagesWithBodyParams() {
+        return this.serviceClient.getSinglePagesWithBodyParamsAsync();
     }
 
     /**

--- a/azure-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceClient.java
+++ b/azure-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceClient.java
@@ -63,34 +63,6 @@ public final class AutoRestPagingTestServiceClient {
     }
 
     /**
-     * A paging operation that gets an empty next link and should stop after page 1.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getEmptyNextLinkNamePages() {
-        return this.serviceClient.getEmptyNextLinkNamePages();
-    }
-
-    /**
-     * A paging operation that gets an empty next link and should stop after page 1.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getEmptyNextLinkNamePages(Context context) {
-        return this.serviceClient.getEmptyNextLinkNamePages(context);
-    }
-
-    /**
      * A paging operation that must ignore any kind of nextLink, and stop after page 1.
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
@@ -144,50 +116,6 @@ public final class AutoRestPagingTestServiceClient {
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedIterable<Product> getSinglePages(Context context) {
         return this.serviceClient.getSinglePages(context);
-    }
-
-    /**
-     * A paging operation that finishes on the first call with body params without a nextlink.
-     *
-     * @param name The name parameter.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getSinglePagesWithBodyParams(String name) {
-        return this.serviceClient.getSinglePagesWithBodyParams(name);
-    }
-
-    /**
-     * A paging operation that finishes on the first call with body params without a nextlink.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getSinglePagesWithBodyParams() {
-        return this.serviceClient.getSinglePagesWithBodyParams();
-    }
-
-    /**
-     * A paging operation that finishes on the first call with body params without a nextlink.
-     *
-     * @param name The name parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getSinglePagesWithBodyParams(String name, Context context) {
-        return this.serviceClient.getSinglePagesWithBodyParams(name, context);
     }
 
     /**

--- a/azure-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceClient.java
+++ b/azure-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceClient.java
@@ -63,6 +63,34 @@ public final class AutoRestPagingTestServiceClient {
     }
 
     /**
+     * A paging operation that gets an empty next link and should stop after page 1.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getEmptyNextLinkNamePages() {
+        return this.serviceClient.getEmptyNextLinkNamePages();
+    }
+
+    /**
+     * A paging operation that gets an empty next link and should stop after page 1.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getEmptyNextLinkNamePages(Context context) {
+        return this.serviceClient.getEmptyNextLinkNamePages(context);
+    }
+
+    /**
      * A paging operation that must ignore any kind of nextLink, and stop after page 1.
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
@@ -116,6 +144,50 @@ public final class AutoRestPagingTestServiceClient {
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedIterable<Product> getSinglePages(Context context) {
         return this.serviceClient.getSinglePages(context);
+    }
+
+    /**
+     * A paging operation that finishes on the first call with body params without a nextlink.
+     *
+     * @param name The name parameter.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getSinglePagesWithBodyParams(String name) {
+        return this.serviceClient.getSinglePagesWithBodyParams(name);
+    }
+
+    /**
+     * A paging operation that finishes on the first call with body params without a nextlink.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getSinglePagesWithBodyParams() {
+        return this.serviceClient.getSinglePagesWithBodyParams();
+    }
+
+    /**
+     * A paging operation that finishes on the first call with body params without a nextlink.
+     *
+     * @param name The name parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getSinglePagesWithBodyParams(String name, Context context) {
+        return this.serviceClient.getSinglePagesWithBodyParams(name, context);
     }
 
     /**

--- a/azure-tests/src/main/java/fixtures/paging/implementation/PagingsImpl.java
+++ b/azure-tests/src/main/java/fixtures/paging/implementation/PagingsImpl.java
@@ -4,6 +4,7 @@
 
 package fixtures.paging.implementation;
 
+import com.azure.core.annotation.BodyParam;
 import com.azure.core.annotation.ExpectedResponses;
 import com.azure.core.annotation.Get;
 import com.azure.core.annotation.HeaderParam;
@@ -25,6 +26,7 @@ import com.azure.core.http.rest.Response;
 import com.azure.core.http.rest.RestProxy;
 import com.azure.core.util.Context;
 import com.azure.core.util.FluxUtil;
+import fixtures.paging.models.BodyParamModel;
 import fixtures.paging.models.CustomParameterGroup;
 import fixtures.paging.models.OdataProductResult;
 import fixtures.paging.models.PagingGetMultiplePagesLroOptions;
@@ -68,6 +70,12 @@ public final class PagingsImpl {
         Mono<Response<ProductResultValue>> getNoItemNamePages(
                 @HostParam("$host") String host, @HeaderParam("Accept") String accept, Context context);
 
+        @Get("/paging/emptynextlink")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(HttpResponseException.class)
+        Mono<Response<ProductResultValue>> getEmptyNextLinkNamePages(
+                @HostParam("$host") String host, @HeaderParam("Accept") String accept, Context context);
+
         @Get("/paging/nullnextlink")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(HttpResponseException.class)
@@ -79,6 +87,15 @@ public final class PagingsImpl {
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<ProductResult>> getSinglePages(
                 @HostParam("$host") String host, @HeaderParam("Accept") String accept, Context context);
+
+        @Get("/paging/single/getWithBodyParams")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(HttpResponseException.class)
+        Mono<Response<ProductResult>> getSinglePagesWithBodyParams(
+                @HostParam("$host") String host,
+                @BodyParam("application/json") BodyParamModel parameters,
+                @HeaderParam("Accept") String accept,
+                Context context);
 
         @Get("/paging/firstResponseEmpty/1")
         @ExpectedResponses({200})
@@ -276,7 +293,25 @@ public final class PagingsImpl {
         @Get("{nextLink}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(HttpResponseException.class)
+        Mono<Response<ProductResultValue>> getEmptyNextLinkNamePagesNext(
+                @PathParam(value = "nextLink", encoded = true) String nextLink,
+                @HostParam("$host") String host,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Get("{nextLink}")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<ProductResult>> getSinglePagesNext(
+                @PathParam(value = "nextLink", encoded = true) String nextLink,
+                @HostParam("$host") String host,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Get("{nextLink}")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(HttpResponseException.class)
+        Mono<Response<ProductResult>> getSinglePagesWithBodyParamsNext(
                 @PathParam(value = "nextLink", encoded = true) String nextLink,
                 @HostParam("$host") String host,
                 @HeaderParam("Accept") String accept,
@@ -566,6 +601,143 @@ public final class PagingsImpl {
     }
 
     /**
+     * A paging operation that gets an empty next link and should stop after page 1.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<PagedResponse<Product>> getEmptyNextLinkNamePagesSinglePageAsync() {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(
+                        context -> service.getEmptyNextLinkNamePages(this.client.getHost(), accept, context))
+                .map(
+                        res ->
+                                new PagedResponseBase<>(
+                                        res.getRequest(),
+                                        res.getStatusCode(),
+                                        res.getHeaders(),
+                                        res.getValue().getValue(),
+                                        res.getValue().getNextLink(),
+                                        null));
+    }
+
+    /**
+     * A paging operation that gets an empty next link and should stop after page 1.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<PagedResponse<Product>> getEmptyNextLinkNamePagesSinglePageAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getEmptyNextLinkNamePages(this.client.getHost(), accept, context)
+                .map(
+                        res ->
+                                new PagedResponseBase<>(
+                                        res.getRequest(),
+                                        res.getStatusCode(),
+                                        res.getHeaders(),
+                                        res.getValue().getValue(),
+                                        res.getValue().getNextLink(),
+                                        null));
+    }
+
+    /**
+     * A paging operation that gets an empty next link and should stop after page 1.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getEmptyNextLinkNamePagesAsync() {
+        return new PagedFlux<>(
+                () -> getEmptyNextLinkNamePagesSinglePageAsync(),
+                nextLink -> getEmptyNextLinkNamePagesNextSinglePageAsync(nextLink));
+    }
+
+    /**
+     * A paging operation that gets an empty next link and should stop after page 1.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getEmptyNextLinkNamePagesAsync(Context context) {
+        return new PagedFlux<>(
+                () -> getEmptyNextLinkNamePagesSinglePageAsync(context),
+                nextLink -> getEmptyNextLinkNamePagesNextSinglePageAsync(nextLink, context));
+    }
+
+    /**
+     * A paging operation that gets an empty next link and should stop after page 1.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link PagedResponse}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public PagedResponse<Product> getEmptyNextLinkNamePagesSinglePage() {
+        return getEmptyNextLinkNamePagesSinglePageAsync().block();
+    }
+
+    /**
+     * A paging operation that gets an empty next link and should stop after page 1.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link PagedResponse}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public PagedResponse<Product> getEmptyNextLinkNamePagesSinglePage(Context context) {
+        return getEmptyNextLinkNamePagesSinglePageAsync(context).block();
+    }
+
+    /**
+     * A paging operation that gets an empty next link and should stop after page 1.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getEmptyNextLinkNamePages() {
+        return new PagedIterable<>(getEmptyNextLinkNamePagesAsync());
+    }
+
+    /**
+     * A paging operation that gets an empty next link and should stop after page 1.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getEmptyNextLinkNamePages(Context context) {
+        return new PagedIterable<>(getEmptyNextLinkNamePagesAsync(context));
+    }
+
+    /**
      * A paging operation that must ignore any kind of nextLink, and stop after page 1.
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
@@ -830,6 +1002,189 @@ public final class PagingsImpl {
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedIterable<Product> getSinglePages(Context context) {
         return new PagedIterable<>(getSinglePagesAsync(context));
+    }
+
+    /**
+     * A paging operation that finishes on the first call with body params without a nextlink.
+     *
+     * @param name The name parameter.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<PagedResponse<Product>> getSinglePagesWithBodyParamsSinglePageAsync(String name) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        BodyParamModel parameters = new BodyParamModel();
+        parameters.setName(name);
+        return FluxUtil.withContext(
+                        context ->
+                                service.getSinglePagesWithBodyParams(
+                                        this.client.getHost(), parameters, accept, context))
+                .map(
+                        res ->
+                                new PagedResponseBase<>(
+                                        res.getRequest(),
+                                        res.getStatusCode(),
+                                        res.getHeaders(),
+                                        res.getValue().getValues(),
+                                        res.getValue().getNextLink(),
+                                        null));
+    }
+
+    /**
+     * A paging operation that finishes on the first call with body params without a nextlink.
+     *
+     * @param name The name parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<PagedResponse<Product>> getSinglePagesWithBodyParamsSinglePageAsync(String name, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        BodyParamModel parameters = new BodyParamModel();
+        parameters.setName(name);
+        return service.getSinglePagesWithBodyParams(this.client.getHost(), parameters, accept, context)
+                .map(
+                        res ->
+                                new PagedResponseBase<>(
+                                        res.getRequest(),
+                                        res.getStatusCode(),
+                                        res.getHeaders(),
+                                        res.getValue().getValues(),
+                                        res.getValue().getNextLink(),
+                                        null));
+    }
+
+    /**
+     * A paging operation that finishes on the first call with body params without a nextlink.
+     *
+     * @param name The name parameter.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getSinglePagesWithBodyParamsAsync(String name) {
+        return new PagedFlux<>(
+                () -> getSinglePagesWithBodyParamsSinglePageAsync(name),
+                nextLink -> getSinglePagesWithBodyParamsNextSinglePageAsync(nextLink, name));
+    }
+
+    /**
+     * A paging operation that finishes on the first call with body params without a nextlink.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getSinglePagesWithBodyParamsAsync() {
+        final String name = null;
+        return new PagedFlux<>(
+                () -> getSinglePagesWithBodyParamsSinglePageAsync(name),
+                nextLink -> getSinglePagesWithBodyParamsNextSinglePageAsync(nextLink, name));
+    }
+
+    /**
+     * A paging operation that finishes on the first call with body params without a nextlink.
+     *
+     * @param name The name parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getSinglePagesWithBodyParamsAsync(String name, Context context) {
+        return new PagedFlux<>(
+                () -> getSinglePagesWithBodyParamsSinglePageAsync(name, context),
+                nextLink -> getSinglePagesWithBodyParamsNextSinglePageAsync(nextLink, name, context));
+    }
+
+    /**
+     * A paging operation that finishes on the first call with body params without a nextlink.
+     *
+     * @param name The name parameter.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link PagedResponse}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public PagedResponse<Product> getSinglePagesWithBodyParamsSinglePage(String name) {
+        return getSinglePagesWithBodyParamsSinglePageAsync(name).block();
+    }
+
+    /**
+     * A paging operation that finishes on the first call with body params without a nextlink.
+     *
+     * @param name The name parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link PagedResponse}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public PagedResponse<Product> getSinglePagesWithBodyParamsSinglePage(String name, Context context) {
+        return getSinglePagesWithBodyParamsSinglePageAsync(name, context).block();
+    }
+
+    /**
+     * A paging operation that finishes on the first call with body params without a nextlink.
+     *
+     * @param name The name parameter.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getSinglePagesWithBodyParams(String name) {
+        return new PagedIterable<>(getSinglePagesWithBodyParamsAsync(name));
+    }
+
+    /**
+     * A paging operation that finishes on the first call with body params without a nextlink.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getSinglePagesWithBodyParams() {
+        final String name = null;
+        return new PagedIterable<>(getSinglePagesWithBodyParamsAsync(name));
+    }
+
+    /**
+     * A paging operation that finishes on the first call with body params without a nextlink.
+     *
+     * @param name The name parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getSinglePagesWithBodyParams(String name, Context context) {
+        return new PagedIterable<>(getSinglePagesWithBodyParamsAsync(name, context));
     }
 
     /**
@@ -4329,6 +4684,104 @@ public final class PagingsImpl {
      * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<PagedResponse<Product>> getEmptyNextLinkNamePagesNextSinglePageAsync(String nextLink) {
+        if (nextLink == null) {
+            return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
+        }
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(
+                        context ->
+                                service.getEmptyNextLinkNamePagesNext(nextLink, this.client.getHost(), accept, context))
+                .map(
+                        res ->
+                                new PagedResponseBase<>(
+                                        res.getRequest(),
+                                        res.getStatusCode(),
+                                        res.getHeaders(),
+                                        res.getValue().getValue(),
+                                        res.getValue().getNextLink(),
+                                        null));
+    }
+
+    /**
+     * Get the next page of items.
+     *
+     * @param nextLink The URL to get the next list of items
+     *     <p>The nextLink parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<PagedResponse<Product>> getEmptyNextLinkNamePagesNextSinglePageAsync(String nextLink, Context context) {
+        if (nextLink == null) {
+            return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
+        }
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.getEmptyNextLinkNamePagesNext(nextLink, this.client.getHost(), accept, context)
+                .map(
+                        res ->
+                                new PagedResponseBase<>(
+                                        res.getRequest(),
+                                        res.getStatusCode(),
+                                        res.getHeaders(),
+                                        res.getValue().getValue(),
+                                        res.getValue().getNextLink(),
+                                        null));
+    }
+
+    /**
+     * Get the next page of items.
+     *
+     * @param nextLink The URL to get the next list of items
+     *     <p>The nextLink parameter.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link PagedResponse}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public PagedResponse<Product> getEmptyNextLinkNamePagesNextSinglePage(String nextLink) {
+        return getEmptyNextLinkNamePagesNextSinglePageAsync(nextLink).block();
+    }
+
+    /**
+     * Get the next page of items.
+     *
+     * @param nextLink The URL to get the next list of items
+     *     <p>The nextLink parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link PagedResponse}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public PagedResponse<Product> getEmptyNextLinkNamePagesNextSinglePage(String nextLink, Context context) {
+        return getEmptyNextLinkNamePagesNextSinglePageAsync(nextLink, context).block();
+    }
+
+    /**
+     * Get the next page of items.
+     *
+     * @param nextLink The URL to get the next list of items
+     *     <p>The nextLink parameter.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> getSinglePagesNextSinglePageAsync(String nextLink) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
@@ -4413,6 +4866,115 @@ public final class PagingsImpl {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getSinglePagesNextSinglePage(String nextLink, Context context) {
         return getSinglePagesNextSinglePageAsync(nextLink, context).block();
+    }
+
+    /**
+     * Get the next page of items.
+     *
+     * @param nextLink The URL to get the next list of items
+     *     <p>The nextLink parameter.
+     * @param name The name parameter.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<PagedResponse<Product>> getSinglePagesWithBodyParamsNextSinglePageAsync(String nextLink, String name) {
+        if (nextLink == null) {
+            return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
+        }
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        BodyParamModel parameters = new BodyParamModel();
+        parameters.setName(name);
+        return FluxUtil.withContext(
+                        context ->
+                                service.getSinglePagesWithBodyParamsNext(
+                                        nextLink, this.client.getHost(), accept, context))
+                .map(
+                        res ->
+                                new PagedResponseBase<>(
+                                        res.getRequest(),
+                                        res.getStatusCode(),
+                                        res.getHeaders(),
+                                        res.getValue().getValues(),
+                                        res.getValue().getNextLink(),
+                                        null));
+    }
+
+    /**
+     * Get the next page of items.
+     *
+     * @param nextLink The URL to get the next list of items
+     *     <p>The nextLink parameter.
+     * @param name The name parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<PagedResponse<Product>> getSinglePagesWithBodyParamsNextSinglePageAsync(
+            String nextLink, String name, Context context) {
+        if (nextLink == null) {
+            return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
+        }
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        BodyParamModel parameters = new BodyParamModel();
+        parameters.setName(name);
+        return service.getSinglePagesWithBodyParamsNext(nextLink, this.client.getHost(), accept, context)
+                .map(
+                        res ->
+                                new PagedResponseBase<>(
+                                        res.getRequest(),
+                                        res.getStatusCode(),
+                                        res.getHeaders(),
+                                        res.getValue().getValues(),
+                                        res.getValue().getNextLink(),
+                                        null));
+    }
+
+    /**
+     * Get the next page of items.
+     *
+     * @param nextLink The URL to get the next list of items
+     *     <p>The nextLink parameter.
+     * @param name The name parameter.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link PagedResponse}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public PagedResponse<Product> getSinglePagesWithBodyParamsNextSinglePage(String nextLink, String name) {
+        return getSinglePagesWithBodyParamsNextSinglePageAsync(nextLink, name).block();
+    }
+
+    /**
+     * Get the next page of items.
+     *
+     * @param nextLink The URL to get the next list of items
+     *     <p>The nextLink parameter.
+     * @param name The name parameter.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link PagedResponse}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public PagedResponse<Product> getSinglePagesWithBodyParamsNextSinglePage(
+            String nextLink, String name, Context context) {
+        return getSinglePagesWithBodyParamsNextSinglePageAsync(nextLink, name, context).block();
     }
 
     /**

--- a/azure-tests/src/main/java/fixtures/paging/implementation/PagingsImpl.java
+++ b/azure-tests/src/main/java/fixtures/paging/implementation/PagingsImpl.java
@@ -4,7 +4,6 @@
 
 package fixtures.paging.implementation;
 
-import com.azure.core.annotation.BodyParam;
 import com.azure.core.annotation.ExpectedResponses;
 import com.azure.core.annotation.Get;
 import com.azure.core.annotation.HeaderParam;
@@ -26,7 +25,6 @@ import com.azure.core.http.rest.Response;
 import com.azure.core.http.rest.RestProxy;
 import com.azure.core.util.Context;
 import com.azure.core.util.FluxUtil;
-import fixtures.paging.models.BodyParamModel;
 import fixtures.paging.models.CustomParameterGroup;
 import fixtures.paging.models.OdataProductResult;
 import fixtures.paging.models.PagingGetMultiplePagesLroOptions;
@@ -70,12 +68,6 @@ public final class PagingsImpl {
         Mono<Response<ProductResultValue>> getNoItemNamePages(
                 @HostParam("$host") String host, @HeaderParam("Accept") String accept, Context context);
 
-        @Get("/paging/emptynextlink")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(HttpResponseException.class)
-        Mono<Response<ProductResultValue>> getEmptyNextLinkNamePages(
-                @HostParam("$host") String host, @HeaderParam("Accept") String accept, Context context);
-
         @Get("/paging/nullnextlink")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(HttpResponseException.class)
@@ -87,15 +79,6 @@ public final class PagingsImpl {
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<ProductResult>> getSinglePages(
                 @HostParam("$host") String host, @HeaderParam("Accept") String accept, Context context);
-
-        @Get("/paging/single/getWithBodyParams")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(HttpResponseException.class)
-        Mono<Response<ProductResult>> getSinglePagesWithBodyParams(
-                @HostParam("$host") String host,
-                @BodyParam("application/json") BodyParamModel parameters,
-                @HeaderParam("Accept") String accept,
-                Context context);
 
         @Get("/paging/firstResponseEmpty/1")
         @ExpectedResponses({200})
@@ -293,25 +276,7 @@ public final class PagingsImpl {
         @Get("{nextLink}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(HttpResponseException.class)
-        Mono<Response<ProductResultValue>> getEmptyNextLinkNamePagesNext(
-                @PathParam(value = "nextLink", encoded = true) String nextLink,
-                @HostParam("$host") String host,
-                @HeaderParam("Accept") String accept,
-                Context context);
-
-        @Get("{nextLink}")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<ProductResult>> getSinglePagesNext(
-                @PathParam(value = "nextLink", encoded = true) String nextLink,
-                @HostParam("$host") String host,
-                @HeaderParam("Accept") String accept,
-                Context context);
-
-        @Get("{nextLink}")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(HttpResponseException.class)
-        Mono<Response<ProductResult>> getSinglePagesWithBodyParamsNext(
                 @PathParam(value = "nextLink", encoded = true) String nextLink,
                 @HostParam("$host") String host,
                 @HeaderParam("Accept") String accept,
@@ -601,143 +566,6 @@ public final class PagingsImpl {
     }
 
     /**
-     * A paging operation that gets an empty next link and should stop after page 1.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getEmptyNextLinkNamePagesSinglePageAsync() {
-        if (this.client.getHost() == null) {
-            return Mono.error(
-                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        final String accept = "application/json";
-        return FluxUtil.withContext(
-                        context -> service.getEmptyNextLinkNamePages(this.client.getHost(), accept, context))
-                .map(
-                        res ->
-                                new PagedResponseBase<>(
-                                        res.getRequest(),
-                                        res.getStatusCode(),
-                                        res.getHeaders(),
-                                        res.getValue().getValue(),
-                                        res.getValue().getNextLink(),
-                                        null));
-    }
-
-    /**
-     * A paging operation that gets an empty next link and should stop after page 1.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getEmptyNextLinkNamePagesSinglePageAsync(Context context) {
-        if (this.client.getHost() == null) {
-            return Mono.error(
-                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        final String accept = "application/json";
-        return service.getEmptyNextLinkNamePages(this.client.getHost(), accept, context)
-                .map(
-                        res ->
-                                new PagedResponseBase<>(
-                                        res.getRequest(),
-                                        res.getStatusCode(),
-                                        res.getHeaders(),
-                                        res.getValue().getValue(),
-                                        res.getValue().getNextLink(),
-                                        null));
-    }
-
-    /**
-     * A paging operation that gets an empty next link and should stop after page 1.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getEmptyNextLinkNamePagesAsync() {
-        return new PagedFlux<>(
-                () -> getEmptyNextLinkNamePagesSinglePageAsync(),
-                nextLink -> getEmptyNextLinkNamePagesNextSinglePageAsync(nextLink));
-    }
-
-    /**
-     * A paging operation that gets an empty next link and should stop after page 1.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getEmptyNextLinkNamePagesAsync(Context context) {
-        return new PagedFlux<>(
-                () -> getEmptyNextLinkNamePagesSinglePageAsync(context),
-                nextLink -> getEmptyNextLinkNamePagesNextSinglePageAsync(nextLink, context));
-    }
-
-    /**
-     * A paging operation that gets an empty next link and should stop after page 1.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link PagedResponse}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public PagedResponse<Product> getEmptyNextLinkNamePagesSinglePage() {
-        return getEmptyNextLinkNamePagesSinglePageAsync().block();
-    }
-
-    /**
-     * A paging operation that gets an empty next link and should stop after page 1.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link PagedResponse}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public PagedResponse<Product> getEmptyNextLinkNamePagesSinglePage(Context context) {
-        return getEmptyNextLinkNamePagesSinglePageAsync(context).block();
-    }
-
-    /**
-     * A paging operation that gets an empty next link and should stop after page 1.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getEmptyNextLinkNamePages() {
-        return new PagedIterable<>(getEmptyNextLinkNamePagesAsync());
-    }
-
-    /**
-     * A paging operation that gets an empty next link and should stop after page 1.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getEmptyNextLinkNamePages(Context context) {
-        return new PagedIterable<>(getEmptyNextLinkNamePagesAsync(context));
-    }
-
-    /**
      * A paging operation that must ignore any kind of nextLink, and stop after page 1.
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
@@ -1002,189 +830,6 @@ public final class PagingsImpl {
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedIterable<Product> getSinglePages(Context context) {
         return new PagedIterable<>(getSinglePagesAsync(context));
-    }
-
-    /**
-     * A paging operation that finishes on the first call with body params without a nextlink.
-     *
-     * @param name The name parameter.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getSinglePagesWithBodyParamsSinglePageAsync(String name) {
-        if (this.client.getHost() == null) {
-            return Mono.error(
-                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        final String accept = "application/json";
-        BodyParamModel parameters = new BodyParamModel();
-        parameters.setName(name);
-        return FluxUtil.withContext(
-                        context ->
-                                service.getSinglePagesWithBodyParams(
-                                        this.client.getHost(), parameters, accept, context))
-                .map(
-                        res ->
-                                new PagedResponseBase<>(
-                                        res.getRequest(),
-                                        res.getStatusCode(),
-                                        res.getHeaders(),
-                                        res.getValue().getValues(),
-                                        res.getValue().getNextLink(),
-                                        null));
-    }
-
-    /**
-     * A paging operation that finishes on the first call with body params without a nextlink.
-     *
-     * @param name The name parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getSinglePagesWithBodyParamsSinglePageAsync(String name, Context context) {
-        if (this.client.getHost() == null) {
-            return Mono.error(
-                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        final String accept = "application/json";
-        BodyParamModel parameters = new BodyParamModel();
-        parameters.setName(name);
-        return service.getSinglePagesWithBodyParams(this.client.getHost(), parameters, accept, context)
-                .map(
-                        res ->
-                                new PagedResponseBase<>(
-                                        res.getRequest(),
-                                        res.getStatusCode(),
-                                        res.getHeaders(),
-                                        res.getValue().getValues(),
-                                        res.getValue().getNextLink(),
-                                        null));
-    }
-
-    /**
-     * A paging operation that finishes on the first call with body params without a nextlink.
-     *
-     * @param name The name parameter.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getSinglePagesWithBodyParamsAsync(String name) {
-        return new PagedFlux<>(
-                () -> getSinglePagesWithBodyParamsSinglePageAsync(name),
-                nextLink -> getSinglePagesWithBodyParamsNextSinglePageAsync(nextLink, name));
-    }
-
-    /**
-     * A paging operation that finishes on the first call with body params without a nextlink.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getSinglePagesWithBodyParamsAsync() {
-        final String name = null;
-        return new PagedFlux<>(
-                () -> getSinglePagesWithBodyParamsSinglePageAsync(name),
-                nextLink -> getSinglePagesWithBodyParamsNextSinglePageAsync(nextLink, name));
-    }
-
-    /**
-     * A paging operation that finishes on the first call with body params without a nextlink.
-     *
-     * @param name The name parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getSinglePagesWithBodyParamsAsync(String name, Context context) {
-        return new PagedFlux<>(
-                () -> getSinglePagesWithBodyParamsSinglePageAsync(name, context),
-                nextLink -> getSinglePagesWithBodyParamsNextSinglePageAsync(nextLink, name, context));
-    }
-
-    /**
-     * A paging operation that finishes on the first call with body params without a nextlink.
-     *
-     * @param name The name parameter.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link PagedResponse}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public PagedResponse<Product> getSinglePagesWithBodyParamsSinglePage(String name) {
-        return getSinglePagesWithBodyParamsSinglePageAsync(name).block();
-    }
-
-    /**
-     * A paging operation that finishes on the first call with body params without a nextlink.
-     *
-     * @param name The name parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link PagedResponse}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public PagedResponse<Product> getSinglePagesWithBodyParamsSinglePage(String name, Context context) {
-        return getSinglePagesWithBodyParamsSinglePageAsync(name, context).block();
-    }
-
-    /**
-     * A paging operation that finishes on the first call with body params without a nextlink.
-     *
-     * @param name The name parameter.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getSinglePagesWithBodyParams(String name) {
-        return new PagedIterable<>(getSinglePagesWithBodyParamsAsync(name));
-    }
-
-    /**
-     * A paging operation that finishes on the first call with body params without a nextlink.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getSinglePagesWithBodyParams() {
-        final String name = null;
-        return new PagedIterable<>(getSinglePagesWithBodyParamsAsync(name));
-    }
-
-    /**
-     * A paging operation that finishes on the first call with body params without a nextlink.
-     *
-     * @param name The name parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getSinglePagesWithBodyParams(String name, Context context) {
-        return new PagedIterable<>(getSinglePagesWithBodyParamsAsync(name, context));
     }
 
     /**
@@ -4684,104 +4329,6 @@ public final class PagingsImpl {
      * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getEmptyNextLinkNamePagesNextSinglePageAsync(String nextLink) {
-        if (nextLink == null) {
-            return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
-        }
-        if (this.client.getHost() == null) {
-            return Mono.error(
-                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        final String accept = "application/json";
-        return FluxUtil.withContext(
-                        context ->
-                                service.getEmptyNextLinkNamePagesNext(nextLink, this.client.getHost(), accept, context))
-                .map(
-                        res ->
-                                new PagedResponseBase<>(
-                                        res.getRequest(),
-                                        res.getStatusCode(),
-                                        res.getHeaders(),
-                                        res.getValue().getValue(),
-                                        res.getValue().getNextLink(),
-                                        null));
-    }
-
-    /**
-     * Get the next page of items.
-     *
-     * @param nextLink The URL to get the next list of items
-     *     <p>The nextLink parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getEmptyNextLinkNamePagesNextSinglePageAsync(String nextLink, Context context) {
-        if (nextLink == null) {
-            return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
-        }
-        if (this.client.getHost() == null) {
-            return Mono.error(
-                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        final String accept = "application/json";
-        return service.getEmptyNextLinkNamePagesNext(nextLink, this.client.getHost(), accept, context)
-                .map(
-                        res ->
-                                new PagedResponseBase<>(
-                                        res.getRequest(),
-                                        res.getStatusCode(),
-                                        res.getHeaders(),
-                                        res.getValue().getValue(),
-                                        res.getValue().getNextLink(),
-                                        null));
-    }
-
-    /**
-     * Get the next page of items.
-     *
-     * @param nextLink The URL to get the next list of items
-     *     <p>The nextLink parameter.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link PagedResponse}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public PagedResponse<Product> getEmptyNextLinkNamePagesNextSinglePage(String nextLink) {
-        return getEmptyNextLinkNamePagesNextSinglePageAsync(nextLink).block();
-    }
-
-    /**
-     * Get the next page of items.
-     *
-     * @param nextLink The URL to get the next list of items
-     *     <p>The nextLink parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link PagedResponse}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public PagedResponse<Product> getEmptyNextLinkNamePagesNextSinglePage(String nextLink, Context context) {
-        return getEmptyNextLinkNamePagesNextSinglePageAsync(nextLink, context).block();
-    }
-
-    /**
-     * Get the next page of items.
-     *
-     * @param nextLink The URL to get the next list of items
-     *     <p>The nextLink parameter.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> getSinglePagesNextSinglePageAsync(String nextLink) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
@@ -4866,115 +4413,6 @@ public final class PagingsImpl {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getSinglePagesNextSinglePage(String nextLink, Context context) {
         return getSinglePagesNextSinglePageAsync(nextLink, context).block();
-    }
-
-    /**
-     * Get the next page of items.
-     *
-     * @param nextLink The URL to get the next list of items
-     *     <p>The nextLink parameter.
-     * @param name The name parameter.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getSinglePagesWithBodyParamsNextSinglePageAsync(String nextLink, String name) {
-        if (nextLink == null) {
-            return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
-        }
-        if (this.client.getHost() == null) {
-            return Mono.error(
-                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        final String accept = "application/json";
-        BodyParamModel parameters = new BodyParamModel();
-        parameters.setName(name);
-        return FluxUtil.withContext(
-                        context ->
-                                service.getSinglePagesWithBodyParamsNext(
-                                        nextLink, this.client.getHost(), accept, context))
-                .map(
-                        res ->
-                                new PagedResponseBase<>(
-                                        res.getRequest(),
-                                        res.getStatusCode(),
-                                        res.getHeaders(),
-                                        res.getValue().getValues(),
-                                        res.getValue().getNextLink(),
-                                        null));
-    }
-
-    /**
-     * Get the next page of items.
-     *
-     * @param nextLink The URL to get the next list of items
-     *     <p>The nextLink parameter.
-     * @param name The name parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getSinglePagesWithBodyParamsNextSinglePageAsync(
-            String nextLink, String name, Context context) {
-        if (nextLink == null) {
-            return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
-        }
-        if (this.client.getHost() == null) {
-            return Mono.error(
-                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        final String accept = "application/json";
-        BodyParamModel parameters = new BodyParamModel();
-        parameters.setName(name);
-        return service.getSinglePagesWithBodyParamsNext(nextLink, this.client.getHost(), accept, context)
-                .map(
-                        res ->
-                                new PagedResponseBase<>(
-                                        res.getRequest(),
-                                        res.getStatusCode(),
-                                        res.getHeaders(),
-                                        res.getValue().getValues(),
-                                        res.getValue().getNextLink(),
-                                        null));
-    }
-
-    /**
-     * Get the next page of items.
-     *
-     * @param nextLink The URL to get the next list of items
-     *     <p>The nextLink parameter.
-     * @param name The name parameter.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link PagedResponse}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public PagedResponse<Product> getSinglePagesWithBodyParamsNextSinglePage(String nextLink, String name) {
-        return getSinglePagesWithBodyParamsNextSinglePageAsync(nextLink, name).block();
-    }
-
-    /**
-     * Get the next page of items.
-     *
-     * @param nextLink The URL to get the next list of items
-     *     <p>The nextLink parameter.
-     * @param name The name parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link PagedResponse}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public PagedResponse<Product> getSinglePagesWithBodyParamsNextSinglePage(
-            String nextLink, String name, Context context) {
-        return getSinglePagesWithBodyParamsNextSinglePageAsync(nextLink, name, context).block();
     }
 
     /**

--- a/azure-tests/src/main/java/fixtures/paging/models/OperationResultStatus.java
+++ b/azure-tests/src/main/java/fixtures/paging/models/OperationResultStatus.java
@@ -44,6 +44,14 @@ public final class OperationResultStatus extends ExpandableStringEnum<OperationR
     public static final OperationResultStatus OK = fromString("OK");
 
     /**
+     * Creates a new instance of OperationResultStatus value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public OperationResultStatus() {}
+
+    /**
      * Creates or finds a OperationResultStatus from its string representation.
      *
      * @param name a name to look for.

--- a/cadl-tests/src/main/java/com/cadl/builtin/models/KnownValues.java
+++ b/cadl-tests/src/main/java/com/cadl/builtin/models/KnownValues.java
@@ -17,6 +17,14 @@ public final class KnownValues extends ExpandableStringEnum<KnownValues> {
     public static final KnownValues VALUE2 = fromString("Value2");
 
     /**
+     * Creates a new instance of KnownValues value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public KnownValues() {}
+
+    /**
      * Creates or finds a KnownValues from its string representation.
      *
      * @param name a name to look for.

--- a/cadl-tests/src/main/java/com/cadl/builtin/models/KnownValuesScalar.java
+++ b/cadl-tests/src/main/java/com/cadl/builtin/models/KnownValuesScalar.java
@@ -17,6 +17,14 @@ public final class KnownValuesScalar extends ExpandableStringEnum<KnownValuesSca
     public static final KnownValuesScalar VALUE2 = fromString("Value2");
 
     /**
+     * Creates a new instance of KnownValuesScalar value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public KnownValuesScalar() {}
+
+    /**
      * Creates or finds a KnownValuesScalar from its string representation.
      *
      * @param name a name to look for.

--- a/cadl-tests/src/main/java/com/cadl/enumservice/models/ColorModel.java
+++ b/cadl-tests/src/main/java/com/cadl/enumservice/models/ColorModel.java
@@ -20,6 +20,14 @@ public final class ColorModel extends ExpandableStringEnum<ColorModel> {
     public static final ColorModel GREEN = fromString("Green");
 
     /**
+     * Creates a new instance of ColorModel value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public ColorModel() {}
+
+    /**
      * Creates or finds a ColorModel from its string representation.
      *
      * @param name a name to look for.

--- a/cadl-tests/src/main/java/com/cadl/longrunning/models/OperationState.java
+++ b/cadl-tests/src/main/java/com/cadl/longrunning/models/OperationState.java
@@ -23,6 +23,14 @@ public final class OperationState extends ExpandableStringEnum<OperationState> {
     public static final OperationState CANCELED = fromString("Canceled");
 
     /**
+     * Creates a new instance of OperationState value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public OperationState() {}
+
+    /**
      * Creates or finds a OperationState from its string representation.
      *
      * @param name a name to look for.

--- a/cadl-tests/src/main/java/com/cadl/naming/models/DataStatus.java
+++ b/cadl-tests/src/main/java/com/cadl/naming/models/DataStatus.java
@@ -24,6 +24,14 @@ public final class DataStatus extends ExpandableStringEnum<DataStatus> {
     public static final DataStatus FAILED = fromString("Failed");
 
     /**
+     * Creates a new instance of DataStatus value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public DataStatus() {}
+
+    /**
      * Creates or finds a DataStatus from its string representation.
      *
      * @param name a name to look for.

--- a/cadl-tests/src/main/java/com/enums/extensible/models/DaysOfWeekExtensibleEnum.java
+++ b/cadl-tests/src/main/java/com/enums/extensible/models/DaysOfWeekExtensibleEnum.java
@@ -32,6 +32,14 @@ public final class DaysOfWeekExtensibleEnum extends ExpandableStringEnum<DaysOfW
     public static final DaysOfWeekExtensibleEnum SUNDAY = fromString("Sunday");
 
     /**
+     * Creates a new instance of DaysOfWeekExtensibleEnum value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public DaysOfWeekExtensibleEnum() {}
+
+    /**
      * Creates or finds a DaysOfWeekExtensibleEnum from its string representation.
      *
      * @param name a name to look for.

--- a/cadl-tests/src/main/java/com/models/property/types/models/InnerEnum.java
+++ b/cadl-tests/src/main/java/com/models/property/types/models/InnerEnum.java
@@ -17,6 +17,14 @@ public final class InnerEnum extends ExpandableStringEnum<InnerEnum> {
     public static final InnerEnum VALUE_TWO = fromString("ValueTwo");
 
     /**
+     * Creates a new instance of InnerEnum value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public InnerEnum() {}
+
+    /**
      * Creates or finds a InnerEnum from its string representation.
      *
      * @param name a name to look for.

--- a/cadl-tests/src/main/java/com/resiliency/devdriven/models/Mode.java
+++ b/cadl-tests/src/main/java/com/resiliency/devdriven/models/Mode.java
@@ -17,6 +17,14 @@ public final class Mode extends ExpandableStringEnum<Mode> {
     public static final Mode MODEL = fromString("model");
 
     /**
+     * Creates a new instance of Mode value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public Mode() {}
+
+    /**
      * Creates or finds a Mode from its string representation.
      *
      * @param name a name to look for.

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/CMYKColors.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/CMYKColors.java
@@ -23,6 +23,14 @@ public final class CMYKColors extends ExpandableStringEnum<CMYKColors> {
     public static final CMYKColors BLACK = fromString("blacK");
 
     /**
+     * Creates a new instance of CMYKColors value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public CMYKColors() {}
+
+    /**
      * Creates or finds a CMYKColors from its string representation.
      *
      * @param name a name to look for.

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/GoblinSharkColor.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/GoblinSharkColor.java
@@ -26,6 +26,14 @@ public final class GoblinSharkColor extends ExpandableStringEnum<GoblinSharkColo
     public static final GoblinSharkColor LOWER_RED = fromString("red");
 
     /**
+     * Creates a new instance of GoblinSharkColor value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public GoblinSharkColor() {}
+
+    /**
      * Creates or finds a GoblinSharkColor from its string representation.
      *
      * @param name a name to look for.

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/MyKind.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/MyKind.java
@@ -14,6 +14,14 @@ public final class MyKind extends ExpandableStringEnum<MyKind> {
     public static final MyKind KIND1 = fromString("Kind1");
 
     /**
+     * Creates a new instance of MyKind value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public MyKind() {}
+
+    /**
      * Creates or finds a MyKind from its string representation.
      *
      * @param name a name to look for.

--- a/javagen/src/main/java/com/azure/autorest/model/javamodel/JavaJavadocComment.java
+++ b/javagen/src/main/java/com/azure/autorest/model/javamodel/JavaJavadocComment.java
@@ -65,4 +65,9 @@ public class JavaJavadocComment {
         addExpectedLineSeparator();
         contents.line("{@inheritDoc}");
     }
+
+    public final void deprecated(String description) {
+        addExpectedLineSeparator();
+        contents.line(String.format("@deprecated %1$s", description));
+    }
 }

--- a/javagen/src/main/java/com/azure/autorest/template/EnumTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/EnumTemplate.java
@@ -62,6 +62,16 @@ public class EnumTemplate implements IJavaTemplate<EnumType, JavaFile> {
                     enumValue.getName(), pascalTypeName, elementType.defaultValueExpression(value)));
             }
 
+            // ctor, marked as Deprecated
+            classBlock.javadocComment(comment -> {
+                comment.description("Creates a new instance of " + enumName + " value.");
+                comment.deprecated(String.format("Use the {@link #fromString(%1$s)} factory method.", typeName));
+            });
+            classBlock.annotation("Deprecated");
+            classBlock.publicConstructor(enumName + "()", ctor -> {
+            });
+
+            // fromString(typeName)
             classBlock.javadocComment(comment -> {
                 comment.description("Creates or finds a " + enumName + " from its string representation.");
                 comment.param("name", "a name to look for");
@@ -78,6 +88,7 @@ public class EnumTemplate implements IJavaTemplate<EnumType, JavaFile> {
                     function.methodReturn("fromString(" + stringValue + ", " + enumName + ".class)");
                 });
 
+            // values()
             classBlock.javadocComment(comment -> {
                 comment.description("Gets known " + enumName + " values.");
                 comment.methodReturns("known " + enumName + " values");

--- a/protocol-tests/src/main/java/fixtures/dpgcustomization/models/ProductReceived.java
+++ b/protocol-tests/src/main/java/fixtures/dpgcustomization/models/ProductReceived.java
@@ -17,6 +17,14 @@ public final class ProductReceived extends ExpandableStringEnum<ProductReceived>
     public static final ProductReceived MODEL = fromString("model");
 
     /**
+     * Creates a new instance of ProductReceived value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public ProductReceived() {}
+
+    /**
      * Creates or finds a ProductReceived from its string representation.
      *
      * @param name a name to look for.

--- a/protocol-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceAsyncClient.java
+++ b/protocol-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceAsyncClient.java
@@ -60,6 +60,33 @@ public final class AutoRestPagingTestServiceAsyncClient {
     }
 
     /**
+     * A paging operation that gets an empty next link and should stop after page 1.
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     properties (Optional): {
+     *         id: Integer (Optional)
+     *         name: String (Optional)
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<BinaryData> getEmptyNextLinkNamePages(RequestOptions requestOptions) {
+        return this.serviceClient.getEmptyNextLinkNamePagesAsync(requestOptions);
+    }
+
+    /**
      * A paging operation that must ignore any kind of nextLink, and stop after page 1.
      *
      * <p><strong>Response Body Schema</strong>
@@ -111,6 +138,42 @@ public final class AutoRestPagingTestServiceAsyncClient {
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedFlux<BinaryData> getSinglePages(RequestOptions requestOptions) {
         return this.serviceClient.getSinglePagesAsync(requestOptions);
+    }
+
+    /**
+     * A paging operation that finishes on the first call with body params without a nextlink.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     name: String (Optional)
+     * }
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     properties (Optional): {
+     *         id: Integer (Optional)
+     *         name: String (Optional)
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param parameters put {'name': 'body'} to pass the test.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<BinaryData> getSinglePagesWithBodyParams(BinaryData parameters, RequestOptions requestOptions) {
+        return this.serviceClient.getSinglePagesWithBodyParamsAsync(parameters, requestOptions);
     }
 
     /**

--- a/protocol-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceAsyncClient.java
+++ b/protocol-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceAsyncClient.java
@@ -60,33 +60,6 @@ public final class AutoRestPagingTestServiceAsyncClient {
     }
 
     /**
-     * A paging operation that gets an empty next link and should stop after page 1.
-     *
-     * <p><strong>Response Body Schema</strong>
-     *
-     * <pre>{@code
-     * {
-     *     properties (Optional): {
-     *         id: Integer (Optional)
-     *         name: String (Optional)
-     *     }
-     * }
-     * }</pre>
-     *
-     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<BinaryData> getEmptyNextLinkNamePages(RequestOptions requestOptions) {
-        return this.serviceClient.getEmptyNextLinkNamePagesAsync(requestOptions);
-    }
-
-    /**
      * A paging operation that must ignore any kind of nextLink, and stop after page 1.
      *
      * <p><strong>Response Body Schema</strong>
@@ -138,42 +111,6 @@ public final class AutoRestPagingTestServiceAsyncClient {
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedFlux<BinaryData> getSinglePages(RequestOptions requestOptions) {
         return this.serviceClient.getSinglePagesAsync(requestOptions);
-    }
-
-    /**
-     * A paging operation that finishes on the first call with body params without a nextlink.
-     *
-     * <p><strong>Request Body Schema</strong>
-     *
-     * <pre>{@code
-     * {
-     *     name: String (Optional)
-     * }
-     * }</pre>
-     *
-     * <p><strong>Response Body Schema</strong>
-     *
-     * <pre>{@code
-     * {
-     *     properties (Optional): {
-     *         id: Integer (Optional)
-     *         name: String (Optional)
-     *     }
-     * }
-     * }</pre>
-     *
-     * @param parameters put {'name': 'body'} to pass the test.
-     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<BinaryData> getSinglePagesWithBodyParams(BinaryData parameters, RequestOptions requestOptions) {
-        return this.serviceClient.getSinglePagesWithBodyParamsAsync(parameters, requestOptions);
     }
 
     /**

--- a/protocol-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceClient.java
+++ b/protocol-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceClient.java
@@ -59,6 +59,33 @@ public final class AutoRestPagingTestServiceClient {
     }
 
     /**
+     * A paging operation that gets an empty next link and should stop after page 1.
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     properties (Optional): {
+     *         id: Integer (Optional)
+     *         name: String (Optional)
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<BinaryData> getEmptyNextLinkNamePages(RequestOptions requestOptions) {
+        return new PagedIterable<>(this.client.getEmptyNextLinkNamePages(requestOptions));
+    }
+
+    /**
      * A paging operation that must ignore any kind of nextLink, and stop after page 1.
      *
      * <p><strong>Response Body Schema</strong>
@@ -110,6 +137,43 @@ public final class AutoRestPagingTestServiceClient {
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedIterable<BinaryData> getSinglePages(RequestOptions requestOptions) {
         return new PagedIterable<>(this.client.getSinglePages(requestOptions));
+    }
+
+    /**
+     * A paging operation that finishes on the first call with body params without a nextlink.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     name: String (Optional)
+     * }
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     properties (Optional): {
+     *         id: Integer (Optional)
+     *         name: String (Optional)
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param parameters put {'name': 'body'} to pass the test.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<BinaryData> getSinglePagesWithBodyParams(
+            BinaryData parameters, RequestOptions requestOptions) {
+        return new PagedIterable<>(this.client.getSinglePagesWithBodyParams(parameters, requestOptions));
     }
 
     /**

--- a/protocol-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceClient.java
+++ b/protocol-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceClient.java
@@ -59,33 +59,6 @@ public final class AutoRestPagingTestServiceClient {
     }
 
     /**
-     * A paging operation that gets an empty next link and should stop after page 1.
-     *
-     * <p><strong>Response Body Schema</strong>
-     *
-     * <pre>{@code
-     * {
-     *     properties (Optional): {
-     *         id: Integer (Optional)
-     *         name: String (Optional)
-     *     }
-     * }
-     * }</pre>
-     *
-     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getEmptyNextLinkNamePages(RequestOptions requestOptions) {
-        return new PagedIterable<>(this.client.getEmptyNextLinkNamePages(requestOptions));
-    }
-
-    /**
      * A paging operation that must ignore any kind of nextLink, and stop after page 1.
      *
      * <p><strong>Response Body Schema</strong>
@@ -137,43 +110,6 @@ public final class AutoRestPagingTestServiceClient {
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedIterable<BinaryData> getSinglePages(RequestOptions requestOptions) {
         return new PagedIterable<>(this.client.getSinglePages(requestOptions));
-    }
-
-    /**
-     * A paging operation that finishes on the first call with body params without a nextlink.
-     *
-     * <p><strong>Request Body Schema</strong>
-     *
-     * <pre>{@code
-     * {
-     *     name: String (Optional)
-     * }
-     * }</pre>
-     *
-     * <p><strong>Response Body Schema</strong>
-     *
-     * <pre>{@code
-     * {
-     *     properties (Optional): {
-     *         id: Integer (Optional)
-     *         name: String (Optional)
-     *     }
-     * }
-     * }</pre>
-     *
-     * @param parameters put {'name': 'body'} to pass the test.
-     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getSinglePagesWithBodyParams(
-            BinaryData parameters, RequestOptions requestOptions) {
-        return new PagedIterable<>(this.client.getSinglePagesWithBodyParams(parameters, requestOptions));
     }
 
     /**

--- a/protocol-tests/src/main/java/fixtures/paging/implementation/PagingsImpl.java
+++ b/protocol-tests/src/main/java/fixtures/paging/implementation/PagingsImpl.java
@@ -4,7 +4,6 @@
 
 package fixtures.paging.implementation;
 
-import com.azure.core.annotation.BodyParam;
 import com.azure.core.annotation.ExpectedResponses;
 import com.azure.core.annotation.Get;
 import com.azure.core.annotation.HeaderParam;
@@ -79,24 +78,6 @@ public final class PagingsImpl {
                 RequestOptions requestOptions,
                 Context context);
 
-        @Get("/paging/emptynextlink")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(
-                value = ClientAuthenticationException.class,
-                code = {401})
-        @UnexpectedResponseExceptionType(
-                value = ResourceNotFoundException.class,
-                code = {404})
-        @UnexpectedResponseExceptionType(
-                value = ResourceModifiedException.class,
-                code = {409})
-        @UnexpectedResponseExceptionType(HttpResponseException.class)
-        Mono<Response<BinaryData>> getEmptyNextLinkNamePages(
-                @HostParam("$host") String host,
-                @HeaderParam("Accept") String accept,
-                RequestOptions requestOptions,
-                Context context);
-
         @Get("/paging/nullnextlink")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(
@@ -129,25 +110,6 @@ public final class PagingsImpl {
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<BinaryData>> getSinglePages(
                 @HostParam("$host") String host,
-                @HeaderParam("Accept") String accept,
-                RequestOptions requestOptions,
-                Context context);
-
-        @Get("/paging/single/getWithBodyParams")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(
-                value = ClientAuthenticationException.class,
-                code = {401})
-        @UnexpectedResponseExceptionType(
-                value = ResourceNotFoundException.class,
-                code = {404})
-        @UnexpectedResponseExceptionType(
-                value = ResourceModifiedException.class,
-                code = {409})
-        @UnexpectedResponseExceptionType(HttpResponseException.class)
-        Mono<Response<BinaryData>> getSinglePagesWithBodyParams(
-                @HostParam("$host") String host,
-                @BodyParam("application/json") BinaryData parameters,
                 @HeaderParam("Accept") String accept,
                 RequestOptions requestOptions,
                 Context context);
@@ -578,45 +540,7 @@ public final class PagingsImpl {
                 value = ResourceModifiedException.class,
                 code = {409})
         @UnexpectedResponseExceptionType(HttpResponseException.class)
-        Mono<Response<BinaryData>> getEmptyNextLinkNamePagesNext(
-                @PathParam(value = "nextLink", encoded = true) String nextLink,
-                @HostParam("$host") String host,
-                @HeaderParam("Accept") String accept,
-                RequestOptions requestOptions,
-                Context context);
-
-        @Get("{nextLink}")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(
-                value = ClientAuthenticationException.class,
-                code = {401})
-        @UnexpectedResponseExceptionType(
-                value = ResourceNotFoundException.class,
-                code = {404})
-        @UnexpectedResponseExceptionType(
-                value = ResourceModifiedException.class,
-                code = {409})
-        @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<BinaryData>> getSinglePagesNext(
-                @PathParam(value = "nextLink", encoded = true) String nextLink,
-                @HostParam("$host") String host,
-                @HeaderParam("Accept") String accept,
-                RequestOptions requestOptions,
-                Context context);
-
-        @Get("{nextLink}")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(
-                value = ClientAuthenticationException.class,
-                code = {401})
-        @UnexpectedResponseExceptionType(
-                value = ResourceNotFoundException.class,
-                code = {404})
-        @UnexpectedResponseExceptionType(
-                value = ResourceModifiedException.class,
-                code = {409})
-        @UnexpectedResponseExceptionType(HttpResponseException.class)
-        Mono<Response<BinaryData>> getSinglePagesWithBodyParamsNext(
                 @PathParam(value = "nextLink", encoded = true) String nextLink,
                 @HostParam("$host") String host,
                 @HeaderParam("Accept") String accept,
@@ -1006,104 +930,6 @@ public final class PagingsImpl {
     }
 
     /**
-     * A paging operation that gets an empty next link and should stop after page 1.
-     *
-     * <p><strong>Response Body Schema</strong>
-     *
-     * <pre>{@code
-     * {
-     *     properties (Optional): {
-     *         id: Integer (Optional)
-     *         name: String (Optional)
-     *     }
-     * }
-     * }</pre>
-     *
-     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<BinaryData>> getEmptyNextLinkNamePagesSinglePageAsync(RequestOptions requestOptions) {
-        final String accept = "application/json";
-        return FluxUtil.withContext(
-                        context ->
-                                service.getEmptyNextLinkNamePages(
-                                        this.client.getHost(), accept, requestOptions, context))
-                .map(
-                        res ->
-                                new PagedResponseBase<>(
-                                        res.getRequest(),
-                                        res.getStatusCode(),
-                                        res.getHeaders(),
-                                        getValues(res.getValue(), "value"),
-                                        getNextLink(res.getValue(), "nextLink"),
-                                        null));
-    }
-
-    /**
-     * A paging operation that gets an empty next link and should stop after page 1.
-     *
-     * <p><strong>Response Body Schema</strong>
-     *
-     * <pre>{@code
-     * {
-     *     properties (Optional): {
-     *         id: Integer (Optional)
-     *         name: String (Optional)
-     *     }
-     * }
-     * }</pre>
-     *
-     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<BinaryData> getEmptyNextLinkNamePagesAsync(RequestOptions requestOptions) {
-        RequestOptions requestOptionsForNextPage = new RequestOptions();
-        requestOptionsForNextPage.setContext(
-                requestOptions != null && requestOptions.getContext() != null
-                        ? requestOptions.getContext()
-                        : Context.NONE);
-        return new PagedFlux<>(
-                () -> getEmptyNextLinkNamePagesSinglePageAsync(requestOptions),
-                nextLink -> getEmptyNextLinkNamePagesNextSinglePageAsync(nextLink, requestOptionsForNextPage));
-    }
-
-    /**
-     * A paging operation that gets an empty next link and should stop after page 1.
-     *
-     * <p><strong>Response Body Schema</strong>
-     *
-     * <pre>{@code
-     * {
-     *     properties (Optional): {
-     *         id: Integer (Optional)
-     *         name: String (Optional)
-     *     }
-     * }
-     * }</pre>
-     *
-     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getEmptyNextLinkNamePages(RequestOptions requestOptions) {
-        return new PagedIterable<>(getEmptyNextLinkNamePagesAsync(requestOptions));
-    }
-
-    /**
      * A paging operation that must ignore any kind of nextLink, and stop after page 1.
      *
      * <p><strong>Response Body Schema</strong>
@@ -1288,134 +1114,6 @@ public final class PagingsImpl {
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedIterable<BinaryData> getSinglePages(RequestOptions requestOptions) {
         return new PagedIterable<>(getSinglePagesAsync(requestOptions));
-    }
-
-    /**
-     * A paging operation that finishes on the first call with body params without a nextlink.
-     *
-     * <p><strong>Request Body Schema</strong>
-     *
-     * <pre>{@code
-     * {
-     *     name: String (Optional)
-     * }
-     * }</pre>
-     *
-     * <p><strong>Response Body Schema</strong>
-     *
-     * <pre>{@code
-     * {
-     *     properties (Optional): {
-     *         id: Integer (Optional)
-     *         name: String (Optional)
-     *     }
-     * }
-     * }</pre>
-     *
-     * @param parameters put {'name': 'body'} to pass the test.
-     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<BinaryData>> getSinglePagesWithBodyParamsSinglePageAsync(
-            BinaryData parameters, RequestOptions requestOptions) {
-        final String accept = "application/json";
-        return FluxUtil.withContext(
-                        context ->
-                                service.getSinglePagesWithBodyParams(
-                                        this.client.getHost(), parameters, accept, requestOptions, context))
-                .map(
-                        res ->
-                                new PagedResponseBase<>(
-                                        res.getRequest(),
-                                        res.getStatusCode(),
-                                        res.getHeaders(),
-                                        getValues(res.getValue(), "values"),
-                                        getNextLink(res.getValue(), "nextLink"),
-                                        null));
-    }
-
-    /**
-     * A paging operation that finishes on the first call with body params without a nextlink.
-     *
-     * <p><strong>Request Body Schema</strong>
-     *
-     * <pre>{@code
-     * {
-     *     name: String (Optional)
-     * }
-     * }</pre>
-     *
-     * <p><strong>Response Body Schema</strong>
-     *
-     * <pre>{@code
-     * {
-     *     properties (Optional): {
-     *         id: Integer (Optional)
-     *         name: String (Optional)
-     *     }
-     * }
-     * }</pre>
-     *
-     * @param parameters put {'name': 'body'} to pass the test.
-     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<BinaryData> getSinglePagesWithBodyParamsAsync(
-            BinaryData parameters, RequestOptions requestOptions) {
-        RequestOptions requestOptionsForNextPage = new RequestOptions();
-        requestOptionsForNextPage.setContext(
-                requestOptions != null && requestOptions.getContext() != null
-                        ? requestOptions.getContext()
-                        : Context.NONE);
-        return new PagedFlux<>(
-                () -> getSinglePagesWithBodyParamsSinglePageAsync(parameters, requestOptions),
-                nextLink -> getSinglePagesWithBodyParamsNextSinglePageAsync(nextLink, requestOptionsForNextPage));
-    }
-
-    /**
-     * A paging operation that finishes on the first call with body params without a nextlink.
-     *
-     * <p><strong>Request Body Schema</strong>
-     *
-     * <pre>{@code
-     * {
-     *     name: String (Optional)
-     * }
-     * }</pre>
-     *
-     * <p><strong>Response Body Schema</strong>
-     *
-     * <pre>{@code
-     * {
-     *     properties (Optional): {
-     *         id: Integer (Optional)
-     *         name: String (Optional)
-     *     }
-     * }
-     * }</pre>
-     *
-     * @param parameters put {'name': 'body'} to pass the test.
-     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getSinglePagesWithBodyParams(
-            BinaryData parameters, RequestOptions requestOptions) {
-        return new PagedIterable<>(getSinglePagesWithBodyParamsAsync(parameters, requestOptions));
     }
 
     /**
@@ -3617,96 +3315,12 @@ public final class PagingsImpl {
      * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<BinaryData>> getEmptyNextLinkNamePagesNextSinglePageAsync(
-            String nextLink, RequestOptions requestOptions) {
-        final String accept = "application/json";
-        return FluxUtil.withContext(
-                        context ->
-                                service.getEmptyNextLinkNamePagesNext(
-                                        nextLink, this.client.getHost(), accept, requestOptions, context))
-                .map(
-                        res ->
-                                new PagedResponseBase<>(
-                                        res.getRequest(),
-                                        res.getStatusCode(),
-                                        res.getHeaders(),
-                                        getValues(res.getValue(), "value"),
-                                        getNextLink(res.getValue(), "nextLink"),
-                                        null));
-    }
-
-    /**
-     * Get the next page of items.
-     *
-     * <p><strong>Response Body Schema</strong>
-     *
-     * <pre>{@code
-     * {
-     *     properties (Optional): {
-     *         id: Integer (Optional)
-     *         name: String (Optional)
-     *     }
-     * }
-     * }</pre>
-     *
-     * @param nextLink The URL to get the next list of items
-     *     <p>The nextLink parameter.
-     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
     private Mono<PagedResponse<BinaryData>> getSinglePagesNextSinglePageAsync(
             String nextLink, RequestOptions requestOptions) {
         final String accept = "application/json";
         return FluxUtil.withContext(
                         context ->
                                 service.getSinglePagesNext(
-                                        nextLink, this.client.getHost(), accept, requestOptions, context))
-                .map(
-                        res ->
-                                new PagedResponseBase<>(
-                                        res.getRequest(),
-                                        res.getStatusCode(),
-                                        res.getHeaders(),
-                                        getValues(res.getValue(), "values"),
-                                        getNextLink(res.getValue(), "nextLink"),
-                                        null));
-    }
-
-    /**
-     * Get the next page of items.
-     *
-     * <p><strong>Response Body Schema</strong>
-     *
-     * <pre>{@code
-     * {
-     *     properties (Optional): {
-     *         id: Integer (Optional)
-     *         name: String (Optional)
-     *     }
-     * }
-     * }</pre>
-     *
-     * @param nextLink The URL to get the next list of items
-     *     <p>The nextLink parameter.
-     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<BinaryData>> getSinglePagesWithBodyParamsNextSinglePageAsync(
-            String nextLink, RequestOptions requestOptions) {
-        final String accept = "application/json";
-        return FluxUtil.withContext(
-                        context ->
-                                service.getSinglePagesWithBodyParamsNext(
                                         nextLink, this.client.getHost(), accept, requestOptions, context))
                 .map(
                         res ->

--- a/protocol-tests/src/main/java/fixtures/paging/implementation/PagingsImpl.java
+++ b/protocol-tests/src/main/java/fixtures/paging/implementation/PagingsImpl.java
@@ -4,6 +4,7 @@
 
 package fixtures.paging.implementation;
 
+import com.azure.core.annotation.BodyParam;
 import com.azure.core.annotation.ExpectedResponses;
 import com.azure.core.annotation.Get;
 import com.azure.core.annotation.HeaderParam;
@@ -78,6 +79,24 @@ public final class PagingsImpl {
                 RequestOptions requestOptions,
                 Context context);
 
+        @Get("/paging/emptynextlink")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(
+                value = ClientAuthenticationException.class,
+                code = {401})
+        @UnexpectedResponseExceptionType(
+                value = ResourceNotFoundException.class,
+                code = {404})
+        @UnexpectedResponseExceptionType(
+                value = ResourceModifiedException.class,
+                code = {409})
+        @UnexpectedResponseExceptionType(HttpResponseException.class)
+        Mono<Response<BinaryData>> getEmptyNextLinkNamePages(
+                @HostParam("$host") String host,
+                @HeaderParam("Accept") String accept,
+                RequestOptions requestOptions,
+                Context context);
+
         @Get("/paging/nullnextlink")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(
@@ -110,6 +129,25 @@ public final class PagingsImpl {
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<BinaryData>> getSinglePages(
                 @HostParam("$host") String host,
+                @HeaderParam("Accept") String accept,
+                RequestOptions requestOptions,
+                Context context);
+
+        @Get("/paging/single/getWithBodyParams")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(
+                value = ClientAuthenticationException.class,
+                code = {401})
+        @UnexpectedResponseExceptionType(
+                value = ResourceNotFoundException.class,
+                code = {404})
+        @UnexpectedResponseExceptionType(
+                value = ResourceModifiedException.class,
+                code = {409})
+        @UnexpectedResponseExceptionType(HttpResponseException.class)
+        Mono<Response<BinaryData>> getSinglePagesWithBodyParams(
+                @HostParam("$host") String host,
+                @BodyParam("application/json") BinaryData parameters,
                 @HeaderParam("Accept") String accept,
                 RequestOptions requestOptions,
                 Context context);
@@ -540,7 +578,45 @@ public final class PagingsImpl {
                 value = ResourceModifiedException.class,
                 code = {409})
         @UnexpectedResponseExceptionType(HttpResponseException.class)
+        Mono<Response<BinaryData>> getEmptyNextLinkNamePagesNext(
+                @PathParam(value = "nextLink", encoded = true) String nextLink,
+                @HostParam("$host") String host,
+                @HeaderParam("Accept") String accept,
+                RequestOptions requestOptions,
+                Context context);
+
+        @Get("{nextLink}")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(
+                value = ClientAuthenticationException.class,
+                code = {401})
+        @UnexpectedResponseExceptionType(
+                value = ResourceNotFoundException.class,
+                code = {404})
+        @UnexpectedResponseExceptionType(
+                value = ResourceModifiedException.class,
+                code = {409})
+        @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<BinaryData>> getSinglePagesNext(
+                @PathParam(value = "nextLink", encoded = true) String nextLink,
+                @HostParam("$host") String host,
+                @HeaderParam("Accept") String accept,
+                RequestOptions requestOptions,
+                Context context);
+
+        @Get("{nextLink}")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(
+                value = ClientAuthenticationException.class,
+                code = {401})
+        @UnexpectedResponseExceptionType(
+                value = ResourceNotFoundException.class,
+                code = {404})
+        @UnexpectedResponseExceptionType(
+                value = ResourceModifiedException.class,
+                code = {409})
+        @UnexpectedResponseExceptionType(HttpResponseException.class)
+        Mono<Response<BinaryData>> getSinglePagesWithBodyParamsNext(
                 @PathParam(value = "nextLink", encoded = true) String nextLink,
                 @HostParam("$host") String host,
                 @HeaderParam("Accept") String accept,
@@ -930,6 +1006,104 @@ public final class PagingsImpl {
     }
 
     /**
+     * A paging operation that gets an empty next link and should stop after page 1.
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     properties (Optional): {
+     *         id: Integer (Optional)
+     *         name: String (Optional)
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    private Mono<PagedResponse<BinaryData>> getEmptyNextLinkNamePagesSinglePageAsync(RequestOptions requestOptions) {
+        final String accept = "application/json";
+        return FluxUtil.withContext(
+                        context ->
+                                service.getEmptyNextLinkNamePages(
+                                        this.client.getHost(), accept, requestOptions, context))
+                .map(
+                        res ->
+                                new PagedResponseBase<>(
+                                        res.getRequest(),
+                                        res.getStatusCode(),
+                                        res.getHeaders(),
+                                        getValues(res.getValue(), "value"),
+                                        getNextLink(res.getValue(), "nextLink"),
+                                        null));
+    }
+
+    /**
+     * A paging operation that gets an empty next link and should stop after page 1.
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     properties (Optional): {
+     *         id: Integer (Optional)
+     *         name: String (Optional)
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<BinaryData> getEmptyNextLinkNamePagesAsync(RequestOptions requestOptions) {
+        RequestOptions requestOptionsForNextPage = new RequestOptions();
+        requestOptionsForNextPage.setContext(
+                requestOptions != null && requestOptions.getContext() != null
+                        ? requestOptions.getContext()
+                        : Context.NONE);
+        return new PagedFlux<>(
+                () -> getEmptyNextLinkNamePagesSinglePageAsync(requestOptions),
+                nextLink -> getEmptyNextLinkNamePagesNextSinglePageAsync(nextLink, requestOptionsForNextPage));
+    }
+
+    /**
+     * A paging operation that gets an empty next link and should stop after page 1.
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     properties (Optional): {
+     *         id: Integer (Optional)
+     *         name: String (Optional)
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<BinaryData> getEmptyNextLinkNamePages(RequestOptions requestOptions) {
+        return new PagedIterable<>(getEmptyNextLinkNamePagesAsync(requestOptions));
+    }
+
+    /**
      * A paging operation that must ignore any kind of nextLink, and stop after page 1.
      *
      * <p><strong>Response Body Schema</strong>
@@ -1114,6 +1288,134 @@ public final class PagingsImpl {
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedIterable<BinaryData> getSinglePages(RequestOptions requestOptions) {
         return new PagedIterable<>(getSinglePagesAsync(requestOptions));
+    }
+
+    /**
+     * A paging operation that finishes on the first call with body params without a nextlink.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     name: String (Optional)
+     * }
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     properties (Optional): {
+     *         id: Integer (Optional)
+     *         name: String (Optional)
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param parameters put {'name': 'body'} to pass the test.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    private Mono<PagedResponse<BinaryData>> getSinglePagesWithBodyParamsSinglePageAsync(
+            BinaryData parameters, RequestOptions requestOptions) {
+        final String accept = "application/json";
+        return FluxUtil.withContext(
+                        context ->
+                                service.getSinglePagesWithBodyParams(
+                                        this.client.getHost(), parameters, accept, requestOptions, context))
+                .map(
+                        res ->
+                                new PagedResponseBase<>(
+                                        res.getRequest(),
+                                        res.getStatusCode(),
+                                        res.getHeaders(),
+                                        getValues(res.getValue(), "values"),
+                                        getNextLink(res.getValue(), "nextLink"),
+                                        null));
+    }
+
+    /**
+     * A paging operation that finishes on the first call with body params without a nextlink.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     name: String (Optional)
+     * }
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     properties (Optional): {
+     *         id: Integer (Optional)
+     *         name: String (Optional)
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param parameters put {'name': 'body'} to pass the test.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<BinaryData> getSinglePagesWithBodyParamsAsync(
+            BinaryData parameters, RequestOptions requestOptions) {
+        RequestOptions requestOptionsForNextPage = new RequestOptions();
+        requestOptionsForNextPage.setContext(
+                requestOptions != null && requestOptions.getContext() != null
+                        ? requestOptions.getContext()
+                        : Context.NONE);
+        return new PagedFlux<>(
+                () -> getSinglePagesWithBodyParamsSinglePageAsync(parameters, requestOptions),
+                nextLink -> getSinglePagesWithBodyParamsNextSinglePageAsync(nextLink, requestOptionsForNextPage));
+    }
+
+    /**
+     * A paging operation that finishes on the first call with body params without a nextlink.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     name: String (Optional)
+     * }
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     properties (Optional): {
+     *         id: Integer (Optional)
+     *         name: String (Optional)
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param parameters put {'name': 'body'} to pass the test.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<BinaryData> getSinglePagesWithBodyParams(
+            BinaryData parameters, RequestOptions requestOptions) {
+        return new PagedIterable<>(getSinglePagesWithBodyParamsAsync(parameters, requestOptions));
     }
 
     /**
@@ -3315,12 +3617,96 @@ public final class PagingsImpl {
      * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
+    private Mono<PagedResponse<BinaryData>> getEmptyNextLinkNamePagesNextSinglePageAsync(
+            String nextLink, RequestOptions requestOptions) {
+        final String accept = "application/json";
+        return FluxUtil.withContext(
+                        context ->
+                                service.getEmptyNextLinkNamePagesNext(
+                                        nextLink, this.client.getHost(), accept, requestOptions, context))
+                .map(
+                        res ->
+                                new PagedResponseBase<>(
+                                        res.getRequest(),
+                                        res.getStatusCode(),
+                                        res.getHeaders(),
+                                        getValues(res.getValue(), "value"),
+                                        getNextLink(res.getValue(), "nextLink"),
+                                        null));
+    }
+
+    /**
+     * Get the next page of items.
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     properties (Optional): {
+     *         id: Integer (Optional)
+     *         name: String (Optional)
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param nextLink The URL to get the next list of items
+     *     <p>The nextLink parameter.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
     private Mono<PagedResponse<BinaryData>> getSinglePagesNextSinglePageAsync(
             String nextLink, RequestOptions requestOptions) {
         final String accept = "application/json";
         return FluxUtil.withContext(
                         context ->
                                 service.getSinglePagesNext(
+                                        nextLink, this.client.getHost(), accept, requestOptions, context))
+                .map(
+                        res ->
+                                new PagedResponseBase<>(
+                                        res.getRequest(),
+                                        res.getStatusCode(),
+                                        res.getHeaders(),
+                                        getValues(res.getValue(), "values"),
+                                        getNextLink(res.getValue(), "nextLink"),
+                                        null));
+    }
+
+    /**
+     * Get the next page of items.
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     properties (Optional): {
+     *         id: Integer (Optional)
+     *         name: String (Optional)
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param nextLink The URL to get the next list of items
+     *     <p>The nextLink parameter.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    private Mono<PagedResponse<BinaryData>> getSinglePagesWithBodyParamsNextSinglePageAsync(
+            String nextLink, RequestOptions requestOptions) {
+        final String accept = "application/json";
+        return FluxUtil.withContext(
+                        context ->
+                                service.getSinglePagesWithBodyParamsNext(
                                         nextLink, this.client.getHost(), accept, requestOptions, context))
                 .map(
                         res ->

--- a/vanilla-tests/src/main/java/fixtures/annotatedgettersandsetters/models/SkuFamily.java
+++ b/vanilla-tests/src/main/java/fixtures/annotatedgettersandsetters/models/SkuFamily.java
@@ -14,6 +14,14 @@ public final class SkuFamily extends ExpandableStringEnum<SkuFamily> {
     public static final SkuFamily A = fromString("A");
 
     /**
+     * Creates a new instance of SkuFamily value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public SkuFamily() {}
+
+    /**
      * Creates or finds a SkuFamily from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/bodyarray/models/Enum0.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyarray/models/Enum0.java
@@ -20,6 +20,14 @@ public final class Enum0 extends ExpandableStringEnum<Enum0> {
     public static final Enum0 FOO3 = fromString("foo3");
 
     /**
+     * Creates a new instance of Enum0 value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public Enum0() {}
+
+    /**
      * Creates or finds a Enum0 from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/bodyarray/models/Enum1.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyarray/models/Enum1.java
@@ -20,6 +20,14 @@ public final class Enum1 extends ExpandableStringEnum<Enum1> {
     public static final Enum1 FOO3 = fromString("foo3");
 
     /**
+     * Creates a new instance of Enum1 value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public Enum1() {}
+
+    /**
      * Creates or finds a Enum1 from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/CMYKColors.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/CMYKColors.java
@@ -23,6 +23,14 @@ public final class CMYKColors extends ExpandableStringEnum<CMYKColors> {
     public static final CMYKColors BLACK = fromString("blacK");
 
     /**
+     * Creates a new instance of CMYKColors value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public CMYKColors() {}
+
+    /**
      * Creates or finds a CMYKColors from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/GoblinSharkColor.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/GoblinSharkColor.java
@@ -26,6 +26,14 @@ public final class GoblinSharkColor extends ExpandableStringEnum<GoblinSharkColo
     public static final GoblinSharkColor LOWER_RED = fromString("red");
 
     /**
+     * Creates a new instance of GoblinSharkColor value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public GoblinSharkColor() {}
+
+    /**
      * Creates or finds a GoblinSharkColor from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/MyKind.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/MyKind.java
@@ -14,6 +14,14 @@ public final class MyKind extends ExpandableStringEnum<MyKind> {
     public static final MyKind KIND1 = fromString("Kind1");
 
     /**
+     * Creates a new instance of MyKind value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public MyKind() {}
+
+    /**
      * Creates or finds a MyKind from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/bodyformdataurlencoded/models/PetFood.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyformdataurlencoded/models/PetFood.java
@@ -20,6 +20,14 @@ public final class PetFood extends ExpandableStringEnum<PetFood> {
     public static final PetFood PLANT = fromString("plant");
 
     /**
+     * Creates a new instance of PetFood value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public PetFood() {}
+
+    /**
      * Creates or finds a PetFood from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/clientdefaultvalue/models/SkuFamily.java
+++ b/vanilla-tests/src/main/java/fixtures/clientdefaultvalue/models/SkuFamily.java
@@ -14,6 +14,14 @@ public final class SkuFamily extends ExpandableStringEnum<SkuFamily> {
     public static final SkuFamily A = fromString("A");
 
     /**
+     * Creates a new instance of SkuFamily value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public SkuFamily() {}
+
+    /**
      * Creates or finds a SkuFamily from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringNoRequiredOneValueDefaultEnum.java
+++ b/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringNoRequiredOneValueDefaultEnum.java
@@ -15,6 +15,14 @@ public final class ModelAsStringNoRequiredOneValueDefaultEnum
     public static final ModelAsStringNoRequiredOneValueDefaultEnum VALUE1 = fromString("value1");
 
     /**
+     * Creates a new instance of ModelAsStringNoRequiredOneValueDefaultEnum value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public ModelAsStringNoRequiredOneValueDefaultEnum() {}
+
+    /**
      * Creates or finds a ModelAsStringNoRequiredOneValueDefaultEnum from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringNoRequiredOneValueDefaultOpEnum.java
+++ b/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringNoRequiredOneValueDefaultOpEnum.java
@@ -15,6 +15,14 @@ public final class ModelAsStringNoRequiredOneValueDefaultOpEnum
     public static final ModelAsStringNoRequiredOneValueDefaultOpEnum VALUE1 = fromString("value1");
 
     /**
+     * Creates a new instance of ModelAsStringNoRequiredOneValueDefaultOpEnum value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public ModelAsStringNoRequiredOneValueDefaultOpEnum() {}
+
+    /**
      * Creates or finds a ModelAsStringNoRequiredOneValueDefaultOpEnum from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringNoRequiredOneValueNoDefaultEnum.java
+++ b/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringNoRequiredOneValueNoDefaultEnum.java
@@ -15,6 +15,14 @@ public final class ModelAsStringNoRequiredOneValueNoDefaultEnum
     public static final ModelAsStringNoRequiredOneValueNoDefaultEnum VALUE1 = fromString("value1");
 
     /**
+     * Creates a new instance of ModelAsStringNoRequiredOneValueNoDefaultEnum value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public ModelAsStringNoRequiredOneValueNoDefaultEnum() {}
+
+    /**
      * Creates or finds a ModelAsStringNoRequiredOneValueNoDefaultEnum from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringNoRequiredOneValueNoDefaultOpEnum.java
+++ b/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringNoRequiredOneValueNoDefaultOpEnum.java
@@ -15,6 +15,14 @@ public final class ModelAsStringNoRequiredOneValueNoDefaultOpEnum
     public static final ModelAsStringNoRequiredOneValueNoDefaultOpEnum VALUE1 = fromString("value1");
 
     /**
+     * Creates a new instance of ModelAsStringNoRequiredOneValueNoDefaultOpEnum value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public ModelAsStringNoRequiredOneValueNoDefaultOpEnum() {}
+
+    /**
      * Creates or finds a ModelAsStringNoRequiredOneValueNoDefaultOpEnum from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringNoRequiredTwoValueDefaultEnum.java
+++ b/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringNoRequiredTwoValueDefaultEnum.java
@@ -18,6 +18,14 @@ public final class ModelAsStringNoRequiredTwoValueDefaultEnum
     public static final ModelAsStringNoRequiredTwoValueDefaultEnum VALUE2 = fromString("value2");
 
     /**
+     * Creates a new instance of ModelAsStringNoRequiredTwoValueDefaultEnum value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public ModelAsStringNoRequiredTwoValueDefaultEnum() {}
+
+    /**
      * Creates or finds a ModelAsStringNoRequiredTwoValueDefaultEnum from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringNoRequiredTwoValueDefaultOpEnum.java
+++ b/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringNoRequiredTwoValueDefaultOpEnum.java
@@ -18,6 +18,14 @@ public final class ModelAsStringNoRequiredTwoValueDefaultOpEnum
     public static final ModelAsStringNoRequiredTwoValueDefaultOpEnum VALUE2 = fromString("value2");
 
     /**
+     * Creates a new instance of ModelAsStringNoRequiredTwoValueDefaultOpEnum value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public ModelAsStringNoRequiredTwoValueDefaultOpEnum() {}
+
+    /**
      * Creates or finds a ModelAsStringNoRequiredTwoValueDefaultOpEnum from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringNoRequiredTwoValueNoDefaultEnum.java
+++ b/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringNoRequiredTwoValueNoDefaultEnum.java
@@ -18,6 +18,14 @@ public final class ModelAsStringNoRequiredTwoValueNoDefaultEnum
     public static final ModelAsStringNoRequiredTwoValueNoDefaultEnum VALUE2 = fromString("value2");
 
     /**
+     * Creates a new instance of ModelAsStringNoRequiredTwoValueNoDefaultEnum value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public ModelAsStringNoRequiredTwoValueNoDefaultEnum() {}
+
+    /**
      * Creates or finds a ModelAsStringNoRequiredTwoValueNoDefaultEnum from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringNoRequiredTwoValueNoDefaultOpEnum.java
+++ b/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringNoRequiredTwoValueNoDefaultOpEnum.java
@@ -18,6 +18,14 @@ public final class ModelAsStringNoRequiredTwoValueNoDefaultOpEnum
     public static final ModelAsStringNoRequiredTwoValueNoDefaultOpEnum VALUE2 = fromString("value2");
 
     /**
+     * Creates a new instance of ModelAsStringNoRequiredTwoValueNoDefaultOpEnum value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public ModelAsStringNoRequiredTwoValueNoDefaultOpEnum() {}
+
+    /**
      * Creates or finds a ModelAsStringNoRequiredTwoValueNoDefaultOpEnum from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringRequiredOneValueDefaultEnum.java
+++ b/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringRequiredOneValueDefaultEnum.java
@@ -15,6 +15,14 @@ public final class ModelAsStringRequiredOneValueDefaultEnum
     public static final ModelAsStringRequiredOneValueDefaultEnum VALUE1 = fromString("value1");
 
     /**
+     * Creates a new instance of ModelAsStringRequiredOneValueDefaultEnum value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public ModelAsStringRequiredOneValueDefaultEnum() {}
+
+    /**
      * Creates or finds a ModelAsStringRequiredOneValueDefaultEnum from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringRequiredOneValueDefaultOpEnum.java
+++ b/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringRequiredOneValueDefaultOpEnum.java
@@ -15,6 +15,14 @@ public final class ModelAsStringRequiredOneValueDefaultOpEnum
     public static final ModelAsStringRequiredOneValueDefaultOpEnum VALUE1 = fromString("value1");
 
     /**
+     * Creates a new instance of ModelAsStringRequiredOneValueDefaultOpEnum value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public ModelAsStringRequiredOneValueDefaultOpEnum() {}
+
+    /**
      * Creates or finds a ModelAsStringRequiredOneValueDefaultOpEnum from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringRequiredOneValueNoDefaultEnum.java
+++ b/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringRequiredOneValueNoDefaultEnum.java
@@ -15,6 +15,14 @@ public final class ModelAsStringRequiredOneValueNoDefaultEnum
     public static final ModelAsStringRequiredOneValueNoDefaultEnum VALUE1 = fromString("value1");
 
     /**
+     * Creates a new instance of ModelAsStringRequiredOneValueNoDefaultEnum value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public ModelAsStringRequiredOneValueNoDefaultEnum() {}
+
+    /**
      * Creates or finds a ModelAsStringRequiredOneValueNoDefaultEnum from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringRequiredOneValueNoDefaultOpEnum.java
+++ b/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringRequiredOneValueNoDefaultOpEnum.java
@@ -15,6 +15,14 @@ public final class ModelAsStringRequiredOneValueNoDefaultOpEnum
     public static final ModelAsStringRequiredOneValueNoDefaultOpEnum VALUE1 = fromString("value1");
 
     /**
+     * Creates a new instance of ModelAsStringRequiredOneValueNoDefaultOpEnum value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public ModelAsStringRequiredOneValueNoDefaultOpEnum() {}
+
+    /**
      * Creates or finds a ModelAsStringRequiredOneValueNoDefaultOpEnum from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringRequiredTwoValueDefaultEnum.java
+++ b/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringRequiredTwoValueDefaultEnum.java
@@ -18,6 +18,14 @@ public final class ModelAsStringRequiredTwoValueDefaultEnum
     public static final ModelAsStringRequiredTwoValueDefaultEnum VALUE2 = fromString("value2");
 
     /**
+     * Creates a new instance of ModelAsStringRequiredTwoValueDefaultEnum value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public ModelAsStringRequiredTwoValueDefaultEnum() {}
+
+    /**
      * Creates or finds a ModelAsStringRequiredTwoValueDefaultEnum from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringRequiredTwoValueDefaultOpEnum.java
+++ b/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringRequiredTwoValueDefaultOpEnum.java
@@ -18,6 +18,14 @@ public final class ModelAsStringRequiredTwoValueDefaultOpEnum
     public static final ModelAsStringRequiredTwoValueDefaultOpEnum VALUE2 = fromString("value2");
 
     /**
+     * Creates a new instance of ModelAsStringRequiredTwoValueDefaultOpEnum value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public ModelAsStringRequiredTwoValueDefaultOpEnum() {}
+
+    /**
      * Creates or finds a ModelAsStringRequiredTwoValueDefaultOpEnum from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringRequiredTwoValueNoDefaultEnum.java
+++ b/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringRequiredTwoValueNoDefaultEnum.java
@@ -18,6 +18,14 @@ public final class ModelAsStringRequiredTwoValueNoDefaultEnum
     public static final ModelAsStringRequiredTwoValueNoDefaultEnum VALUE2 = fromString("value2");
 
     /**
+     * Creates a new instance of ModelAsStringRequiredTwoValueNoDefaultEnum value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public ModelAsStringRequiredTwoValueNoDefaultEnum() {}
+
+    /**
      * Creates or finds a ModelAsStringRequiredTwoValueNoDefaultEnum from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringRequiredTwoValueNoDefaultOpEnum.java
+++ b/vanilla-tests/src/main/java/fixtures/constants/models/ModelAsStringRequiredTwoValueNoDefaultOpEnum.java
@@ -18,6 +18,14 @@ public final class ModelAsStringRequiredTwoValueNoDefaultOpEnum
     public static final ModelAsStringRequiredTwoValueNoDefaultOpEnum VALUE2 = fromString("value2");
 
     /**
+     * Creates a new instance of ModelAsStringRequiredTwoValueNoDefaultOpEnum value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public ModelAsStringRequiredTwoValueNoDefaultOpEnum() {}
+
+    /**
      * Creates or finds a ModelAsStringRequiredTwoValueNoDefaultOpEnum from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/discriminatorflattening/clientflatten/models/Odatatype.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorflattening/clientflatten/models/Odatatype.java
@@ -23,6 +23,14 @@ public final class Odatatype extends ExpandableStringEnum<Odatatype> {
             fromString("Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria");
 
     /**
+     * Creates a new instance of Odatatype value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public Odatatype() {}
+
+    /**
      * Creates or finds a Odatatype from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/discriminatorflattening/models/Odatatype.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorflattening/models/Odatatype.java
@@ -23,6 +23,14 @@ public final class Odatatype extends ExpandableStringEnum<Odatatype> {
             fromString("Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria");
 
     /**
+     * Creates a new instance of Odatatype value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public Odatatype() {}
+
+    /**
      * Creates or finds a Odatatype from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/discriminatorflattening/noflatten/models/Odatatype.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorflattening/noflatten/models/Odatatype.java
@@ -23,6 +23,14 @@ public final class Odatatype extends ExpandableStringEnum<Odatatype> {
             fromString("Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria");
 
     /**
+     * Creates a new instance of Odatatype value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public Odatatype() {}
+
+    /**
      * Creates or finds a Odatatype from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/discriminatorflattening/requirexmsflattened/models/Odatatype.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorflattening/requirexmsflattened/models/Odatatype.java
@@ -23,6 +23,14 @@ public final class Odatatype extends ExpandableStringEnum<Odatatype> {
             fromString("Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria");
 
     /**
+     * Creates a new instance of Odatatype value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public Odatatype() {}
+
+    /**
      * Creates or finds a Odatatype from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/extensibleenums/models/DaysOfWeekExtensibleEnum.java
+++ b/vanilla-tests/src/main/java/fixtures/extensibleenums/models/DaysOfWeekExtensibleEnum.java
@@ -32,6 +32,14 @@ public final class DaysOfWeekExtensibleEnum extends ExpandableStringEnum<DaysOfW
     public static final DaysOfWeekExtensibleEnum SUNDAY = fromString("Sunday");
 
     /**
+     * Creates a new instance of DaysOfWeekExtensibleEnum value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public DaysOfWeekExtensibleEnum() {}
+
+    /**
      * Creates or finds a DaysOfWeekExtensibleEnum from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/extensibleenums/models/IntEnum.java
+++ b/vanilla-tests/src/main/java/fixtures/extensibleenums/models/IntEnum.java
@@ -20,6 +20,14 @@ public final class IntEnum extends ExpandableStringEnum<IntEnum> {
     public static final IntEnum THREE = fromString("3");
 
     /**
+     * Creates a new instance of IntEnum value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public IntEnum() {}
+
+    /**
      * Creates or finds a IntEnum from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/inheritance/donotpassdiscriminator/models/Odatatype.java
+++ b/vanilla-tests/src/main/java/fixtures/inheritance/donotpassdiscriminator/models/Odatatype.java
@@ -23,6 +23,14 @@ public final class Odatatype extends ExpandableStringEnum<Odatatype> {
             fromString("Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria");
 
     /**
+     * Creates a new instance of Odatatype value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public Odatatype() {}
+
+    /**
      * Creates or finds a Odatatype from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/inheritance/passdiscriminator/models/Odatatype.java
+++ b/vanilla-tests/src/main/java/fixtures/inheritance/passdiscriminator/models/Odatatype.java
@@ -23,6 +23,14 @@ public final class Odatatype extends ExpandableStringEnum<Odatatype> {
             fromString("Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria");
 
     /**
+     * Creates a new instance of Odatatype value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public Odatatype() {}
+
+    /**
      * Creates or finds a Odatatype from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/lro/models/OperationResultStatus.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/OperationResultStatus.java
@@ -44,6 +44,14 @@ public final class OperationResultStatus extends ExpandableStringEnum<OperationR
     public static final OperationResultStatus OK = fromString("OK");
 
     /**
+     * Creates a new instance of OperationResultStatus value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public OperationResultStatus() {}
+
+    /**
      * Creates or finds a OperationResultStatus from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/lro/models/ProductPropertiesProvisioningStateValues.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/ProductPropertiesProvisioningStateValues.java
@@ -45,6 +45,14 @@ public final class ProductPropertiesProvisioningStateValues
     public static final ProductPropertiesProvisioningStateValues OK = fromString("OK");
 
     /**
+     * Creates a new instance of ProductPropertiesProvisioningStateValues value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public ProductPropertiesProvisioningStateValues() {}
+
+    /**
      * Creates or finds a ProductPropertiesProvisioningStateValues from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/lro/models/SubProductPropertiesProvisioningStateValues.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/SubProductPropertiesProvisioningStateValues.java
@@ -45,6 +45,14 @@ public final class SubProductPropertiesProvisioningStateValues
     public static final SubProductPropertiesProvisioningStateValues OK = fromString("OK");
 
     /**
+     * Creates a new instance of SubProductPropertiesProvisioningStateValues value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public SubProductPropertiesProvisioningStateValues() {}
+
+    /**
      * Creates or finds a SubProductPropertiesProvisioningStateValues from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/modelflattening/models/FlattenedProductPropertiesProvisioningStateValues.java
+++ b/vanilla-tests/src/main/java/fixtures/modelflattening/models/FlattenedProductPropertiesProvisioningStateValues.java
@@ -45,6 +45,14 @@ public final class FlattenedProductPropertiesProvisioningStateValues
     public static final FlattenedProductPropertiesProvisioningStateValues OK = fromString("OK");
 
     /**
+     * Creates a new instance of FlattenedProductPropertiesProvisioningStateValues value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public FlattenedProductPropertiesProvisioningStateValues() {}
+
+    /**
      * Creates or finds a FlattenedProductPropertiesProvisioningStateValues from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/nonstringenum/models/FloatEnum.java
+++ b/vanilla-tests/src/main/java/fixtures/nonstringenum/models/FloatEnum.java
@@ -26,6 +26,14 @@ public final class FloatEnum extends ExpandableStringEnum<FloatEnum> {
     public static final FloatEnum FOUR_HUNDRED_TWENTY_NINE1 = fromFloat(429.1f);
 
     /**
+     * Creates a new instance of FloatEnum value.
+     *
+     * @deprecated Use the {@link #fromString(float)} factory method.
+     */
+    @Deprecated
+    public FloatEnum() {}
+
+    /**
      * Creates or finds a FloatEnum from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/nonstringenum/models/IntEnum.java
+++ b/vanilla-tests/src/main/java/fixtures/nonstringenum/models/IntEnum.java
@@ -26,6 +26,14 @@ public final class IntEnum extends ExpandableStringEnum<IntEnum> {
     public static final IntEnum FOUR_HUNDRED_TWENTY_NINE = fromInt(429);
 
     /**
+     * Creates a new instance of IntEnum value.
+     *
+     * @deprecated Use the {@link #fromString(int)} factory method.
+     */
+    @Deprecated
+    public IntEnum() {}
+
+    /**
      * Creates or finds a IntEnum from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/CMYKColors.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/CMYKColors.java
@@ -22,6 +22,14 @@ public final class CMYKColors extends ExpandableStringEnum<CMYKColors> {
     public static final CMYKColors BLACK = fromString("blacK");
 
     /**
+     * Creates a new instance of CMYKColors value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public CMYKColors() {}
+
+    /**
      * Creates or finds a CMYKColors from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/GoblinSharkColor.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/GoblinSharkColor.java
@@ -25,6 +25,14 @@ public final class GoblinSharkColor extends ExpandableStringEnum<GoblinSharkColo
     public static final GoblinSharkColor LOWER_RED = fromString("red");
 
     /**
+     * Creates a new instance of GoblinSharkColor value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public GoblinSharkColor() {}
+
+    /**
      * Creates or finds a GoblinSharkColor from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/MyKind.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/MyKind.java
@@ -13,6 +13,14 @@ public final class MyKind extends ExpandableStringEnum<MyKind> {
     public static final MyKind KIND1 = fromString("Kind1");
 
     /**
+     * Creates a new instance of MyKind value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public MyKind() {}
+
+    /**
      * Creates or finds a MyKind from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/AccessTier.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/AccessTier.java
@@ -40,6 +40,14 @@ public final class AccessTier extends ExpandableStringEnum<AccessTier> {
     public static final AccessTier ARCHIVE = fromString("Archive");
 
     /**
+     * Creates a new instance of AccessTier value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public AccessTier() {}
+
+    /**
      * Creates or finds a AccessTier from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/ArchiveStatus.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/ArchiveStatus.java
@@ -16,6 +16,14 @@ public final class ArchiveStatus extends ExpandableStringEnum<ArchiveStatus> {
     public static final ArchiveStatus REHYDRATE_PENDING_TO_COOL = fromString("rehydrate-pending-to-cool");
 
     /**
+     * Creates a new instance of ArchiveStatus value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public ArchiveStatus() {}
+
+    /**
      * Creates or finds a ArchiveStatus from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/PublicAccessType.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/PublicAccessType.java
@@ -16,6 +16,14 @@ public final class PublicAccessType extends ExpandableStringEnum<PublicAccessTyp
     public static final PublicAccessType BLOB = fromString("blob");
 
     /**
+     * Creates a new instance of PublicAccessType value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public PublicAccessType() {}
+
+    /**
      * Creates or finds a PublicAccessType from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/AccessTier.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/AccessTier.java
@@ -41,6 +41,14 @@ public final class AccessTier extends ExpandableStringEnum<AccessTier> {
     public static final AccessTier ARCHIVE = fromString("Archive");
 
     /**
+     * Creates a new instance of AccessTier value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public AccessTier() {}
+
+    /**
      * Creates or finds a AccessTier from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/ArchiveStatus.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/ArchiveStatus.java
@@ -17,6 +17,14 @@ public final class ArchiveStatus extends ExpandableStringEnum<ArchiveStatus> {
     public static final ArchiveStatus REHYDRATE_PENDING_TO_COOL = fromString("rehydrate-pending-to-cool");
 
     /**
+     * Creates a new instance of ArchiveStatus value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public ArchiveStatus() {}
+
+    /**
      * Creates or finds a ArchiveStatus from its string representation.
      *
      * @param name a name to look for.

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/PublicAccessType.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/PublicAccessType.java
@@ -17,6 +17,14 @@ public final class PublicAccessType extends ExpandableStringEnum<PublicAccessTyp
     public static final PublicAccessType BLOB = fromString("blob");
 
     /**
+     * Creates a new instance of PublicAccessType value.
+     *
+     * @deprecated Use the {@link #fromString(String)} factory method.
+     */
+    @Deprecated
+    public PublicAccessType() {}
+
+    /**
      * Creates or finds a PublicAccessType from its string representation.
      *
      * @param name a name to look for.


### PR DESCRIPTION
Javadoc of Java 17 requires ctor and its javadoc.

code change https://github.com/Azure/autorest.java/pull/1921/commits/47ee41df5270cf958d6e8228db87ad55d43f555e

real SDK: commit https://github.com/Azure/azure-sdk-for-java/pull/32846/commits/7058a2f5bc001697e52c013261a2a89d8a98b095 in https://github.com/Azure/azure-sdk-for-java/pull/32846

"Build Analyze" CI is good: https://dev.azure.com/azure-sdk/public/_build/results?buildId=2103025&view=logs&jobId=b70e5e73-bbb6-5567-0939-8415943fadb9