### PR TITLE
Remove the need for enable-xml

### DIFF
--- a/Generate.ps1
+++ b/Generate.ps1
@@ -48,23 +48,18 @@ SUCCEEDED
 }
 
 function singleThreadGenerate($arguments) {
+    Write-Host "
+========================
+autorest $arguments
+========================
+    "
     $generateOutput = Invoke-Expression "autorest $arguments"
     $global:ExitCode = $global:ExitCode -bor $LASTEXITCODE
 
     if ($LASTEXITCODE -ne 0) {
-        Write-Host "
-========================
-autorest $arguments
-========================
-$([String]::Join("`n", $generateOutput))
-        "
+        Write-Host $([String]::Join("`n", $generateOutput))
     } else {
-        Write-Host "
-========================
-autorest $arguments
-========================
-SUCCEEDED
-        "
+        Write-Host "SUCCEEDED"
     }
 }
 
@@ -78,144 +73,93 @@ if (Test-Path ./vanilla-tests/src/main) {
     Remove-Item ./vanilla-tests/src/main -Recurse -Force | Out-Null
 }
 
-$job = @(
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/additionalProperties.json --namespace=fixtures.additionalproperties",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-array.json --namespace=fixtures.bodyarray",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-boolean.json --namespace=fixtures.bodyboolean --client-logger",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-boolean.quirks.json --namespace=fixtures.bodyboolean.quirks",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-complex.json --namespace=fixtures.bodycomplex --required-fields-as-ctor-args --client-logger --output-model-immutable --generate-tests",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-complex.json --namespace=fixtures.streamstyleserialization --enable-sync-stack --stream-style-serialization --client-logger --pass-discriminator-to-child-deserialization",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-complex.json --namespace=fixtures.streamstyleserializationctorargs --enable-sync-stack --stream-style-serialization --required-fields-as-ctor-args --client-logger --pass-discriminator-to-child-deserialization",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-file.json --namespace=fixtures.bodyfile",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-string.json --namespace=fixtures.bodystring --generate-client-interfaces",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/custom-baseUrl.json --namespace=fixtures.custombaseuri",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/custom-baseUrl-more-options.json --namespace=fixtures.custombaseuri.moreoptions",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/head.json --namespace=fixtures.head",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/head-exceptions.json --namespace=fixtures.headexceptions",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/header.json --namespace=fixtures.header",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/header.json --namespace=fixtures.nonamedresponsetypes --generic-response-type --no-custom-headers",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-dictionary.json --namespace=fixtures.bodydictionary --generate-sync-async-clients --generate-send-request-method",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-duration.json --namespace=fixtures.bodyduration",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-integer.json --namespace=fixtures.bodyinteger",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-number.json --namespace=fixtures.bodynumber --disable-client-builder",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/httpInfrastructure.json --namespace=fixtures.httpinfrastructure",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-byte.json --namespace=fixtures.bodybyte",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-date.json --namespace=fixtures.bodydate",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-datetime.json --namespace=fixtures.bodydatetime",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-datetime-rfc1123.json --namespace=fixtures.bodydatetimerfc1123",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/url.json --namespace=fixtures.url",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/url-multi-collectionFormat.json --namespace=fixtures.url.multi",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/extensible-enums-swagger.json --namespace=fixtures.extensibleenums",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/required-optional.json --namespace=fixtures.requiredoptional",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/xml-service.json --namespace=fixtures.xmlservice --enable-xml --url-as-string=false",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/xml-service.json --namespace=fixtures.streamstylexmlserialization --stream-style-serialization --enable-xml --url-as-string=false",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/parameter-flattening.json --namespace=fixtures.parameterflattening --payload-flattening-threshold=1",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/model-flattening.json --namespace=fixtures.modelflattening --payload-flattening-threshold=1 --optional-constant-as-enum=true",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/media_types.json --namespace=fixtures.mediatypes --payload-flattening-threshold=1 --modelerfour.lenient-model-deduplication",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/validation.json --namespace=fixtures.validation",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/non-string-enum.json --namespace=fixtures.nonstringenum --generate-sync-async-clients --disable-client-builder",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/multiple-inheritance.json --namespace=fixtures.multipleinheritance",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/report.json --namespace=fixtures.report --payload-flattening-threshold=1",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-formdata-urlencoded.json --namespace=fixtures.bodyformdataurlencoded",
-    "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/constants.json --namespace=fixtures.constants",
-    "--version=$AUTOREST_CORE_VERSION --use=./ vanilla-tests/swagger/lro.md",
-    "--version=$AUTOREST_CORE_VERSION --use=./ vanilla-tests/swagger/custom-http-exception-mapping.md"
-) | ForEach-Object -Parallel $generateScript -AsJob -ThrottleLimit $PARALLELIZATION
-if ($false -eq $notimeout) {
-    $job | Wait-Job -Timeout 400
-} else {
-    $job | Wait-Job
-}
-if ($job.State -notin @('Completed', 'Failed')) {
-    throw "Vanilla code generation failed to complete within 400 seconds."
-} else {
-    $job | Receive-Job
-}
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/additionalProperties.json --namespace=fixtures.additionalproperties"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-array.json --namespace=fixtures.bodyarray"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-boolean.json --namespace=fixtures.bodyboolean --client-logger"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-boolean.quirks.json --namespace=fixtures.bodyboolean.quirks"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-complex.json --namespace=fixtures.bodycomplex --required-fields-as-ctor-args --client-logger --output-model-immutable --generate-tests"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-complex.json --namespace=fixtures.streamstyleserialization --enable-sync-stack --stream-style-serialization --client-logger --pass-discriminator-to-child-deserialization"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-complex.json --namespace=fixtures.streamstyleserializationctorargs --enable-sync-stack --stream-style-serialization --required-fields-as-ctor-args --client-logger --pass-discriminator-to-child-deserialization"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-file.json --namespace=fixtures.bodyfile"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-string.json --namespace=fixtures.bodystring --generate-client-interfaces"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/custom-baseUrl.json --namespace=fixtures.custombaseuri"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/custom-baseUrl-more-options.json --namespace=fixtures.custombaseuri.moreoptions"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/head.json --namespace=fixtures.head"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/head-exceptions.json --namespace=fixtures.headexceptions"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/header.json --namespace=fixtures.header"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/header.json --namespace=fixtures.nonamedresponsetypes --generic-response-type --no-custom-headers"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-dictionary.json --namespace=fixtures.bodydictionary --generate-sync-async-clients --generate-send-request-method"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-duration.json --namespace=fixtures.bodyduration"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-integer.json --namespace=fixtures.bodyinteger"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-number.json --namespace=fixtures.bodynumber --disable-client-builder"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/httpInfrastructure.json --namespace=fixtures.httpinfrastructure"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-byte.json --namespace=fixtures.bodybyte"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-date.json --namespace=fixtures.bodydate"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-datetime.json --namespace=fixtures.bodydatetime"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-datetime-rfc1123.json --namespace=fixtures.bodydatetimerfc1123"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/url.json --namespace=fixtures.url"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/url-multi-collectionFormat.json --namespace=fixtures.url.multi"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/extensible-enums-swagger.json --namespace=fixtures.extensibleenums"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/required-optional.json --namespace=fixtures.requiredoptional"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/xml-service.json --namespace=fixtures.xmlservice --enable-xml --url-as-string=false"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/xml-service.json --namespace=fixtures.streamstylexmlserialization --stream-style-serialization --enable-xml --url-as-string=false"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/parameter-flattening.json --namespace=fixtures.parameterflattening --payload-flattening-threshold=1"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/model-flattening.json --namespace=fixtures.modelflattening --payload-flattening-threshold=1 --optional-constant-as-enum=true"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/media_types.json --namespace=fixtures.mediatypes --payload-flattening-threshold=1 --modelerfour.lenient-model-deduplication"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/validation.json --namespace=fixtures.validation"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/non-string-enum.json --namespace=fixtures.nonstringenum --generate-sync-async-clients --disable-client-builder"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/multiple-inheritance.json --namespace=fixtures.multipleinheritance"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/report.json --namespace=fixtures.report --payload-flattening-threshold=1"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-formdata-urlencoded.json --namespace=fixtures.bodyformdataurlencoded"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/constants.json --namespace=fixtures.constants"
+singleThreadGenerate "--version=$AUTOREST_CORE_VERSION --use=./ vanilla-tests/swagger/lro.md"
+singleThreadGenerate "--version=$AUTOREST_CORE_VERSION --use=./ vanilla-tests/swagger/custom-http-exception-mapping.md"
 
 if (Test-Path ./vanilla-tests/swagger/CoverageReporter.java) {
     Move-Item ./vanilla-tests/swagger/CoverageReporter.java ./vanilla-tests/src/main/java/fixtures/report/CoverageReporter.java -Force | Out-Null
 }
 
 # local swagger
-$job = @(
-    "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/discriminator-flattening.json --namespace=fixtures.discriminatorflattening --client-flattened-annotation-target=FIELD",
-    "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/discriminator-flattening.json --namespace=fixtures.discriminatorflattening.requirexmsflattened --require-x-ms-flattened-to-flatten=true",
-    "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/discriminator-flattening.json --namespace=fixtures.discriminatorflattening.noflatten --modelerfour.flatten-models=false",
-    "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/discriminator-flattening.json --namespace=fixtures.discriminatorflattening.clientflatten --modelerfour.flatten-models=false --client-flattened-annotation-target=NONE",
-    "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/client-default-value.json --namespace=fixtures.clientdefaultvalue --modelerfour.flatten-models=false",
-    "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/discriminator-flattening.json --namespace=fixtures.inheritance.donotpassdiscriminator",
-    "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/discriminator-flattening.json --namespace=fixtures.inheritance.passdiscriminator --pass-discriminator-to-child-deserialization=true",
-    "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/client-default-value.json --namespace=fixtures.annotatedgettersandsetters --annotate-getters-and-setters-for-serialization=true",
-    "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/xml-tag-with-attribute-and-value.json --namespace=fixtures.complexxmltag --enable-xml",
-    "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/xml-tag-with-attribute-and-value.json --namespace=fixtures.complexstreamstylexmlserialization --stream-style-serialization --enable-xml",
-    "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/security-info.json --namespace=fixtures.securityinfo",
-    "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/special-header.json --namespace=fixtures.specialheader",
-    "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/required-fields-as-ctor-args-transformation.json --namespace=fixtures.requiredfieldsascotrargstransformation --required-fields-as-ctor-args=true --output-model-immutable"
-) | ForEach-Object -Parallel $generateScript -AsJob -ThrottleLimit $PARALLELIZATION
-if ($false -eq $notimeout) {
-    $job | Wait-Job -Timeout 180
-} else {
-    $job | Wait-Job
-}
-if ($job.State -notin @('Completed', 'Failed')) {
-    throw "Local swagger code generation failed to complete within 180 seconds."
-} else {
-    $job | Receive-Job
-}
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/discriminator-flattening.json --namespace=fixtures.discriminatorflattening --client-flattened-annotation-target=FIELD"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/discriminator-flattening.json --namespace=fixtures.discriminatorflattening.requirexmsflattened --require-x-ms-flattened-to-flatten=true"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/discriminator-flattening.json --namespace=fixtures.discriminatorflattening.noflatten --modelerfour.flatten-models=false"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/discriminator-flattening.json --namespace=fixtures.discriminatorflattening.clientflatten --modelerfour.flatten-models=false --client-flattened-annotation-target=NONE"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/client-default-value.json --namespace=fixtures.clientdefaultvalue --modelerfour.flatten-models=false"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/discriminator-flattening.json --namespace=fixtures.inheritance.donotpassdiscriminator"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/discriminator-flattening.json --namespace=fixtures.inheritance.passdiscriminator --pass-discriminator-to-child-deserialization=true"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/client-default-value.json --namespace=fixtures.annotatedgettersandsetters --annotate-getters-and-setters-for-serialization=true"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/xml-tag-with-attribute-and-value.json --namespace=fixtures.complexxmltag --enable-xml"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/xml-tag-with-attribute-and-value.json --namespace=fixtures.complexstreamstylexmlserialization --stream-style-serialization --enable-xml"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/security-info.json --namespace=fixtures.securityinfo"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/special-header.json --namespace=fixtures.specialheader"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/required-fields-as-ctor-args-transformation.json --namespace=fixtures.requiredfieldsascotrargstransformation --required-fields-as-ctor-args=true --output-model-immutable"
 
 # Azure Data Plane
 if (Test-Path ./azure-dataplane-tests/src/main) {
     Remove-Item ./azure-dataplane-tests/src/main -Recurse -Force | Out-Null
 }
 
-$job = @(
-    "$AZURE_DATAPLANE_ARGUMENTS $AZURE_SDK_FOR_JAVA/schemaregistry/azure-data-schemaregistry/swagger/README.md"
-    "$AZURE_DATAPLANE_ARGUMENTS $AZURE_SDK_FOR_JAVA/containerregistry/azure-containers-containerregistry/swagger/autorest.md"
-    # Form recognizer in Azure SDK for Java repo does not configure polling operations. So, using local configuration
-    # to generate polling methods.
-    "$AZURE_DATAPLANE_ARGUMENTS $AZURE_DATAPLANE_PATH/form-recognizer.md"
-    "$AZURE_DATAPLANE_ARGUMENTS $AZURE_DATAPLANE_PATH/form-recognizer-dpg.md"
-) | ForEach-Object -Parallel $generateScript -AsJob -ThrottleLimit $PARALLELIZATION
-if ($false -eq $notimeout) {
-    $job | Wait-Job -Timeout 120
-} else {
-    $job | Wait-Job
-}
-if ($job.State -notin @('Completed', 'Failed')) {
-    throw "Azure Data Plane code generation failed to complete within 120 seconds."
-} else {
-    $job | Receive-Job
-}
+singleThreadGenerate "$AZURE_DATAPLANE_ARGUMENTS $AZURE_SDK_FOR_JAVA/schemaregistry/azure-data-schemaregistry/swagger/README.md"
+singleThreadGenerate "$AZURE_DATAPLANE_ARGUMENTS $AZURE_SDK_FOR_JAVA/containerregistry/azure-containers-containerregistry/swagger/autorest.md"
+# Form recognizer in Azure SDK for Java repo does not configure polling operations. So, using local configuration
+# to generate polling methods.
+singleThreadGenerate "$AZURE_DATAPLANE_ARGUMENTS $AZURE_DATAPLANE_PATH/form-recognizer.md"
+singleThreadGenerate "$AZURE_DATAPLANE_ARGUMENTS $AZURE_DATAPLANE_PATH/form-recognizer-dpg.md"
+
 Remove-Item ./azure-dataplane-tests/src/main/java/module-info.java -Force | Out-Null
 
 # Azure
-$job = @(
-    "$AZURE_ARGUMENTS --input-file=$SWAGGER_PATH/paging.json --namespace=fixtures.paging --payload-flattening-threshold=1 --generate-sync-async-clients",
-    "$AZURE_ARGUMENTS --input-file=$SWAGGER_PATH/custom-baseUrl-paging.json --namespace=fixtures.custombaseuri.paging --payload-flattening-threshold=1",
-    "$AZURE_ARGUMENTS --input-file=$SWAGGER_PATH/azure-special-properties.json --namespace=fixtures.azurespecials --payload-flattening-threshold=1",
-    "$AZURE_ARGUMENTS --input-file=$SWAGGER_PATH/azure-parameter-grouping.json --namespace=fixtures.azureparametergrouping --payload-flattening-threshold=1",
-    "$AZURE_ARGUMENTS --input-file=$SWAGGER_PATH/subscriptionId-apiVersion.json --namespace=fixtures.subscriptionidapiversion --payload-flattening-threshold=1",
-    "$AZURE_ARGUMENTS --input-file=$SWAGGER_PATH/azure-report.json --namespace=fixtures.azurereport --payload-flattening-threshold=1"
-) | ForEach-Object -Parallel $generateScript -AsJob -ThrottleLimit $PARALLELIZATION
-if ($false -eq $notimeout) {
-    $job | Wait-Job -Timeout 180
-} else {
-    $job | Wait-Job
-}
-if ($job.State -notin @('Completed', 'Failed')) {
-    throw "Azure code generation failed to complete within 180 seconds."
-} else {
-    $job | Receive-Job
-}
+singleThreadGenerate "$AZURE_ARGUMENTS --input-file=$SWAGGER_PATH/paging.json --namespace=fixtures.paging --payload-flattening-threshold=1 --generate-sync-async-clients"
+singleThreadGenerate "$AZURE_ARGUMENTS --input-file=$SWAGGER_PATH/custom-baseUrl-paging.json --namespace=fixtures.custombaseuri.paging --payload-flattening-threshold=1"
+singleThreadGenerate "$AZURE_ARGUMENTS --input-file=$SWAGGER_PATH/azure-special-properties.json --namespace=fixtures.azurespecials --payload-flattening-threshold=1"
+singleThreadGenerate "$AZURE_ARGUMENTS --input-file=$SWAGGER_PATH/azure-parameter-grouping.json --namespace=fixtures.azureparametergrouping --payload-flattening-threshold=1"
+singleThreadGenerate "$AZURE_ARGUMENTS --input-file=$SWAGGER_PATH/subscriptionId-apiVersion.json --namespace=fixtures.subscriptionidapiversion --payload-flattening-threshold=1"
+singleThreadGenerate "$AZURE_ARGUMENTS --input-file=$SWAGGER_PATH/azure-report.json --namespace=fixtures.azurereport --payload-flattening-threshold=1"
 
 # # Azure but use Fluent
 # $ARM_ARGUMENTS = "--version=$AUTOREST_CORE_VERSION --java --use=. --output-folder=azure-tests --azure-arm --fluent=lite --regenerate-pom=false"
-# $job = @(
-#     "$ARM_ARGUMENTS --input-file=$SWAGGER_PATH/lro.json --namespace=fixtures.lro"
-#     "$ARM_ARGUMENTS --input-file=$SWAGGER_PATH/lro-parameterized-endpoints.json --namespace=fixtures.lroparameterizedendpoints"
-# ) | ForEach-Object -Parallel $generateScript -ThrottleLimit $PARALLELIZATION -AsJob
-# $job | Wait-Job -Timeout 120
-# $job | Receive-Job
+# singleThreadGenerate "$ARM_ARGUMENTS --input-file=$SWAGGER_PATH/lro.json --namespace=fixtures.lro"
+# singleThreadGenerate "$ARM_ARGUMENTS --input-file=$SWAGGER_PATH/lro-parameterized-endpoints.json --namespace=fixtures.lroparameterizedendpoints"
 # Remove-Item ./azure-tests/src/main/java/module-info.java -Force
 
 # Protocol
@@ -226,41 +170,29 @@ if (Test-Path ./protocol-tests/src/samples) {
     Remove-Item ./protocol-tests/src/samples -Recurse -Force | Out-Null
 }
 
-$job = @(
-    "$PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/body-string.json --namespace=fixtures.bodystring",
-    "$PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/paging.json --namespace=fixtures.paging",
-    "$PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/body-complex.json --namespace=fixtures.bodycomplex",
-    "$PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/header.json --namespace=fixtures.header",
-    "$PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/httpInfrastructure.json --namespace=fixtures.httpinfrastructure",
-    "$PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/media_types.json --namespace=fixtures.mediatypes",
-    "$PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/url.json --namespace=fixtures.url",
-    "$PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/url-multi-collectionFormat.json --namespace=fixtures.url.multi",
-    "$PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/lro.json --namespace=fixtures.lro",
-    "$PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/dpg-initial.json --namespace=fixtures.llcinitial",
-    "$PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/dpg-update1.json --namespace=fixtures.llcupdate1 --generate-send-request-method",
-    "$PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/parameterized-endpoint.json --namespace=fixtures.parameterizedendpoint --generate-send-request-method",
-    "$PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/constants.json --namespace=fixtures.constants",
-    "$PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/body-file.json --namespace=fixtures.bodyfile",
-    "$PROTOCOL_ARGUMENTS --input-file=vanilla-tests/swagger/special-header.json --namespace=fixtures.specialheader",
-    "$PROTOCOL_ARGUMENTS --input-file=protocol-tests/swagger/required-header-query.json --namespace=fixtures.requiredheaderquery",
-    "$PROTOCOL_ARGUMENTS --input-file=protocol-tests/swagger/constant-and-from-client-parameters.json --namespace=fixtures.constantandclientparam",
-    "$PROTOCOL_ARGUMENTS --input-file=protocol-tests/swagger/multi-media-types.json --namespace=fixtures.multimediatypes",
-    "$PROTOCOL_ARGUMENTS --input-file=protocol-tests/swagger/required-optional-body.json --namespace=fixtures.requiredoptionalbody",
-    "$PROTOCOL_ARGUMENTS --input-file=protocol-tests/swagger/enums.json --namespace=fixtures.enums",
-    "$PROTOCOL_ARGUMENTS --input-file=protocol-tests/swagger/endpoint-lro.json --namespace=fixtures.endpointlro --service-name=LroEndpoint",
-    "--version=$AUTOREST_CORE_VERSION --use=./ protocol-tests/swagger/dpg-customization.md",
-    "--version=$AUTOREST_CORE_VERSION --use=./ protocol-tests/swagger/custom-http-exception-mapping.md"
-) | ForEach-Object -Parallel $generateScript -AsJob -ThrottleLimit $PARALLELIZATION
-if ($false -eq $notimeout) {
-    $job | Wait-Job -Timeout 300
-} else {
-    $job | Wait-Job
-}
-if ($job.State -notin @('Completed', 'Failed')) {
-    throw "Protocol code generation failed to complete within 300 seconds."
-} else {
-    $job | Receive-Job
-}
+singleThreadGenerate "$PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/body-string.json --namespace=fixtures.bodystring"
+singleThreadGenerate "$PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/paging.json --namespace=fixtures.paging"
+singleThreadGenerate "$PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/body-complex.json --namespace=fixtures.bodycomplex"
+singleThreadGenerate "$PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/header.json --namespace=fixtures.header"
+singleThreadGenerate "$PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/httpInfrastructure.json --namespace=fixtures.httpinfrastructure"
+singleThreadGenerate "$PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/media_types.json --namespace=fixtures.mediatypes"
+singleThreadGenerate "$PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/url.json --namespace=fixtures.url"
+singleThreadGenerate "$PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/url-multi-collectionFormat.json --namespace=fixtures.url.multi"
+singleThreadGenerate "$PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/lro.json --namespace=fixtures.lro"
+singleThreadGenerate "$PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/dpg-initial.json --namespace=fixtures.llcinitial"
+singleThreadGenerate "$PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/dpg-update1.json --namespace=fixtures.llcupdate1 --generate-send-request-method"
+singleThreadGenerate "$PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/parameterized-endpoint.json --namespace=fixtures.parameterizedendpoint --generate-send-request-method"
+singleThreadGenerate "$PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/constants.json --namespace=fixtures.constants"
+singleThreadGenerate "$PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/body-file.json --namespace=fixtures.bodyfile"
+singleThreadGenerate "$PROTOCOL_ARGUMENTS --input-file=vanilla-tests/swagger/special-header.json --namespace=fixtures.specialheader"
+singleThreadGenerate "$PROTOCOL_ARGUMENTS --input-file=protocol-tests/swagger/required-header-query.json --namespace=fixtures.requiredheaderquery"
+singleThreadGenerate "$PROTOCOL_ARGUMENTS --input-file=protocol-tests/swagger/constant-and-from-client-parameters.json --namespace=fixtures.constantandclientparam"
+singleThreadGenerate "$PROTOCOL_ARGUMENTS --input-file=protocol-tests/swagger/multi-media-types.json --namespace=fixtures.multimediatypes"
+singleThreadGenerate "$PROTOCOL_ARGUMENTS --input-file=protocol-tests/swagger/required-optional-body.json --namespace=fixtures.requiredoptionalbody"
+singleThreadGenerate "$PROTOCOL_ARGUMENTS --input-file=protocol-tests/swagger/enums.json --namespace=fixtures.enums"
+singleThreadGenerate "$PROTOCOL_ARGUMENTS --input-file=protocol-tests/swagger/endpoint-lro.json --namespace=fixtures.endpointlro --service-name=LroEndpoint"
+singleThreadGenerate "--version=$AUTOREST_CORE_VERSION --use=./ protocol-tests/swagger/dpg-customization.md"
+singleThreadGenerate "--version=$AUTOREST_CORE_VERSION --use=./ protocol-tests/swagger/custom-http-exception-mapping.md"
 
 New-Item ./protocol-tests/src/main/java/fixtures/headexceptions/models -ItemType Directory -Force | Out-Null
 Copy-Item -Path ./protocol-tests/swagger/CustomizedException.java -Destination ./protocol-tests/src/main/java/fixtures/headexceptions/models/CustomizedException.java -Force | Out-Null

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Schema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Schema.java
@@ -11,83 +11,68 @@ import java.util.Set;
 
 public class Schema extends Metadata {
     /**
-     * all schema types
-     * (Required)
-     * 
+     * all schema types (Required)
      */
     private Schema.AllSchemaTypes type;
     /**
      * a short description
-     * 
      */
     private String summary;
     /**
      * example information
-     * 
      */
     private Object example;
     /**
      * If the value isn't sent on the wire, the service will assume this
-     * 
      */
     private Object defaultValue;
     // serialization and usage in SchemaUsage
     /**
      * custom extensible metadata for individual serialization formats
-     * 
      */
     private SerializationFormats serialization;
+    /**
+     * List of serialization formats the Schema is used with, ex JSON, XML, etc.
+     */
+    private Set<String> serializationFormats;
     /**
      * Usage of the schema.
      */
     private Set<SchemaContext> usage;
     /**
-     * 
      * (Required)
-     * 
      */
     private String uid;
     /**
-     * common name of the aspect -- in OAI3 this was typically the key in the parent dictionary
-     * (Required)
-     * 
+     * common name of the aspect -- in OAI3 this was typically the key in the parent dictionary (Required)
      */
     private String $key;
     /**
-     * description of the aspect.
-     * (Required)
-     * 
+     * description of the aspect. (Required)
      */
     private String description;
     /**
      * API versions that this applies to. Undefined means all versions
-     * 
      */
     private List<ApiVersion> apiVersions = new ArrayList<ApiVersion>();
     /**
      * represents  deprecation information for a given aspect
-     * 
      */
     private Deprecation deprecated;
     /**
      * a reference to external documentation
-     * 
      */
     private ExternalDocumentation externalDocs;
 
     /**
-     * all schema types
-     * (Required)
-     * 
+     * all schema types (Required)
      */
     public Schema.AllSchemaTypes getType() {
         return type;
     }
 
     /**
-     * all schema types
-     * (Required)
-     * 
+     * all schema types (Required)
      */
     public void setType(Schema.AllSchemaTypes type) {
         this.type = type;
@@ -95,7 +80,6 @@ public class Schema extends Metadata {
 
     /**
      * a short description
-     * 
      */
     public String getSummary() {
         return summary;
@@ -103,7 +87,6 @@ public class Schema extends Metadata {
 
     /**
      * a short description
-     * 
      */
     public void setSummary(String summary) {
         this.summary = summary;
@@ -111,7 +94,6 @@ public class Schema extends Metadata {
 
     /**
      * example information
-     * 
      */
     public Object getExample() {
         return example;
@@ -119,7 +101,6 @@ public class Schema extends Metadata {
 
     /**
      * example information
-     * 
      */
     public void setExample(Object example) {
         this.example = example;
@@ -127,7 +108,6 @@ public class Schema extends Metadata {
 
     /**
      * If the value isn't sent on the wire, the service will assume this
-     * 
      */
     public Object getDefaultValue() {
         return defaultValue;
@@ -135,7 +115,6 @@ public class Schema extends Metadata {
 
     /**
      * If the value isn't sent on the wire, the service will assume this
-     * 
      */
     public void setDefaultValue(Object defaultValue) {
         this.defaultValue = defaultValue;
@@ -143,7 +122,6 @@ public class Schema extends Metadata {
 
     /**
      * custom extensible metadata for individual serialization formats
-     * 
      */
     public SerializationFormats getSerialization() {
         return serialization;
@@ -151,61 +129,66 @@ public class Schema extends Metadata {
 
     /**
      * custom extensible metadata for individual serialization formats
-     * 
      */
     public void setSerialization(SerializationFormats serialization) {
         this.serialization = serialization;
     }
 
     /**
-     * 
+     * Gets the set of serialization formats this Schema is used with, ex. JSON, XML, etc.
+     *
+     * @return The serialization formats.
+     */
+    public Set<String> getSerializationFormats() {
+        return serializationFormats;
+    }
+
+    /**
+     * Sets the set of serialization formats this Schema is used with, ex. JSON, XML, etc.
+     *
+     * @param serializationFormats The serialization formats.
+     */
+    public void setSerializationFormats(Set<String> serializationFormats) {
+        this.serializationFormats = serializationFormats;
+    }
+
+    /**
      * (Required)
-     * 
      */
     public String getUid() {
         return uid;
     }
 
     /**
-     * 
      * (Required)
-     * 
      */
     public void setUid(String uid) {
         this.uid = uid;
     }
 
     /**
-     * common name of the aspect -- in OAI3 this was typically the key in the parent dictionary
-     * (Required)
-     * 
+     * common name of the aspect -- in OAI3 this was typically the key in the parent dictionary (Required)
      */
     public String get$key() {
         return $key;
     }
 
     /**
-     * common name of the aspect -- in OAI3 this was typically the key in the parent dictionary
-     * (Required)
-     * 
+     * common name of the aspect -- in OAI3 this was typically the key in the parent dictionary (Required)
      */
     public void set$key(String $key) {
         this.$key = $key;
     }
 
     /**
-     * description of the aspect.
-     * (Required)
-     * 
+     * description of the aspect. (Required)
      */
     public String getDescription() {
         return description;
     }
 
     /**
-     * description of the aspect.
-     * (Required)
-     * 
+     * description of the aspect. (Required)
      */
     public void setDescription(String description) {
         this.description = description;
@@ -213,7 +196,6 @@ public class Schema extends Metadata {
 
     /**
      * API versions that this applies to. Undefined means all versions
-     * 
      */
     public List<ApiVersion> getApiVersions() {
         return apiVersions;
@@ -221,7 +203,6 @@ public class Schema extends Metadata {
 
     /**
      * API versions that this applies to. Undefined means all versions
-     * 
      */
     public void setApiVersions(List<ApiVersion> apiVersions) {
         this.apiVersions = apiVersions;
@@ -229,7 +210,6 @@ public class Schema extends Metadata {
 
     /**
      * represents  deprecation information for a given aspect
-     * 
      */
     public Deprecation getDeprecated() {
         return deprecated;
@@ -237,7 +217,6 @@ public class Schema extends Metadata {
 
     /**
      * represents  deprecation information for a given aspect
-     * 
      */
     public void setDeprecated(Deprecation deprecated) {
         this.deprecated = deprecated;
@@ -245,7 +224,6 @@ public class Schema extends Metadata {
 
     /**
      * a reference to external documentation
-     * 
      */
     public ExternalDocumentation getExternalDocs() {
         return externalDocs;
@@ -253,7 +231,6 @@ public class Schema extends Metadata {
 
     /**
      * a reference to external documentation
-     * 
      */
     public void setExternalDocs(ExternalDocumentation externalDocs) {
         this.externalDocs = externalDocs;
@@ -304,7 +281,7 @@ public class Schema extends Metadata {
         private final static Map<String, Schema.AllSchemaTypes> CONSTANTS = new HashMap<String, Schema.AllSchemaTypes>();
 
         static {
-            for (Schema.AllSchemaTypes c: values()) {
+            for (Schema.AllSchemaTypes c : values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
@@ -76,6 +76,7 @@ public class ModelMapper implements IMapper<ObjectSchema, ClientModel> {
                 .packageName(modelType.getPackage())
                 .type(modelType)
                 .stronglyTypedHeader(compositeType.isStronglyTypedHeader())
+                .usedInXml(SchemaUtil.treatAsXml(compositeType))
                 .implementationDetails(new ImplementationDetails.Builder()
                     .usages(usages)
                     .build());
@@ -131,9 +132,9 @@ public class ModelMapper implements IMapper<ObjectSchema, ClientModel> {
                 propertyClientType.addImportsTo(modelImports, false);
             }
 
+            boolean compositeTypeUsedWithXml = SchemaUtil.treatAsXml(compositeType);
             if (!compositeTypeProperties.isEmpty()) {
-                if (settings.isGenerateXmlSerialization()
-                    || (compositeType.getSerialization() != null && compositeType.getSerialization().getXml() != null)) {
+                if (compositeTypeUsedWithXml) {
                     modelImports.add("com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement");
 
                     if (compositeTypeProperties.stream().anyMatch(p -> p.getSchema() instanceof ArraySchema)) {
@@ -212,16 +213,20 @@ public class ModelMapper implements IMapper<ObjectSchema, ClientModel> {
             }
             builder.derivedModels(derivedTypes);
 
-            // Only configure XML information in the ClientModel if XML is defined in the object or 'enable-xml' is true
-            if (compositeType.getSerialization() != null && compositeType.getSerialization().getXml() != null) {
-                final XmlSerlializationFormat xml = compositeType.getSerialization().getXml();
-                String xmlName = CoreUtils.isNullOrEmpty(xml.getName())
-                    ? compositeType.getLanguage().getDefault().getName()
-                    : xml.getName();
-                builder.xmlName(xmlName);
-                builder.xmlNamespace(xml.getNamespace());
-            } else if (compositeType.getLanguage().getDefault() != null && settings.isGenerateXmlSerialization()) {
-                builder.xmlName(compositeType.getLanguage().getDefault().getName());
+            // Only configure XML information if XML is listed as one of the serialization formats in the ObjectSchema.
+            if (SchemaUtil.treatAsXml(compositeType)) {
+                boolean hasXmlFormat = compositeType.getSerialization() != null
+                    && compositeType.getSerialization().getXml() != null;
+                if (hasXmlFormat) {
+                    final XmlSerlializationFormat xml = compositeType.getSerialization().getXml();
+                    String xmlName = CoreUtils.isNullOrEmpty(xml.getName())
+                        ? compositeType.getLanguage().getDefault().getName()
+                        : xml.getName();
+                    builder.xmlName(xmlName);
+                    builder.xmlNamespace(xml.getNamespace());
+                } else {
+                    builder.xmlName(compositeType.getLanguage().getDefault().getName());
+                }
             }
 
             List<ClientModelProperty> properties = new ArrayList<>();
@@ -273,7 +278,9 @@ public class ModelMapper implements IMapper<ObjectSchema, ClientModel> {
             if (hasAdditionalProperties) {
                 DictionarySchema schema = (DictionarySchema) compositeType.getParents().getImmediate().stream()
                     .filter(s -> s instanceof DictionarySchema)
-                    .findFirst().get();
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException(
+                        "Unable to find DictionarySchema for additional properties property."));
                 Property additionalProperties = new Property();
                 additionalProperties.setReadOnly(false);
                 additionalProperties.setSchema(schema);

--- a/javagen/src/main/java/com/azure/autorest/mapper/ObjectMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ObjectMapper.java
@@ -67,6 +67,7 @@ public class ObjectMapper implements IMapper<ObjectSchema, IType> {
             .packageName(classPackage)
             .name(className)
             .extensions(compositeType.getExtensions())
+            .usedInXml(SchemaUtil.treatAsXml(compositeType))
             .build();
     }
 

--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyParameterMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyParameterMapper.java
@@ -71,7 +71,9 @@ public class ProxyParameterMapper implements IMapper<Parameter, ProxyMethodParam
         }
         builder.clientType(clientType);
 
-        if (wireType instanceof ListType && settings.isGenerateXmlSerialization() && parameterRequestLocation == RequestParameterLocation.BODY){
+        if (wireType instanceof ListType
+            && SchemaUtil.treatAsXml(parameterJvWireType)
+            && parameterRequestLocation == RequestParameterLocation.BODY) {
             String modelTypeName = ((ArraySchema) parameterJvWireType).getElementType().getLanguage().getJava().getName();
             boolean isCustomType = settings.isCustomType(CodeNamer.toPascalCase(modelTypeName + "Wrapper"));
             String packageName = isCustomType
@@ -80,6 +82,7 @@ public class ProxyParameterMapper implements IMapper<Parameter, ProxyMethodParam
             wireType = new ClassType.Builder()
                 .packageName(packageName)
                 .name(modelTypeName + "Wrapper")
+                .usedInXml(true)
                 .build();
         } else if (wireType == ArrayType.ByteArray) {
             if (parameterRequestLocation != RequestParameterLocation.BODY /*&& parameterRequestLocation != RequestParameterLocation.FormData*/) {

--- a/javagen/src/main/java/com/azure/autorest/mapper/UnionMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/UnionMapper.java
@@ -7,6 +7,7 @@ import com.azure.autorest.extension.base.model.codemodel.OrSchema;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.model.clientmodel.ClassType;
 import com.azure.autorest.model.clientmodel.IType;
+import com.azure.autorest.util.SchemaUtil;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -34,18 +35,16 @@ public class UnionMapper implements IMapper<OrSchema, IType> {
     private ClassType createClassType(OrSchema compositeType) {
         JavaSettings settings = JavaSettings.getInstance();
 
-        String classPackage;
         String className = compositeType.getLanguage().getJava().getName();
-        if (settings.isCustomType(compositeType.getLanguage().getJava().getName())) {
-            classPackage = settings.getPackage(settings.getCustomTypesSubpackage());
-        } else {
-            classPackage = settings.getPackage(settings.getModelsSubpackage());
-        }
+        String classPackage = settings.isCustomType(className)
+            ? settings.getPackage(settings.getCustomTypesSubpackage())
+            : settings.getPackage(settings.getModelsSubpackage());
 
         return new ClassType.Builder()
-                .packageName(classPackage)
-                .name(className)
-                .extensions(compositeType.getExtensions())
-                .build();
+            .packageName(classPackage)
+            .name(className)
+            .extensions(compositeType.getExtensions())
+            .usedInXml(SchemaUtil.treatAsXml(compositeType))
+            .build();
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ArrayType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ArrayType.java
@@ -120,4 +120,9 @@ public class ArrayType implements IType {
         return ClassType.xmlSerializationCallHelper(xmlWriterName, "writeBinary", attributeOrElementName, namespaceUri,
             valueGetter, isAttribute, nameIsVariable);
     }
+
+    @Override
+    public boolean isUsedInXml() {
+        return false;
+    }
 }

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
@@ -377,12 +377,13 @@ public class ClassType implements IType {
     private final String jsonDeserializationMethod;
     private final String xmlAttributeDeserializationTemplate;
     private final String xmlElementDeserializationMethod;
+    private final boolean usedInXml;
 
     private ClassType(String packageKeyword, String name, List<String> implementationImports, XmsExtensions extensions,
         java.util.function.Function<String, String> defaultValueExpressionConverter, boolean isSwaggerType,
         String serializationMethodBase, boolean wrapSerializationWithObjectsToString,
         String jsonDeserializationMethod, String xmlAttributeDeserializationTemplate,
-        String xmlElementDeserializationMethod) {
+        String xmlElementDeserializationMethod, boolean usedInXml) {
         this.fullName = packageKeyword + "." + name;
         this.packageName = packageKeyword;
         this.name = name;
@@ -395,6 +396,7 @@ public class ClassType implements IType {
         this.jsonDeserializationMethod = jsonDeserializationMethod;
         this.xmlAttributeDeserializationTemplate = xmlAttributeDeserializationTemplate;
         this.xmlElementDeserializationMethod = xmlElementDeserializationMethod;
+        this.usedInXml = usedInXml;
     }
 
     public final String getPackage() {
@@ -614,6 +616,11 @@ public class ClassType implements IType {
             value, isAttribute, nameIsVariable);
     }
 
+    @Override
+    public boolean isUsedInXml() {
+        return usedInXml;
+    }
+
     public static class Builder {
         /*
          * Used to indicate if the class type is generated based on a Swagger definition and isn't a pre-defined,
@@ -631,6 +638,7 @@ public class ClassType implements IType {
         private String serializationMethodBase;
         private String xmlAttributeDeserializationTemplate;
         private String xmlElementDeserializationMethod;
+        private boolean usedInXml;
 
         public Builder() {
             this(true);
@@ -715,6 +723,11 @@ public class ClassType implements IType {
             return this;
         }
 
+        public Builder usedInXml(boolean usedInXml) {
+            this.usedInXml = usedInXml;
+            return this;
+        }
+
         public ClassType build() {
             // Deserialization of Swagger types needs to be handled differently as the named reader needs
             // to be passed to the deserialization method and the reader name cannot be determined here.
@@ -725,7 +738,8 @@ public class ClassType implements IType {
 
             return new ClassType(packageName, name, implementationImports, extensions, defaultValueExpressionConverter,
                 isSwaggerType, serializationMethodBase, wrapSerializationWithObjectsToString,
-                jsonDeserializationMethod, xmlAttributeDeserializationTemplate, xmlElementDeserializationMethod);
+                jsonDeserializationMethod, xmlAttributeDeserializationTemplate, xmlElementDeserializationMethod,
+                usedInXml);
         }
     }
 

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/EnumType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/EnumType.java
@@ -197,6 +197,11 @@ public class EnumType implements IType {
     }
 
     @Override
+    public boolean isUsedInXml() {
+        return false;
+    }
+
+    @Override
     public String toString() {
         return getName();
     }

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/GenericType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/GenericType.java
@@ -292,6 +292,11 @@ public class GenericType implements IType {
     }
 
     @Override
+    public boolean isUsedInXml() {
+        return false;
+    }
+
+    @Override
     public String validate(String expression) {
         return null;
     }

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/IType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/IType.java
@@ -155,4 +155,11 @@ public interface IType {
      */
     String xmlSerializationMethodCall(String xmlWriterName, String attributeOrElementName, String namespaceUri,
         String valueGetter, boolean isAttribute, boolean nameIsVariable);
+
+    /**
+     * Whether the type is used with XML serialization.
+     *
+     * @return Whether the type is used with XML serialization.
+     */
+    boolean isUsedInXml();
 }

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/PrimitiveType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/PrimitiveType.java
@@ -296,6 +296,11 @@ public class PrimitiveType implements IType {
     }
 
     @Override
+    public boolean isUsedInXml() {
+        return false;
+    }
+
+    @Override
     public String toString() {
         return getName();
     }

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -448,8 +448,7 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
                 }
             }
 
-            if (settings.isGenerateXmlSerialization()
-                && parameterClientType instanceof ListType
+            if (parameter.getWireType().isUsedInXml() && parameterClientType instanceof ListType
                 && (parameterLocation == RequestParameterLocation.BODY /*|| parameterLocation == RequestParameterLocation.FormData*/)) {
                 function.line("%s %s = new %s(%s);", parameter.getWireType(), parameterWireName,
                     parameter.getWireType(), alwaysNull ? "null" : parameterName);

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -54,8 +54,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static com.azure.autorest.util.ClientModelUtil.treatAsXml;
-
 /**
  * Writes a ClientModel to a JavaFile.
  */
@@ -99,7 +97,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
         final boolean hasDerivedModels = !model.getDerivedModels().isEmpty();
         final boolean immutableOutputModel = settings.isOutputModelImmutable()
             && model.getImplementationDetails() != null && !model.getImplementationDetails().isInput();
-        boolean treatAsXml = treatAsXml(settings, model);
+        boolean treatAsXml = model.isUsedInXml();
 
         // Handle adding annotations if the model is polymorphic.
         handlePolymorphism(model, hasDerivedModels, settings.isDiscriminatorPassedToChildDeserialization(), javaFile);
@@ -448,7 +446,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
      * @param settings Autorest generation settings.
      */
     protected void addClassLevelAnnotations(ClientModel model, JavaFile javaFile, JavaSettings settings) {
-        if (treatAsXml(settings, model)) {
+        if (model.isUsedInXml()) {
             if (!CoreUtils.isNullOrEmpty(model.getXmlNamespace())) {
                 javaFile.annotation(String.format("JacksonXmlRootElement(localName = \"%1$s\", namespace = \"%2$s\")",
                     model.getXmlName(), model.getXmlNamespace()));
@@ -515,7 +513,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
             IType propertyType = property.getWireType();
 
             String fieldSignature;
-            if (treatAsXml(settings, model)) {
+            if (model.isUsedInXml()) {
                 if (property.isXmlWrapper() && !settings.isStreamStyleSerialization()) {
                     String xmlWrapperClassName = getPropertyXmlWrapperClassName(property);
                     classBlock.staticFinalClass(JavaVisibility.PackagePrivate, xmlWrapperClassName,
@@ -629,7 +627,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
             classBlock.annotation("JsonInclude(value = JsonInclude.Include.NON_NULL, content = JsonInclude.Include.ALWAYS)");
         }
 
-        boolean treatAsXml = treatAsXml(settings, model);
+        boolean treatAsXml = model.isUsedInXml();
         if (!CoreUtils.isNullOrEmpty(property.getHeaderCollectionPrefix())) {
             classBlock.annotation("HeaderCollection(\"" + property.getHeaderCollectionPrefix() + "\")");
         } else if (treatAsXml && property.isXmlAttribute()) {

--- a/javagen/src/main/java/com/azure/autorest/util/ClientModelUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/ClientModelUtil.java
@@ -505,18 +505,4 @@ public class ClientModelUtil {
         return property.isRequired() && settings.isRequiredFieldsAsConstructorArgs()
             && (!property.isReadOnly() || settings.isIncludeReadOnlyInConstructorArgs());
     }
-
-    /**
-     * Determines whether the caller should treat the model as XML.
-     * <p>
-     * XML is used when either {@link JavaSettings#isGenerateXmlSerialization()} is true or the model or property was
-     * defined in Swagger with an {@code xml} property.
-     *
-     * @param settings The Autorest generation settings.
-     * @param model The model.
-     * @return Whether the model should be treated as XML.
-     */
-    public static boolean treatAsXml(JavaSettings settings, ClientModel model) {
-        return settings.isGenerateXmlSerialization() || model.getXmlName() != null;
-    }
 }

--- a/javagen/src/main/java/com/azure/autorest/util/SchemaUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/SchemaUtil.java
@@ -49,9 +49,9 @@ public class SchemaUtil {
                 chain = new LinkedList<>();
                 chain.addFirst(schema);
                 while (schema instanceof ObjectSchema
-                        && ((ObjectSchema) schema).getParents() != null
-                        && ((ObjectSchema) schema).getParents().getImmediate() != null
-                        && !((ObjectSchema) schema).getParents().getImmediate().isEmpty()) {
+                    && ((ObjectSchema) schema).getParents() != null
+                    && ((ObjectSchema) schema).getParents().getImmediate() != null
+                    && !((ObjectSchema) schema).getParents().getImmediate().isEmpty()) {
                     // Assume always inheriting from an ObjectSchema and no multiple inheritance
                     schema = ((ObjectSchema) schema).getParents().getImmediate().get(0);
                     chain.addFirst(schema);
@@ -60,9 +60,9 @@ public class SchemaUtil {
                 Stack<Schema> newChain = new Stack<>();
                 newChain.push(schema);
                 while (schema instanceof ObjectSchema
-                        && ((ObjectSchema) schema).getParents() != null
-                        && ((ObjectSchema) schema).getParents().getImmediate() != null
-                        && !((ObjectSchema) schema).getParents().getImmediate().isEmpty()) {
+                    && ((ObjectSchema) schema).getParents() != null
+                    && ((ObjectSchema) schema).getParents().getImmediate() != null
+                    && !((ObjectSchema) schema).getParents().getImmediate().isEmpty()) {
                     // Assume always inheriting from an ObjectSchema and no multiple inheritance
                     schema = ((ObjectSchema) schema).getParents().getImmediate().get(0);
                     newChain.push(schema);
@@ -109,7 +109,7 @@ public class SchemaUtil {
 
         if (responseBodyType == null) {
             if (operation.getRequests().stream().anyMatch(req -> HttpMethod.HEAD.name().equalsIgnoreCase(req.getProtocol().getHttp().getMethod()))
-                    && operation.getResponses().stream().flatMap(r -> r.getProtocol().getHttp().getStatusCodes().stream()).anyMatch(c -> c.equals("404"))) {
+                && operation.getResponses().stream().flatMap(r -> r.getProtocol().getHttp().getStatusCodes().stream()).anyMatch(c -> c.equals("404"))) {
                 // Azure core would internally convert the response status code to boolean.
                 responseBodyType = PrimitiveType.Boolean;
             } else if (containsBinaryResponse(operation)) {
@@ -160,7 +160,7 @@ public class SchemaUtil {
         }
         if (discriminator == null) {
             throw new IllegalArgumentException(String.format("discriminator not found in type %s and its parents",
-                    compositeType.getLanguage().getJava().getName()));
+                compositeType.getLanguage().getJava().getName()));
         }
         return discriminator;
     }
@@ -176,10 +176,10 @@ public class SchemaUtil {
      */
     public static boolean responseContainsHeaderSchemas(Operation operation, JavaSettings settings) {
         return operation.getResponses().stream()
-                .filter(r -> r.getProtocol() != null && r.getProtocol().getHttp() != null && r.getProtocol().getHttp().getHeaders() != null)
-                .flatMap(r -> r.getProtocol().getHttp().getHeaders().stream().map(Header::getSchema))
-                .anyMatch(Objects::nonNull)
-                && notFluentLRO(operation, settings) && notDataPlaneLRO(operation, settings);
+            .filter(r -> r.getProtocol() != null && r.getProtocol().getHttp() != null && r.getProtocol().getHttp().getHeaders() != null)
+            .flatMap(r -> r.getProtocol().getHttp().getHeaders().stream().map(Header::getSchema))
+            .anyMatch(Objects::nonNull)
+            && notFluentLRO(operation, settings) && notDataPlaneLRO(operation, settings);
     }
 
     /**
@@ -211,13 +211,13 @@ public class SchemaUtil {
         if (parameterRequestLocation == RequestParameterLocation.BODY) {
             returnType = ClassType.BinaryData;
         } else if (!(returnType instanceof PrimitiveType)) {
-            if(type instanceof EnumType) {
+            if (type instanceof EnumType) {
                 returnType = ClassType.String;
             }
-            if(type instanceof IterableType && ((IterableType) type).getElementType() instanceof EnumType) {
+            if (type instanceof IterableType && ((IterableType) type).getElementType() instanceof EnumType) {
                 returnType = new IterableType(ClassType.String);
             }
-            if(type instanceof ListType && ((ListType) type).getElementType() instanceof EnumType) {
+            if (type instanceof ListType && ((ListType) type).getElementType() instanceof EnumType) {
                 returnType = new ListType(ClassType.String);
             }
         }
@@ -251,13 +251,14 @@ public class SchemaUtil {
 
                     // https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/core/azure-core-experimental/src/main/java/com/azure/core/experimental/models/PollResult.java
                     if ("PollResult".equals(name)
-                            && compositeType.getLanguage().getJava() != null
-                            && compositeType.getLanguage().getJava().getNamespace() != null
-                            && compositeType.getLanguage().getJava().getNamespace().startsWith("com.azure.core")) {
+                        && compositeType.getLanguage().getJava() != null
+                        && compositeType.getLanguage().getJava().getNamespace() != null
+                        && compositeType.getLanguage().getJava().getNamespace().startsWith("com.azure.core")) {
                         classType = new ClassType.Builder()
-                                .name(name)
-                                .packageName(compositeType.getLanguage().getJava().getNamespace())
-                                .build();
+                            .name(name)
+                            .packageName(compositeType.getLanguage().getJava().getNamespace())
+                            .usedInXml(treatAsXml(compositeType))
+                            .build();
                     }
                 }
             }
@@ -276,8 +277,8 @@ public class SchemaUtil {
             return Collections.emptySet();
         }
         return schemaContexts.stream()
-                .map(c -> ImplementationDetails.Usage.fromValue(c.value()))
-                .collect(Collectors.toSet());
+            .map(c -> ImplementationDetails.Usage.fromValue(c.value()))
+            .collect(Collectors.toSet());
     }
 
     private static boolean containsBinaryResponse(Operation operation) {
@@ -305,5 +306,10 @@ public class SchemaUtil {
             return null;
         }
         return m.getLanguage().getJava().getName();
+    }
+
+    public static boolean treatAsXml(Schema schema) {
+        return (schema.getSerializationFormats() != null && schema.getSerializationFormats().contains("xml"))
+            || (schema.getSerialization() != null && schema.getSerialization().getXml() != null);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/JsonInput.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/JsonInput.java
@@ -5,17 +5,15 @@
 package fixtures.streamstylexmlserialization.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.util.CoreUtils;
-import com.azure.xml.XmlReader;
-import com.azure.xml.XmlSerializable;
-import com.azure.xml.XmlToken;
-import com.azure.xml.XmlWriter;
-import javax.xml.namespace.QName;
-import javax.xml.stream.XMLStreamException;
+import com.azure.json.JsonReader;
+import com.azure.json.JsonSerializable;
+import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
+import java.io.IOException;
 
 /** The JsonInput model. */
 @Fluent
-public final class JsonInput implements XmlSerializable<JsonInput> {
+public final class JsonInput implements JsonSerializable<JsonInput> {
     /*
      * The id property.
      */
@@ -52,53 +50,32 @@ public final class JsonInput implements XmlSerializable<JsonInput> {
     public void validate() {}
 
     @Override
-    public XmlWriter toXml(XmlWriter xmlWriter) throws XMLStreamException {
-        return toXml(xmlWriter, null);
-    }
-
-    @Override
-    public XmlWriter toXml(XmlWriter xmlWriter, String rootElementName) throws XMLStreamException {
-        rootElementName = CoreUtils.isNullOrEmpty(rootElementName) ? "JsonInput" : rootElementName;
-        xmlWriter.writeStartElement(rootElementName);
-        xmlWriter.writeNumberElement("id", this.id);
-        return xmlWriter.writeEndElement();
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        jsonWriter.writeStartObject();
+        jsonWriter.writeNumberField("id", this.id);
+        return jsonWriter.writeEndObject();
     }
 
     /**
-     * Reads an instance of JsonInput from the XmlReader.
+     * Reads an instance of JsonInput from the JsonReader.
      *
-     * @param xmlReader The XmlReader being read.
-     * @return An instance of JsonInput if the XmlReader was pointing to an instance of it, or null if it was pointing
-     *     to XML null.
-     * @throws XMLStreamException If an error occurs while reading the JsonInput.
+     * @param jsonReader The JsonReader being read.
+     * @return An instance of JsonInput if the JsonReader was pointing to an instance of it, or null if it was pointing
+     *     to JSON null.
+     * @throws IOException If an error occurs while reading the JsonInput.
      */
-    public static JsonInput fromXml(XmlReader xmlReader) throws XMLStreamException {
-        return fromXml(xmlReader, null);
-    }
-
-    /**
-     * Reads an instance of JsonInput from the XmlReader.
-     *
-     * @param xmlReader The XmlReader being read.
-     * @param rootElementName Optional root element name to override the default defined by the model. Used to support
-     *     cases where the model can deserialize from different root element names.
-     * @return An instance of JsonInput if the XmlReader was pointing to an instance of it, or null if it was pointing
-     *     to XML null.
-     * @throws XMLStreamException If an error occurs while reading the JsonInput.
-     */
-    public static JsonInput fromXml(XmlReader xmlReader, String rootElementName) throws XMLStreamException {
-        String finalRootElementName = CoreUtils.isNullOrEmpty(rootElementName) ? "JsonInput" : rootElementName;
-        return xmlReader.readObject(
-                finalRootElementName,
+    public static JsonInput fromJson(JsonReader jsonReader) throws IOException {
+        return jsonReader.readObject(
                 reader -> {
                     JsonInput deserializedJsonInput = new JsonInput();
-                    while (reader.nextElement() != XmlToken.END_ELEMENT) {
-                        QName elementName = reader.getElementName();
+                    while (reader.nextToken() != JsonToken.END_OBJECT) {
+                        String fieldName = reader.getFieldName();
+                        reader.nextToken();
 
-                        if ("id".equals(elementName.getLocalPart())) {
-                            deserializedJsonInput.id = reader.getNullableElement(Integer::parseInt);
+                        if ("id".equals(fieldName)) {
+                            deserializedJsonInput.id = reader.getNullable(JsonReader::getInt);
                         } else {
-                            reader.skipElement();
+                            reader.skipChildren();
                         }
                     }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/JsonOutput.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/JsonOutput.java
@@ -5,17 +5,15 @@
 package fixtures.streamstylexmlserialization.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.util.CoreUtils;
-import com.azure.xml.XmlReader;
-import com.azure.xml.XmlSerializable;
-import com.azure.xml.XmlToken;
-import com.azure.xml.XmlWriter;
-import javax.xml.namespace.QName;
-import javax.xml.stream.XMLStreamException;
+import com.azure.json.JsonReader;
+import com.azure.json.JsonSerializable;
+import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
+import java.io.IOException;
 
 /** The JsonOutput model. */
 @Fluent
-public final class JsonOutput implements XmlSerializable<JsonOutput> {
+public final class JsonOutput implements JsonSerializable<JsonOutput> {
     /*
      * The id property.
      */
@@ -52,53 +50,32 @@ public final class JsonOutput implements XmlSerializable<JsonOutput> {
     public void validate() {}
 
     @Override
-    public XmlWriter toXml(XmlWriter xmlWriter) throws XMLStreamException {
-        return toXml(xmlWriter, null);
-    }
-
-    @Override
-    public XmlWriter toXml(XmlWriter xmlWriter, String rootElementName) throws XMLStreamException {
-        rootElementName = CoreUtils.isNullOrEmpty(rootElementName) ? "JsonOutput" : rootElementName;
-        xmlWriter.writeStartElement(rootElementName);
-        xmlWriter.writeNumberElement("id", this.id);
-        return xmlWriter.writeEndElement();
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        jsonWriter.writeStartObject();
+        jsonWriter.writeNumberField("id", this.id);
+        return jsonWriter.writeEndObject();
     }
 
     /**
-     * Reads an instance of JsonOutput from the XmlReader.
+     * Reads an instance of JsonOutput from the JsonReader.
      *
-     * @param xmlReader The XmlReader being read.
-     * @return An instance of JsonOutput if the XmlReader was pointing to an instance of it, or null if it was pointing
-     *     to XML null.
-     * @throws XMLStreamException If an error occurs while reading the JsonOutput.
+     * @param jsonReader The JsonReader being read.
+     * @return An instance of JsonOutput if the JsonReader was pointing to an instance of it, or null if it was pointing
+     *     to JSON null.
+     * @throws IOException If an error occurs while reading the JsonOutput.
      */
-    public static JsonOutput fromXml(XmlReader xmlReader) throws XMLStreamException {
-        return fromXml(xmlReader, null);
-    }
-
-    /**
-     * Reads an instance of JsonOutput from the XmlReader.
-     *
-     * @param xmlReader The XmlReader being read.
-     * @param rootElementName Optional root element name to override the default defined by the model. Used to support
-     *     cases where the model can deserialize from different root element names.
-     * @return An instance of JsonOutput if the XmlReader was pointing to an instance of it, or null if it was pointing
-     *     to XML null.
-     * @throws XMLStreamException If an error occurs while reading the JsonOutput.
-     */
-    public static JsonOutput fromXml(XmlReader xmlReader, String rootElementName) throws XMLStreamException {
-        String finalRootElementName = CoreUtils.isNullOrEmpty(rootElementName) ? "JsonOutput" : rootElementName;
-        return xmlReader.readObject(
-                finalRootElementName,
+    public static JsonOutput fromJson(JsonReader jsonReader) throws IOException {
+        return jsonReader.readObject(
                 reader -> {
                     JsonOutput deserializedJsonOutput = new JsonOutput();
-                    while (reader.nextElement() != XmlToken.END_ELEMENT) {
-                        QName elementName = reader.getElementName();
+                    while (reader.nextToken() != JsonToken.END_OBJECT) {
+                        String fieldName = reader.getFieldName();
+                        reader.nextToken();
 
-                        if ("id".equals(elementName.getLocalPart())) {
-                            deserializedJsonOutput.id = reader.getNullableElement(Integer::parseInt);
+                        if ("id".equals(fieldName)) {
+                            deserializedJsonOutput.id = reader.getNullable(JsonReader::getInt);
                         } else {
-                            reader.skipElement();
+                            reader.skipChildren();
                         }
                     }
 

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/JsonInput.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/JsonInput.java
@@ -6,10 +6,8 @@ package fixtures.xmlservice.models;
 
 import com.azure.core.annotation.Fluent;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /** The JsonInput model. */
-@JacksonXmlRootElement(localName = "JsonInput")
 @Fluent
 public final class JsonInput {
     /*

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/JsonOutput.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/JsonOutput.java
@@ -6,10 +6,8 @@ package fixtures.xmlservice.models;
 
 import com.azure.core.annotation.Fluent;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /** The JsonOutput model. */
-@JacksonXmlRootElement(localName = "JsonOutput")
 @Fluent
 public final class JsonOutput {
     /*

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/XmlsGetHeadersHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/XmlsGetHeadersHeaders.java
@@ -8,10 +8,8 @@ import com.azure.core.annotation.Fluent;
 import com.azure.core.http.HttpHeaderName;
 import com.azure.core.http.HttpHeaders;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /** The XmlsGetHeadersHeaders model. */
-@JacksonXmlRootElement(localName = "null")
 @Fluent
 public final class XmlsGetHeadersHeaders {
     /*

--- a/vanilla-tests/swagger/xml-tag-with-attribute-and-value.json
+++ b/vanilla-tests/swagger/xml-tag-with-attribute-and-value.json
@@ -22,6 +22,7 @@
   },
   "definitions": {
     "BlobName": {
+      "xml": {},
       "type": "object",
       "properties": {
         "Encoded": {


### PR DESCRIPTION
This PR updates code generation to take into account `serializationFormats` produced by modeler four to determine which serialization formats a model or property uses. With this change `enable-xml` is no longer needed or used anywhere in code generation and can be removed at a later date.