### PR TITLE
client, adapt reflection code, upon sync version with new azure-core

### DIFF
--- a/androidgen/pom.xml
+++ b/androidgen/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.38.0</version>
+      <version>1.39.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/azure-dataplane-tests/pom.xml
+++ b/azure-dataplane-tests/pom.xml
@@ -52,12 +52,12 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-core</artifactId>
-            <version>1.38.0</version>
+            <version>1.39.0</version>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-json</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-core-http-netty</artifactId>
-            <version>1.13.2</version>
+            <version>1.13.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/azure-tests/pom.xml
+++ b/azure-tests/pom.xml
@@ -22,18 +22,18 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.38.0</version>
+      <version>1.39.0</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-management</artifactId>
-      <version>1.11.0</version>
+      <version>1.11.1</version>
     </dependency>
 
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-http-netty</artifactId>
-      <version>1.13.2</version>
+      <version>1.13.3</version>
       <scope>test</scope>
     </dependency>
 

--- a/customization-base/pom.xml
+++ b/customization-base/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-json</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.1</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>

--- a/customization-base/src/main/resources/pom.xml
+++ b/customization-base/src/main/resources/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-json</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.1</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
@@ -40,19 +40,19 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.38.0</version>
+      <version>1.39.0</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-http-netty</artifactId>
-      <version>1.13.2</version>
+      <version>1.13.3</version>
     </dependency>
 
     <!-- Test Dependencies -->
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-test</artifactId>
-      <version>1.16.2</version>
+      <version>1.17.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/customization-tests/pom.xml
+++ b/customization-tests/pom.xml
@@ -34,19 +34,19 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.38.0</version>
+      <version>1.39.0</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-http-netty</artifactId>
-      <version>1.13.2</version>
+      <version>1.13.3</version>
     </dependency>
 
     <!-- Test Dependencies -->
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-test</artifactId>
-      <version>1.16.2</version>
+      <version>1.17.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/fluent-tests/pom.xml
+++ b/fluent-tests/pom.xml
@@ -100,24 +100,24 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.38.0</version>
+      <version>1.39.0</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-management</artifactId>
-      <version>1.11.0</version>
+      <version>1.11.1</version>
     </dependency>
 
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-http-netty</artifactId>
-      <version>1.13.2</version>
+      <version>1.13.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-identity</artifactId>
-      <version>1.8.2</version>
+      <version>1.8.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/fluentgen/src/test/java/com/azure/autorest/fluent/util/RetryOptionsTests.java
+++ b/fluentgen/src/test/java/com/azure/autorest/fluent/util/RetryOptionsTests.java
@@ -3,6 +3,7 @@
 
 package com.azure.autorest.fluent.util;
 
+import com.azure.core.http.HttpHeaderName;
 import com.azure.core.http.policy.ExponentialBackoff;
 import com.azure.core.http.policy.ExponentialBackoffOptions;
 import com.azure.core.http.policy.FixedDelay;
@@ -95,12 +96,12 @@ public class RetryOptionsTests {
         retryAfterHeaderField.setAccessible(true);
         retryAfterTimeUnitField.setAccessible(true);
         retryStrategyField.setAccessible(true);
-        String retryAfterHeader = (String) retryAfterHeaderField.get(retryPolicy);
+        HttpHeaderName retryAfterHeader = (HttpHeaderName) retryAfterHeaderField.get(retryPolicy);
         ChronoUnit retryAfterTimeUnit = (ChronoUnit) retryAfterTimeUnitField.get(retryPolicy);
         if (retryAfterHeaderAsNull) {
             Assertions.assertNull(retryAfterHeader);
         } else {
-            Assertions.assertEquals("Retry-After", retryAfterHeader);
+            Assertions.assertEquals("retry-after", retryAfterHeader.getCaseInsensitiveName());
             Assertions.assertEquals(ChronoUnit.SECONDS, retryAfterTimeUnit);
         }
 

--- a/fluentnamer/pom.xml
+++ b/fluentnamer/pom.xml
@@ -39,13 +39,13 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.38.0</version>
+      <version>1.39.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-management</artifactId>
-      <version>1.11.0</version>
+      <version>1.11.1</version>
     </dependency>
   </dependencies>
 

--- a/javagen/pom.xml
+++ b/javagen/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-json</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.1</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.38.0</version>
+      <version>1.39.0</version>
     </dependency>
     <dependency>
       <groupId>org.atteo</groupId>

--- a/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
+++ b/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
@@ -52,13 +52,13 @@ public class Project {
     public enum Dependency {
         // azure
         AZURE_CLIENT_SDK_PARENT("com.azure", "azure-client-sdk-parent", "1.7.0"),
-        AZURE_JSON("com.azure", "azure-json", "1.0.0"),
+        AZURE_JSON("com.azure", "azure-json", "1.0.1"),
         AZURE_XML("com.azure", "azure-xml", "1.0.0-beta.1"),
-        AZURE_CORE("com.azure", "azure-core", "1.38.0"),
-        AZURE_CORE_MANAGEMENT("com.azure", "azure-core-management", "1.11.0"),
-        AZURE_CORE_HTTP_NETTY("com.azure", "azure-core-http-netty", "1.13.2"),
-        AZURE_CORE_TEST("com.azure", "azure-core-test", "1.16.2"),
-        AZURE_IDENTITY("com.azure", "azure-identity", "1.8.2"),
+        AZURE_CORE("com.azure", "azure-core", "1.39.0"),
+        AZURE_CORE_MANAGEMENT("com.azure", "azure-core-management", "1.11.1"),
+        AZURE_CORE_HTTP_NETTY("com.azure", "azure-core-http-netty", "1.13.3"),
+        AZURE_CORE_TEST("com.azure", "azure-core-test", "1.17.0"),
+        AZURE_IDENTITY("com.azure", "azure-identity", "1.8.3"),
 
         // external
         JUNIT_JUPITER_API("org.junit.jupiter", "junit-jupiter-api", "5.9.1"),

--- a/partial-update-tests/pom.xml
+++ b/partial-update-tests/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.38.0</version>
+      <version>1.39.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/protocol-resilience-test/pom.xml
+++ b/protocol-resilience-test/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.38.0</version>
+      <version>1.39.0</version>
     </dependency>
   </dependencies>
 

--- a/protocol-sdk-integration-tests/eng/versioning/version_client.txt
+++ b/protocol-sdk-integration-tests/eng/versioning/version_client.txt
@@ -1,8 +1,8 @@
-com.azure:azure-core;1.38.0;1.38.0
-com.azure:azure-core-experimental;1.0.0-beta.38;1.0.0-beta.38
-com.azure:azure-core-http-netty;1.13.2;1.13.2
-com.azure:azure-core-management;1.11.0;1.11.0
-com.azure:azure-core-test;1.16.2;1.16.2
+com.azure:azure-core;1.39.0;1.39.0
+com.azure:azure-core-experimental;1.0.0-beta.39;1.0.0-beta.39
+com.azure:azure-core-http-netty;1.13.3;1.13.3
+com.azure:azure-core-management;1.11.1;1.11.1
+com.azure:azure-core-test;1.17.0;1.17.0
 
-com.azure:azure-identity;1.8.2;1.8.2
-com.azure:azure-json;1.0.0;1.0.0
+com.azure:azure-identity;1.8.3;1.8.3
+com.azure:azure-json;1.0.1;1.0.1

--- a/protocol-tests/pom.xml
+++ b/protocol-tests/pom.xml
@@ -39,12 +39,12 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.38.0</version>
+      <version>1.39.0</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-http-netty</artifactId>
-      <version>1.13.2</version>
+      <version>1.13.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/typespec-extension/pom.xml
+++ b/typespec-extension/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.38.0</version>
+      <version>1.39.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.googlejavaformat</groupId>

--- a/typespec-extension/src/utils.ts
+++ b/typespec-extension/src/utils.ts
@@ -29,7 +29,7 @@ import { CodeModel } from "./common/code-model.js";
 import { EmitterOptions } from "./emitter.js";
 import { getVersion } from "@typespec/versioning";
 
-export const specialHeaderNames = new Set(["repeatability-request-id", "repeatability-first-sent"]);
+export const specialHeaderNames = new Set(["repeatability-request-id", "repeatability-first-sent", "x-ms-client-request-id"]);
 
 export const originApiVersion = "modelerfour:synthesized/api-version";
 

--- a/typespec-extension/src/utils.ts
+++ b/typespec-extension/src/utils.ts
@@ -29,7 +29,11 @@ import { CodeModel } from "./common/code-model.js";
 import { EmitterOptions } from "./emitter.js";
 import { getVersion } from "@typespec/versioning";
 
-export const specialHeaderNames = new Set(["repeatability-request-id", "repeatability-first-sent", "x-ms-client-request-id"]);
+export const specialHeaderNames = new Set([
+  "repeatability-request-id",
+  "repeatability-first-sent",
+  "x-ms-client-request-id",
+]);
 
 export const originApiVersion = "modelerfour:synthesized/api-version";
 

--- a/typespec-tests/pom.xml
+++ b/typespec-tests/pom.xml
@@ -35,17 +35,17 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.38.0</version>
+      <version>1.39.0</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-identity</artifactId>
-      <version>1.8.2</version>
+      <version>1.8.3</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-http-netty</artifactId>
-      <version>1.13.2</version>
+      <version>1.13.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-test</artifactId>
-      <version>1.16.2</version>
+      <version>1.17.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/traits/TraitsAsyncClient.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/traits/TraitsAsyncClient.java
@@ -49,7 +49,6 @@ public final class TraitsAsyncClient {
      *     <tr><td>If-None-Match</td><td>String</td><td>No</td><td>The request should only proceed if no entity matches this string.</td></tr>
      *     <tr><td>If-Unmodified-Since</td><td>OffsetDateTime</td><td>No</td><td>The request should only proceed if the entity was not modified after this time.</td></tr>
      *     <tr><td>If-Modified-Since</td><td>OffsetDateTime</td><td>No</td><td>The request should only proceed if the entity was modified after this time.</td></tr>
-     *     <tr><td>x-ms-client-request-id</td><td>String</td><td>No</td><td>An opaque, globally-unique, client-generated string identifier for the request.</td></tr>
      * </table>
      *
      * You can add these to a request with {@link RequestOptions#addHeader}
@@ -88,7 +87,6 @@ public final class TraitsAsyncClient {
      * @param ifNoneMatch The request should only proceed if no entity matches this string.
      * @param ifUnmodifiedSince The request should only proceed if the entity was not modified after this time.
      * @param ifModifiedSince The request should only proceed if the entity was modified after this time.
-     * @param clientRequestId An opaque, globally-unique, client-generated string identifier for the request.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -105,8 +103,7 @@ public final class TraitsAsyncClient {
             String ifMatch,
             String ifNoneMatch,
             OffsetDateTime ifUnmodifiedSince,
-            OffsetDateTime ifModifiedSince,
-            String clientRequestId) {
+            OffsetDateTime ifModifiedSince) {
         // Generated convenience method for smokeTestWithResponse
         RequestOptions requestOptions = new RequestOptions();
         if (ifMatch != null) {
@@ -120,9 +117,6 @@ public final class TraitsAsyncClient {
         }
         if (ifModifiedSince != null) {
             requestOptions.setHeader("If-Modified-Since", String.valueOf(new DateTimeRfc1123(ifModifiedSince)));
-        }
-        if (clientRequestId != null) {
-            requestOptions.setHeader("x-ms-client-request-id", clientRequestId);
         }
         return smokeTestWithResponse(id, foo, requestOptions)
                 .flatMap(FluxUtil::toMono)

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/traits/TraitsClient.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/traits/TraitsClient.java
@@ -47,7 +47,6 @@ public final class TraitsClient {
      *     <tr><td>If-None-Match</td><td>String</td><td>No</td><td>The request should only proceed if no entity matches this string.</td></tr>
      *     <tr><td>If-Unmodified-Since</td><td>OffsetDateTime</td><td>No</td><td>The request should only proceed if the entity was not modified after this time.</td></tr>
      *     <tr><td>If-Modified-Since</td><td>OffsetDateTime</td><td>No</td><td>The request should only proceed if the entity was modified after this time.</td></tr>
-     *     <tr><td>x-ms-client-request-id</td><td>String</td><td>No</td><td>An opaque, globally-unique, client-generated string identifier for the request.</td></tr>
      * </table>
      *
      * You can add these to a request with {@link RequestOptions#addHeader}
@@ -85,7 +84,6 @@ public final class TraitsClient {
      * @param ifNoneMatch The request should only proceed if no entity matches this string.
      * @param ifUnmodifiedSince The request should only proceed if the entity was not modified after this time.
      * @param ifModifiedSince The request should only proceed if the entity was modified after this time.
-     * @param clientRequestId An opaque, globally-unique, client-generated string identifier for the request.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -102,8 +100,7 @@ public final class TraitsClient {
             String ifMatch,
             String ifNoneMatch,
             OffsetDateTime ifUnmodifiedSince,
-            OffsetDateTime ifModifiedSince,
-            String clientRequestId) {
+            OffsetDateTime ifModifiedSince) {
         // Generated convenience method for smokeTestWithResponse
         RequestOptions requestOptions = new RequestOptions();
         if (ifMatch != null) {
@@ -117,9 +114,6 @@ public final class TraitsClient {
         }
         if (ifModifiedSince != null) {
             requestOptions.setHeader("If-Modified-Since", String.valueOf(new DateTimeRfc1123(ifModifiedSince)));
-        }
-        if (clientRequestId != null) {
-            requestOptions.setHeader("x-ms-client-request-id", clientRequestId);
         }
         return smokeTestWithResponse(id, foo, requestOptions).getValue().toObject(User.class);
     }

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/traits/implementation/TraitsClientImpl.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/traits/implementation/TraitsClientImpl.java
@@ -173,7 +173,6 @@ public final class TraitsClientImpl {
      *     <tr><td>If-None-Match</td><td>String</td><td>No</td><td>The request should only proceed if no entity matches this string.</td></tr>
      *     <tr><td>If-Unmodified-Since</td><td>OffsetDateTime</td><td>No</td><td>The request should only proceed if the entity was not modified after this time.</td></tr>
      *     <tr><td>If-Modified-Since</td><td>OffsetDateTime</td><td>No</td><td>The request should only proceed if the entity was modified after this time.</td></tr>
-     *     <tr><td>x-ms-client-request-id</td><td>String</td><td>No</td><td>An opaque, globally-unique, client-generated string identifier for the request.</td></tr>
      * </table>
      *
      * You can add these to a request with {@link RequestOptions#addHeader}
@@ -218,7 +217,6 @@ public final class TraitsClientImpl {
      *     <tr><td>If-None-Match</td><td>String</td><td>No</td><td>The request should only proceed if no entity matches this string.</td></tr>
      *     <tr><td>If-Unmodified-Since</td><td>OffsetDateTime</td><td>No</td><td>The request should only proceed if the entity was not modified after this time.</td></tr>
      *     <tr><td>If-Modified-Since</td><td>OffsetDateTime</td><td>No</td><td>The request should only proceed if the entity was modified after this time.</td></tr>
-     *     <tr><td>x-ms-client-request-id</td><td>String</td><td>No</td><td>An opaque, globally-unique, client-generated string identifier for the request.</td></tr>
      * </table>
      *
      * You can add these to a request with {@link RequestOptions#addHeader}

--- a/typespec-tests/src/test/java/com/_specs_/azure/core/traits/TraitsTests.java
+++ b/typespec-tests/src/test/java/com/_specs_/azure/core/traits/TraitsTests.java
@@ -20,7 +20,7 @@ public class TraitsTests {
         OffsetDateTime modifiedSince = OffsetDateTime.of(2021, 8, 26, 14, 38, 0, 0, ZoneOffset.UTC);
 
         client.smokeTest(1, "123",
-                "valid", "invalid",
+                "\"valid\"", "\"invalid\"",
                 unmodifiedSince, modifiedSince, UUID.randomUUID().toString());
     }
 }

--- a/typespec-tests/src/test/java/com/_specs_/azure/core/traits/TraitsTests.java
+++ b/typespec-tests/src/test/java/com/_specs_/azure/core/traits/TraitsTests.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.UUID;
 
 public class TraitsTests {
 
@@ -21,6 +20,6 @@ public class TraitsTests {
 
         client.smokeTest(1, "123",
                 "\"valid\"", "\"invalid\"",
-                unmodifiedSince, modifiedSince, UUID.randomUUID().toString());
+                unmodifiedSince, modifiedSince);
     }
 }

--- a/vanilla-tests/pom.xml
+++ b/vanilla-tests/pom.xml
@@ -40,12 +40,12 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.38.0</version>
+      <version>1.39.0</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-json</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.1</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-http-netty</artifactId>
-      <version>1.13.2</version>
+      <version>1.13.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
manual change after core upgrade https://github.com/Azure/autorest.java/pull/2124/commits/a629bc7a0491a7e311e5ac8025889a428e9d02cf

fix for cadl-ranch upgrade https://github.com/Azure/autorest.java/pull/2124/commits/1e9b08faea01db6ec5bd69d1e3b806b4913b7ea4

remove x-ms-client-request-id from method signature https://github.com/Azure/autorest.java/pull/2124/commits/773558b016b7d27a46c7d9e82ce55f70fd0efb10 (https://github.com/Azure/autorest.java/issues/2064)