### PR TITLE
mgmt, bug fix on proxy method default Exception

### DIFF
--- a/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/models/OciImageManifest.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/models/OciImageManifest.java
@@ -33,7 +33,7 @@ public final class OciImageManifest implements JsonSerializable<OciImageManifest
     /*
      * Schema version
      */
-    private Integer schemaVersion;
+    private int schemaVersion = 2;
 
     /** Creates an instance of OciImageManifest class. */
     public OciImageManifest() {}
@@ -103,7 +103,7 @@ public final class OciImageManifest implements JsonSerializable<OciImageManifest
      *
      * @return the schemaVersion value.
      */
-    public Integer getSchemaVersion() {
+    public int getSchemaVersion() {
         return this.schemaVersion;
     }
 
@@ -113,7 +113,7 @@ public final class OciImageManifest implements JsonSerializable<OciImageManifest
      * @param schemaVersion the schemaVersion value to set.
      * @return the OciImageManifest object itself.
      */
-    public OciImageManifest setSchemaVersion(Integer schemaVersion) {
+    public OciImageManifest setSchemaVersion(int schemaVersion) {
         this.schemaVersion = schemaVersion;
         return this;
     }
@@ -121,10 +121,10 @@ public final class OciImageManifest implements JsonSerializable<OciImageManifest
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
+        jsonWriter.writeIntField("schemaVersion", this.schemaVersion);
         jsonWriter.writeJsonField("config", this.config);
         jsonWriter.writeArrayField("layers", this.layers, (writer, element) -> writer.writeJson(element));
         jsonWriter.writeJsonField("annotations", this.annotations);
-        jsonWriter.writeNumberField("schemaVersion", this.schemaVersion);
         return jsonWriter.writeEndObject();
     }
 
@@ -134,6 +134,7 @@ public final class OciImageManifest implements JsonSerializable<OciImageManifest
      * @param jsonReader The JsonReader being read.
      * @return An instance of OciImageManifest if the JsonReader was pointing to an instance of it, or null if it was
      *     pointing to JSON null.
+     * @throws IllegalStateException If the deserialized JSON object was missing any required properties.
      * @throws IOException If an error occurs while reading the OciImageManifest.
      */
     public static OciImageManifest fromJson(JsonReader jsonReader) throws IOException {
@@ -144,15 +145,15 @@ public final class OciImageManifest implements JsonSerializable<OciImageManifest
                         String fieldName = reader.getFieldName();
                         reader.nextToken();
 
-                        if ("config".equals(fieldName)) {
+                        if ("schemaVersion".equals(fieldName)) {
+                            deserializedOciImageManifest.schemaVersion = reader.getInt();
+                        } else if ("config".equals(fieldName)) {
                             deserializedOciImageManifest.config = OciDescriptor.fromJson(reader);
                         } else if ("layers".equals(fieldName)) {
                             List<OciDescriptor> layers = reader.readArray(reader1 -> OciDescriptor.fromJson(reader1));
                             deserializedOciImageManifest.layers = layers;
                         } else if ("annotations".equals(fieldName)) {
                             deserializedOciImageManifest.annotations = OciAnnotations.fromJson(reader);
-                        } else if ("schemaVersion".equals(fieldName)) {
-                            deserializedOciImageManifest.schemaVersion = reader.getNullable(JsonReader::getInt);
                         } else {
                             reader.skipChildren();
                         }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
@@ -125,7 +125,7 @@ public class FluentGen extends Javagen {
                 if (!settings.isSkipFormatting()) {
                     // formatter
                     boolean isSampleOrTestJavaFile = path.contains("src/samples/java/") || path.contains("src/test/java/");
-                    content = new JavaFormatter(content, path).format(!isSampleOrTestJavaFile);
+                    content = new JavaFormatter(content, path).format();
                 }
 
                 writeFile(path, content, null);

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/checker/JavaFormatter.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/checker/JavaFormatter.java
@@ -9,9 +9,6 @@ import com.azure.core.util.CoreUtils;
 import org.slf4j.Logger;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.regex.Pattern;
 
 public class JavaFormatter {
@@ -50,7 +47,7 @@ public class JavaFormatter {
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public String format(boolean breakOverlongStringLiteral) {
+    public String format() {
         if (!ENABLED) {
             return content;
         }
@@ -64,10 +61,10 @@ public class JavaFormatter {
             Object formatterInstance = formatterClass.getConstructor().newInstance();
             Method formatSourceMethod = formatterClass.getMethod("formatSourceAndFixImports", String.class);
             String formattedCode = (String) formatSourceMethod.invoke(formatterInstance, content);
-            if (breakOverlongStringLiteral) {
-                final int lengthLimit = 120;
-                formattedCode = fixOverlongStringLiteral(formattedCode, lengthLimit);
-            }
+//            if (breakOverlongStringLiteral) {
+//                final int lengthLimit = 120;
+//                formattedCode = fixOverlongStringLiteral(formattedCode, lengthLimit);
+//            }
             return formattedCode;
         } catch (Exception e) {
             LOGGER.warn("Failed to parse Java file '{}', message: '{}'",
@@ -77,71 +74,71 @@ public class JavaFormatter {
         }
     }
 
-    static String fixOverlongStringLiteral(String content, int lengthLimit) {
-        final String quote = "\"";
-
-        List<String> formattedLines = new ArrayList<>();
-        String[] lines = NEW_LINE.split(content, -1);
-        for (String line : lines) {
-            if (line.length() > lengthLimit) {
-                int firstQuote = line.indexOf(quote);
-                int lastQuote = line.lastIndexOf(quote);
-                if (firstQuote < lastQuote) {
-                    int lineIndent = 0;
-                    for (int j = 0; j < line.length(); ++j) {
-                        if (line.charAt(j) != ' ') {
-                            lineIndent = j;
-                            break;
-                        }
-                    }
-                    lineIndent += 4;
-                    String lineIndentStr = String.join("", Collections.nCopies(lineIndent, " "));
-
-                    String stringLiteral = line.substring(firstQuote + 1, lastQuote);
-                    char breakChar = 0;
-                    if (stringLiteral.contains("/")) {
-                        breakChar = '/';
-                    } else if (stringLiteral.contains(".")) {
-                        breakChar = '.';
-                    } else if (stringLiteral.contains(",")) {
-                        breakChar = ',';
-                    } else if (stringLiteral.contains(" ")) {
-                        breakChar = ' ';
-                    }
-
-                    for (int i = Math.min(lastQuote, lengthLimit) - 2; i >= 0; --i) {
-                        char c = line.charAt(i + 1);
-                        if (breakChar == 0 || breakChar == c) {
-                            String firstLine = line.substring(0, i + 1) + quote;
-                            formattedLines.add(firstLine);
-
-                            String brokenLine = lineIndentStr + "+ " + quote + line.substring(i + 1);
-                            while (brokenLine.length() > lengthLimit) {
-                                lastQuote = brokenLine.lastIndexOf(quote);
-
-                                for (int j = Math.min(lastQuote, lengthLimit) - 2; j >= 0; --j) {
-                                    c = brokenLine.charAt(j + 1);
-                                    if (breakChar == 0 || breakChar == c) {
-                                        String nextBrokenLine = lineIndentStr + "+ " + quote + brokenLine.substring(j + 1);
-                                        brokenLine = brokenLine.substring(0, j + 1) + quote;
-
-                                        formattedLines.add(brokenLine);
-                                        brokenLine = nextBrokenLine;
-                                        break;
-                                    }
-                                }
-                            }
-                            formattedLines.add(brokenLine);
-                            break;
-                        }
-                    }
-                } else {
-                    formattedLines.add(line);
-                }
-            } else {
-                formattedLines.add(line);
-            }
-        }
-        return String.join(System.lineSeparator(), formattedLines);
-    }
+//    static String fixOverlongStringLiteral(String content, int lengthLimit) {
+//        final String quote = "\"";
+//
+//        List<String> formattedLines = new ArrayList<>();
+//        String[] lines = NEW_LINE.split(content, -1);
+//        for (String line : lines) {
+//            if (line.length() > lengthLimit) {
+//                int firstQuote = line.indexOf(quote);
+//                int lastQuote = line.lastIndexOf(quote);
+//                if (firstQuote < lastQuote) {
+//                    int lineIndent = 0;
+//                    for (int j = 0; j < line.length(); ++j) {
+//                        if (line.charAt(j) != ' ') {
+//                            lineIndent = j;
+//                            break;
+//                        }
+//                    }
+//                    lineIndent += 4;
+//                    String lineIndentStr = String.join("", Collections.nCopies(lineIndent, " "));
+//
+//                    String stringLiteral = line.substring(firstQuote + 1, lastQuote);
+//                    char breakChar = 0;
+//                    if (stringLiteral.contains("/")) {
+//                        breakChar = '/';
+//                    } else if (stringLiteral.contains(".")) {
+//                        breakChar = '.';
+//                    } else if (stringLiteral.contains(",")) {
+//                        breakChar = ',';
+//                    } else if (stringLiteral.contains(" ")) {
+//                        breakChar = ' ';
+//                    }
+//
+//                    for (int i = Math.min(lastQuote, lengthLimit) - 2; i >= 0; --i) {
+//                        char c = line.charAt(i + 1);
+//                        if (breakChar == 0 || breakChar == c) {
+//                            String firstLine = line.substring(0, i + 1) + quote;
+//                            formattedLines.add(firstLine);
+//
+//                            String brokenLine = lineIndentStr + "+ " + quote + line.substring(i + 1);
+//                            while (brokenLine.length() > lengthLimit) {
+//                                lastQuote = brokenLine.lastIndexOf(quote);
+//
+//                                for (int j = Math.min(lastQuote, lengthLimit) - 2; j >= 0; --j) {
+//                                    c = brokenLine.charAt(j + 1);
+//                                    if (breakChar == 0 || breakChar == c) {
+//                                        String nextBrokenLine = lineIndentStr + "+ " + quote + brokenLine.substring(j + 1);
+//                                        brokenLine = brokenLine.substring(0, j + 1) + quote;
+//
+//                                        formattedLines.add(brokenLine);
+//                                        brokenLine = nextBrokenLine;
+//                                        break;
+//                                    }
+//                                }
+//                            }
+//                            formattedLines.add(brokenLine);
+//                            break;
+//                        }
+//                    }
+//                } else {
+//                    formattedLines.add(line);
+//                }
+//            } else {
+//                formattedLines.add(line);
+//            }
+//        }
+//        return String.join(System.lineSeparator(), formattedLines);
+//    }
 }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/SampleTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/SampleTemplate.java
@@ -80,7 +80,7 @@ public class SampleTemplate {
         content = String.join(System.lineSeparator(), formattedLines);
 
         if (!JavaSettings.getInstance().isSkipFormatting()) {
-            content = new JavaFormatter(content, path).format(false);
+            content = new JavaFormatter(content, path).format();
         }
         return content;
     }

--- a/fluentgen/src/test/java/com/azure/autorest/fluent/checker/JavaFormatterTests.java
+++ b/fluentgen/src/test/java/com/azure/autorest/fluent/checker/JavaFormatterTests.java
@@ -6,13 +6,7 @@ package com.azure.autorest.fluent.checker;
 import com.azure.autorest.fluent.FluentGen;
 import com.azure.autorest.fluent.FluentGenAccessor;
 import com.azure.autorest.fluent.TestUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
-
-import java.util.Arrays;
 
 public class JavaFormatterTests {
 
@@ -48,21 +42,21 @@ public class JavaFormatterTests {
         fluentgenAccessor = new FluentGenAccessor(fluentgen);
     }
 
-    @Test
-    @EnabledForJreRange(min = JRE.JAVA_11, max = JRE.JAVA_15)
-    public void testFormatter() {
-        JavaFormatter formatter = new JavaFormatter(JAVA_CONTENT, "mock");
-        String content = formatter.format(true);
-        String[] lines = content.split("\r?\n", -1);
-        Assertions.assertTrue(Arrays.stream(lines).noneMatch(s -> s.equals("import com.azure.autorest.extension.base.plugin.PluginLogger;")));
-    }
-
-    @Test
-    @EnabledForJreRange(min = JRE.JAVA_11, max = JRE.JAVA_15)
-    public void testLengthLimit() {
-        final int lengthLimit = 120;
-        String content = JavaFormatter.fixOverlongStringLiteral(JAVA_CONTENT, lengthLimit);
-        String[] lines = content.split("\r?\n", -1);
-        Assertions.assertTrue(Arrays.stream(lines).allMatch(s -> s.length() <= lengthLimit));
-    }
+//    @Test
+//    @EnabledForJreRange(min = JRE.JAVA_11, max = JRE.JAVA_15)
+//    public void testFormatter() {
+//        JavaFormatter formatter = new JavaFormatter(JAVA_CONTENT, "mock");
+//        String content = formatter.format(true);
+//        String[] lines = content.split("\r?\n", -1);
+//        Assertions.assertTrue(Arrays.stream(lines).noneMatch(s -> s.equals("import com.azure.autorest.extension.base.plugin.PluginLogger;")));
+//    }
+//
+//    @Test
+//    @EnabledForJreRange(min = JRE.JAVA_11, max = JRE.JAVA_15)
+//    public void testLengthLimit() {
+//        final int lengthLimit = 120;
+//        String content = JavaFormatter.fixOverlongStringLiteral(JAVA_CONTENT, lengthLimit);
+//        String[] lines = content.split("\r?\n", -1);
+//        Assertions.assertTrue(Arrays.stream(lines).allMatch(s -> s.length() <= lengthLimit));
+//    }
 }

--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
@@ -565,7 +565,7 @@ public class ProxyMethodMapper implements IMapper<Operation, Map<Request, List<P
     }
 
     private ClassType getExceptionType(Response exception, JavaSettings settings) {
-        ClassType exceptionType = ClassType.HttpResponseException;  // default as HttpResponseException
+        ClassType exceptionType = getHttpResponseExceptionType();  // default as HttpResponseException
 
         if (exception != null && exception.getSchema() != null) {
             ClassType errorType = (ClassType) Mappers.getSchemaMapper().map(exception.getSchema());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/java",
-  "version": "4.1.15",
+  "version": "4.1.16",
   "description": "The Java extension for classic generators in AutoRest.",
   "scripts": {
     "autorest": "autorest",


### PR DESCRIPTION
https://github.com/Azure/autorest.java/pull/2033/commits/871a245fd438c7bfaa5f2a1b786b2f3f13ef5064

The case when swagger write 404 without schema.

data-plane and mgmt-plane would fallback to different Exception class.

---

Also disable `fixOverlongStringLiteral` (was for overlong string like URL)