### PR TITLE
tsp, skip operation used in pollingOperation

### DIFF
--- a/typespec-tests/src/main/java/com/_specs_/azure/core/lro/rpc/RpcAsyncClient.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/lro/rpc/RpcAsyncClient.java
@@ -18,11 +18,8 @@ import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
-import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.FluxUtil;
 import com.azure.core.util.polling.PollerFlux;
-import reactor.core.publisher.Mono;
 
 /** Initializes a new instance of the asynchronous RpcClient type. */
 @ServiceClient(builder = RpcClientBuilder.class, isAsync = true)
@@ -94,52 +91,6 @@ public final class RpcAsyncClient {
     }
 
     /**
-     * Gets the status of a Job.
-     *
-     * <p><strong>Response Body Schema</strong>
-     *
-     * <pre>{@code
-     * {
-     *     jobId: String (Required)
-     *     comment: String (Required)
-     *     status: String(InProgress/Succeeded/Failed/Canceled) (Required)
-     *     errors (Optional): [
-     *          (Optional){
-     *             error (Required): {
-     *                 code: String (Required)
-     *                 message: String (Required)
-     *                 target: String (Optional)
-     *                 details (Optional): [
-     *                     (recursive schema, see above)
-     *                 ]
-     *                 innererror (Optional): {
-     *                     code: String (Optional)
-     *                     innererror (Optional): (recursive schema, see innererror above)
-     *                 }
-     *             }
-     *         }
-     *     ]
-     *     results (Required): [
-     *         String (Required)
-     *     ]
-     * }
-     * }</pre>
-     *
-     * @param jobId A processing job identifier.
-     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @return the status of a Job along with {@link Response} on successful completion of {@link Mono}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<BinaryData>> getJobWithResponse(String jobId, RequestOptions requestOptions) {
-        return this.serviceClient.getJobWithResponseAsync(jobId, requestOptions);
-    }
-
-    /**
      * Creates a Job.
      *
      * <p><strong>Request Body Schema</strong>
@@ -175,32 +126,6 @@ public final class RpcAsyncClient {
     }
 
     /**
-     * Gets the status of a Job.
-     *
-     * <p><strong>Response Body Schema</strong>
-     *
-     * <pre>{@code
-     * {
-     *     operationId: String (Required)
-     *     status: String(InProgress/Succeeded/Failed/Canceled) (Required)
-     * }
-     * }</pre>
-     *
-     * @param operationId Operation identifier.
-     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @return the status of a Job along with {@link Response} on successful completion of {@link Mono}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<BinaryData>> getPollWithResponse(String operationId, RequestOptions requestOptions) {
-        return this.serviceClient.getPollWithResponseAsync(operationId, requestOptions);
-    }
-
-    /**
      * Creates a Job.
      *
      * @param jobData Data of the job.
@@ -218,28 +143,6 @@ public final class RpcAsyncClient {
         // Generated convenience method for beginCreateJobWithModel
         RequestOptions requestOptions = new RequestOptions();
         return serviceClient.beginCreateJobWithModelAsync(BinaryData.fromObject(jobData), requestOptions);
-    }
-
-    /**
-     * Gets the status of a Job.
-     *
-     * @param jobId A processing job identifier.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the status of a Job on successful completion of {@link Mono}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<JobResult> getJob(String jobId) {
-        // Generated convenience method for getJobWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        return getJobWithResponse(jobId, requestOptions)
-                .flatMap(FluxUtil::toMono)
-                .map(protocolMethodData -> protocolMethodData.toObject(JobResult.class));
     }
 
     /**
@@ -262,27 +165,5 @@ public final class RpcAsyncClient {
         RequestOptions requestOptions = new RequestOptions();
         return serviceClient.beginCreateJobFinalOnLocationWithModelAsync(
                 BinaryData.fromObject(jobData), requestOptions);
-    }
-
-    /**
-     * Gets the status of a Job.
-     *
-     * @param operationId Operation identifier.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the status of a Job on successful completion of {@link Mono}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<JobPollResult> getPoll(String operationId) {
-        // Generated convenience method for getPollWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        return getPollWithResponse(operationId, requestOptions)
-                .flatMap(FluxUtil::toMono)
-                .map(protocolMethodData -> protocolMethodData.toObject(JobPollResult.class));
     }
 }

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/lro/rpc/RpcClient.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/lro/rpc/RpcClient.java
@@ -18,7 +18,6 @@ import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
-import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
 import com.azure.core.util.polling.SyncPoller;
 
@@ -92,52 +91,6 @@ public final class RpcClient {
     }
 
     /**
-     * Gets the status of a Job.
-     *
-     * <p><strong>Response Body Schema</strong>
-     *
-     * <pre>{@code
-     * {
-     *     jobId: String (Required)
-     *     comment: String (Required)
-     *     status: String(InProgress/Succeeded/Failed/Canceled) (Required)
-     *     errors (Optional): [
-     *          (Optional){
-     *             error (Required): {
-     *                 code: String (Required)
-     *                 message: String (Required)
-     *                 target: String (Optional)
-     *                 details (Optional): [
-     *                     (recursive schema, see above)
-     *                 ]
-     *                 innererror (Optional): {
-     *                     code: String (Optional)
-     *                     innererror (Optional): (recursive schema, see innererror above)
-     *                 }
-     *             }
-     *         }
-     *     ]
-     *     results (Required): [
-     *         String (Required)
-     *     ]
-     * }
-     * }</pre>
-     *
-     * @param jobId A processing job identifier.
-     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @return the status of a Job along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getJobWithResponse(String jobId, RequestOptions requestOptions) {
-        return this.serviceClient.getJobWithResponse(jobId, requestOptions);
-    }
-
-    /**
      * Creates a Job.
      *
      * <p><strong>Request Body Schema</strong>
@@ -173,32 +126,6 @@ public final class RpcClient {
     }
 
     /**
-     * Gets the status of a Job.
-     *
-     * <p><strong>Response Body Schema</strong>
-     *
-     * <pre>{@code
-     * {
-     *     operationId: String (Required)
-     *     status: String(InProgress/Succeeded/Failed/Canceled) (Required)
-     * }
-     * }</pre>
-     *
-     * @param operationId Operation identifier.
-     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @return the status of a Job along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getPollWithResponse(String operationId, RequestOptions requestOptions) {
-        return this.serviceClient.getPollWithResponse(operationId, requestOptions);
-    }
-
-    /**
      * Creates a Job.
      *
      * @param jobData Data of the job.
@@ -216,26 +143,6 @@ public final class RpcClient {
         // Generated convenience method for beginCreateJobWithModel
         RequestOptions requestOptions = new RequestOptions();
         return serviceClient.beginCreateJobWithModel(BinaryData.fromObject(jobData), requestOptions);
-    }
-
-    /**
-     * Gets the status of a Job.
-     *
-     * @param jobId A processing job identifier.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the status of a Job.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public JobResult getJob(String jobId) {
-        // Generated convenience method for getJobWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        return getJobWithResponse(jobId, requestOptions).getValue().toObject(JobResult.class);
     }
 
     /**
@@ -257,25 +164,5 @@ public final class RpcClient {
         // Generated convenience method for beginCreateJobFinalOnLocationWithModel
         RequestOptions requestOptions = new RequestOptions();
         return serviceClient.beginCreateJobFinalOnLocationWithModel(BinaryData.fromObject(jobData), requestOptions);
-    }
-
-    /**
-     * Gets the status of a Job.
-     *
-     * @param operationId Operation identifier.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the status of a Job.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public JobPollResult getPoll(String operationId) {
-        // Generated convenience method for getPollWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        return getPollWithResponse(operationId, requestOptions).getValue().toObject(JobPollResult.class);
     }
 }

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/lro/rpc/implementation/RpcClientImpl.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/lro/rpc/implementation/RpcClientImpl.java
@@ -10,10 +10,8 @@ import com._specs_.azure.core.lro.rpc.models.JobPollResult;
 import com._specs_.azure.core.lro.rpc.models.JobResult;
 import com.azure.core.annotation.BodyParam;
 import com.azure.core.annotation.ExpectedResponses;
-import com.azure.core.annotation.Get;
 import com.azure.core.annotation.HeaderParam;
 import com.azure.core.annotation.Host;
-import com.azure.core.annotation.PathParam;
 import com.azure.core.annotation.Post;
 import com.azure.core.annotation.QueryParam;
 import com.azure.core.annotation.ReturnType;
@@ -168,44 +166,6 @@ public final class RpcClientImpl {
                 RequestOptions requestOptions,
                 Context context);
 
-        @Get("/azure/core/lro/rpc/same-poll-result/jobs/{jobId}")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(
-                value = ClientAuthenticationException.class,
-                code = {401})
-        @UnexpectedResponseExceptionType(
-                value = ResourceNotFoundException.class,
-                code = {404})
-        @UnexpectedResponseExceptionType(
-                value = ResourceModifiedException.class,
-                code = {409})
-        @UnexpectedResponseExceptionType(HttpResponseException.class)
-        Mono<Response<BinaryData>> getJob(
-                @QueryParam("api-version") String apiVersion,
-                @PathParam("jobId") String jobId,
-                @HeaderParam("accept") String accept,
-                RequestOptions requestOptions,
-                Context context);
-
-        @Get("/azure/core/lro/rpc/same-poll-result/jobs/{jobId}")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(
-                value = ClientAuthenticationException.class,
-                code = {401})
-        @UnexpectedResponseExceptionType(
-                value = ResourceNotFoundException.class,
-                code = {404})
-        @UnexpectedResponseExceptionType(
-                value = ResourceModifiedException.class,
-                code = {409})
-        @UnexpectedResponseExceptionType(HttpResponseException.class)
-        Response<BinaryData> getJobSync(
-                @QueryParam("api-version") String apiVersion,
-                @PathParam("jobId") String jobId,
-                @HeaderParam("accept") String accept,
-                RequestOptions requestOptions,
-                Context context);
-
         @Post("/azure/core/lro/rpc/different-poll-result/jobs")
         @ExpectedResponses({200, 202})
         @UnexpectedResponseExceptionType(
@@ -241,44 +201,6 @@ public final class RpcClientImpl {
                 @QueryParam("api-version") String apiVersion,
                 @HeaderParam("accept") String accept,
                 @BodyParam("application/json") BinaryData jobData,
-                RequestOptions requestOptions,
-                Context context);
-
-        @Get("/azure/core/lro/rpc/different-poll-result/jobs/operations/{operationId}")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(
-                value = ClientAuthenticationException.class,
-                code = {401})
-        @UnexpectedResponseExceptionType(
-                value = ResourceNotFoundException.class,
-                code = {404})
-        @UnexpectedResponseExceptionType(
-                value = ResourceModifiedException.class,
-                code = {409})
-        @UnexpectedResponseExceptionType(HttpResponseException.class)
-        Mono<Response<BinaryData>> getPoll(
-                @QueryParam("api-version") String apiVersion,
-                @PathParam("operationId") String operationId,
-                @HeaderParam("accept") String accept,
-                RequestOptions requestOptions,
-                Context context);
-
-        @Get("/azure/core/lro/rpc/different-poll-result/jobs/operations/{operationId}")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(
-                value = ClientAuthenticationException.class,
-                code = {401})
-        @UnexpectedResponseExceptionType(
-                value = ResourceNotFoundException.class,
-                code = {404})
-        @UnexpectedResponseExceptionType(
-                value = ResourceModifiedException.class,
-                code = {409})
-        @UnexpectedResponseExceptionType(HttpResponseException.class)
-        Response<BinaryData> getPollSync(
-                @QueryParam("api-version") String apiVersion,
-                @PathParam("operationId") String operationId,
-                @HeaderParam("accept") String accept,
                 RequestOptions requestOptions,
                 Context context);
     }
@@ -653,100 +575,6 @@ public final class RpcClientImpl {
     }
 
     /**
-     * Gets the status of a Job.
-     *
-     * <p><strong>Response Body Schema</strong>
-     *
-     * <pre>{@code
-     * {
-     *     jobId: String (Required)
-     *     comment: String (Required)
-     *     status: String(InProgress/Succeeded/Failed/Canceled) (Required)
-     *     errors (Optional): [
-     *          (Optional){
-     *             error (Required): {
-     *                 code: String (Required)
-     *                 message: String (Required)
-     *                 target: String (Optional)
-     *                 details (Optional): [
-     *                     (recursive schema, see above)
-     *                 ]
-     *                 innererror (Optional): {
-     *                     code: String (Optional)
-     *                     innererror (Optional): (recursive schema, see innererror above)
-     *                 }
-     *             }
-     *         }
-     *     ]
-     *     results (Required): [
-     *         String (Required)
-     *     ]
-     * }
-     * }</pre>
-     *
-     * @param jobId A processing job identifier.
-     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @return the status of a Job along with {@link Response} on successful completion of {@link Mono}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<BinaryData>> getJobWithResponseAsync(String jobId, RequestOptions requestOptions) {
-        final String accept = "application/json";
-        return FluxUtil.withContext(
-                context ->
-                        service.getJob(this.getServiceVersion().getVersion(), jobId, accept, requestOptions, context));
-    }
-
-    /**
-     * Gets the status of a Job.
-     *
-     * <p><strong>Response Body Schema</strong>
-     *
-     * <pre>{@code
-     * {
-     *     jobId: String (Required)
-     *     comment: String (Required)
-     *     status: String(InProgress/Succeeded/Failed/Canceled) (Required)
-     *     errors (Optional): [
-     *          (Optional){
-     *             error (Required): {
-     *                 code: String (Required)
-     *                 message: String (Required)
-     *                 target: String (Optional)
-     *                 details (Optional): [
-     *                     (recursive schema, see above)
-     *                 ]
-     *                 innererror (Optional): {
-     *                     code: String (Optional)
-     *                     innererror (Optional): (recursive schema, see innererror above)
-     *                 }
-     *             }
-     *         }
-     *     ]
-     *     results (Required): [
-     *         String (Required)
-     *     ]
-     * }
-     * }</pre>
-     *
-     * @param jobId A processing job identifier.
-     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @return the status of a Job along with {@link Response}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getJobWithResponse(String jobId, RequestOptions requestOptions) {
-        final String accept = "application/json";
-        return service.getJobSync(this.getServiceVersion().getVersion(), jobId, accept, requestOptions, Context.NONE);
-    }
-
-    /**
      * Creates a Job.
      *
      * <p><strong>Request Body Schema</strong>
@@ -998,61 +826,5 @@ public final class RpcClientImpl {
                                                 : Context.NONE)),
                 TypeReference.createInstance(JobPollResult.class),
                 TypeReference.createInstance(JobDataJobResultJobPollResultLongRunningFinalLocationJobResult.class));
-    }
-
-    /**
-     * Gets the status of a Job.
-     *
-     * <p><strong>Response Body Schema</strong>
-     *
-     * <pre>{@code
-     * {
-     *     operationId: String (Required)
-     *     status: String(InProgress/Succeeded/Failed/Canceled) (Required)
-     * }
-     * }</pre>
-     *
-     * @param operationId Operation identifier.
-     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @return the status of a Job along with {@link Response} on successful completion of {@link Mono}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<BinaryData>> getPollWithResponseAsync(String operationId, RequestOptions requestOptions) {
-        final String accept = "application/json";
-        return FluxUtil.withContext(
-                context ->
-                        service.getPoll(
-                                this.getServiceVersion().getVersion(), operationId, accept, requestOptions, context));
-    }
-
-    /**
-     * Gets the status of a Job.
-     *
-     * <p><strong>Response Body Schema</strong>
-     *
-     * <pre>{@code
-     * {
-     *     operationId: String (Required)
-     *     status: String(InProgress/Succeeded/Failed/Canceled) (Required)
-     * }
-     * }</pre>
-     *
-     * @param operationId Operation identifier.
-     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @return the status of a Job along with {@link Response}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getPollWithResponse(String operationId, RequestOptions requestOptions) {
-        final String accept = "application/json";
-        return service.getPollSync(
-                this.getServiceVersion().getVersion(), operationId, accept, requestOptions, Context.NONE);
     }
 }


### PR DESCRIPTION
automatically skip the `getImageOperationStatus` op in https://github.com/glecaros/azure-rest-api-specs/blob/8a2813190adba6fcd71460dc1d1e69fe7868025f/specification/cognitiveservices/OpenAI.Inference/routes.tsp#L55-L80, as it was used by LRO `startGenerateImage` in `@pollingOperation`