### PR TITLE
client, exclude serializationFormats=xml, if model only used in Exception

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/util/SchemaUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/SchemaUtil.java
@@ -317,7 +317,8 @@ public class SchemaUtil {
     }
 
     public static boolean treatAsXml(Schema schema) {
-        return (schema.getSerializationFormats() != null && schema.getSerializationFormats().contains("xml"))
-            || (schema.getSerialization() != null && schema.getSerialization().getXml() != null);
+        return (schema.getUsage() == null || !Objects.equals(schema.getUsage(), Collections.singleton(SchemaContext.EXCEPTION)))
+            && ((schema.getSerializationFormats() != null && schema.getSerializationFormats().contains("xml"))
+            || (schema.getSerialization() != null && schema.getSerialization().getXml() != null));
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/util/SchemaUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/SchemaUtil.java
@@ -317,7 +317,7 @@ public class SchemaUtil {
     }
 
     public static boolean treatAsXml(Schema schema) {
-        return (schema.getUsage() == null || !Objects.equals(schema.getUsage(), Collections.singleton(SchemaContext.EXCEPTION)))
+        return (schema.getUsage() == null || !Objects.equals(schema.getUsage(), Collections.singleton(SchemaContext.EXCEPTION)))    // exclude model for Exception, as Azure required error response to be JSON
             && ((schema.getSerializationFormats() != null && schema.getSerializationFormats().contains("xml"))
             || (schema.getSerialization() != null && schema.getSerialization().getXml() != null));
     }


### PR DESCRIPTION
There is swagger that writes this way
https://github.com/Azure/azure-rest-api-specs/blob/main/specification/web/resource-manager/Microsoft.Web/stable/2022-09-01/WebApps.json#L8295-L8348

It specifies `produces=application/xml` as response, and response is file. But that XML applies to the error response as well, hence `serializationFormats` be `json` and `xml`.

Without it, mgmt will have
```java
@Immutable
@JacksonXmlRootElement
public final class DefaultErrorResponseError extends ManagementError {
```