### PR TITLE
mgmt, bug fix on multiple error response

### DIFF
--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentProxyMethodMapper.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentProxyMethodMapper.java
@@ -8,10 +8,10 @@ import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.fluent.model.FluentType;
 import com.azure.autorest.fluent.model.clientmodel.FluentStatic;
 import com.azure.autorest.fluent.util.Utils;
-import com.azure.autorest.mapper.Mappers;
 import com.azure.autorest.mapper.ProxyMethodMapper;
 import com.azure.autorest.model.clientmodel.ClassType;
 import com.azure.autorest.model.clientmodel.ProxyMethod;
+import com.azure.core.util.CoreUtils;
 
 import java.util.List;
 import java.util.Objects;
@@ -28,11 +28,8 @@ public class FluentProxyMethodMapper extends ProxyMethodMapper {
     protected void buildUnexpectedResponseExceptionTypes(ProxyMethod.Builder builder,
                                                          Operation operation, List<Integer> expectedStatusCodes,
                                                          JavaSettings settings) {
-        ClassType errorType = null;
-        if (operation.getExceptions() != null && !operation.getExceptions().isEmpty()) {
-            errorType = (ClassType) Mappers.getSchemaMapper().map(operation.getExceptions().get(0).getSchema());
-        }
-        if (errorType == null || !FluentType.nonManagementError(errorType)) {
+        if (CoreUtils.isNullOrEmpty(operation.getExceptions())) {
+            // use ManagementException
             builder.unexpectedResponseExceptionType(FluentType.ManagementException);
         } else {
             super.buildUnexpectedResponseExceptionTypes(builder, operation, expectedStatusCodes, settings);
@@ -67,6 +64,15 @@ public class FluentProxyMethodMapper extends ProxyMethodMapper {
         }
         builder.unexpectedResponseExceptionTypes(unexpectedResponseExceptionTypes);
         */
+    }
+
+    @Override
+    protected ClassType processExceptionClassType(ClassType errorType, JavaSettings settings) {
+        if (!FluentType.nonManagementError(errorType)) {
+            return FluentType.ManagementException;
+        } else {
+            return super.processExceptionClassType(errorType, settings);
+        }
     }
 
     @Override

--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
@@ -63,6 +63,7 @@ public class ProxyMethodMapper implements IMapper<Operation, Map<Request, List<P
     private static final Pattern APOSTROPHE = Pattern.compile("'");
 
     private final Map<Request, List<ProxyMethod>> parsed = new ConcurrentHashMap<>();
+
     protected ProxyMethodMapper() {
     }
 
@@ -492,7 +493,7 @@ public class ProxyMethodMapper implements IMapper<Operation, Map<Request, List<P
         }
     }
 
-    private static SwaggerExceptionDefinitions getSwaggerExceptionDefinitions(Operation operation,
+    private SwaggerExceptionDefinitions getSwaggerExceptionDefinitions(Operation operation,
         JavaSettings settings) {
 
         SwaggerExceptionDefinitions exceptionDefinitions = new SwaggerExceptionDefinitions();
@@ -557,7 +558,7 @@ public class ProxyMethodMapper implements IMapper<Operation, Map<Request, List<P
         private Map<Integer, ClassType> exceptionTypeMapping;
     }
 
-    private static ClassType getExceptionType(Response exception, JavaSettings settings) {
+    private ClassType getExceptionType(Response exception, JavaSettings settings) {
         ClassType exceptionType = ClassType.HttpResponseException;  // default as HttpResponseException
 
         if (exception != null && exception.getSchema() != null) {
@@ -570,7 +571,14 @@ public class ProxyMethodMapper implements IMapper<Operation, Map<Request, List<P
         return exceptionType;
     }
 
-    private static ClassType processExceptionClassType(ClassType errorType, JavaSettings settings) {
+    /**
+     * Extension for map error ClassType to exception ClassType.
+     *
+     * @param errorType the error class.
+     * @param settings the Java settings.
+     * @return the exception ClassType.
+     */
+    protected ClassType processExceptionClassType(ClassType errorType, JavaSettings settings) {
         if (errorType == null) {
             return null;
         }


### PR DESCRIPTION
Re-use logic in `ProxyMethodMapper`.

Change is for built-in `ManagementError`, use built-in `ManagementException`.