### PR TITLE
tsp, version 0.7.4

### DIFF
--- a/fluent-tests/pom.xml
+++ b/fluent-tests/pom.xml
@@ -117,7 +117,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-identity</artifactId>
-      <version>1.9.0</version>
+      <version>1.9.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/fluent-tests/src/test/java/com/azure/mgmttest/RuntimeTests.java
+++ b/fluent-tests/src/test/java/com/azure/mgmttest/RuntimeTests.java
@@ -6,7 +6,6 @@ package com.azure.mgmttest;
 import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
-import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.HttpLogDetailLevel;
 import com.azure.core.http.policy.HttpLogOptions;
 import com.azure.core.http.policy.HttpLoggingPolicy;
@@ -103,7 +102,7 @@ public class RuntimeTests {
     @Test
     public void testManagementClient() {
         StorageManagementClient storageManagementClient = new StorageManagementClientBuilder()
-                .pipeline(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build())
+                .pipeline(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy()).build())
                 .endpoint(AzureEnvironment.AZURE.getResourceManagerEndpoint())
                 .subscriptionId(MOCK_SUBSCRIPTION_ID)
                 .buildClient();

--- a/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
+++ b/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
@@ -62,7 +62,7 @@ public class Project {
         AZURE_CORE_MANAGEMENT("com.azure", "azure-core-management", "1.11.2"),
         AZURE_CORE_HTTP_NETTY("com.azure", "azure-core-http-netty", "1.13.4"),
         AZURE_CORE_TEST("com.azure", "azure-core-test", "1.18.0"),
-        AZURE_IDENTITY("com.azure", "azure-identity", "1.9.0"),
+        AZURE_IDENTITY("com.azure", "azure-identity", "1.9.1"),
         AZURE_CORE_EXPERIMENTAL("com.azure", "azure-core-experimental", "1.0.0-beta.40"),
 
         // external

--- a/protocol-sdk-integration-tests/eng/versioning/version_client.txt
+++ b/protocol-sdk-integration-tests/eng/versioning/version_client.txt
@@ -4,5 +4,5 @@ com.azure:azure-core-http-netty;1.13.4;1.13.4
 com.azure:azure-core-management;1.11.2;1.11.2
 com.azure:azure-core-test;1.18.0;1.18.0
 
-com.azure:azure-identity;1.9.0;1.9.0
+com.azure:azure-identity;1.9.1;1.9.1
 com.azure:azure-json;1.0.1;1.0.1

--- a/typespec-extension/changelog.md
+++ b/typespec-extension/changelog.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.7.4 (Unreleased)
+## 0.7.4 (2023-06-06)
 
 Compatible with compiler 0.44.
 

--- a/typespec-extension/package.json
+++ b/typespec-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "TypeSpec library for emitting Java client from the TypeSpec REST protocol binding",
   "keywords": [
     "TypeSpec"

--- a/typespec-extension/src/code-model-builder.ts
+++ b/typespec-extension/src/code-model-builder.ts
@@ -1767,8 +1767,10 @@ export class CodeModelBuilder {
       case "uuid":
       case "eTag":
         return this.processStringSchema(type, nameHint);
+      default:
+        this.logWarning(`Unrecognized string format: '${format}'.`);
+        return this.processStringSchema(type, nameHint);
     }
-    throw new Error(`Unrecognized string format: '${format}'.`);
   }
 
   private processUnionSchema(type: Union, name: string): Schema {

--- a/typespec-tests/package.json
+++ b/typespec-tests/package.json
@@ -12,7 +12,7 @@
     "@typespec/openapi": ">=0.44.0 <1.0.0",
     "@azure-tools/typespec-autorest": ">=0.30.0 <1.0.0",
     "@azure-tools/cadl-ranch-specs": "~0.15.0",
-    "@azure-tools/typespec-java": "file:/../typespec-extension/azure-tools-typespec-java-0.7.3.tgz"
+    "@azure-tools/typespec-java": "file:/../typespec-extension/azure-tools-typespec-java-0.7.4.tgz"
   },
   "devDependencies": {
     "@typespec/prettier-plugin-typespec": ">=0.44.0 <1.0.0",

--- a/typespec-tests/pom.xml
+++ b/typespec-tests/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-identity</artifactId>
-      <version>1.9.0</version>
+      <version>1.9.1</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>

--- a/typespec-tests/src/test/java/com/_specs_/azure/core/basic/CoreTests.java
+++ b/typespec-tests/src/test/java/com/_specs_/azure/core/basic/CoreTests.java
@@ -4,9 +4,11 @@
 package com._specs_.azure.core.basic;
 
 import com._specs_.azure.core.basic.models.User;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.rest.PagedFlux;
 import com.azure.core.http.rest.PagedIterable;
 import com.azure.core.http.rest.Response;
+import com.azure.core.test.http.AssertingHttpClientBuilder;
 import com.azure.core.util.BinaryData;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
@@ -24,9 +26,11 @@ import java.util.stream.Collectors;
 public class CoreTests {
 
     private BasicAsyncClient client = new BasicClientBuilder()
+            .httpClient(new AssertingHttpClientBuilder(HttpClient.createDefault()).assertAsync().build())
             .buildAsyncClient();
 
     private BasicClient syncClient = new BasicClientBuilder()
+            .httpClient(new AssertingHttpClientBuilder(HttpClient.createDefault()).assertSync().build())
             .buildClient();
 
     @Test


### PR DESCRIPTION
Other change
- log warning instead of error when find string `@format` not recognized (fallback to string)
- minor change in test
- bump azure-identity to latest June