### PR TITLE
Where applicable, update Windows pools used to `azsdk-pool-mms-win-2022-general` and rename `vmImage` to the `windows-20xx` format

### DIFF
--- a/eng/pipelines/fluent_integration.yaml
+++ b/eng/pipelines/fluent_integration.yaml
@@ -18,7 +18,7 @@ jobs:
   timeoutInMinutes: 60
   pool:
     name: azsdk-pool-mms-win-2022-general
-    vmImage: MMS2022Compliant
+    vmImage: windows-2022
 
   steps:
   - task: NodeTool@0


### PR DESCRIPTION
This PR is a follow-up to:
- #1980

Where applicable, update Windows pools used to `azsdk-pool-mms-win-2022-general` and rename `vmImage` to the `windows-20xx` format.

This discussion explains why we chose given `vmImage` format:

[Mike Harder: 1ES Hosted Pool image name changes](https://teams.microsoft.com/l/message/19:59dbfadafb5e41c4890e2cd3d74cc7ba@thread.skype/1676491855184?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&parentMessageId=1676491855184&teamName=Azure%20SDK&channelName=Engineering%20System%20%F0%9F%9B%A0%EF%B8%8F&createdTime=1676491855184)
posted in Azure SDK / Engineering System 🛠️ at Wednesday, February 15, 2023 12:10 PM

For further context, please see:
- https://github.com/Azure/azure-sdk-tools/issues/3407
