### PR TITLE
cadl, use reactor-test

### DIFF
--- a/azure-dataplane-tests/pom.xml
+++ b/azure-dataplane-tests/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
-            <version>3.4.14</version>
+            <version>3.4.26</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/cadl-tests/pom.xml
+++ b/cadl-tests/pom.xml
@@ -61,6 +61,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>io.projectreactor</groupId>
+      <artifactId>reactor-test</artifactId>
+      <version>3.4.26</version>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>1.7.36</version>

--- a/cadl-tests/src/test/java/com/_specs_/azure/core/CoreTests.java
+++ b/cadl-tests/src/test/java/com/_specs_/azure/core/CoreTests.java
@@ -4,13 +4,15 @@
 package com._specs_.azure.core;
 
 import com._specs_.azure.core.models.User;
+import com.azure.core.http.rest.PagedFlux;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public class CoreTests {
@@ -22,52 +24,82 @@ public class CoreTests {
     public void testCreateOrUpdate() {
         Map<String, String> body = new HashMap<>();
         body.put("name", "Madge");
-        Response<BinaryData> response = client.createOrUpdateWithResponse(1, BinaryData.fromObject(body), null).block();
+        Mono<Response<BinaryData>> response = client.createOrUpdateWithResponse(1, BinaryData.fromObject(body), null);
 
-        Assertions.assertEquals(200, response.getStatusCode());
-        Map<String, Object> responseBody = response.getValue().toObject(Map.class);
-        Assertions.assertEquals(1, responseBody.get("id"));
-        Assertions.assertEquals("Madge", responseBody.get("name"));
+        StepVerifier.create(response)
+                .assertNext(r -> {
+                    Assertions.assertEquals(200, r.getStatusCode());
+                    Map<String, Object> responseBody = r.getValue().toObject(Map.class);
+                    Assertions.assertEquals(1, responseBody.get("id"));
+                    Assertions.assertEquals("Madge", responseBody.get("name"));
+                })
+                .expectComplete()
+                .verify();
     }
 
     @Test
     public void testCreateOrReplace() {
-        User user = client.createOrReplace(1, new User("Madge")).block();
+        Mono<User> response = client.createOrReplace(1, new User("Madge"));
 
-        Assertions.assertEquals(1, user.getId());
-        Assertions.assertEquals("Madge", user.getName());
+        StepVerifier.create(response)
+                .assertNext(user -> {
+                    Assertions.assertEquals(1, user.getId());
+                    Assertions.assertEquals("Madge", user.getName());
+                })
+                .expectComplete()
+                .verify();
     }
 
     @Test
     public void testGet() {
-        User user = client.get(1).block();
+        Mono<User> response = client.get(1);
 
-        Assertions.assertEquals(1, user.getId());
-        Assertions.assertEquals("Madge", user.getName());
+        StepVerifier.create(response)
+                .assertNext(user -> {
+                    Assertions.assertEquals(1, user.getId());
+                    Assertions.assertEquals("Madge", user.getName());
+                })
+                .expectComplete()
+                .verify();
     }
 
     @Test
     public void testList() {
-        List<User> users = client.list().collectList().block();
+        PagedFlux<User> response = client.list();
 
-        Assertions.assertEquals(2, users.size());
-        Assertions.assertEquals(1, users.get(0).getId());
-        Assertions.assertEquals("Madge", users.get(0).getName());
-        Assertions.assertEquals(2, users.get(1).getId());
-        Assertions.assertEquals("John", users.get(1).getName());
+        StepVerifier.create(response)
+                .assertNext(user -> {
+                    Assertions.assertEquals(1, user.getId());
+                    Assertions.assertEquals("Madge", user.getName());
+                })
+                .assertNext(user -> {
+                    Assertions.assertEquals(2, user.getId());
+                    Assertions.assertEquals("John", user.getName());
+                })
+                .expectComplete()
+                .verify();
     }
 
 
     @Test
     public void testDelete() {
-        client.delete(1).block();
+        Mono<Void> response = client.delete(1);
+
+        StepVerifier.create(response)
+                .expectComplete()
+                .verify();
     }
 
     @Test
     public void testAction() {
-        User user = client.export(1, "json").block();
+        Mono<User> response = client.export(1, "json");
 
-        Assertions.assertEquals(1, user.getId());
-        Assertions.assertEquals("Madge", user.getName());
+        StepVerifier.create(response)
+                .assertNext(user -> {
+                    Assertions.assertEquals(1, user.getId());
+                    Assertions.assertEquals("Madge", user.getName());
+                })
+                .expectComplete()
+                .verify();
     }
 }

--- a/cadl-tests/src/test/java/com/azure/lro/LroTests.java
+++ b/cadl-tests/src/test/java/com/azure/lro/LroTests.java
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.lro;
+
+import com.azure.core.util.BinaryData;
+import com.azure.core.util.polling.LongRunningOperationStatus;
+import com.azure.core.util.polling.PollResponse;
+import com.azure.core.util.polling.PollerFlux;
+import com.azure.core.util.polling.SyncPoller;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+public class LroTests {
+
+    private final LroAsyncClient client = new LroClientBuilder()
+            .buildAsyncClient();
+
+    @Disabled("response of poll is {status: Succeeded}, not a String")
+    @Test
+    public void testLro() {
+        PollerFlux<String, String> lroFlux = client.beginCreate();
+        SyncPoller<String, String> lroPoller = lroFlux.getSyncPoller();
+
+        PollResponse<String> pollResponse = lroPoller.waitForCompletion();
+
+        Assertions.assertEquals(LongRunningOperationStatus.SUCCESSFULLY_COMPLETED, pollResponse.getStatus());
+        Assertions.assertEquals("Test for polling succeed", lroPoller.getFinalResult());
+    }
+
+    @Test
+    public void testLroProtocol() {
+        PollerFlux<BinaryData, BinaryData> lroFlux = client.beginCreate(null);
+        SyncPoller<BinaryData, BinaryData> lroPoller = lroFlux.getSyncPoller();
+
+        PollResponse<BinaryData> pollResponse = lroPoller.waitForCompletion();
+
+        Assertions.assertEquals(LongRunningOperationStatus.SUCCESSFULLY_COMPLETED, pollResponse.getStatus());
+        Assertions.assertEquals("Test for polling succeed", lroPoller.getFinalResult().toObject(String.class));
+    }
+}

--- a/eng/versioning/external_dependencies.txt
+++ b/eng/versioning/external_dependencies.txt
@@ -13,6 +13,7 @@ org.slf4j:slf4j-simple
 junit:junit
 org.junit.jupiter:junit-jupiter-api
 org.junit.jupiter:junit-jupiter-engine
+io.projectreactor:reactor-test
 
 org.apache.maven.plugins:maven-antrun-plugin
 org.apache.maven.plugins:maven-assembly-plugin

--- a/vanilla-tests/pom.xml
+++ b/vanilla-tests/pom.xml
@@ -85,7 +85,7 @@
     <dependency>
       <groupId>io.projectreactor</groupId>
       <artifactId>reactor-test</artifactId>
-      <version>3.4.14</version>
+      <version>3.4.26</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Use `StepVerifier`. No logic change.

Add a test for lro-basic. Cadl-ranch is not correct, hence use protocol API. https://github.com/Azure/autorest.java/pull/1973/commits/71b1295fe06f6a23f16e5231129863dc81eb0ac9