### PR TITLE
mgmt, redact "authorization" property, also redact values in Map

### DIFF
--- a/Generate-TypeSpec.ps1
+++ b/Generate-TypeSpec.ps1
@@ -2,7 +2,7 @@
 #
 # The purpose of this script is to compact the steps required to regenerate TypeSpec into a single script.
 #
-# Before running this script the 'cadl' profile must be built, 'mvn install -P local,cadl'.
+# Before running this script the 'tsp' profile must be built, 'mvn install -P local,tsp'.
 #
 # This script can only be ran from the root of the repository.
 

--- a/fluentgen/src/test/java/com/azure/autorest/fluent/template/FluentExampleTests.java
+++ b/fluentgen/src/test/java/com/azure/autorest/fluent/template/FluentExampleTests.java
@@ -59,7 +59,7 @@ public class FluentExampleTests {
             FluentExampleTemplate.getInstance().write(example, javaFile);
             String content = javaFile.getContents().toString();
             // Map
-            Assertions.assertTrue(content.contains(".withTags(mapOf(\"key1\", \"value1\", \"key2\", \"value2\"))"));
+            Assertions.assertTrue(content.contains(".withTags(mapOf(\"key1\","));
             // identity
             Assertions.assertTrue(content.contains(".withIdentity(new Identity().withType(IdentityType.USER_ASSIGNED).withUserAssignedIdentities(mapOf(\"/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}\", new UserAssignedIdentity())))"));
             // create

--- a/javagen/src/main/java/com/azure/autorest/util/ModelExampleUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/ModelExampleUtil.java
@@ -83,7 +83,14 @@ public class ModelExampleUtil {
 
                 Map<String, Object> dict = (Map<String, Object>) objectValue;
                 for (Map.Entry<String, Object> entry : dict.entrySet()) {
-                    ExampleNode childNode = parseNode(elementType, entry.getValue());
+                    Object value = entry.getValue();
+
+                    // redact possible credential
+                    if (elementType == ClassType.String && entry.getValue() instanceof String) {
+                        value = ModelTestCaseUtil.redactStringValue(Collections.singletonList(entry.getKey()), (String) value);
+                    }
+
+                    ExampleNode childNode = parseNode(elementType, value);
                     node.getChildNodes().add(childNode);
                     mapNode.getKeys().add(entry.getKey());
                 }

--- a/javagen/src/main/java/com/azure/autorest/util/ModelTestCaseUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/ModelTestCaseUtil.java
@@ -261,7 +261,8 @@ public class ModelTestCaseUtil {
             "credential",
             "password",
             "token",
-            "secret"
+            "secret",
+            "authorization"
     );
 
     private static void checkCredential(List<String> serializedNames) {


### PR DESCRIPTION
Previously redact happen to Model properties (but not for values in Map)

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2669462&view=logs&j=bc67675d-56bf-581f-e0a2-208848ba68ca&t=7eee3a58-6120-518b-7fcb-7e943712aa81&l=102