### PR TITLE
Support XML namespaces in more locations in stream-style serialization

### DIFF
--- a/customization-base/src/main/java/com/azure/autorest/customization/ClassCustomization.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/ClassCustomization.java
@@ -470,7 +470,7 @@ public final class ClassCustomization extends CodeCustomization {
                 }
                 FileEvent fileEvent = new FileEvent();
                 fileEvent.setUri(edit.getKey());
-                if (oldEntry.endsWith(className + ".java")) {
+                if (oldEntry.endsWith("/" + className + ".java")) {
                     String newEntry = oldEntry.replace(className + ".java", newName + ".java");
                     editor.renameFile(oldEntry, newEntry);
                     URI newUri = URI.create(edit.getKey().toString().replace(className + ".java", newName + ".java"));

--- a/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
@@ -417,6 +417,8 @@ public class ModelMapper implements IMapper<ObjectSchema, ClientModel> {
             .serializedName(serializedName)
             .xmlWrapper(discriminatorProperty.isXmlWrapper())
             .xmlListElementName(discriminatorProperty.getXmlListElementName())
+            .xmlListElementNamespace(discriminatorProperty.getXmlListElementNamespace())
+            .xmlListElementPrefix(discriminatorProperty.getXmlListElementPrefix())
             .xmlPrefix(discriminatorProperty.getXmlPrefix())
             .wireType(discriminatorProperty.getWireType())
             .clientType(discriminatorProperty.getClientType())

--- a/javagen/src/main/java/com/azure/autorest/mapper/ModelPropertyMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ModelPropertyMapper.java
@@ -173,8 +173,11 @@ public class ModelPropertyMapper implements IMapper<Property, ClientModelPropert
                 && sequence.getElementType().getSerialization().getXml() != null
                 && sequence.getElementType().getSerialization().getXml().getName() != null) {
                 builder.xmlListElementName(sequence.getElementType().getSerialization().getXml().getName());
+                builder.xmlListElementNamespace(sequence.getElementType().getSerialization().getXml().getNamespace());
+                builder.xmlListElementPrefix(sequence.getElementType().getSerialization().getXml().getPrefix());
             } else {
                 builder.xmlListElementName(sequence.getElementType().getLanguage().getDefault().getName());
+                builder.xmlListElementNamespace(sequence.getElementType().getLanguage().getDefault().getNamespace());
             }
         }
 

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModelProperty.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModelProperty.java
@@ -55,6 +55,11 @@ public class ClientModelProperty implements ClientModelPropertyAccess {
      */
     private final String xmlListElementName;
     /**
+     * The namespace of each list element tag within an XML list property.
+     */
+    private final String xmlListElementNamespace;
+    private final String xmlListElementPrefix;
+    /**
      * The type of this property as it is transmitted across the network (across the wire).
      */
     private final IType wireType;
@@ -118,10 +123,10 @@ public class ClientModelProperty implements ClientModelPropertyAccess {
      */
     private ClientModelProperty(String name, String description, String annotationArguments, boolean isXmlAttribute,
         String xmlName, String xmlNamespace, String serializedName, boolean isXmlWrapper, String xmlListElementName,
-        IType wireType, IType clientType, boolean isConstant, String defaultValue, boolean isReadOnly,
-        List<Mutability> mutabilities, boolean isRequired, String headerCollectionPrefix,
-        boolean isAdditionalProperties, boolean needsFlatten, boolean clientFlatten, boolean polymorphicDiscriminator,
-        boolean isXmlText, String xmlPrefix) {
+        String xmlListElementNamespace, String xmlListElementPrefix, IType wireType, IType clientType,
+        boolean isConstant, String defaultValue, boolean isReadOnly, List<Mutability> mutabilities, boolean isRequired,
+        String headerCollectionPrefix, boolean isAdditionalProperties, boolean needsFlatten, boolean clientFlatten,
+        boolean polymorphicDiscriminator, boolean isXmlText, String xmlPrefix) {
         this.name = name;
         this.description = description;
         this.annotationArguments = annotationArguments;
@@ -131,6 +136,8 @@ public class ClientModelProperty implements ClientModelPropertyAccess {
         this.serializedName = serializedName;
         this.isXmlWrapper = isXmlWrapper;
         this.xmlListElementName = xmlListElementName;
+        this.xmlListElementNamespace = xmlListElementNamespace;
+        this.xmlListElementPrefix = xmlListElementPrefix;
         this.wireType = wireType;
         this.clientType = clientType;
         this.isConstant = isConstant;
@@ -189,6 +196,14 @@ public class ClientModelProperty implements ClientModelPropertyAccess {
 
     public final String getXmlListElementName() {
         return xmlListElementName;
+    }
+
+    public final String getXmlListElementNamespace() {
+        return xmlListElementNamespace;
+    }
+
+    public final String getXmlListElementPrefix() {
+        return xmlListElementPrefix;
     }
 
     public final IType getWireType() {
@@ -344,6 +359,8 @@ public class ClientModelProperty implements ClientModelPropertyAccess {
         private String serializedName;
         private boolean isXmlWrapper;
         private String xmlListElementName;
+        private String xmlListElementNamespace;
+        private String xmlListElementPrefix;
         private IType wireType;
         private IType clientType;
         private boolean isConstant = false;
@@ -447,6 +464,26 @@ public class ClientModelProperty implements ClientModelPropertyAccess {
          */
         public Builder xmlListElementName(String xmlListElementName) {
             this.xmlListElementName = xmlListElementName;
+            return this;
+        }
+
+        /**
+         * Sets the namespace of each list element tag within an XML list property.
+         * @param xmlListElementNamespace the namespace of each list element tag within an XML list property
+         * @return the Builder itself
+         */
+        public Builder xmlListElementNamespace(String xmlListElementNamespace) {
+            this.xmlListElementNamespace = xmlListElementNamespace;
+            return this;
+        }
+
+        /**
+         * Sets the prefix of each list element tag within an XML list property.
+         * @param xmlListElementPrefix the prefix of each list element tag within an XML list property
+         * @return the Builder itself
+         */
+        public Builder xmlListElementPrefix(String xmlListElementPrefix) {
+            this.xmlListElementPrefix = xmlListElementPrefix;
             return this;
         }
 
@@ -601,9 +638,10 @@ public class ClientModelProperty implements ClientModelPropertyAccess {
 
         public ClientModelProperty build() {
             return new ClientModelProperty(name, description, annotationArguments, isXmlAttribute, xmlName,
-                xmlNamespace, serializedName, isXmlWrapper, xmlListElementName, wireType, clientType, isConstant,
-                defaultValue, isReadOnly, mutabilities, isRequired, headerCollectionPrefix, isAdditionalProperties,
-                needsFlatten, clientFlatten, polymorphicDiscriminator, isXmlText, xmlPrefix);
+                xmlNamespace, serializedName, isXmlWrapper, xmlListElementName, xmlListElementNamespace,
+                xmlListElementPrefix, wireType, clientType, isConstant, defaultValue, isReadOnly, mutabilities,
+                isRequired, headerCollectionPrefix, isAdditionalProperties, needsFlatten, clientFlatten,
+                polymorphicDiscriminator, isXmlText, xmlPrefix);
         }
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -171,15 +171,6 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                     methodBlock -> addGetterMethod(propertyWireType, propertyClientType, property, treatAsXml,
                         methodBlock, settings));
 
-                // If the model has derived types and the properties is an XML wrapper and stream-style serialization
-                // is being generated, generate an internal method that can access the direct value of the XML wrapper
-                // static class.
-                if (hasDerivedModels && property.isXmlWrapper() && settings.isStreamStyleSerialization()) {
-                    classBlock.method(JavaVisibility.PackagePrivate, null,
-                        getPropertyXmlWrapperClassName(property) + " " + getGetterName(model, property) + "Internal()",
-                        methodBlock -> methodBlock.methodReturn("this." + property.getName()));
-                }
-
                 if (ClientModelUtil.hasSetter(property, settings) && !immutableOutputModel) {
                     generateSetterJavadoc(classBlock, model, property);
                     addGeneratedAnnotation(classBlock);
@@ -188,19 +179,6 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                         model.getName() + " " + property.getSetterName() + "(" + propertyClientType + " " + property.getName() + ")",
                         methodBlock -> addSetterMethod(propertyWireType, propertyClientType, property, treatAsXml,
                             methodBlock, settings));
-
-                    // If the model has derived types and the properties is an XML wrapper and stream-style serialization
-                    // is being generated, generate an internal method that can access the direct value of the XML wrapper
-                    // static class.
-                    if (hasDerivedModels && property.isXmlWrapper() && settings.isStreamStyleSerialization()) {
-                        classBlock.method(JavaVisibility.PackagePrivate, null,
-                            model.getName() + " " + property.getSetterName()
-                                + "Internal(" + getPropertyXmlWrapperClassName(property) + " " + property.getName() + ")",
-                            methodBlock -> {
-                                methodBlock.line("this." + property.getName() + " = " + property.getName() + ";");
-                                methodBlock.methodReturn("this");
-                            });
-                    }
                 }
 
                 // If the property is additional properties, and stream-style serialization isn't being used, add a

--- a/javagen/src/main/java/com/azure/autorest/template/StreamSerializationModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/StreamSerializationModelTemplate.java
@@ -1646,14 +1646,14 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
             }
 
             // TODO (alzimmer): Handle nested container types when needed.
-            if (fromSuper) {
-                // When the property is maintained by the super class use the setter to set a new ArrayList.
-                deserializationBlock.line(propertiesManager.getDeserializedModelName() + "." + property.getSetterName()
-                    + "(new ArrayList<>());");
-            } else {
-                deserializationBlock.ifBlock(fieldAccess + " == null",
-                    ifStatement -> ifStatement.line(fieldAccess + " = new ArrayList<>();"));
-            }
+            deserializationBlock.ifBlock(fieldAccess + " == null", ifStatement -> {
+                if (fromSuper) {
+                    ifStatement.line(propertiesManager.getDeserializedModelName() + "." + property.getSetterName()
+                        + "(new ArrayList<>());");
+                } else {
+                    ifStatement.line(fieldAccess + " = new ArrayList<>();");
+                }
+            });
 
             if (sameNames) {
                 deserializationBlock.line(fieldAccess + ".add(" + elementDeserialization + ");");
@@ -1759,7 +1759,7 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
 
     private static String getXmlNameConditional(String localPart, String namespace, String elementName) {
         String condition = "\"" + localPart + "\".equals(" + elementName + ".getLocalPart())";
-        if (namespace != null) {
+        if (!CoreUtils.isNullOrEmpty(namespace)) {
             condition += " && \"" + namespace + "\".equals(" + elementName + ".getNamespaceURI())";
         }
 

--- a/javagen/src/main/java/com/azure/autorest/template/XmlSequenceWrapperTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/XmlSequenceWrapperTemplate.java
@@ -17,6 +17,7 @@ import com.azure.xml.XmlSerializable;
 import com.azure.xml.XmlToken;
 import com.azure.xml.XmlWriter;
 
+import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
 import java.util.ArrayList;
 
@@ -46,9 +47,9 @@ public class XmlSequenceWrapperTemplate implements IJavaTemplate<XmlSequenceWrap
         javaFile.declareImport(xmlSequenceWrapper.getImports());
 
         if (settings.isStreamStyleSerialization()) {
-            javaFile.declareImport(ArrayList.class.getName(), CoreUtils.class.getName(), XmlProviders.class.getName(),
-                XmlReader.class.getName(), XmlSerializable.class.getName(),  XMLStreamException.class.getName(),
-                XmlToken.class.getName(), XmlWriter.class.getName());
+            javaFile.declareImport(ArrayList.class.getName(), CoreUtils.class.getName(), QName.class.getName(),
+                XmlProviders.class.getName(), XmlReader.class.getName(), XmlSerializable.class.getName(),
+                XMLStreamException.class.getName(), XmlToken.class.getName(), XmlWriter.class.getName());
         }
 
         javaFile.javadocComment(comment -> comment.description(

--- a/javagen/src/main/java/com/azure/autorest/template/XmlSequenceWrapperTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/XmlSequenceWrapperTemplate.java
@@ -111,7 +111,8 @@ public class XmlSequenceWrapperTemplate implements IJavaTemplate<XmlSequenceWrap
         addGetter(classBlock, sequenceType, xmlElementNameCamelCase);
 
         StreamSerializationModelTemplate.xmlWrapperClassXmlSerializableImplementation(classBlock,
-            xmlSequenceWrapper.getWrapperClassName(), sequenceType, xmlRootElementName, xmlListElementName,
-            xmlElementNameCamelCase, null);
+            xmlSequenceWrapper.getWrapperClassName(), sequenceType, xmlRootElementName,
+            xmlSequenceWrapper.getXmlRootElementNamespace(), xmlListElementName,
+            xmlElementNameCamelCase, xmlSequenceWrapper.getXmlListElementNamespace());
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/implementation/models/BananaWrapper.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/implementation/models/BananaWrapper.java
@@ -12,6 +12,7 @@ import com.azure.xml.XmlWriter;
 import fixtures.streamstylexmlserialization.models.Banana;
 import java.util.ArrayList;
 import java.util.List;
+import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
 
 /** A wrapper around List&lt;Banana&gt; which provides top-level metadata for serialization. */
@@ -65,9 +66,9 @@ public final class BananaWrapper implements XmlSerializable<BananaWrapper> {
                     List<Banana> items = null;
 
                     while (reader.nextElement() != XmlToken.END_ELEMENT) {
-                        String elementName = reader.getElementName().getLocalPart();
+                        QName elementName = reader.getElementName();
 
-                        if ("banana".equals(elementName)) {
+                        if ("banana".equals(elementName.getLocalPart())) {
                             if (items == null) {
                                 items = new ArrayList<>();
                             }

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/implementation/models/SignedIdentifierWrapper.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/implementation/models/SignedIdentifierWrapper.java
@@ -12,6 +12,7 @@ import com.azure.xml.XmlWriter;
 import fixtures.streamstylexmlserialization.models.SignedIdentifier;
 import java.util.ArrayList;
 import java.util.List;
+import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
 
 /** A wrapper around List&lt;SignedIdentifier&gt; which provides top-level metadata for serialization. */
@@ -66,9 +67,9 @@ public final class SignedIdentifierWrapper implements XmlSerializable<SignedIden
                     List<SignedIdentifier> items = null;
 
                     while (reader.nextElement() != XmlToken.END_ELEMENT) {
-                        String elementName = reader.getElementName().getLocalPart();
+                        QName elementName = reader.getElementName();
 
-                        if ("SignedIdentifier".equals(elementName)) {
+                        if ("SignedIdentifier".equals(elementName.getLocalPart())) {
                             if (items == null) {
                                 items = new ArrayList<>();
                             }


### PR DESCRIPTION
Adds support for XML namespace in more locations in stream-style serialization. 

Internal methods for setting XML wrapped values have been removed as #2182 changed stream-style serialization to no longer need a wrapping class for wrapped XML elements as that is handled within serialization and deserialization in `toXml` and `fromXml`.

Checking the discriminator field for XML deserialization is also fixed for code generation that doesn't have required properties be part of the class constructor.

Also fixes a bug where `ClassCustomization.rename` could rename other classes that ended with the same string as the class being renamed, ex `RuleFilter` being renamed changing the name of `SqlRuleFilter` as both ended with `RuleFilter`. This now checks that the full class name is equal to what is being renamed.