### PR TITLE
Support Generating XML Based on Swagger XML Property

### DIFF
--- a/Generate-TypeSpec.ps1
+++ b/Generate-TypeSpec.ps1
@@ -19,36 +19,41 @@ function invokeExpressionAndCaptureOutput([string]$expression) {
 }
 
 Write-Host "Changing directory to './cadl-extension'"
-Set-Location ./cadl-extension
+try {
+  Push-Location ./cadl-extension
 
-Write-Host "Installing dependencies for TypeSpec Java ('npm install')"
-invokeExpressionAndCaptureOutput("npm install")
+  Write-Host "Installing dependencies for TypeSpec Java ('npm install')"
+  invokeExpressionAndCaptureOutput("npm install")
 
-Write-Host "Building TypeSpec Java ('npm run build')"
-invokeExpressionAndCaptureOutput("npm run build")
+  Write-Host "Building TypeSpec Java ('npm run build')"
+  invokeExpressionAndCaptureOutput("npm run build")
 
-Write-Host "Linting TypeSpec Java ('npm run lint')"
-invokeExpressionAndCaptureOutput("npm run lint")
+  Write-Host "Linting TypeSpec Java ('npm run lint')"
+  invokeExpressionAndCaptureOutput("npm run lint")
 
-Write-Host "Checking TypeSpec Java format ('npm run check-format')"
-invokeExpressionAndCaptureOutput("npm run check-format")
+  Write-Host "Checking TypeSpec Java format ('npm run check-format')"
+  invokeExpressionAndCaptureOutput("npm run check-format")
 
-Write-Host "Packing TypeSpec Java ('npm pack')"
-invokeExpressionAndCaptureOutput("npm pack")
+  Write-Host "Packing TypeSpec Java ('npm pack')"
+  invokeExpressionAndCaptureOutput("npm pack")
 
-Write-Host "Returning to root directory ('..')"
-Set-Location ..
+  Write-Host "Returning to root directory ('..')"
+} finally {
+  Pop-Location
+}
 
 Write-Host "Installing TypeSpec ('npm install -g @typespec/compiler')"
 invokeExpressionAndCaptureOutput("npm install -g @typespec/compiler")
 
-Write-Host "Changing directory to './cadl-tests'"
-Set-Location ./cadl-tests
+try {
+  Write-Host "Changing directory to './cadl-tests'"
+  Push-Location ./cadl-tests
 
-Write-Host "Generating code ('Generate.ps1' in './cadl-tests')"
-invokeExpressionAndCaptureOutput("./Generate.ps1")
+  Write-Host "Generating code ('Generate.ps1' in './cadl-tests')"
+  invokeExpressionAndCaptureOutput("./Generate.ps1")
 
-Write-Host "Checking format of generated code ('npm run check-format')"
-invokeExpressionAndCaptureOutput("npm run check-format")
-
-Set-Location ..
+  Write-Host "Checking format of generated code ('npm run check-format')"
+  invokeExpressionAndCaptureOutput("npm run check-format")
+} finally {
+  Pop-Location
+}

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModel.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModel.java
@@ -4,6 +4,7 @@
 package com.azure.autorest.model.clientmodel;
 
 import com.azure.autorest.extension.base.plugin.JavaSettings;
+import com.azure.autorest.util.ClientModelUtil;
 
 import java.util.Collections;
 import java.util.List;
@@ -17,47 +18,47 @@ public class ClientModel {
     /**
      * The package that this model class belongs to.
      */
-    private String packageName;
+    private final String packageName;
     /**
      * Get the name of this model.
      */
-    private String name;
+    private final String name;
     /**
      * Get the imports for this model.
      */
-    private List<String> imports;
+    private final List<String> imports;
     /**
      * Get the description of this model.
      */
-    private String description;
+    private final String description;
     /**
      * Get whether this model has model types that derive from it.
      */
-    private boolean isPolymorphic;
+    private final boolean isPolymorphic;
     /**
      * Get the name of the property that determines which polymorphic model type to create.
      */
-    private String polymorphicDiscriminator;
+    private final String polymorphicDiscriminator;
     /**
      * Get the name that is used for this model when it is serialized.
      */
-    private String serializedName;
+    private final String serializedName;
     /**
      * Get whether this model needs serialization flattening.
      */
-    private boolean needsFlatten;
+    private final boolean needsFlatten;
     /**
      * Get the parent model of this model.
      */
-    private String parentModelName;
+    private final String parentModelName;
     /**
      * Get the models that derive from this model.
      */
-    private List<ClientModel> derivedModels;
+    private final List<ClientModel> derivedModels;
     /**
      * Get the name that will be used for this model's XML element representation.
      */
-    private String xmlName;
+    private final String xmlName;
 
     /**
      * The xml namesapce for a model.
@@ -67,11 +68,11 @@ public class ClientModel {
     /**
      * Get the properties for this model.
      */
-    private List<ClientModelProperty> properties;
+    private final List<ClientModelProperty> properties;
 
-    private List<ClientModelPropertyReference> propertyReferences;
+    private final List<ClientModelPropertyReference> propertyReferences;
 
-    private IType modelType;
+    private final IType modelType;
 
     /*
      * Whether this model is a strongly-typed HTTP headers class.
@@ -249,7 +250,7 @@ public class ClientModel {
         }
 
         for (ClientModelProperty property : getProperties()) {
-            property.addImportsTo(imports, settings.isGenerateXmlSerialization());
+            property.addImportsTo(imports, ClientModelUtil.treatAsXml(settings, this));
         }
     }
 

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -52,6 +52,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.azure.autorest.util.ClientModelUtil.treatAsXml;
+
 /**
  * Writes a ClientModel to a JavaFile.
  */
@@ -95,6 +97,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
         final boolean hasDerivedModels = !model.getDerivedModels().isEmpty();
         final boolean immutableOutputModel = settings.isOutputModelImmutable()
             && model.getImplementationDetails() != null && !model.getImplementationDetails().isInput();
+        boolean treatAsXml = treatAsXml(settings, model);
 
         // Handle adding annotations if the model is polymorphic.
         handlePolymorphism(model, hasDerivedModels, settings.isDiscriminatorPassedToChildDeserialization(), javaFile);
@@ -164,14 +167,14 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                 }
 
                 classBlock.method(methodVisibility, null, propertyClientType + " " + getGetterName(model, property) + "()",
-                    methodBlock -> addGetterMethod(propertyWireType, propertyClientType, property, settings, methodBlock));
+                    methodBlock -> addGetterMethod(propertyWireType, propertyClientType, property, treatAsXml, methodBlock));
 
                 if (ClientModelUtil.hasSetter(property, settings) && !immutableOutputModel) {
                     generateSetterJavadoc(classBlock, model, property);
                     TemplateUtil.addJsonSetter(classBlock, settings, property.getSerializedName());
                     classBlock.method(methodVisibility, null,
                         model.getName() + " " + property.getSetterName() + "(" + propertyClientType + " " + property.getName() + ")",
-                        methodBlock -> addSetterMethod(propertyWireType, propertyClientType, property, settings, methodBlock));
+                        methodBlock -> addSetterMethod(propertyWireType, propertyClientType, property, treatAsXml, methodBlock));
                 }
 
                 // If the property is additional properties, and stream-style serialization isn't being used, add a
@@ -411,7 +414,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
      * @param settings Autorest generation settings.
      */
     protected void addClassLevelAnnotations(ClientModel model, JavaFile javaFile, JavaSettings settings) {
-        if (settings.isGenerateXmlSerialization()) {
+        if (treatAsXml(settings, model)) {
             if (!CoreUtils.isNullOrEmpty(model.getXmlNamespace())) {
                 javaFile.annotation(String.format("JacksonXmlRootElement(localName = \"%1$s\", namespace = \"%2$s\")",
                     model.getXmlName(), model.getXmlNamespace()));
@@ -478,7 +481,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
             IType propertyType = property.getWireType();
 
             String fieldSignature;
-            if (settings.isGenerateXmlSerialization()) {
+            if (treatAsXml(settings, model)) {
                 if (property.isXmlWrapper()) {
                     String xmlWrapperClassName = getPropertyXmlWrapperClassName(property);
 
@@ -582,17 +585,18 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
             classBlock.annotation("JsonTypeId");
         }
 
+        boolean treatAsXml = treatAsXml(settings, model);
         if (!CoreUtils.isNullOrEmpty(property.getHeaderCollectionPrefix())) {
             classBlock.annotation("HeaderCollection(\"" + property.getHeaderCollectionPrefix() + "\")");
-        } else if (settings.isGenerateXmlSerialization() && property.isXmlAttribute()) {
+        } else if (treatAsXml && property.isXmlAttribute()) {
             classBlock.annotation("JacksonXmlProperty(localName = \"" + property.getXmlName() + "\", isAttribute = true)");
-        } else if (settings.isGenerateXmlSerialization() && property.getXmlNamespace() != null && !property.getXmlNamespace().isEmpty()) {
+        } else if (treatAsXml && property.getXmlNamespace() != null && !property.getXmlNamespace().isEmpty()) {
             classBlock.annotation("JacksonXmlProperty(localName = \"" + property.getXmlName() + "\", namespace = \"" + property.getXmlNamespace() + "\")");
-        } else if (settings.isGenerateXmlSerialization() && property.isXmlText()) {
+        } else if (treatAsXml && property.isXmlText()) {
             classBlock.annotation("JacksonXmlText");
         } else if (property.isAdditionalProperties()) {
             classBlock.annotation("JsonIgnore");
-        } else if (settings.isGenerateXmlSerialization() && property.getWireType() instanceof ListType && !property.isXmlWrapper()) {
+        } else if (treatAsXml && property.getWireType() instanceof ListType && !property.isXmlWrapper()) {
             classBlock.annotation("JsonProperty(\"" + property.getXmlListElementName() + "\")");
         } else if (!CoreUtils.isNullOrEmpty(property.getAnnotationArguments())) {
             classBlock.annotation("JsonProperty(" + property.getAnnotationArguments() + ")");
@@ -738,11 +742,11 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
      * @param propertyWireType The property wire type.
      * @param propertyClientType The client property type.
      * @param property The property.
-     * @param settings AutoRest configuration settings.
+     * @param treatAsXml Whether the getter should treat the property as XML.
      * @param methodBlock Where the getter method is being added.
      */
     private static void addGetterMethod(IType propertyWireType, IType propertyClientType, ClientModelProperty property,
-        JavaSettings settings, JavaBlock methodBlock) {
+        boolean treatAsXml, JavaBlock methodBlock) {
         String sourceTypeName = propertyWireType.toString();
         String targetTypeName = propertyClientType.toString();
         String expression = property.isPolymorphicDiscriminator()
@@ -753,8 +757,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
         }
 
         if (sourceTypeName.equals(targetTypeName)) {
-            if (settings.isGenerateXmlSerialization() && property.isXmlWrapper()
-                && (property.getWireType() instanceof IterableType)) {
+            if (treatAsXml && property.isXmlWrapper() && (property.getWireType() instanceof IterableType)) {
                 methodBlock.ifBlock(String.format("this.%s == null", property.getName()), ifBlock ->
                     ifBlock.line("this.%s = new %s(new ArrayList<%s>());", property.getName(),
                         getPropertyXmlWrapperClassName(property),
@@ -784,11 +787,11 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
      * @param propertyWireType The property wire type.
      * @param propertyClientType The client property type.
      * @param property The property.
-     * @param settings AutoRest configuration settings.
+     * @param treatAsXml Whether the setter should treat the property as XML.
      * @param methodBlock Where the setter method is being added.
      */
     private static void addSetterMethod(IType propertyWireType, IType propertyClientType, ClientModelProperty property,
-        JavaSettings settings, JavaBlock methodBlock) {
+        boolean treatAsXml, JavaBlock methodBlock) {
         String expression = (propertyClientType.equals(ArrayType.ByteArray))
             ? "CoreUtils.clone(" + property.getName() + ")"
             : property.getName();
@@ -802,7 +805,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                 .elseBlock(elseBlock ->
                     elseBlock.line("this.%s = %s;", property.getName(), propertyWireType.convertFromClientType(expression)));
         } else {
-            if (settings.isGenerateXmlSerialization() && property.isXmlWrapper()) {
+            if (treatAsXml && property.isXmlWrapper()) {
                 methodBlock.line("this.%s = new %s(%s);", property.getName(),
                     getPropertyXmlWrapperClassName(property), expression);
             } else {

--- a/javagen/src/main/java/com/azure/autorest/util/ClientModelUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/ClientModelUtil.java
@@ -490,4 +490,18 @@ public class ClientModelUtil {
         return property.isRequired() && settings.isRequiredFieldsAsConstructorArgs()
             && (!property.isReadOnly() || settings.isIncludeReadOnlyInConstructorArgs());
     }
+
+    /**
+     * Determines whether the caller should treat the model as XML.
+     * <p>
+     * XML is used when either {@link JavaSettings#isGenerateXmlSerialization()} is true or the model or property was
+     * defined in Swagger with an {@code xml} property.
+     *
+     * @param settings The Autorest generation settings.
+     * @param model The model.
+     * @return Whether the model should be treated as XML.
+     */
+    public static boolean treatAsXml(JavaSettings settings, ClientModel model) {
+        return settings.isGenerateXmlSerialization() || model.getXmlName() != null;
+    }
 }

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/AppleBarrel.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/AppleBarrel.java
@@ -10,7 +10,6 @@ import com.azure.xml.XmlSerializable;
 import com.azure.xml.XmlToken;
 import com.azure.xml.XmlWriter;
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
@@ -187,28 +186,22 @@ public final class AppleBarrel implements XmlSerializable<AppleBarrel> {
         return xmlReader.readObject(
                 "AppleBarrel",
                 reader -> {
-                    List<String> goodApples = null;
-                    List<String> badApples = null;
+                    GoodApplesWrapper goodApples = null;
+                    BadApplesWrapper badApples = null;
                     while (reader.nextElement() != XmlToken.END_ELEMENT) {
                         QName fieldName = reader.getElementName();
 
                         if ("GoodApples".equals(fieldName.getLocalPart())) {
-                            if (goodApples == null) {
-                                goodApples = new LinkedList<>();
-                            }
-                            goodApples.add(reader.getStringElement());
+                            goodApples = GoodApplesWrapper.fromXml(reader);
                         } else if ("BadApples".equals(fieldName.getLocalPart())) {
-                            if (badApples == null) {
-                                badApples = new LinkedList<>();
-                            }
-                            badApples.add(reader.getStringElement());
+                            badApples = BadApplesWrapper.fromXml(reader);
                         } else {
                             reader.skipElement();
                         }
                     }
                     AppleBarrel deserializedAppleBarrel = new AppleBarrel();
-                    deserializedAppleBarrel.setGoodApples(goodApples);
-                    deserializedAppleBarrel.setBadApples(badApples);
+                    deserializedAppleBarrel.goodApples = goodApples;
+                    deserializedAppleBarrel.badApples = badApples;
 
                     return deserializedAppleBarrel;
                 });

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/ListContainersResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/ListContainersResponse.java
@@ -10,7 +10,6 @@ import com.azure.xml.XmlSerializable;
 import com.azure.xml.XmlToken;
 import com.azure.xml.XmlWriter;
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
@@ -265,7 +264,7 @@ public final class ListContainersResponse implements XmlSerializable<ListContain
                     String prefix = null;
                     String marker = null;
                     int maxResults = 0;
-                    List<Container> containers = null;
+                    ContainersWrapper containers = null;
                     String nextMarker = null;
                     while (reader.nextElement() != XmlToken.END_ELEMENT) {
                         QName fieldName = reader.getElementName();
@@ -277,10 +276,7 @@ public final class ListContainersResponse implements XmlSerializable<ListContain
                         } else if ("MaxResults".equals(fieldName.getLocalPart())) {
                             maxResults = reader.getIntElement();
                         } else if ("Containers".equals(fieldName.getLocalPart())) {
-                            if (containers == null) {
-                                containers = new LinkedList<>();
-                            }
-                            containers.add(Container.fromXml(reader));
+                            containers = ContainersWrapper.fromXml(reader);
                         } else if ("NextMarker".equals(fieldName.getLocalPart())) {
                             nextMarker = reader.getStringElement();
                         } else {
@@ -293,7 +289,7 @@ public final class ListContainersResponse implements XmlSerializable<ListContain
                     deserializedListContainersResponse.maxResults = maxResults;
                     deserializedListContainersResponse.nextMarker = nextMarker;
                     deserializedListContainersResponse.marker = marker;
-                    deserializedListContainersResponse.setContainers(containers);
+                    deserializedListContainersResponse.containers = containers;
 
                     return deserializedListContainersResponse;
                 });

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/StorageServiceProperties.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/StorageServiceProperties.java
@@ -10,7 +10,6 @@ import com.azure.xml.XmlSerializable;
 import com.azure.xml.XmlToken;
 import com.azure.xml.XmlWriter;
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
@@ -270,7 +269,7 @@ public final class StorageServiceProperties implements XmlSerializable<StorageSe
                     Logging logging = null;
                     Metrics hourMetrics = null;
                     Metrics minuteMetrics = null;
-                    List<CorsRule> cors = null;
+                    CorsWrapper cors = null;
                     String defaultServiceVersion = null;
                     RetentionPolicy deleteRetentionPolicy = null;
                     while (reader.nextElement() != XmlToken.END_ELEMENT) {
@@ -283,10 +282,7 @@ public final class StorageServiceProperties implements XmlSerializable<StorageSe
                         } else if ("MinuteMetrics".equals(fieldName.getLocalPart())) {
                             minuteMetrics = Metrics.fromXml(reader);
                         } else if ("Cors".equals(fieldName.getLocalPart())) {
-                            if (cors == null) {
-                                cors = new LinkedList<>();
-                            }
-                            cors.add(CorsRule.fromXml(reader));
+                            cors = CorsWrapper.fromXml(reader);
                         } else if ("DefaultServiceVersion".equals(fieldName.getLocalPart())) {
                             defaultServiceVersion = reader.getStringElement();
                         } else if ("DeleteRetentionPolicy".equals(fieldName.getLocalPart())) {
@@ -299,7 +295,7 @@ public final class StorageServiceProperties implements XmlSerializable<StorageSe
                     deserializedStorageServiceProperties.logging = logging;
                     deserializedStorageServiceProperties.hourMetrics = hourMetrics;
                     deserializedStorageServiceProperties.minuteMetrics = minuteMetrics;
-                    deserializedStorageServiceProperties.setCors(cors);
+                    deserializedStorageServiceProperties.cors = cors;
                     deserializedStorageServiceProperties.defaultServiceVersion = defaultServiceVersion;
                     deserializedStorageServiceProperties.deleteRetentionPolicy = deleteRetentionPolicy;
 


### PR DESCRIPTION
Fixes #827 

Updates `javagen` to support generating XML without the requirement of `enable-xml: true`. To continue with previous functionality, for the time being while libraries using `enable-xml: true` are validated, if `enable-xml: true` is set all definitions in Swagger will be treated as XML models. But, now with this PR, when `enable-xml` is set to `false` or isn't defined models will generate as XML if the Swagger definition has an `XML` property.

Additionally, this PR resolves an issue where if the Swagger definition has an `xml` property but is empty the XML name will be the name of the definition.

Longer term there is future enhancements to serialization generation that should be supported, mainly determining which REST API definitions the model is used in and basing JSON, XML, and other serialization support on the `consumes` and `produces` of the REST APIs the model is used in. For example, and this isn't something common, if the model is used both in JSON and XML APIs we should generate the model to support both JSON and XML instead of being either JSON or XML.