### PR TITLE
mgmt, bug fix, nextLink in parent model

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -1429,10 +1429,10 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
             .filter(p -> p.getSerializedName().equals(xmsPageable.getNextLinkName()))
             .map(ClientModelProperty::getClientType).findAny().orElse(null);
         if (nextLinkType == null && !CoreUtils.isNullOrEmpty(responseBodyModel.getParentModelName())) {
-            return getPageableNextLinkType(xmsPageable, responseBodyModel.getParentModelName());
-        } else {
-            return nextLinkType;
+            // try find nextLink property in parent model
+            nextLinkType = getPageableNextLinkType(xmsPageable, responseBodyModel.getParentModelName());
         }
+        return nextLinkType;
     }
 
     private IType getPollingIntermediateType(JavaSettings.PollingDetails details, IType syncReturnType) {

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -1112,7 +1112,8 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
     protected static String nextLinkLine(ClientMethod clientMethod, String valueExpression) {
         return String.format("res.%3$s.%1$s()%2$s,",
             CodeNamer.getModelNamer().modelPropertyGetterName(clientMethod.getMethodPageDetails().getNextLinkName()),
-            (clientMethod.getMethodPageDetails().getNextLinkType() == ClassType.String ? "" : ".toString()"),   // nextLink could be type URL
+            // nextLink could be type URL
+            (clientMethod.getMethodPageDetails().getNextLinkType() == ClassType.URL ? ".toString()" : ""),
             valueExpression);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/java",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "The Java extension for classic generators in AutoRest.",
   "scripts": {
     "autorest": "autorest",


### PR DESCRIPTION
code is in javagen, but only fluentgen would try to distinguish `nextLink().toString()` for URL and `nextLink()` for String in template.

Though now the default flag is treat URL as String.