### PR TITLE
client, add azure-core-experimental in Project

### DIFF
--- a/eng/versioning/external_dependencies.txt
+++ b/eng/versioning/external_dependencies.txt
@@ -1,4 +1,5 @@
 com.azure:azure-core
+com.azure:azure-core-experimental
 com.azure:azure-core-http-netty
 com.azure:azure-core-management
 com.azure:azure-core-test

--- a/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
+++ b/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
@@ -58,6 +58,7 @@ public class Project {
         private String azureCoreManagementVersion = "1.11.0";
         private String azureCoreHttpNettyVersion = "1.13.2";
         private String azureCoreTestVersion = "1.16.0";
+        private String azureCoreExperimentalVersion = "1.0.0-beta.38";
         private String azureIdentityVersion = "1.8.2";
         private String junitVersion = "5.9.1";
         private String mockitoVersion = "4.5.1";
@@ -89,6 +90,10 @@ public class Project {
 
         public String getAzureCoreTestVersion() {
             return azureCoreTestVersion;
+        }
+
+        public String getAzureCoreExperimentalVersion() {
+            return azureCoreExperimentalVersion;
         }
 
         public String getAzureIdentityVersion() {
@@ -262,6 +267,7 @@ public class Project {
                 checkArtifact(line, "com.azure:azure-core-management").ifPresent(v -> packageVersions.azureCoreManagementVersion = v);
                 checkArtifact(line, "com.azure:azure-core-http-netty").ifPresent(v -> packageVersions.azureCoreHttpNettyVersion = v);
                 checkArtifact(line, "com.azure:azure-core-test").ifPresent(v -> packageVersions.azureCoreTestVersion = v);
+                checkArtifact(line, "com.azure:azure-core-experimental").ifPresent(v -> packageVersions.azureCoreExperimentalVersion = v);
                 checkArtifact(line, "com.azure:azure-identity").ifPresent(v -> packageVersions.azureIdentityVersion = v);
                 checkArtifact(line, "org.slf4j:slf4j-simple").ifPresent(v -> packageVersions.slf4jSimpleVersion = v);
             });

--- a/protocol-sdk-integration-tests/eng/versioning/version_client.txt
+++ b/protocol-sdk-integration-tests/eng/versioning/version_client.txt
@@ -1,4 +1,5 @@
 com.azure:azure-core;1.38.0;1.38.0
+com.azure:azure-core-experimental;1.0.0-beta.38;1.0.0-beta.39
 com.azure:azure-core-http-netty;1.13.2;1.13.2
 com.azure:azure-core-management;1.11.0;1.11.0
 com.azure:azure-core-test;1.16.0;1.16.0


### PR DESCRIPTION
We will use this lib for `OperationLocationPollingStrategy`
https://github.com/Azure/azure-sdk-for-java/pull/34525

The lib should not be included in POM, if this feature is not used in that SDK.

---

If possible, we should use the "external" feature, e.g. https://github.com/Azure/autorest.java/issues/1967

But we may still go with hardcoded reference to azure-core-experimental for this one.