### PR TITLE
client, bump identity version

### DIFF
--- a/cadl-tests/pom.xml
+++ b/cadl-tests/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-identity</artifactId>
-      <version>1.7.3</version>
+      <version>1.8.0</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>

--- a/customization-base/pom.xml
+++ b/customization-base/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-json</artifactId>
-      <version>1.0.0-beta.1</version>
+      <version>1.0.0-beta.2</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>

--- a/fluent-tests/pom.xml
+++ b/fluent-tests/pom.xml
@@ -117,7 +117,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-identity</artifactId>
-      <version>1.7.3</version>
+      <version>1.8.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
+++ b/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
@@ -58,7 +58,7 @@ public class Project {
         private String azureCoreManagementVersion = "1.10.1";
         private String azureCoreHttpNettyVersion = "1.13.0";
         private String azureCoreTestVersion = "1.14.1";
-        private String azureIdentityVersion = "1.7.3";
+        private String azureIdentityVersion = "1.8.0";
         private String junitVersion = "5.9.1";
         private String mockitoVersion = "4.5.1";
         private String slf4jSimpleVersion = "1.7.36";

--- a/protocol-sdk-integration-tests/eng/versioning/version_client.txt
+++ b/protocol-sdk-integration-tests/eng/versioning/version_client.txt
@@ -16,4 +16,5 @@ com.azure:azure-core-serializer-json-jackson;1.2.25;1.3.0-beta.1
 com.azure:azure-core-test;1.14.1;1.15.0-beta.1
 com.azure:azure-core-tracing-opentelemetry;1.0.0-beta.32;1.0.0-beta.33
 
-com.azure:azure-identity;1.7.3;1.8.0-beta.1
+com.azure:azure-identity;1.8.0;1.9.0-beta.1
+com.azure:azure-json;1.0.0-beta.2;1.0.0-beta.3


### PR DESCRIPTION
will try to enhance the sync_version script, so that it covers `Project.java` and that `version_client.txt` in test folder.