### PR TITLE
mgmt, remove xml from serializationFormats

### DIFF
--- a/fluentnamer/src/main/java/com/azure/autorest/fluent/transformer/FluentTransformer.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluent/transformer/FluentTransformer.java
@@ -14,6 +14,7 @@ import com.azure.autorest.extension.base.plugin.PluginLogger;
 import com.azure.autorest.fluent.util.FluentJavaSettings;
 import com.azure.autorest.fluent.util.Utils;
 import com.azure.autorest.fluentnamer.FluentNamer;
+import com.azure.core.util.CoreUtils;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
@@ -33,6 +34,7 @@ public class FluentTransformer {
     }
 
     public CodeModel preTransform(CodeModel codeModel) {
+        codeModel = removeXml(codeModel);
         codeModel = deduplicateOperations(codeModel);
         codeModel = normalizeParameterLocation(codeModel);
         codeModel = renameUngroupedOperationGroup(codeModel, fluentJavaSettings);
@@ -40,7 +42,6 @@ public class FluentTransformer {
         codeModel = new ConstantSchemaOptimization().process(codeModel);
         codeModel = renameHostParameter(codeModel);
         codeModel = transformSubscriptionIdUuid(codeModel);
-        //codeModel = addStartOperationForLROs(codeModel);
         return codeModel;
     }
 
@@ -168,63 +169,15 @@ public class FluentTransformer {
         return codeModel;
     }
 
-//    /**
-//     * Adds start operation for LROs (e.g. BeginCreateFoo for CreateFoo LRO).
-//     *
-//     * @param codeModel Code model.
-//     * @return Processed code model.
-//     */
-//    protected CodeModel addStartOperationForLROs(CodeModel codeModel) {
-//        codeModel.getOperationGroups().forEach(operationGroup -> {
-//            if (operationGroup.getOperations() != null && operationGroup.getOperations().stream().anyMatch(FluentTransformer::hasLongRunningOperationExtension)) {
-//                List<Operation> operations = new ArrayList<>(operationGroup.getOperations());
-//
-//                for (Operation operation : operationGroup.getOperations()) {
-//                    if (hasLongRunningOperationExtension(operation)) {
-//                        Operation newOperation = new Operation();
-//                        Utils.shallowCopy(operation, newOperation, Operation.class, logger);
-//
-//                        Language updatedDefault = new Language();
-//                        Utils.shallowCopy(operation.getLanguage().getDefault(), updatedDefault, Language.class, logger);
-//                        updatedDefault.setName("Begin" + operation.getLanguage().getDefault().getName() + "WithoutPolling");
-//
-//                        Languages updatedLanguages = new Languages();
-//                        Utils.shallowCopy(operation.getLanguage(), updatedLanguages, Languages.class, logger);
-//                        updatedLanguages.setDefault(updatedDefault);
-//                        newOperation.setLanguage(updatedLanguages);
-//
-//                        XmsExtensions updatedExtensions = new XmsExtensions();
-//                        Utils.shallowCopy(operation.getExtensions(), updatedExtensions, XmsExtensions.class, logger);
-//                        updatedExtensions.setXmsLongRunningOperation(false);
-//                        newOperation.setExtensions(updatedExtensions);
-//
-//                        List<Request> newRequests = new ArrayList<>();
-//                        for (Request request : operation.getRequests()) {
-//                            Request newRequest = new Request();
-//                            Utils.shallowCopy(request, newRequest, Request.class, logger);
-//
-//                            // Transformer will change request.parameters
-//                            newRequest.setParameters(new ArrayList<>(request.getParameters()));
-//
-//                            newRequests.add(newRequest);
-//                        }
-//                        newOperation.setRequests(newRequests);
-//
-//                        operations.add(newOperation);
-//                    }
-//                }
-//
-//                operationGroup.setOperations(operations);
-//            }
-//        });
-//        return codeModel;
-//    }
-//
-//    private static boolean hasLongRunningOperationExtension(Operation operation) {
-//        return operation.getExtensions() != null && operation.getExtensions().isXmsLongRunningOperation();
-//    }
-//
-//    private static boolean hasPaging(Operation operation) {
-//        return operation.getExtensions() != null && operation.getExtensions().getXmsPageable() != null;
-//    }
+    private static CodeModel removeXml(CodeModel codeModel) {
+        // remove xml from serializationFormats, as mgmt currently does not have dependency on jackson-dataformat-xml package
+        if (!CoreUtils.isNullOrEmpty(codeModel.getSchemas().getObjects())) {
+            codeModel.getSchemas().getObjects().forEach(o -> {
+                if (!CoreUtils.isNullOrEmpty(o.getSerializationFormats())) {
+                    o.getSerializationFormats().remove("xml");
+                }
+            });
+        }
+        return codeModel;
+    }
 }

--- a/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
@@ -133,11 +133,10 @@ public class ModelMapper implements IMapper<ObjectSchema, ClientModel> {
             }
 
             boolean compositeTypeUsedWithXml = SchemaUtil.treatAsXml(compositeType);
-            if (compositeTypeUsedWithXml) {
-                modelImports.add("com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement");
-            }
             if (!compositeTypeProperties.isEmpty()) {
                 if (compositeTypeUsedWithXml) {
+                    modelImports.add("com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement");
+
                     if (compositeTypeProperties.stream().anyMatch(p -> p.getSchema() instanceof ArraySchema)) {
                         modelImports.add(ArrayList.class.getName());
                     }

--- a/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
@@ -133,10 +133,11 @@ public class ModelMapper implements IMapper<ObjectSchema, ClientModel> {
             }
 
             boolean compositeTypeUsedWithXml = SchemaUtil.treatAsXml(compositeType);
+            if (compositeTypeUsedWithXml) {
+                modelImports.add("com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement");
+            }
             if (!compositeTypeProperties.isEmpty()) {
                 if (compositeTypeUsedWithXml) {
-                    modelImports.add("com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement");
-
                     if (compositeTypeProperties.stream().anyMatch(p -> p.getSchema() instanceof ArraySchema)) {
                         modelImports.add(ArrayList.class.getName());
                     }


### PR DESCRIPTION
To avoid model generated with XML support, as mgmt does not depend on jackson-dataformat-xml (so e.g. `JacksonXmlRootElement` in model code won't compile)