### PR TITLE
Fix Stream Style Serialization Generation for Unix Times

### DIFF
--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -1068,7 +1068,7 @@ public class JavaSettings {
         "Licensed under the Apache License, Version 2.0 (the \"License\");",
         "you may not use this file except in compliance with the License.",
         "You may obtain a copy of the License at",
-        "  http://www.apache.org/licenses/LICENSE-2.0\r\n",
+        "  https://www.apache.org/licenses/LICENSE-2.0\r\n",
         "Unless required by applicable law or agreed to in writing, software",
         "distributed under the License is distributed on an \"AS IS\" BASIS,",
         "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\r\n",

--- a/javagen/src/main/java/com/azure/autorest/template/StreamSerializationModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/StreamSerializationModelTemplate.java
@@ -316,7 +316,7 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
                 serializedName, propertyValueGetter, 0);
         } else {
             // TODO (alzimmer): Resolve this as deserialization logic generation needs to handle all cases.
-            throw new RuntimeException("Unknown wire type " + wireType + " in serialization. Need to add support for it.");
+            throw new RuntimeException("Unknown wire type " + wireType.getClass() + " in serialization. Need to add support for it.");
         }
     }
 


### PR DESCRIPTION
Fixes stream-style serialization generation for Unix times. They were missing configuration on how they should be handled and resulted in an exception being thrown about them not being supported when attempting to generate Key Vault Administration with stream-style serialization.