### PR TITLE
client, default pom enable jacoco

### DIFF
--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentPomTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentPomTemplate.java
@@ -3,6 +3,7 @@
 
 package com.azure.autorest.fluent.template;
 
+import com.azure.autorest.model.xmlmodel.XmlBlock;
 import com.azure.autorest.template.PomTemplate;
 
 public class FluentPomTemplate extends PomTemplate {
@@ -16,6 +17,14 @@ public class FluentPomTemplate extends PomTemplate {
 
     public static FluentPomTemplate getInstance() {
         return INSTANCE;
+    }
+
+    @Override
+    protected void writeJacoco(XmlBlock propertiesBlock) {
+        super.writeJacoco(propertiesBlock);
+
+        propertiesBlock.tag("jacoco.min.linecoverage", "0");
+        propertiesBlock.tag("jacoco.min.branchcoverage", "0");
     }
 
 //    public static void setProject(FluentProject project) {

--- a/javagen/src/main/java/com/azure/autorest/template/PomTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/PomTemplate.java
@@ -94,8 +94,7 @@ public class PomTemplate implements IXmlTemplate<Pom, XmlFile> {
 
             projectBlock.block("properties", propertiesBlock -> {
                 propertiesBlock.tag("project.build.sourceEncoding", "UTF-8");
-                // skip jacoco coverage check
-                propertiesBlock.tag("jacoco.skip", "true");
+                writeJacoco(propertiesBlock);
             });
 
             if (pom.getDependencyIdentifiers() != null && pom.getDependencyIdentifiers().size() > 0) {
@@ -140,9 +139,18 @@ public class PomTemplate implements IXmlTemplate<Pom, XmlFile> {
     }
 
     /**
+     * Extension for writing jacoco configuration.
+     *
+     * @param propertiesBlock the "properties" xml block.
+     */
+    protected void writeJacoco(XmlBlock propertiesBlock) {
+        // NOOP for data-plane
+    }
+
+    /**
      * Extension for writing a "build" block, with array of "plugin" within.
      *
-     * @param projectBlock the project block.
+     * @param projectBlock the "project" xml block.
      * @param pom the pom model.
      */
     protected void writeBuildBlock(XmlBlock projectBlock, Pom pom) {
@@ -155,6 +163,11 @@ public class PomTemplate implements IXmlTemplate<Pom, XmlFile> {
         }
     }
 
+    /**
+     * Write a "maven-compiler-plugin" block, for SDK not using com.azure:azure-client-sdk-parent
+     *
+     * @param pluginsBlock the "plugins" xml block.
+     */
     protected void writeStandAlonePlugins(XmlBlock pluginsBlock) {
         // maven-compiler-plugin
         pluginsBlock.block("plugin", pluginBlock -> {

--- a/protocol-sdk-integration-tests/test.py
+++ b/protocol-sdk-integration-tests/test.py
@@ -55,6 +55,7 @@ def run(script_path: str, output_folder: str, json_path: str, namespace: str,
     cmd = [
         MAVEN_CLI,
         'verify',
+        '-Djacoco.skip',
         '-Drevapi.skip',
         '-Dmaven.javadoc.skip',
         '--no-transfer-progress'


### PR DESCRIPTION
fix https://github.com/Azure/autorest.java/issues/1979

We likely need to add `-Djacoco.skip` in automation
https://github.com/Azure/azure-sdk-for-java/blob/main/eng/mgmt/automation/generate_data.py#L392