### PR TITLE
tsp, use HttpHeaderName for headers on RequestOptions

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/template/ConvenienceMethodTemplateBase.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ConvenienceMethodTemplateBase.java
@@ -23,6 +23,7 @@ import com.azure.autorest.model.javamodel.JavaBlock;
 import com.azure.autorest.model.javamodel.JavaClass;
 import com.azure.autorest.model.javamodel.JavaType;
 import com.azure.autorest.model.javamodel.JavaVisibility;
+import com.azure.autorest.template.util.ModelTemplateHeaderHelper;
 import com.azure.autorest.util.ClientModelUtil;
 import com.azure.autorest.util.CodeNamer;
 import com.azure.autorest.util.TemplateUtil;
@@ -277,6 +278,7 @@ abstract class ConvenienceMethodTemplateBase {
                     }
                 });
 
+        ClassType.HTTP_HEADER_NAME.addImportsTo(imports, false);
         ClassType.BinaryData.addImportsTo(imports, false);
         ClassType.RequestOptions.addImportsTo(imports, false);
         imports.add(Collectors.class.getName());
@@ -364,7 +366,7 @@ abstract class ConvenienceMethodTemplateBase {
     private static void writeHeader(MethodParameter parameter, JavaBlock methodBlock) {
         Consumer<JavaBlock> writeLine = javaBlock -> javaBlock.line(
                 String.format("requestOptions.setHeader(%1$s, %2$s);",
-                        ClassType.String.defaultValueExpression(parameter.getSerializedName()),
+                        ModelTemplateHeaderHelper.getHttpHeaderNameInstanceExpression(parameter.getSerializedName()),
                         expressionConvertToString(parameter.getName(), parameter.getClientMethodParameter().getWireType(), parameter.getProxyMethodParameter())));
         if (!parameter.getClientMethodParameter().isRequired()) {
             methodBlock.ifBlock(String.format("%s != null", parameter.getName()), ifBlock -> {

--- a/javagen/src/main/java/com/azure/autorest/template/util/ModelTemplateHeaderHelper.java
+++ b/javagen/src/main/java/com/azure/autorest/template/util/ModelTemplateHeaderHelper.java
@@ -93,6 +93,26 @@ public final class ModelTemplateHeaderHelper {
     }
 
     /**
+     * Gets an expression of HttpHeaderName instance.
+     * <p>
+     * For known name, it would be {@code HttpHeaderName.IF_MATCH}. For unknown name, it would be {@code HttpHeaderName.fromString("foo")}.
+     *
+     * @param headerName the header name
+     * @return the expression of HttpHeaderName instance.
+     */
+    public static String getHttpHeaderNameInstanceExpression(String headerName) {
+        // match the init logic of HEADER_TO_KNOWN_HTTPHEADERNAME
+        String caseInsensitiveName = HttpHeaderName.fromString(headerName).getCaseInsensitiveName();
+
+        if (HEADER_TO_KNOWN_HTTPHEADERNAME.containsKey(caseInsensitiveName)) {
+            // known name
+            return String.format("HttpHeaderName.%s", HEADER_TO_KNOWN_HTTPHEADERNAME.get(caseInsensitiveName));
+        } else {
+            return String.format("HttpHeaderName.fromString(%s)", ClassType.String.defaultValueExpression(headerName));
+        }
+    }
+
+    /**
      * Adds {@code private static final} {@link HttpHeaderName} constants representing the headers that are used by the
      * {@link ClientModel}.
      *

--- a/typespec-extension/src/code-model-builder.ts
+++ b/typespec-extension/src/code-model-builder.ts
@@ -176,7 +176,7 @@ export class CodeModelBuilder {
     this.program = program1;
 
     if (this.options["skip-special-headers"]) {
-      this.options["skip-special-headers"].forEach((it) => specialHeaderNames.add(it));
+      this.options["skip-special-headers"].forEach((it) => specialHeaderNames.add(it.toLowerCase()));
     }
 
     this.sdkContext = createSdkContext(context as EmitContext<any>);

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/traits/TraitsAsyncClient.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/traits/TraitsAsyncClient.java
@@ -16,6 +16,7 @@ import com.azure.core.exception.ClientAuthenticationException;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
+import com.azure.core.http.HttpHeaderName;
 import com.azure.core.http.RequestConditions;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
@@ -151,16 +152,18 @@ public final class TraitsAsyncClient {
         OffsetDateTime ifUnmodifiedSince = requestConditions == null ? null : requestConditions.getIfUnmodifiedSince();
         OffsetDateTime ifModifiedSince = requestConditions == null ? null : requestConditions.getIfModifiedSince();
         if (ifMatch != null) {
-            requestOptions.setHeader("If-Match", ifMatch);
+            requestOptions.setHeader(HttpHeaderName.IF_MATCH, ifMatch);
         }
         if (ifNoneMatch != null) {
-            requestOptions.setHeader("If-None-Match", ifNoneMatch);
+            requestOptions.setHeader(HttpHeaderName.IF_NONE_MATCH, ifNoneMatch);
         }
         if (ifUnmodifiedSince != null) {
-            requestOptions.setHeader("If-Unmodified-Since", String.valueOf(new DateTimeRfc1123(ifUnmodifiedSince)));
+            requestOptions.setHeader(
+                    HttpHeaderName.IF_UNMODIFIED_SINCE, String.valueOf(new DateTimeRfc1123(ifUnmodifiedSince)));
         }
         if (ifModifiedSince != null) {
-            requestOptions.setHeader("If-Modified-Since", String.valueOf(new DateTimeRfc1123(ifModifiedSince)));
+            requestOptions.setHeader(
+                    HttpHeaderName.IF_MODIFIED_SINCE, String.valueOf(new DateTimeRfc1123(ifModifiedSince)));
         }
         return smokeTestWithResponse(id, foo, requestOptions)
                 .flatMap(FluxUtil::toMono)

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/traits/TraitsClient.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/traits/TraitsClient.java
@@ -16,6 +16,7 @@ import com.azure.core.exception.ClientAuthenticationException;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
+import com.azure.core.http.HttpHeaderName;
 import com.azure.core.http.RequestConditions;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
@@ -148,16 +149,18 @@ public final class TraitsClient {
         OffsetDateTime ifUnmodifiedSince = requestConditions == null ? null : requestConditions.getIfUnmodifiedSince();
         OffsetDateTime ifModifiedSince = requestConditions == null ? null : requestConditions.getIfModifiedSince();
         if (ifMatch != null) {
-            requestOptions.setHeader("If-Match", ifMatch);
+            requestOptions.setHeader(HttpHeaderName.IF_MATCH, ifMatch);
         }
         if (ifNoneMatch != null) {
-            requestOptions.setHeader("If-None-Match", ifNoneMatch);
+            requestOptions.setHeader(HttpHeaderName.IF_NONE_MATCH, ifNoneMatch);
         }
         if (ifUnmodifiedSince != null) {
-            requestOptions.setHeader("If-Unmodified-Since", String.valueOf(new DateTimeRfc1123(ifUnmodifiedSince)));
+            requestOptions.setHeader(
+                    HttpHeaderName.IF_UNMODIFIED_SINCE, String.valueOf(new DateTimeRfc1123(ifUnmodifiedSince)));
         }
         if (ifModifiedSince != null) {
-            requestOptions.setHeader("If-Modified-Since", String.valueOf(new DateTimeRfc1123(ifModifiedSince)));
+            requestOptions.setHeader(
+                    HttpHeaderName.IF_MODIFIED_SINCE, String.valueOf(new DateTimeRfc1123(ifModifiedSince)));
         }
         return smokeTestWithResponse(id, foo, requestOptions).getValue().toObject(User.class);
     }

--- a/typespec-tests/src/main/java/com/cadl/builtin/BuiltinAsyncClient.java
+++ b/typespec-tests/src/main/java/com/cadl/builtin/BuiltinAsyncClient.java
@@ -12,6 +12,7 @@ import com.azure.core.exception.ClientAuthenticationException;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
+import com.azure.core.http.HttpHeaderName;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
@@ -218,7 +219,8 @@ public final class BuiltinAsyncClient {
         // Generated convenience method for readWithResponse
         RequestOptions requestOptions = new RequestOptions();
         if (dateTime != null) {
-            requestOptions.setHeader("x-ms-date", String.valueOf(new DateTimeRfc1123(dateTime)));
+            requestOptions.setHeader(
+                    HttpHeaderName.fromString("x-ms-date"), String.valueOf(new DateTimeRfc1123(dateTime)));
         }
         if (filter != null) {
             requestOptions.addQueryParam("filter", filter, false);

--- a/typespec-tests/src/main/java/com/cadl/builtin/BuiltinClient.java
+++ b/typespec-tests/src/main/java/com/cadl/builtin/BuiltinClient.java
@@ -12,6 +12,7 @@ import com.azure.core.exception.ClientAuthenticationException;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
+import com.azure.core.http.HttpHeaderName;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
@@ -216,7 +217,8 @@ public final class BuiltinClient {
         // Generated convenience method for readWithResponse
         RequestOptions requestOptions = new RequestOptions();
         if (dateTime != null) {
-            requestOptions.setHeader("x-ms-date", String.valueOf(new DateTimeRfc1123(dateTime)));
+            requestOptions.setHeader(
+                    HttpHeaderName.fromString("x-ms-date"), String.valueOf(new DateTimeRfc1123(dateTime)));
         }
         if (filter != null) {
             requestOptions.addQueryParam("filter", filter, false);

--- a/typespec-tests/src/main/java/com/cadl/enumservice/EnumServiceAsyncClient.java
+++ b/typespec-tests/src/main/java/com/cadl/enumservice/EnumServiceAsyncClient.java
@@ -12,6 +12,7 @@ import com.azure.core.exception.ClientAuthenticationException;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
+import com.azure.core.http.HttpHeaderName;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
@@ -1104,7 +1105,7 @@ public final class EnumServiceAsyncClient {
         RequestOptions requestOptions = new RequestOptions();
         if (colorArrayOpt != null) {
             requestOptions.setHeader(
-                    "color-array-opt",
+                    HttpHeaderName.fromString("color-array-opt"),
                     JacksonAdapter.createDefaultSerializerAdapter()
                             .serializeIterable(colorArrayOpt, CollectionFormat.CSV));
         }

--- a/typespec-tests/src/main/java/com/cadl/enumservice/EnumServiceClient.java
+++ b/typespec-tests/src/main/java/com/cadl/enumservice/EnumServiceClient.java
@@ -12,6 +12,7 @@ import com.azure.core.exception.ClientAuthenticationException;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
+import com.azure.core.http.HttpHeaderName;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
@@ -1074,7 +1075,7 @@ public final class EnumServiceClient {
         RequestOptions requestOptions = new RequestOptions();
         if (colorArrayOpt != null) {
             requestOptions.setHeader(
-                    "color-array-opt",
+                    HttpHeaderName.fromString("color-array-opt"),
                     JacksonAdapter.createDefaultSerializerAdapter()
                             .serializeIterable(colorArrayOpt, CollectionFormat.CSV));
         }

--- a/typespec-tests/src/main/java/com/cadl/naming/NamingAsyncClient.java
+++ b/typespec-tests/src/main/java/com/cadl/naming/NamingAsyncClient.java
@@ -12,6 +12,7 @@ import com.azure.core.exception.ClientAuthenticationException;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
+import com.azure.core.http.HttpHeaderName;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
@@ -103,7 +104,7 @@ public final class NamingAsyncClient {
         // Generated convenience method for postWithResponse
         RequestOptions requestOptions = new RequestOptions();
         if (etag != null) {
-            requestOptions.setHeader("etag", etag);
+            requestOptions.setHeader(HttpHeaderName.ETAG, etag);
         }
         return postWithResponse(name, requestOptions)
                 .flatMap(FluxUtil::toMono)

--- a/typespec-tests/src/main/java/com/cadl/naming/NamingClient.java
+++ b/typespec-tests/src/main/java/com/cadl/naming/NamingClient.java
@@ -12,6 +12,7 @@ import com.azure.core.exception.ClientAuthenticationException;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
+import com.azure.core.http.HttpHeaderName;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
@@ -101,7 +102,7 @@ public final class NamingClient {
         // Generated convenience method for postWithResponse
         RequestOptions requestOptions = new RequestOptions();
         if (etag != null) {
-            requestOptions.setHeader("etag", etag);
+            requestOptions.setHeader(HttpHeaderName.ETAG, etag);
         }
         return postWithResponse(name, requestOptions).getValue().toObject(DataResponse.class);
     }

--- a/typespec-tests/src/main/java/com/cadl/optional/OptionalAsyncClient.java
+++ b/typespec-tests/src/main/java/com/cadl/optional/OptionalAsyncClient.java
@@ -12,6 +12,7 @@ import com.azure.core.exception.ClientAuthenticationException;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
+import com.azure.core.http.HttpHeaderName;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
@@ -188,7 +189,7 @@ public final class OptionalAsyncClient {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
         if (requestHeaderOptional != null) {
-            requestOptions.setHeader("request-header-optional", requestHeaderOptional);
+            requestOptions.setHeader(HttpHeaderName.fromString("request-header-optional"), requestHeaderOptional);
         }
         if (booleanNullable != null) {
             requestOptions.addQueryParam("booleanNullable", String.valueOf(booleanNullable), false);

--- a/typespec-tests/src/main/java/com/cadl/optional/OptionalClient.java
+++ b/typespec-tests/src/main/java/com/cadl/optional/OptionalClient.java
@@ -12,6 +12,7 @@ import com.azure.core.exception.ClientAuthenticationException;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
+import com.azure.core.http.HttpHeaderName;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
@@ -186,7 +187,7 @@ public final class OptionalClient {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
         if (requestHeaderOptional != null) {
-            requestOptions.setHeader("request-header-optional", requestHeaderOptional);
+            requestOptions.setHeader(HttpHeaderName.fromString("request-header-optional"), requestHeaderOptional);
         }
         if (booleanNullable != null) {
             requestOptions.addQueryParam("booleanNullable", String.valueOf(booleanNullable), false);

--- a/typespec-tests/src/main/java/com/cadl/specialheaders/SpecialHeadersAsyncClient.java
+++ b/typespec-tests/src/main/java/com/cadl/specialheaders/SpecialHeadersAsyncClient.java
@@ -12,6 +12,7 @@ import com.azure.core.exception.ClientAuthenticationException;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
+import com.azure.core.http.HttpHeaderName;
 import com.azure.core.http.MatchConditions;
 import com.azure.core.http.RequestConditions;
 import com.azure.core.http.rest.RequestOptions;
@@ -489,16 +490,18 @@ public final class SpecialHeadersAsyncClient {
         OffsetDateTime ifUnmodifiedSince = requestConditions == null ? null : requestConditions.getIfUnmodifiedSince();
         OffsetDateTime ifModifiedSince = requestConditions == null ? null : requestConditions.getIfModifiedSince();
         if (ifMatch != null) {
-            requestOptions.setHeader("If-Match", ifMatch);
+            requestOptions.setHeader(HttpHeaderName.IF_MATCH, ifMatch);
         }
         if (ifNoneMatch != null) {
-            requestOptions.setHeader("If-None-Match", ifNoneMatch);
+            requestOptions.setHeader(HttpHeaderName.IF_NONE_MATCH, ifNoneMatch);
         }
         if (ifUnmodifiedSince != null) {
-            requestOptions.setHeader("If-Unmodified-Since", String.valueOf(new DateTimeRfc1123(ifUnmodifiedSince)));
+            requestOptions.setHeader(
+                    HttpHeaderName.IF_UNMODIFIED_SINCE, String.valueOf(new DateTimeRfc1123(ifUnmodifiedSince)));
         }
         if (ifModifiedSince != null) {
-            requestOptions.setHeader("If-Modified-Since", String.valueOf(new DateTimeRfc1123(ifModifiedSince)));
+            requestOptions.setHeader(
+                    HttpHeaderName.IF_MODIFIED_SINCE, String.valueOf(new DateTimeRfc1123(ifModifiedSince)));
         }
         return putWithRequestHeadersWithResponse(name, BinaryData.fromObject(resource), requestOptions)
                 .flatMap(FluxUtil::toMono)
@@ -550,10 +553,10 @@ public final class SpecialHeadersAsyncClient {
         String ifMatch = matchConditions == null ? null : matchConditions.getIfMatch();
         String ifNoneMatch = matchConditions == null ? null : matchConditions.getIfNoneMatch();
         if (ifMatch != null) {
-            requestOptions.setHeader("If-Match", ifMatch);
+            requestOptions.setHeader(HttpHeaderName.IF_MATCH, ifMatch);
         }
         if (ifNoneMatch != null) {
-            requestOptions.setHeader("If-None-Match", ifNoneMatch);
+            requestOptions.setHeader(HttpHeaderName.IF_NONE_MATCH, ifNoneMatch);
         }
         return patchWithMatchHeadersWithResponse(name, BinaryData.fromObject(resource), requestOptions)
                 .flatMap(FluxUtil::toMono)
@@ -617,22 +620,24 @@ public final class SpecialHeadersAsyncClient {
             requestOptions.addQueryParam("filter", filter, false);
         }
         if (timestamp != null) {
-            requestOptions.setHeader("timestamp", String.valueOf(timestamp.toEpochSecond()));
+            requestOptions.setHeader(HttpHeaderName.fromString("timestamp"), String.valueOf(timestamp.toEpochSecond()));
         }
         if (body != null) {
             requestOptions.setBody(BinaryData.fromObject(body));
         }
         if (ifMatch != null) {
-            requestOptions.setHeader("If-Match", ifMatch);
+            requestOptions.setHeader(HttpHeaderName.IF_MATCH, ifMatch);
         }
         if (ifNoneMatch != null) {
-            requestOptions.setHeader("If-None-Match", ifNoneMatch);
+            requestOptions.setHeader(HttpHeaderName.IF_NONE_MATCH, ifNoneMatch);
         }
         if (ifUnmodifiedSince != null) {
-            requestOptions.setHeader("If-Unmodified-Since", String.valueOf(new DateTimeRfc1123(ifUnmodifiedSince)));
+            requestOptions.setHeader(
+                    HttpHeaderName.IF_UNMODIFIED_SINCE, String.valueOf(new DateTimeRfc1123(ifUnmodifiedSince)));
         }
         if (ifModifiedSince != null) {
-            requestOptions.setHeader("If-Modified-Since", String.valueOf(new DateTimeRfc1123(ifModifiedSince)));
+            requestOptions.setHeader(
+                    HttpHeaderName.IF_MODIFIED_SINCE, String.valueOf(new DateTimeRfc1123(ifModifiedSince)));
         }
         return putWithOptionalBodyWithResponse(format, requestOptions)
                 .flatMap(FluxUtil::toMono)

--- a/typespec-tests/src/main/java/com/cadl/specialheaders/SpecialHeadersClient.java
+++ b/typespec-tests/src/main/java/com/cadl/specialheaders/SpecialHeadersClient.java
@@ -12,6 +12,7 @@ import com.azure.core.exception.ClientAuthenticationException;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
+import com.azure.core.http.HttpHeaderName;
 import com.azure.core.http.MatchConditions;
 import com.azure.core.http.RequestConditions;
 import com.azure.core.http.rest.RequestOptions;
@@ -482,16 +483,18 @@ public final class SpecialHeadersClient {
         OffsetDateTime ifUnmodifiedSince = requestConditions == null ? null : requestConditions.getIfUnmodifiedSince();
         OffsetDateTime ifModifiedSince = requestConditions == null ? null : requestConditions.getIfModifiedSince();
         if (ifMatch != null) {
-            requestOptions.setHeader("If-Match", ifMatch);
+            requestOptions.setHeader(HttpHeaderName.IF_MATCH, ifMatch);
         }
         if (ifNoneMatch != null) {
-            requestOptions.setHeader("If-None-Match", ifNoneMatch);
+            requestOptions.setHeader(HttpHeaderName.IF_NONE_MATCH, ifNoneMatch);
         }
         if (ifUnmodifiedSince != null) {
-            requestOptions.setHeader("If-Unmodified-Since", String.valueOf(new DateTimeRfc1123(ifUnmodifiedSince)));
+            requestOptions.setHeader(
+                    HttpHeaderName.IF_UNMODIFIED_SINCE, String.valueOf(new DateTimeRfc1123(ifUnmodifiedSince)));
         }
         if (ifModifiedSince != null) {
-            requestOptions.setHeader("If-Modified-Since", String.valueOf(new DateTimeRfc1123(ifModifiedSince)));
+            requestOptions.setHeader(
+                    HttpHeaderName.IF_MODIFIED_SINCE, String.valueOf(new DateTimeRfc1123(ifModifiedSince)));
         }
         return putWithRequestHeadersWithResponse(name, BinaryData.fromObject(resource), requestOptions)
                 .getValue()
@@ -543,10 +546,10 @@ public final class SpecialHeadersClient {
         String ifMatch = matchConditions == null ? null : matchConditions.getIfMatch();
         String ifNoneMatch = matchConditions == null ? null : matchConditions.getIfNoneMatch();
         if (ifMatch != null) {
-            requestOptions.setHeader("If-Match", ifMatch);
+            requestOptions.setHeader(HttpHeaderName.IF_MATCH, ifMatch);
         }
         if (ifNoneMatch != null) {
-            requestOptions.setHeader("If-None-Match", ifNoneMatch);
+            requestOptions.setHeader(HttpHeaderName.IF_NONE_MATCH, ifNoneMatch);
         }
         return patchWithMatchHeadersWithResponse(name, BinaryData.fromObject(resource), requestOptions)
                 .getValue()
@@ -610,22 +613,24 @@ public final class SpecialHeadersClient {
             requestOptions.addQueryParam("filter", filter, false);
         }
         if (timestamp != null) {
-            requestOptions.setHeader("timestamp", String.valueOf(timestamp.toEpochSecond()));
+            requestOptions.setHeader(HttpHeaderName.fromString("timestamp"), String.valueOf(timestamp.toEpochSecond()));
         }
         if (body != null) {
             requestOptions.setBody(BinaryData.fromObject(body));
         }
         if (ifMatch != null) {
-            requestOptions.setHeader("If-Match", ifMatch);
+            requestOptions.setHeader(HttpHeaderName.IF_MATCH, ifMatch);
         }
         if (ifNoneMatch != null) {
-            requestOptions.setHeader("If-None-Match", ifNoneMatch);
+            requestOptions.setHeader(HttpHeaderName.IF_NONE_MATCH, ifNoneMatch);
         }
         if (ifUnmodifiedSince != null) {
-            requestOptions.setHeader("If-Unmodified-Since", String.valueOf(new DateTimeRfc1123(ifUnmodifiedSince)));
+            requestOptions.setHeader(
+                    HttpHeaderName.IF_UNMODIFIED_SINCE, String.valueOf(new DateTimeRfc1123(ifUnmodifiedSince)));
         }
         if (ifModifiedSince != null) {
-            requestOptions.setHeader("If-Modified-Since", String.valueOf(new DateTimeRfc1123(ifModifiedSince)));
+            requestOptions.setHeader(
+                    HttpHeaderName.IF_MODIFIED_SINCE, String.valueOf(new DateTimeRfc1123(ifModifiedSince)));
         }
         return putWithOptionalBodyWithResponse(format, requestOptions).getValue().toObject(Resource.class);
     }


### PR DESCRIPTION
String based API was deprecated
https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/core/azure-core/src/main/java/com/azure/core/http/rest/RequestOptions.java#L207-L208