### PR TITLE
tsp, bug fix, add external package, if model used in convenient API

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ModuleInfo.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ModuleInfo.java
@@ -140,6 +140,7 @@ public class ModuleInfo {
     public void checkForAdditionalDependencies(List<ClientModel> models) {
         Set<String> externalPackageNames = models.stream()
                 .filter(m -> m.getImplementationDetails() != null && m.getImplementationDetails().getUsages() != null
+                        && m.getImplementationDetails().getUsages().contains(ImplementationDetails.Usage.CONVENIENCE_API)
                         && m.getImplementationDetails().getUsages().contains(ImplementationDetails.Usage.EXTERNAL))
                 .map(ClientModel::getPackage)
                 .collect(Collectors.toSet());

--- a/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
+++ b/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
@@ -125,6 +125,7 @@ public class Project {
     public void checkForAdditionalDependencies(List<ClientModel> models) {
         Set<String> externalPackageNames = models.stream()
                 .filter(m -> m.getImplementationDetails() != null && m.getImplementationDetails().getUsages() != null
+                        && m.getImplementationDetails().getUsages().contains(ImplementationDetails.Usage.CONVENIENCE_API)
                         && m.getImplementationDetails().getUsages().contains(ImplementationDetails.Usage.EXTERNAL))
                 .map(ClientModel::getPackage)
                 .collect(Collectors.toSet());


### PR DESCRIPTION
bug is that, the LRO API is protocol (as it is json-merge-patch), but `PollResult` is in polling response, hence `com.azure.core.experimental` get added to pom and module-info.

---

OK, even if model is not generated, LRO code still have `com.azure.core.experimental.util.polling.OperationLocationPollingStrategy`, which still needs `com.azure.core.experimental`

loadtesting is special, as the generated LRO get dropped, for there is customized API on it.
relate to https://github.com/Azure/autorest.java/issues/2186