### PR TITLE
Update pool used by `eng/pipelines/fluent_integration.yaml` to azsdk-pool-mms-win-2022-general / MMS2022Compliant

### DIFF
--- a/eng/pipelines/fluent_integration.yaml
+++ b/eng/pipelines/fluent_integration.yaml
@@ -17,8 +17,8 @@ jobs:
 - job: 'Build'
   timeoutInMinutes: 60
   pool:
-    name: "azsdk-pool-mms-win-2019-general"
-    vmImage: "MMS2019"
+    name: azsdk-pool-mms-win-2022-general
+    vmImage: MMS2022Compliant
 
   steps:
   - task: NodeTool@0


### PR DESCRIPTION
Updating used pool to compliant image, v. 2022:
- https://github.com/Azure/azure-sdk-tools/issues/3407