### PR TITLE
tsp, fix dead store in non sync stack

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/template/ConvenienceMethodTemplateBase.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ConvenienceMethodTemplateBase.java
@@ -181,7 +181,6 @@ abstract class ConvenienceMethodTemplateBase {
                 });
             }
         }
-
     }
 
     abstract void writeThrowException(ClientMethodType methodType, String exceptionExpression, JavaBlock methodBlock);

--- a/javagen/src/main/java/com/azure/autorest/template/ConvenienceSyncMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ConvenienceSyncMethodTemplate.java
@@ -58,6 +58,33 @@ public class ConvenienceSyncMethodTemplate extends ConvenienceMethodTemplateBase
     }
 
     @Override
+    protected void writeMethodImplementation(
+            ClientMethod protocolMethod,
+            ClientMethod convenienceMethod,
+            JavaBlock methodBlock,
+            Set<GenericType> typeReferenceStaticClasses) {
+        if (!JavaSettings.getInstance().isSyncStackEnabled()) {
+            if (protocolMethod.getType() == ClientMethodType.PagingSync) {
+                // Call the convenience method from async client
+                // It would need rework, when underlying sync method in Impl is switched to sync protocol method
+
+                String methodInvoke = "new PagedIterable<>(" + getMethodInvokeViaAsyncClient(convenienceMethod) + ")";
+
+                methodBlock.methodReturn(methodInvoke);
+            } else if (protocolMethod.getType() == ClientMethodType.LongRunningBeginSync) {
+                // Call the convenience method from async client
+                String methodInvoke = getMethodInvokeViaAsyncClient(convenienceMethod) + ".getSyncPoller()";
+
+                methodBlock.methodReturn(methodInvoke);
+            } else {
+                super.writeMethodImplementation(protocolMethod, convenienceMethod, methodBlock, typeReferenceStaticClasses);
+            }
+        } else {
+            super.writeMethodImplementation(protocolMethod, convenienceMethod, methodBlock, typeReferenceStaticClasses);
+        }
+    }
+
+    @Override
     protected void writeInvocationAndConversion(
             ClientMethod convenienceMethod,
             ClientMethod protocolMethod,
@@ -71,26 +98,14 @@ public class ConvenienceSyncMethodTemplate extends ConvenienceMethodTemplateBase
                 ? "" : ".getValue()";
 
         if (convenienceMethod.getType() == ClientMethodType.PagingSync) {
-            if (JavaSettings.getInstance().isSyncStackEnabled()) {
-                methodBlock.methodReturn(String.format(
-                        "serviceClient.%1$s(%2$s).mapPage(value -> %3$s)",
-                        protocolMethod.getName(),
-                        invocationExpression,
-                        expressionConvertFromBinaryData(responseBodyType, "value", typeReferenceStaticClasses)));
-            } else {
-                // Call the convenience method from async client
-                String methodInvoke = "new PagedIterable<>(" + getMethodInvokeViaAsyncClient(convenienceMethod) + ")";
-                methodBlock.methodReturn(methodInvoke);
-            }
+            methodBlock.methodReturn(String.format(
+                    "serviceClient.%1$s(%2$s).mapPage(value -> %3$s)",
+                    protocolMethod.getName(),
+                    invocationExpression,
+                    expressionConvertFromBinaryData(responseBodyType, "value", typeReferenceStaticClasses)));
         } else if (convenienceMethod.getType() == ClientMethodType.LongRunningBeginSync){
-            if (JavaSettings.getInstance().isSyncStackEnabled()) {
-                String methodName = protocolMethod.getName();
-                methodBlock.methodReturn(String.format("serviceClient.%1$s(%2$s)", methodName, invocationExpression));
-            } else {
-                // Call the convenience method from async client
-                String methodInvoke = getMethodInvokeViaAsyncClient(convenienceMethod) + ".getSyncPoller()";
-                methodBlock.methodReturn(methodInvoke);
-            }
+            String methodName = protocolMethod.getName();
+            methodBlock.methodReturn(String.format("serviceClient.%1$s(%2$s)", methodName, invocationExpression));
         } else if (convenienceMethod.getType() == ClientMethodType.SimpleSyncRestResponse
                 && !(responseBodyType.asNullable() == ClassType.Void || responseBodyType == ClassType.BinaryData)) {
 

--- a/javagen/src/main/java/com/azure/autorest/template/ConvenienceSyncMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ConvenienceSyncMethodTemplate.java
@@ -149,15 +149,6 @@ public class ConvenienceSyncMethodTemplate extends ConvenienceMethodTemplateBase
     }
 
     @Override
-    protected void writeValidationForVersioning(ClientMethod convenienceMethod, Set<MethodParameter> parameters, JavaBlock methodBlock) {
-        if (JavaSettings.getInstance().isSyncStackEnabled()) {
-            super.writeValidationForVersioning(convenienceMethod, parameters, methodBlock);
-        } else {
-            // async client will do the validation
-        }
-    }
-
-    @Override
     protected void writeThrowException(ClientMethodType methodType, String exceptionExpression, JavaBlock methodBlock) {
         if (JavaSettings.getInstance().isUseClientLogger()) {
             methodBlock.line(String.format("throw LOGGER.logExceptionAsError(%s);", exceptionExpression));

--- a/typespec-extension/changelog.md
+++ b/typespec-extension/changelog.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 0.7.3 (2023-05-30)
+
+Compatible with compiler 0.44.
+
 ## 0.7.2 (2023-05-24)
 
 Compatible with compiler 0.44.

--- a/typespec-extension/package.json
+++ b/typespec-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "TypeSpec library for emitting Java client from the TypeSpec REST protocol binding",
   "keywords": [
     "TypeSpec"

--- a/typespec-tests/package.json
+++ b/typespec-tests/package.json
@@ -12,7 +12,7 @@
     "@typespec/openapi": ">=0.44.0 <1.0.0",
     "@azure-tools/typespec-autorest": ">=0.30.0 <1.0.0",
     "@azure-tools/cadl-ranch-specs": "~0.15.0",
-    "@azure-tools/typespec-java": "file:/../typespec-extension/azure-tools-typespec-java-0.7.2.tgz"
+    "@azure-tools/typespec-java": "file:/../typespec-extension/azure-tools-typespec-java-0.7.3.tgz"
   },
   "devDependencies": {
     "@typespec/prettier-plugin-typespec": ">=0.44.0 <1.0.0",


### PR DESCRIPTION
fix following, `requestOptions` would trigger spotbugs on dead store.

```java
    public SyncPoller<ResourceOperationStatusWidgetWidgetError, Void> beginDeleteWidget(String widgetName) {
        // Generated convenience method for beginDeleteWidgetWithModel
        RequestOptions requestOptions = new RequestOptions();
        return client.beginDeleteWidget(widgetName).getSyncPoller();
    }

    public PagedIterable<Widget> listWidgets() {
        // Generated convenience method for listWidgets
        RequestOptions requestOptions = new RequestOptions();
        return new PagedIterable<>(client.listWidgets());
    }
```

besides the `requestOptions` line, these lines are likely also not required
https://github.com/Azure/autorest.java/blob/9041648f93f87f8a0573f7ae55ecd9eeb3616b51/javagen/src/main/java/com/azure/autorest/template/ConvenienceMethodTemplateBase.java#L99-L104

---

fix `writeValidationForVersioning` as well.

same logic, if it calls convenient API in async client directly, it does not need to do these versioning check.