### PR TITLE
tsp, support head boolean

### DIFF
--- a/typespec-extension/changelog.md
+++ b/typespec-extension/changelog.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 0.7.2 (2023-05-24)
+
+Compatible with compiler 0.44.
+
 ## 0.7.1 (2023-05-19)
 
 Compatible with compiler 0.44.

--- a/typespec-extension/package.json
+++ b/typespec-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "TypeSpec library for emitting Java client from the TypeSpec REST protocol binding",
   "keywords": [
     "TypeSpec"

--- a/typespec-extension/src/code-model-builder.ts
+++ b/typespec-extension/src/code-model-builder.ts
@@ -37,6 +37,7 @@ import {
   getProjectedName,
   getService,
   getEncode,
+  isErrorModel,
 } from "@typespec/compiler";
 import { getResourceOperation, getSegment } from "@typespec/rest";
 import {
@@ -1046,10 +1047,11 @@ export class CodeModelBuilder {
       }
     }
 
+    let bodyType: Type | undefined = undefined;
     let trackConvenienceApi = op.convenienceApi ?? false;
     if (resp.responses && resp.responses.length > 0 && resp.responses[0].body) {
       const responseBody = resp.responses[0].body;
-      const bodyType = this.findResponseBody(responseBody.type);
+      bodyType = this.findResponseBody(responseBody.type);
       if (bodyType.kind === "Scalar" && bodyType.name === "bytes") {
         // binary
         response = new BinaryResponse({
@@ -1152,7 +1154,7 @@ export class CodeModelBuilder {
         },
       });
     }
-    if (resp.statusCode === "*" || Number(resp.statusCode) / 100 > 3) {
+    if (resp.statusCode === "*" || (bodyType && isErrorModel(this.program, bodyType))) {
       // TODO: x-ms-error-response
       op.addException(response);
 

--- a/typespec-extension/src/code-model-builder.ts
+++ b/typespec-extension/src/code-model-builder.ts
@@ -1155,7 +1155,7 @@ export class CodeModelBuilder {
       });
     }
     if (resp.statusCode === "*" || (bodyType && isErrorModel(this.program, bodyType))) {
-      // TODO: x-ms-error-response
+      // "*", or the model is @error
       op.addException(response);
 
       if (response instanceof SchemaResponse) {

--- a/typespec-tests/package.json
+++ b/typespec-tests/package.json
@@ -12,7 +12,7 @@
     "@typespec/openapi": ">=0.44.0 <1.0.0",
     "@azure-tools/typespec-autorest": ">=0.30.0 <1.0.0",
     "@azure-tools/cadl-ranch-specs": "~0.15.0",
-    "@azure-tools/typespec-java": "file:/../typespec-extension/azure-tools-typespec-java-0.7.1.tgz"
+    "@azure-tools/typespec-java": "file:/../typespec-extension/azure-tools-typespec-java-0.7.2.tgz"
   },
   "devDependencies": {
     "@typespec/prettier-plugin-typespec": ">=0.44.0 <1.0.0",

--- a/typespec-tests/src/main/java/com/cadl/response/CoreClientBuilder.java
+++ b/typespec-tests/src/main/java/com/cadl/response/CoreClientBuilder.java
@@ -161,7 +161,7 @@ public final class CoreClientBuilder
     /*
      * Service version
      */
-    @Generated private CoreServiceVersion serviceVersion;
+    @Generated private ResponseServiceVersion serviceVersion;
 
     /**
      * Sets Service version.
@@ -170,7 +170,7 @@ public final class CoreClientBuilder
      * @return the CoreClientBuilder.
      */
     @Generated
-    public CoreClientBuilder serviceVersion(CoreServiceVersion serviceVersion) {
+    public CoreClientBuilder serviceVersion(ResponseServiceVersion serviceVersion) {
         this.serviceVersion = serviceVersion;
         return this;
     }
@@ -200,8 +200,8 @@ public final class CoreClientBuilder
     @Generated
     private CoreClientImpl buildInnerClient() {
         HttpPipeline localPipeline = (pipeline != null) ? pipeline : createHttpPipeline();
-        CoreServiceVersion localServiceVersion =
-                (serviceVersion != null) ? serviceVersion : CoreServiceVersion.getLatest();
+        ResponseServiceVersion localServiceVersion =
+                (serviceVersion != null) ? serviceVersion : ResponseServiceVersion.getLatest();
         CoreClientImpl client =
                 new CoreClientImpl(
                         localPipeline, JacksonAdapter.createDefaultSerializerAdapter(), endpoint, localServiceVersion);

--- a/typespec-tests/src/main/java/com/cadl/response/ResponseAsyncClient.java
+++ b/typespec-tests/src/main/java/com/cadl/response/ResponseAsyncClient.java
@@ -161,6 +161,27 @@ public final class ResponseAsyncClient {
     }
 
     /**
+     * The exists operation.
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * boolean
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @return whether resource exists along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Boolean>> existsWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.existsWithResponseAsync(requestOptions);
+    }
+
+    /**
      * The getBinary operation.
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
@@ -254,6 +275,23 @@ public final class ResponseAsyncClient {
         // Generated convenience method for deleteWithHeadersWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return deleteWithHeadersWithResponse(requestOptions).flatMap(FluxUtil::toMono);
+    }
+
+    /**
+     * The exists operation.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return whether resource exists on successful completion of {@link Mono}.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Boolean> exists() {
+        // Generated convenience method for existsWithResponse
+        RequestOptions requestOptions = new RequestOptions();
+        return existsWithResponse(requestOptions).flatMap(FluxUtil::toMono);
     }
 
     @Generated

--- a/typespec-tests/src/main/java/com/cadl/response/ResponseClient.java
+++ b/typespec-tests/src/main/java/com/cadl/response/ResponseClient.java
@@ -159,6 +159,27 @@ public final class ResponseClient {
     }
 
     /**
+     * The exists operation.
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * boolean
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @return whether resource exists along with {@link Response}.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Boolean> existsWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.existsWithResponse(requestOptions);
+    }
+
+    /**
      * The getBinary operation.
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
@@ -245,6 +266,23 @@ public final class ResponseClient {
         // Generated convenience method for deleteWithHeadersWithResponse
         RequestOptions requestOptions = new RequestOptions();
         deleteWithHeadersWithResponse(requestOptions).getValue();
+    }
+
+    /**
+     * The exists operation.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return whether resource exists.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public boolean exists() {
+        // Generated convenience method for existsWithResponse
+        RequestOptions requestOptions = new RequestOptions();
+        return existsWithResponse(requestOptions).getValue();
     }
 
     @Generated

--- a/typespec-tests/src/main/java/com/cadl/response/ResponseClientBuilder.java
+++ b/typespec-tests/src/main/java/com/cadl/response/ResponseClientBuilder.java
@@ -159,6 +159,23 @@ public final class ResponseClientBuilder
     }
 
     /*
+     * Service version
+     */
+    @Generated private ResponseServiceVersion serviceVersion;
+
+    /**
+     * Sets Service version.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the ResponseClientBuilder.
+     */
+    @Generated
+    public ResponseClientBuilder serviceVersion(ResponseServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
      * The retry policy that will attempt to retry failed requests, if applicable.
      */
     @Generated private RetryPolicy retryPolicy;
@@ -183,8 +200,11 @@ public final class ResponseClientBuilder
     @Generated
     private ResponseClientImpl buildInnerClient() {
         HttpPipeline localPipeline = (pipeline != null) ? pipeline : createHttpPipeline();
+        ResponseServiceVersion localServiceVersion =
+                (serviceVersion != null) ? serviceVersion : ResponseServiceVersion.getLatest();
         ResponseClientImpl client =
-                new ResponseClientImpl(localPipeline, JacksonAdapter.createDefaultSerializerAdapter(), endpoint);
+                new ResponseClientImpl(
+                        localPipeline, JacksonAdapter.createDefaultSerializerAdapter(), endpoint, localServiceVersion);
         return client;
     }
 

--- a/typespec-tests/src/main/java/com/cadl/response/ResponseServiceVersion.java
+++ b/typespec-tests/src/main/java/com/cadl/response/ResponseServiceVersion.java
@@ -6,14 +6,14 @@ package com.cadl.response;
 
 import com.azure.core.util.ServiceVersion;
 
-/** Service version of CoreClient. */
-public enum CoreServiceVersion implements ServiceVersion {
+/** Service version of ResponseClient. */
+public enum ResponseServiceVersion implements ServiceVersion {
     /** Enum value 1.0.0. */
     V1_0_0("1.0.0");
 
     private final String version;
 
-    CoreServiceVersion(String version) {
+    ResponseServiceVersion(String version) {
         this.version = version;
     }
 
@@ -26,9 +26,9 @@ public enum CoreServiceVersion implements ServiceVersion {
     /**
      * Gets the latest service version supported by this client library.
      *
-     * @return The latest {@link CoreServiceVersion}.
+     * @return The latest {@link ResponseServiceVersion}.
      */
-    public static CoreServiceVersion getLatest() {
+    public static ResponseServiceVersion getLatest() {
         return V1_0_0;
     }
 }

--- a/typespec-tests/src/main/java/com/cadl/response/implementation/CoreClientImpl.java
+++ b/typespec-tests/src/main/java/com/cadl/response/implementation/CoreClientImpl.java
@@ -39,7 +39,7 @@ import com.azure.core.util.Context;
 import com.azure.core.util.FluxUtil;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
-import com.cadl.response.CoreServiceVersion;
+import com.cadl.response.ResponseServiceVersion;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -63,14 +63,14 @@ public final class CoreClientImpl {
     }
 
     /** Service version. */
-    private final CoreServiceVersion serviceVersion;
+    private final ResponseServiceVersion serviceVersion;
 
     /**
      * Gets Service version.
      *
      * @return the serviceVersion value.
      */
-    public CoreServiceVersion getServiceVersion() {
+    public ResponseServiceVersion getServiceVersion() {
         return this.serviceVersion;
     }
 
@@ -104,7 +104,7 @@ public final class CoreClientImpl {
      * @param endpoint Server parameter.
      * @param serviceVersion Service version.
      */
-    public CoreClientImpl(String endpoint, CoreServiceVersion serviceVersion) {
+    public CoreClientImpl(String endpoint, ResponseServiceVersion serviceVersion) {
         this(
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
@@ -121,7 +121,7 @@ public final class CoreClientImpl {
      * @param endpoint Server parameter.
      * @param serviceVersion Service version.
      */
-    public CoreClientImpl(HttpPipeline httpPipeline, String endpoint, CoreServiceVersion serviceVersion) {
+    public CoreClientImpl(HttpPipeline httpPipeline, String endpoint, ResponseServiceVersion serviceVersion) {
         this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), endpoint, serviceVersion);
     }
 
@@ -137,7 +137,7 @@ public final class CoreClientImpl {
             HttpPipeline httpPipeline,
             SerializerAdapter serializerAdapter,
             String endpoint,
-            CoreServiceVersion serviceVersion) {
+            ResponseServiceVersion serviceVersion) {
         this.httpPipeline = httpPipeline;
         this.serializerAdapter = serializerAdapter;
         this.endpoint = endpoint;

--- a/typespec-tests/src/main/java/com/cadl/response/implementation/ResponseClientImpl.java
+++ b/typespec-tests/src/main/java/com/cadl/response/implementation/ResponseClientImpl.java
@@ -7,10 +7,12 @@ package com.cadl.response.implementation;
 import com.azure.core.annotation.Delete;
 import com.azure.core.annotation.ExpectedResponses;
 import com.azure.core.annotation.Get;
+import com.azure.core.annotation.Head;
 import com.azure.core.annotation.HeaderParam;
 import com.azure.core.annotation.Host;
 import com.azure.core.annotation.HostParam;
 import com.azure.core.annotation.Put;
+import com.azure.core.annotation.QueryParam;
 import com.azure.core.annotation.ReturnType;
 import com.azure.core.annotation.ServiceInterface;
 import com.azure.core.annotation.ServiceMethod;
@@ -32,6 +34,7 @@ import com.azure.core.util.Context;
 import com.azure.core.util.FluxUtil;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import com.cadl.response.ResponseServiceVersion;
 import reactor.core.publisher.Mono;
 
 /** Initializes a new instance of the ResponseClient type. */
@@ -49,6 +52,18 @@ public final class ResponseClientImpl {
      */
     public String getEndpoint() {
         return this.endpoint;
+    }
+
+    /** Service version. */
+    private final ResponseServiceVersion serviceVersion;
+
+    /**
+     * Gets Service version.
+     *
+     * @return the serviceVersion value.
+     */
+    public ResponseServiceVersion getServiceVersion() {
+        return this.serviceVersion;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -79,14 +94,16 @@ public final class ResponseClientImpl {
      * Initializes an instance of ResponseClient client.
      *
      * @param endpoint Server parameter.
+     * @param serviceVersion Service version.
      */
-    public ResponseClientImpl(String endpoint) {
+    public ResponseClientImpl(String endpoint, ResponseServiceVersion serviceVersion) {
         this(
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
                 JacksonAdapter.createDefaultSerializerAdapter(),
-                endpoint);
+                endpoint,
+                serviceVersion);
     }
 
     /**
@@ -94,9 +111,10 @@ public final class ResponseClientImpl {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      * @param endpoint Server parameter.
+     * @param serviceVersion Service version.
      */
-    public ResponseClientImpl(HttpPipeline httpPipeline, String endpoint) {
-        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), endpoint);
+    public ResponseClientImpl(HttpPipeline httpPipeline, String endpoint, ResponseServiceVersion serviceVersion) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), endpoint, serviceVersion);
     }
 
     /**
@@ -105,11 +123,17 @@ public final class ResponseClientImpl {
      * @param httpPipeline The HTTP pipeline to send requests through.
      * @param serializerAdapter The serializer to serialize an object into a string.
      * @param endpoint Server parameter.
+     * @param serviceVersion Service version.
      */
-    public ResponseClientImpl(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String endpoint) {
+    public ResponseClientImpl(
+            HttpPipeline httpPipeline,
+            SerializerAdapter serializerAdapter,
+            String endpoint,
+            ResponseServiceVersion serviceVersion) {
         this.httpPipeline = httpPipeline;
         this.serializerAdapter = serializerAdapter;
         this.endpoint = endpoint;
+        this.serviceVersion = serviceVersion;
         this.service = RestProxy.create(ResponseClientService.class, this.httpPipeline, this.getSerializerAdapter());
     }
 
@@ -295,6 +319,38 @@ public final class ResponseClientImpl {
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Response<Void> deleteWithHeadersSync(
                 @HostParam("endpoint") String endpoint,
+                @HeaderParam("accept") String accept,
+                RequestOptions requestOptions,
+                Context context);
+
+        @Head("/response/exists")
+        @ExpectedResponses({200, 404})
+        @UnexpectedResponseExceptionType(
+                value = ClientAuthenticationException.class,
+                code = {401})
+        @UnexpectedResponseExceptionType(
+                value = ResourceModifiedException.class,
+                code = {409})
+        @UnexpectedResponseExceptionType(HttpResponseException.class)
+        Mono<Response<Boolean>> exists(
+                @HostParam("endpoint") String endpoint,
+                @QueryParam("api-version") String apiVersion,
+                @HeaderParam("accept") String accept,
+                RequestOptions requestOptions,
+                Context context);
+
+        @Head("/response/exists")
+        @ExpectedResponses({200, 404})
+        @UnexpectedResponseExceptionType(
+                value = ClientAuthenticationException.class,
+                code = {401})
+        @UnexpectedResponseExceptionType(
+                value = ResourceModifiedException.class,
+                code = {409})
+        @UnexpectedResponseExceptionType(HttpResponseException.class)
+        Response<Boolean> existsSync(
+                @HostParam("endpoint") String endpoint,
+                @QueryParam("api-version") String apiVersion,
                 @HeaderParam("accept") String accept,
                 RequestOptions requestOptions,
                 Context context);
@@ -547,5 +603,55 @@ public final class ResponseClientImpl {
     public Response<Void> deleteWithHeadersWithResponse(RequestOptions requestOptions) {
         final String accept = "application/json";
         return service.deleteWithHeadersSync(this.getEndpoint(), accept, requestOptions, Context.NONE);
+    }
+
+    /**
+     * The exists operation.
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * boolean
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @return whether resource exists along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Boolean>> existsWithResponseAsync(RequestOptions requestOptions) {
+        final String accept = "application/json";
+        return FluxUtil.withContext(
+                context ->
+                        service.exists(
+                                this.getEndpoint(),
+                                this.getServiceVersion().getVersion(),
+                                accept,
+                                requestOptions,
+                                context));
+    }
+
+    /**
+     * The exists operation.
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * boolean
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @return whether resource exists along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Boolean> existsWithResponse(RequestOptions requestOptions) {
+        final String accept = "application/json";
+        return service.existsSync(
+                this.getEndpoint(), this.getServiceVersion().getVersion(), accept, requestOptions, Context.NONE);
     }
 }

--- a/typespec-tests/tsp/response.tsp
+++ b/typespec-tests/tsp/response.tsp
@@ -16,6 +16,20 @@ using Azure.ClientGenerator.Core;
 @useDependency(Azure.Core.Versions.v1_0_Preview_2)
 namespace Cadl.Response;
 
+@Foundations.Private.needsRoute
+op RpcOperationWithAdditionalResponse<
+  TParams,
+  TResponse extends TypeSpec.Reflection.Model,
+  TAdditionalResponse extends object,
+  Traits extends object = {},
+  TErrorResponse = Azure.Core.Foundations.ErrorResponse
+> is Foundations.Operation<
+  TParams & Azure.Core.Traits.Private.TraitProperties<Traits, TraitLocation.Parameters>,
+  (TResponse & Azure.Core.Traits.Private.TraitProperties<Traits, TraitLocation.Response>) | TAdditionalResponse,
+  Traits,
+  TErrorResponse
+>;
+
 @resource("resources")
 model Resource {
   @visibility("read")
@@ -92,4 +106,22 @@ interface ResponseOp {
     @header("operation-location")
     operationLocation: ResourceLocation<Resource>;
   };
+
+  @route("/exists")
+  @head
+  exists is RpcOperationWithAdditionalResponse<
+    {},
+    {
+      @doc("A response containing headers related to the Job Schedule, if it exists.")
+      @statusCode
+      code: "200";
+    },
+    {
+      @doc("A response containing headers related to the Job Schedule, if it exists.")
+      @statusCode
+      code: "404";
+    },
+    {},
+    Foundations.ErrorResponse
+  >;
 }


### PR DESCRIPTION
Enhancement for response error.

"*" is regarded as error, model with `@error` is regarded as error e.g. https://github.com/Azure/typespec-azure/blob/main/packages/typespec-azure-core/lib/foundations.tsp#L113-L124
Else be normal response (non-error response).

Most for the case of HEAD with 200+404 response. Detail https://teams.microsoft.com/l/message/19:906c1efbbec54dc8949ac736633e6bdf@thread.skype/1684272172008?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&parentMessageId=1684272172008&teamName=Azure%20SDK&channelName=TypeSpec%20(Cadl)%20Discussion%20%F0%9F%90%AE&createdTime=1684272172008