### PR TITLE
tsp, warning on unknown query format

### DIFF
--- a/typespec-extension/src/code-model-builder.ts
+++ b/typespec-extension/src/code-model-builder.ts
@@ -298,9 +298,10 @@ export class CodeModelBuilder {
               securitySchemes.push(keyScheme);
             }
             break;
+
           case "http":
             {
-              this.logWarning(scheme.scheme + " auth method is currently not supported.");
+              this.logWarning(`{scheme.scheme} auth method is currently not supported.`);
             }
             break;
         }
@@ -676,12 +677,26 @@ export class CodeModelBuilder {
               style = SerializationStyle.Form;
               explode = true;
               break;
+
+            // TODO there is bug in @typespec/http that ssv etc. is not in queryParamOptions.format
+
+            default:
+              if (queryParamOptions?.format) {
+                this.logWarning(`Unrecognized query parameter format: '${queryParamOptions?.format}'.`);
+              }
+              break;
           }
         } else if (param.type === "header") {
           const headerFieldOptions = getHeaderFieldOptions(this.program, param.param);
           switch (headerFieldOptions?.format) {
             case "csv":
               style = SerializationStyle.Simple;
+              break;
+
+            default:
+              if (headerFieldOptions?.format) {
+                this.logWarning(`Unrecognized header parameter format: '${headerFieldOptions?.format}'.`);
+              }
               break;
           }
         }


### PR DESCRIPTION
just to output warning

```
warning typespec-java: Unrecognized query parameter type: 'ssv'.
warning typespec-java: Unrecognized query parameter type: 'tsv'.
warning typespec-java: Unrecognized query parameter type: 'pipes'.
```

tsp http lib got bug, that union does not have these.

will wait for their next release, rather than coding `as any` (no one really need these right now, except cadl-ranch).