### PR TITLE
tsp, use openapi, also use pascalCaseForOperationId

### DIFF
--- a/typespec-extension/package.json
+++ b/typespec-extension/package.json
@@ -47,6 +47,7 @@
   "peerDependencies": {
     "@typespec/compiler": ">=0.44.0 <1.0.0",
     "@typespec/rest": ">=0.44.0 <1.0.0",
+    "@typespec/openapi": ">=0.44.0 <1.0.0",
     "@typespec/versioning": ">=0.44.0 <1.0.0",
     "@azure-tools/typespec-azure-core": ">=0.30.0 <1.0.0",
     "@azure-tools/typespec-client-generator-core": ">=0.30.0 <1.0.0"


### PR DESCRIPTION
fix https://github.com/Azure/autorest.java/issues/2145

I think the cause is `pascalCaseForOperationId` vs `pascalCase`