### PR TITLE
tsp, ignore string format=eTag for nightly build

### DIFF
--- a/androidgen/pom.xml
+++ b/androidgen/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.39.0</version>
+      <version>1.40.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/azure-dataplane-tests/pom.xml
+++ b/azure-dataplane-tests/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-core</artifactId>
-            <version>1.39.0</version>
+            <version>1.40.0</version>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-core-http-netty</artifactId>
-            <version>1.13.3</version>
+            <version>1.13.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
-            <version>3.4.27</version>
+            <version>3.4.29</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/azure-tests/pom.xml
+++ b/azure-tests/pom.xml
@@ -22,18 +22,18 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.39.0</version>
+      <version>1.40.0</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-management</artifactId>
-      <version>1.11.1</version>
+      <version>1.11.2</version>
     </dependency>
 
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-http-netty</artifactId>
-      <version>1.13.3</version>
+      <version>1.13.4</version>
       <scope>test</scope>
     </dependency>
 

--- a/customization-base/src/main/resources/pom.xml
+++ b/customization-base/src/main/resources/pom.xml
@@ -40,19 +40,19 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.39.0</version>
+      <version>1.40.0</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-http-netty</artifactId>
-      <version>1.13.3</version>
+      <version>1.13.4</version>
     </dependency>
 
     <!-- Test Dependencies -->
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-test</artifactId>
-      <version>1.17.0</version>
+      <version>1.18.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/customization-tests/pom.xml
+++ b/customization-tests/pom.xml
@@ -34,19 +34,19 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.39.0</version>
+      <version>1.40.0</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-http-netty</artifactId>
-      <version>1.13.3</version>
+      <version>1.13.4</version>
     </dependency>
 
     <!-- Test Dependencies -->
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-test</artifactId>
-      <version>1.17.0</version>
+      <version>1.18.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/fluent-tests/pom.xml
+++ b/fluent-tests/pom.xml
@@ -100,18 +100,18 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.39.0</version>
+      <version>1.40.0</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-management</artifactId>
-      <version>1.11.1</version>
+      <version>1.11.2</version>
     </dependency>
 
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-http-netty</artifactId>
-      <version>1.13.3</version>
+      <version>1.13.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/fluentnamer/pom.xml
+++ b/fluentnamer/pom.xml
@@ -39,13 +39,13 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.39.0</version>
+      <version>1.40.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-management</artifactId>
-      <version>1.11.1</version>
+      <version>1.11.2</version>
     </dependency>
   </dependencies>
 

--- a/javagen/pom.xml
+++ b/javagen/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.39.0</version>
+      <version>1.40.0</version>
     </dependency>
     <dependency>
       <groupId>org.atteo</groupId>

--- a/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
+++ b/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
@@ -58,12 +58,12 @@ public class Project {
         AZURE_CLIENT_SDK_PARENT("com.azure", "azure-client-sdk-parent", "1.7.0"),
         AZURE_JSON("com.azure", "azure-json", "1.0.1"),
         AZURE_XML("com.azure", "azure-xml", "1.0.0-beta.1"),
-        AZURE_CORE("com.azure", "azure-core", "1.39.0"),
-        AZURE_CORE_MANAGEMENT("com.azure", "azure-core-management", "1.11.1"),
-        AZURE_CORE_HTTP_NETTY("com.azure", "azure-core-http-netty", "1.13.3"),
-        AZURE_CORE_TEST("com.azure", "azure-core-test", "1.17.0"),
+        AZURE_CORE("com.azure", "azure-core", "1.40.0"),
+        AZURE_CORE_MANAGEMENT("com.azure", "azure-core-management", "1.11.2"),
+        AZURE_CORE_HTTP_NETTY("com.azure", "azure-core-http-netty", "1.13.4"),
+        AZURE_CORE_TEST("com.azure", "azure-core-test", "1.18.0"),
         AZURE_IDENTITY("com.azure", "azure-identity", "1.9.0"),
-        AZURE_CORE_EXPERIMENTAL("com.azure", "azure-core-experimental", "1.0.0-beta.39"),
+        AZURE_CORE_EXPERIMENTAL("com.azure", "azure-core-experimental", "1.0.0-beta.40"),
 
         // external
         JUNIT_JUPITER_API("org.junit.jupiter", "junit-jupiter-api", "5.9.1"),

--- a/partial-update-tests/pom.xml
+++ b/partial-update-tests/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.39.0</version>
+      <version>1.40.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/protocol-resilience-test/pom.xml
+++ b/protocol-resilience-test/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.39.0</version>
+      <version>1.40.0</version>
     </dependency>
   </dependencies>
 

--- a/protocol-sdk-integration-tests/eng/versioning/version_client.txt
+++ b/protocol-sdk-integration-tests/eng/versioning/version_client.txt
@@ -1,8 +1,8 @@
-com.azure:azure-core;1.39.0;1.39.0
-com.azure:azure-core-experimental;1.0.0-beta.39;1.0.0-beta.39
-com.azure:azure-core-http-netty;1.13.3;1.13.3
-com.azure:azure-core-management;1.11.1;1.11.1
-com.azure:azure-core-test;1.17.0;1.17.0
+com.azure:azure-core;1.40.0;1.40.0
+com.azure:azure-core-experimental;1.0.0-beta.40;1.0.0-beta.40
+com.azure:azure-core-http-netty;1.13.4;1.13.4
+com.azure:azure-core-management;1.11.2;1.11.2
+com.azure:azure-core-test;1.18.0;1.18.0
 
 com.azure:azure-identity;1.9.0;1.9.0
 com.azure:azure-json;1.0.1;1.0.1

--- a/protocol-tests/pom.xml
+++ b/protocol-tests/pom.xml
@@ -39,12 +39,12 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.39.0</version>
+      <version>1.40.0</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-http-netty</artifactId>
-      <version>1.13.3</version>
+      <version>1.13.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/typespec-extension/pom.xml
+++ b/typespec-extension/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.39.0</version>
+      <version>1.40.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.googlejavaformat</groupId>

--- a/typespec-extension/src/code-model-builder.ts
+++ b/typespec-extension/src/code-model-builder.ts
@@ -1756,6 +1756,7 @@ export class CodeModelBuilder {
       case "password":
       case "url":
       case "uuid":
+      case "eTag":
         return this.processStringSchema(type, nameHint);
     }
     throw new Error(`Unrecognized string format: '${format}'.`);

--- a/typespec-tests/pom.xml
+++ b/typespec-tests/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.39.0</version>
+      <version>1.40.0</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
@@ -45,12 +45,12 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-experimental</artifactId>
-      <version>1.0.0-beta.39</version>
+      <version>1.0.0-beta.40</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-http-netty</artifactId>
-      <version>1.13.3</version>
+      <version>1.13.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>io.projectreactor</groupId>
       <artifactId>reactor-test</artifactId>
-      <version>3.4.27</version>
+      <version>3.4.29</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-test</artifactId>
-      <version>1.17.0</version>
+      <version>1.18.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/vanilla-tests/pom.xml
+++ b/vanilla-tests/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.39.0</version>
+      <version>1.40.0</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-http-netty</artifactId>
-      <version>1.13.3</version>
+      <version>1.13.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -90,7 +90,7 @@
     <dependency>
       <groupId>io.projectreactor</groupId>
       <artifactId>reactor-test</artifactId>
-      <version>3.4.27</version>
+      <version>3.4.29</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2821774&view=logs&j=ca395085-040a-526b-2ce8-bdc85f692774&t=cf4477f9-109f-5399-1612-bcbe5909c9f2

`@format` on string should be deprecated. Why it is here?
https://github.com/Azure/typespec-azure/blob/main/packages/typespec-azure-core/lib/models.tsp#L262-L263

Anyway, Java treats eTag as String.