### PR TITLE
tsp, support possible null value in Dictionary

### DIFF
--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/DictionarySchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/DictionarySchema.java
@@ -4,6 +4,7 @@
 package com.azure.autorest.extension.base.model.codemodel;
 
 
+import java.util.Objects;
 
 /**
  * a schema that represents a key-value collection
@@ -17,6 +18,8 @@ public class DictionarySchema extends ComplexSchema {
      * 
      */
     private Schema elementType;
+
+    private Boolean nullableItems;
 
     /**
      * 
@@ -36,6 +39,14 @@ public class DictionarySchema extends ComplexSchema {
         this.elementType = elementType;
     }
 
+    public Boolean getNullableItems() {
+        return nullableItems;
+    }
+
+    public void setNullableItems(Boolean nullableItems) {
+        this.nullableItems = nullableItems;
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
@@ -53,22 +64,15 @@ public class DictionarySchema extends ComplexSchema {
     }
 
     @Override
-    public int hashCode() {
-        int result = 1;
-        result = ((result* 31)+((this.elementType == null)? 0 :this.elementType.hashCode()));
-        return result;
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DictionarySchema that = (DictionarySchema) o;
+        return Objects.equals(elementType, that.elementType) && Objects.equals(nullableItems, that.nullableItems);
     }
 
     @Override
-    public boolean equals(Object other) {
-        if (other == this) {
-            return true;
-        }
-        if ((other instanceof DictionarySchema) == false) {
-            return false;
-        }
-        DictionarySchema rhs = ((DictionarySchema) other);
-        return ((this.elementType == rhs.elementType)||((this.elementType!= null)&&this.elementType.equals(rhs.elementType)));
+    public int hashCode() {
+        return Objects.hash(elementType, nullableItems);
     }
-
 }

--- a/javagen/src/main/java/com/azure/autorest/mapper/DictionaryMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/DictionaryMapper.java
@@ -32,7 +32,8 @@ public class DictionaryMapper implements IMapper<DictionarySchema, IType> {
             return dictType;
         }
 
-        dictType = new MapType(Mappers.getSchemaMapper().map(dictionaryType.getElementType()));
+        dictType = new MapType(Mappers.getSchemaMapper().map(dictionaryType.getElementType()),
+                dictionaryType.getNullableItems() != null && dictionaryType.getNullableItems());
         parsed.put(dictionaryType, dictType);
 
         return dictType;

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/MapType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/MapType.java
@@ -9,12 +9,20 @@ import java.util.Set;
  * A map type used by a client.
  */
 public class MapType extends GenericType {
+
+    private boolean valueNullable = false;
+
     /**
      * Create a new MapType from the provided properties.
      * @param valueType The type of values that are stored in this dictionary.
      */
     public MapType(IType valueType) {
+        this(valueType, false);
+    }
+
+    public MapType(IType valueType, boolean valueNullable) {
         super("java.util", "Map", ClassType.String, valueType);
+        this.valueNullable = valueNullable;
     }
 
     /**
@@ -22,6 +30,10 @@ public class MapType extends GenericType {
      */
     public final IType getValueType() {
         return getTypeArguments()[1];
+    }
+
+    public boolean isValueNullable() {
+        return valueNullable;
     }
 
     @Override

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -581,6 +581,13 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
             classBlock.annotation("JsonTypeId");
         }
 
+        if (settings.isDataPlaneClient()
+                && !property.isAdditionalProperties()
+                && property.getClientType() instanceof MapType
+                && ((MapType) (property.getClientType())).isValueNullable()) {
+            classBlock.annotation("JsonInclude(value = JsonInclude.Include.NON_NULL, content = JsonInclude.Include.ALWAYS)");
+        }
+
         boolean treatAsXml = treatAsXml(settings, model);
         if (!CoreUtils.isNullOrEmpty(property.getHeaderCollectionPrefix())) {
             classBlock.annotation("HeaderCollection(\"" + property.getHeaderCollectionPrefix() + "\")");

--- a/typespec-extension/src/code-model-builder.ts
+++ b/typespec-extension/src/code-model-builder.ts
@@ -1247,6 +1247,11 @@ export class CodeModelBuilder {
     const elementSchema = this.processSchema(type.indexer.value, name);
     dictSchema.elementType = elementSchema;
 
+    if (type.indexer.value.kind === "Union") {
+      dictSchema.nullableItems =
+        Array.from(type.indexer.value.variants.values()).findIndex((it) => isNullType(it.type)) >= 0;
+    }
+
     return this.codeModel.schemas.add(dictSchema);
   }
 

--- a/typespec-tests/src/main/java/com/cadl/builtin/BuiltinAsyncClient.java
+++ b/typespec-tests/src/main/java/com/cadl/builtin/BuiltinAsyncClient.java
@@ -94,6 +94,9 @@ public final class BuiltinAsyncClient {
      *         String: byte[] (Required)
      *     }
      *     url: String (Required)
+     *     nullableFloatDict (Required): {
+     *         String: double (Required)
+     *     }
      * }
      * }</pre>
      *
@@ -148,6 +151,9 @@ public final class BuiltinAsyncClient {
      *         String: byte[] (Required)
      *     }
      *     url: String (Required)
+     *     nullableFloatDict (Required): {
+     *         String: double (Required)
+     *     }
      * }
      * }</pre>
      *

--- a/typespec-tests/src/main/java/com/cadl/builtin/BuiltinClient.java
+++ b/typespec-tests/src/main/java/com/cadl/builtin/BuiltinClient.java
@@ -91,6 +91,9 @@ public final class BuiltinClient {
      *         String: byte[] (Required)
      *     }
      *     url: String (Required)
+     *     nullableFloatDict (Required): {
+     *         String: double (Required)
+     *     }
      * }
      * }</pre>
      *
@@ -145,6 +148,9 @@ public final class BuiltinClient {
      *         String: byte[] (Required)
      *     }
      *     url: String (Required)
+     *     nullableFloatDict (Required): {
+     *         String: double (Required)
+     *     }
      * }
      * }</pre>
      *

--- a/typespec-tests/src/main/java/com/cadl/builtin/implementation/BuiltinClientImpl.java
+++ b/typespec-tests/src/main/java/com/cadl/builtin/implementation/BuiltinClientImpl.java
@@ -217,6 +217,9 @@ public final class BuiltinClientImpl {
      *         String: byte[] (Required)
      *     }
      *     url: String (Required)
+     *     nullableFloatDict (Required): {
+     *         String: double (Required)
+     *     }
      * }
      * }</pre>
      *
@@ -296,6 +299,9 @@ public final class BuiltinClientImpl {
      *         String: byte[] (Required)
      *     }
      *     url: String (Required)
+     *     nullableFloatDict (Required): {
+     *         String: double (Required)
+     *     }
      * }
      * }</pre>
      *
@@ -349,6 +355,9 @@ public final class BuiltinClientImpl {
      *         String: byte[] (Required)
      *     }
      *     url: String (Required)
+     *     nullableFloatDict (Required): {
+     *         String: double (Required)
+     *     }
      * }
      * }</pre>
      *
@@ -402,6 +411,9 @@ public final class BuiltinClientImpl {
      *         String: byte[] (Required)
      *     }
      *     url: String (Required)
+     *     nullableFloatDict (Required): {
+     *         String: double (Required)
+     *     }
      * }
      * }</pre>
      *

--- a/typespec-tests/src/main/java/com/cadl/builtin/models/Builtin.java
+++ b/typespec-tests/src/main/java/com/cadl/builtin/models/Builtin.java
@@ -7,6 +7,7 @@ package com.cadl.builtin.models;
 import com.azure.core.annotation.Immutable;
 import com.azure.core.util.CoreUtils;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Duration;
 import java.time.LocalDate;
@@ -107,6 +108,13 @@ public final class Builtin {
     @JsonProperty(value = "url", required = true)
     private String url;
 
+    /*
+     * The nullableFloatDict property.
+     */
+    @JsonInclude(value = JsonInclude.Include.NON_NULL, content = JsonInclude.Include.ALWAYS)
+    @JsonProperty(value = "nullableFloatDict", required = true)
+    private Map<String, Double> nullableFloatDict;
+
     /**
      * Creates an instance of Builtin class.
      *
@@ -125,6 +133,7 @@ public final class Builtin {
      * @param stringList the stringList value to set.
      * @param bytesDict the bytesDict value to set.
      * @param url the url value to set.
+     * @param nullableFloatDict the nullableFloatDict value to set.
      */
     @JsonCreator
     public Builtin(
@@ -142,7 +151,8 @@ public final class Builtin {
             @JsonProperty(value = "dateTime", required = true) OffsetDateTime dateTime,
             @JsonProperty(value = "stringList", required = true) List<String> stringList,
             @JsonProperty(value = "bytesDict", required = true) Map<String, byte[]> bytesDict,
-            @JsonProperty(value = "url", required = true) String url) {
+            @JsonProperty(value = "url", required = true) String url,
+            @JsonProperty(value = "nullableFloatDict", required = true) Map<String, Double> nullableFloatDict) {
         this.formatString = formatString;
         this.booleanProperty = booleanProperty;
         this.string = string;
@@ -158,6 +168,7 @@ public final class Builtin {
         this.stringList = stringList;
         this.bytesDict = bytesDict;
         this.url = url;
+        this.nullableFloatDict = nullableFloatDict;
     }
 
     /**
@@ -293,5 +304,14 @@ public final class Builtin {
      */
     public String getUrl() {
         return this.url;
+    }
+
+    /**
+     * Get the nullableFloatDict property: The nullableFloatDict property.
+     *
+     * @return the nullableFloatDict value.
+     */
+    public Map<String, Double> getNullableFloatDict() {
+        return this.nullableFloatDict;
     }
 }

--- a/typespec-tests/src/test/java/com/dictionary/NullableFloatValueClientTests.java
+++ b/typespec-tests/src/test/java/com/dictionary/NullableFloatValueClientTests.java
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.dictionary;
+
+import com.azure.core.util.BinaryData;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class NullableFloatValueClientTests {
+
+    private final static ObjectMapper MAPPER = new ObjectMapper();
+
+    private final NullableFloatValueClient client = new DictionaryClientBuilder().buildNullableFloatValueClient();
+
+    @Disabled("cadl-ranch bug")
+    @Test
+    public void get() {
+
+        Map<String, Double> result = client.get();
+
+        Assertions.assertTrue(result.containsKey("k3"));
+        Assertions.assertNull(result.get("k3"));
+    }
+
+    @Disabled("cadl-ranch bug")
+    @Test
+    public void put() throws Exception {
+        MapModel model = new MapModel();
+        model.map = new HashMap<>();
+        model.map.put("k1", 1.1);
+        model.map.put("k2", 2.1);
+        model.map.put("k3", null);
+
+        // Map as request does not work
+        // Model contains Map works, if "@JsonInclude(value = JsonInclude.Include.NON_NULL)" on that Map
+        // see tsp/builtin.tsp and its generated code
+        BinaryData requestAsModel = BinaryData.fromObject(model);
+        JsonNode node = MAPPER.readTree(requestAsModel.toString()).get("map");
+        BinaryData request = BinaryData.fromObject(node);
+
+        client.putWithResponse(request, null);
+    }
+
+    public static class MapModel {
+        @JsonInclude(value = JsonInclude.Include.NON_NULL, content = JsonInclude.Include.ALWAYS)
+        Map<String, Double> map;
+    }
+}

--- a/typespec-tests/tsp/builtin.tsp
+++ b/typespec-tests/tsp/builtin.tsp
@@ -26,6 +26,7 @@ model Builtin {
   stringList: string[];
   bytesDict: Record<bytes>;
   url: url;
+  nullableFloatDict: Record<float64 | null>;
 }
 
 model FormatString {


### PR DESCRIPTION
tsp: `Record<float64 | null>`
m4: `nullableItems=true` in DictionarySchema https://github.com/Azure/autorest/blob/main/packages/libs/codemodel/src/model/common/schemas/dictionary.ts#L14
code: `JsonInclude(value = %1$s, content = JsonInclude.Include.ALWAYS)` line on Map

Currently only enabled for DPG.

Mgmt always true.