### PR TITLE
tsp, enlarge the scope of new lro strategy

### DIFF
--- a/typespec-extension/changelog.md
+++ b/typespec-extension/changelog.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 0.8.2 (2023-06-25)
+
+Compatible with compiler 0.45.
+
 ## 0.8.2 (2023-06-15)
 
 Compatible with compiler 0.45.

--- a/typespec-extension/package.json
+++ b/typespec-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "TypeSpec library for emitting Java client from the TypeSpec REST protocol binding",
   "keywords": [
     "TypeSpec"

--- a/typespec-extension/src/code-model-builder.ts
+++ b/typespec-extension/src/code-model-builder.ts
@@ -603,7 +603,7 @@ export class CodeModelBuilder {
       let finalSchema = undefined;
 
       const verb = httpOperation.verb;
-      const useNewPollStrategy = isLroNewPollingStrategy(operation, lroMetadata);
+      const useNewPollStrategy = isLroNewPollingStrategy(httpOperation, lroMetadata);
 
       let pollingStrategy: Metadata | undefined = undefined;
       if (useNewPollStrategy) {

--- a/typespec-extension/src/operation-utils.ts
+++ b/typespec-extension/src/operation-utils.ts
@@ -142,7 +142,7 @@ export function getServiceVersion(client: CodeModelClient | CodeModel): ServiceV
   return new ServiceVersion(name, description);
 }
 
-export function isLroNewPollingStrategy(operation: Operation, lroMetadata: LroMetadata): boolean {
+export function isLroNewPollingStrategy(httpOperation: HttpOperation, lroMetadata: LroMetadata): boolean {
   // at present, checks if operation uses template from Azure.Core
   const azureCoreLroSvs = [
     "LongRunningResourceCreateOrReplace",
@@ -152,7 +152,8 @@ export function isLroNewPollingStrategy(operation: Operation, lroMetadata: LroMe
     "LongRunningRpcOperation",
   ];
 
-  let ret = false;
+  const operation = httpOperation.operation;
+  let useNewStrategy = false;
   if (
     lroMetadata.pollingInfo &&
     lroMetadata.statusMonitorStep &&
@@ -162,24 +163,29 @@ export function isLroNewPollingStrategy(operation: Operation, lroMetadata: LroMe
     if (operation.node.signature.kind === SyntaxKind.OperationSignatureReference) {
       if (operation.node.signature.baseOperation.target.kind === SyntaxKind.MemberExpression) {
         const sv = operation.node.signature.baseOperation.target.id.sv;
-        ret = azureCoreLroSvs.includes(sv);
+        useNewStrategy = azureCoreLroSvs.includes(sv);
       }
     }
   }
-  return ret;
 
-  // if (verb === "put" && !lroMetadata.finalStep) {
-  //   // PUT without last GET on resource
-  //   useNewPollStrategy = true;
-  // } else if (
-  //   verb === "post" &&
-  //   lroMetadata.finalStep &&
-  //   lroMetadata.finalStep.kind === "pollingSuccessProperty" &&
-  //   lroMetadata.finalStep.target.name === "result"
-  // ) {
-  //   // POST with final result in "result" property
-  //   useNewPollStrategy = true;
-  // }
+  if (!useNewStrategy) {
+    // following 2 pattern in LroMetadata requires new polling strategy
+
+    if (httpOperation.verb === "put" && !lroMetadata.finalStep) {
+      // PUT without last GET on resource
+      useNewStrategy = true;
+    } else if (
+      httpOperation.verb === "post" &&
+      lroMetadata.finalStep &&
+      lroMetadata.finalStep.kind === "pollingSuccessProperty" &&
+      lroMetadata.finalStep.target.name === "result"
+    ) {
+      // POST with final result in "result" property
+      useNewStrategy = true;
+    }
+  }
+
+  return useNewStrategy;
 }
 
 export function cloneOperationParameter(parameter: Parameter): Parameter {

--- a/typespec-tests/package.json
+++ b/typespec-tests/package.json
@@ -12,7 +12,7 @@
     "@typespec/openapi": ">=0.45.0 <1.0.0",
     "@azure-tools/typespec-autorest": ">=0.31.0 <1.0.0",
     "@azure-tools/cadl-ranch-specs": "0.16.1",
-    "@azure-tools/typespec-java": "file:/../typespec-extension/azure-tools-typespec-java-0.8.2.tgz"
+    "@azure-tools/typespec-java": "file:/../typespec-extension/azure-tools-typespec-java-0.8.3.tgz"
   },
   "devDependencies": {
     "@typespec/prettier-plugin-typespec": ">=0.45.0 <1.0.0",


### PR DESCRIPTION
fix an issue that tsp does not use LRO template in Azure.Core, but wrote one that almost same as that in Azure.Core

e.g. https://github.com/Azure/azure-rest-api-specs/pull/24382