### PR TITLE
cadl, revert to csv in odata test case

### DIFF
--- a/cadl-tests/cadl/odata.cadl
+++ b/cadl-tests/cadl/odata.cadl
@@ -31,7 +31,15 @@ interface OdataOp {
     @query skip?: int32,
     @query top?: int32,
     @query maxpagesize?: int32,
-    @query select?: string[],
-    @query expand?: string[]
+
+    @query({
+      format: "csv",
+    })
+    select?: string[],
+
+    @query({
+      format: "csv",
+    })
+    expand?: string[]
   ): ResourceCollection;
 }

--- a/cadl-tests/src/main/java/com/cadl/odata/OdataAsyncClient.java
+++ b/cadl-tests/src/main/java/com/cadl/odata/OdataAsyncClient.java
@@ -20,6 +20,7 @@ import com.azure.core.util.BinaryData;
 import com.cadl.odata.implementation.OdataClientImpl;
 import com.cadl.odata.models.Resource;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import reactor.core.publisher.Flux;
 
@@ -51,8 +52,8 @@ public final class OdataAsyncClient {
      *     <tr><td>skip</td><td>Integer</td><td>No</td><td>The skip parameter</td></tr>
      *     <tr><td>top</td><td>Integer</td><td>No</td><td>The top parameter</td></tr>
      *     <tr><td>maxpagesize</td><td>Integer</td><td>No</td><td>The maxPageSize parameter</td></tr>
-     *     <tr><td>select</td><td>List&lt;String&gt;</td><td>No</td><td>Array of Filter. Call {@link RequestOptions#addQueryParam} to add string to array.</td></tr>
-     *     <tr><td>expand</td><td>List&lt;String&gt;</td><td>No</td><td>Array of Filter. Call {@link RequestOptions#addQueryParam} to add string to array.</td></tr>
+     *     <tr><td>select</td><td>List&lt;String&gt;</td><td>No</td><td>Array of Filter. In the form of "," separated string.</td></tr>
+     *     <tr><td>expand</td><td>List&lt;String&gt;</td><td>No</td><td>Array of Filter. In the form of "," separated string.</td></tr>
      * </table>
      *
      * You can add these to a request with {@link RequestOptions#addQueryParam}
@@ -126,18 +127,18 @@ public final class OdataAsyncClient {
             requestOptions.addQueryParam("maxpagesize", String.valueOf(maxPageSize));
         }
         if (select != null) {
-            for (String paramItemValue : select) {
-                if (paramItemValue != null) {
-                    requestOptions.addQueryParam("select", paramItemValue);
-                }
-            }
+            requestOptions.addQueryParam(
+                    "select",
+                    select.stream()
+                            .map(paramItemValue -> Objects.toString(paramItemValue, ""))
+                            .collect(Collectors.joining(",")));
         }
         if (expand != null) {
-            for (String paramItemValue : expand) {
-                if (paramItemValue != null) {
-                    requestOptions.addQueryParam("expand", paramItemValue);
-                }
-            }
+            requestOptions.addQueryParam(
+                    "expand",
+                    expand.stream()
+                            .map(paramItemValue -> Objects.toString(paramItemValue, ""))
+                            .collect(Collectors.joining(",")));
         }
         PagedFlux<BinaryData> pagedFluxResponse = list(requestOptions);
         return PagedFlux.create(

--- a/cadl-tests/src/main/java/com/cadl/odata/OdataClient.java
+++ b/cadl-tests/src/main/java/com/cadl/odata/OdataClient.java
@@ -46,8 +46,8 @@ public final class OdataClient {
      *     <tr><td>skip</td><td>Integer</td><td>No</td><td>The skip parameter</td></tr>
      *     <tr><td>top</td><td>Integer</td><td>No</td><td>The top parameter</td></tr>
      *     <tr><td>maxpagesize</td><td>Integer</td><td>No</td><td>The maxPageSize parameter</td></tr>
-     *     <tr><td>select</td><td>List&lt;String&gt;</td><td>No</td><td>Array of Filter. Call {@link RequestOptions#addQueryParam} to add string to array.</td></tr>
-     *     <tr><td>expand</td><td>List&lt;String&gt;</td><td>No</td><td>Array of Filter. Call {@link RequestOptions#addQueryParam} to add string to array.</td></tr>
+     *     <tr><td>select</td><td>List&lt;String&gt;</td><td>No</td><td>Array of Filter. In the form of "," separated string.</td></tr>
+     *     <tr><td>expand</td><td>List&lt;String&gt;</td><td>No</td><td>Array of Filter. In the form of "," separated string.</td></tr>
      * </table>
      *
      * You can add these to a request with {@link RequestOptions#addQueryParam}

--- a/cadl-tests/src/main/java/com/cadl/odata/implementation/OdataClientImpl.java
+++ b/cadl-tests/src/main/java/com/cadl/odata/implementation/OdataClientImpl.java
@@ -176,8 +176,8 @@ public final class OdataClientImpl {
      *     <tr><td>skip</td><td>Integer</td><td>No</td><td>The skip parameter</td></tr>
      *     <tr><td>top</td><td>Integer</td><td>No</td><td>The top parameter</td></tr>
      *     <tr><td>maxpagesize</td><td>Integer</td><td>No</td><td>The maxPageSize parameter</td></tr>
-     *     <tr><td>select</td><td>List&lt;String&gt;</td><td>No</td><td>Array of Filter. Call {@link RequestOptions#addQueryParam} to add string to array.</td></tr>
-     *     <tr><td>expand</td><td>List&lt;String&gt;</td><td>No</td><td>Array of Filter. Call {@link RequestOptions#addQueryParam} to add string to array.</td></tr>
+     *     <tr><td>select</td><td>List&lt;String&gt;</td><td>No</td><td>Array of Filter. In the form of "," separated string.</td></tr>
+     *     <tr><td>expand</td><td>List&lt;String&gt;</td><td>No</td><td>Array of Filter. In the form of "," separated string.</td></tr>
      * </table>
      *
      * You can add these to a request with {@link RequestOptions#addQueryParam}
@@ -228,8 +228,8 @@ public final class OdataClientImpl {
      *     <tr><td>skip</td><td>Integer</td><td>No</td><td>The skip parameter</td></tr>
      *     <tr><td>top</td><td>Integer</td><td>No</td><td>The top parameter</td></tr>
      *     <tr><td>maxpagesize</td><td>Integer</td><td>No</td><td>The maxPageSize parameter</td></tr>
-     *     <tr><td>select</td><td>List&lt;String&gt;</td><td>No</td><td>Array of Filter. Call {@link RequestOptions#addQueryParam} to add string to array.</td></tr>
-     *     <tr><td>expand</td><td>List&lt;String&gt;</td><td>No</td><td>Array of Filter. Call {@link RequestOptions#addQueryParam} to add string to array.</td></tr>
+     *     <tr><td>select</td><td>List&lt;String&gt;</td><td>No</td><td>Array of Filter. In the form of "," separated string.</td></tr>
+     *     <tr><td>expand</td><td>List&lt;String&gt;</td><td>No</td><td>Array of Filter. In the form of "," separated string.</td></tr>
      * </table>
      *
      * You can add these to a request with {@link RequestOptions#addQueryParam}
@@ -276,8 +276,8 @@ public final class OdataClientImpl {
      *     <tr><td>skip</td><td>Integer</td><td>No</td><td>The skip parameter</td></tr>
      *     <tr><td>top</td><td>Integer</td><td>No</td><td>The top parameter</td></tr>
      *     <tr><td>maxpagesize</td><td>Integer</td><td>No</td><td>The maxPageSize parameter</td></tr>
-     *     <tr><td>select</td><td>List&lt;String&gt;</td><td>No</td><td>Array of Filter. Call {@link RequestOptions#addQueryParam} to add string to array.</td></tr>
-     *     <tr><td>expand</td><td>List&lt;String&gt;</td><td>No</td><td>Array of Filter. Call {@link RequestOptions#addQueryParam} to add string to array.</td></tr>
+     *     <tr><td>select</td><td>List&lt;String&gt;</td><td>No</td><td>Array of Filter. In the form of "," separated string.</td></tr>
+     *     <tr><td>expand</td><td>List&lt;String&gt;</td><td>No</td><td>Array of Filter. In the form of "," separated string.</td></tr>
      * </table>
      *
      * You can add these to a request with {@link RequestOptions#addQueryParam}


### PR DESCRIPTION
This was unexpectedly affected, when the default of array in query be changed from csv to multi.