### PR TITLE
Set Default Value when Stream-Style Serialization is Used

### DIFF
--- a/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/PathsV3R3RxOauth2TokenPostRequestbodyContentApplicationXWwwFormUrlencodedSchema.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/PathsV3R3RxOauth2TokenPostRequestbodyContentApplicationXWwwFormUrlencodedSchema.java
@@ -35,7 +35,7 @@ public final class PathsV3R3RxOauth2TokenPostRequestbodyContentApplicationXWwwFo
     /*
      * Grant type is expected to be refresh_token
      */
-    private TokenGrantType grantType;
+    private TokenGrantType grantType = TokenGrantType.REFRESH_TOKEN;
 
     /** Creates an instance of PathsV3R3RxOauth2TokenPostRequestbodyContentApplicationXWwwFormUrlencodedSchema class. */
     public PathsV3R3RxOauth2TokenPostRequestbodyContentApplicationXWwwFormUrlencodedSchema() {}

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -502,8 +502,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                     fieldSignature = propertyType + " " + propertyName + " = new " + propertyType + "()";
                 } else {
                     // handle x-ms-client-default
-                    if (property.getDefaultValue() != null
-                        && (!settings.isStreamStyleSerialization() || property.isPolymorphicDiscriminator())) {
+                    if (property.getDefaultValue() != null) {
                         if (property.isPolymorphicDiscriminator()) {
                             fieldSignature = propertyType + " " + CodeNamer.getEnumMemberName(propertyName) + " = " + property.getDefaultValue();
                         } else {


### PR DESCRIPTION
Use `x-ms-default-value` when stream-style serialization is being generated.