### PR TITLE
dpg, support assets.json and ContentSafetyClientTestBase.java

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/Javagen.java
+++ b/javagen/src/main/java/com/azure/autorest/Javagen.java
@@ -316,6 +316,9 @@ public class Javagen extends NewPlugin {
                 }
                 javaPackage.addChangelogMarkdown(project);
 
+                // test proxy asserts.json
+                javaPackage.addTestProxyAssetsJson(project);
+
                 // Blank readme sample
                 javaPackage.addProtocolExamplesBlank();
             }

--- a/javagen/src/main/java/com/azure/autorest/model/javamodel/JavaPackage.java
+++ b/javagen/src/main/java/com/azure/autorest/model/javamodel/JavaPackage.java
@@ -35,6 +35,7 @@ import com.azure.autorest.template.ReadmeTemplate;
 import com.azure.autorest.template.ServiceSyncClientTemplate;
 import com.azure.autorest.template.SwaggerReadmeTemplate;
 import com.azure.autorest.template.Templates;
+import com.azure.autorest.template.TestProxyAssetsTemplate;
 import com.azure.autorest.util.PossibleCredentialException;
 import org.slf4j.Logger;
 
@@ -278,6 +279,12 @@ public class JavaPackage {
 
     public void addChangelogMarkdown(Project project) {
         TextFile textFile = new TextFile("CHANGELOG.md", new ChangelogTemplate().write(project));
+        this.checkDuplicateFile(textFile.getFilePath());
+        textFiles.add(textFile);
+    }
+
+    public void addTestProxyAssetsJson(Project project) {
+        TextFile textFile = new TextFile("assets.json", new TestProxyAssetsTemplate().write(project));
         this.checkDuplicateFile(textFile.getFilePath());
         textFiles.add(textFile);
     }

--- a/javagen/src/main/java/com/azure/autorest/template/ProtocolTestBaseTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ProtocolTestBaseTemplate.java
@@ -26,7 +26,7 @@ public class ProtocolTestBaseTemplate implements IJavaTemplate<TestContext, Java
 
         context.declareImport(writer.getImports());
 
-        context.classBlock(JavaVisibility.PackagePrivate, null, String.format("%s extends TestBase", testContext.getTestBaseClassName()), classBlock -> {
+        context.classBlock(JavaVisibility.PackagePrivate, null, String.format("%s extends TestProxyTestBase", testContext.getTestBaseClassName()), classBlock -> {
 
             writer.writeClientVariables(classBlock);
 

--- a/javagen/src/main/java/com/azure/autorest/template/TestProxyAssetsTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/TestProxyAssetsTemplate.java
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.autorest.template;
+
+import com.azure.autorest.model.projectmodel.Project;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class TestProxyAssetsTemplate {
+
+    static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static class Assets {
+        @JsonProperty("AssetsRepo")
+        private String assetsRepo = "Azure/azure-sdk-assets";
+
+        @JsonProperty("AssetsRepoPrefixPath")
+        private String assetsRepoPrefixPath = "java";
+
+        @JsonProperty("TagPrefix")
+        private String tagPrefix;
+
+        @JsonProperty("Tag")
+        private String tag = "";
+
+        public void setTagPrefix(String tagPrefix) {
+            this.tagPrefix = tagPrefix;
+        }
+    }
+
+    public String write(Project project) {
+        Assets asserts = new Assets();
+        String group;
+        if (project.getSdkRepositoryUri().isPresent()) {
+            String[] segments = project.getSdkRepositoryUri().get().split("/");
+            group = segments[segments.length - 2];
+        } else {
+            // fallback to last segment of artifactId, this could be incorrect
+            String[] segments = project.getArtifactId().split("-");
+            group = segments[segments.length - 1];
+        }
+        asserts.setTagPrefix(String.format("java/%1$s/%2$s", group, project.getArtifactId()));
+        try {
+            return OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(asserts);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/javagen/src/main/java/com/azure/autorest/template/example/ProtocolTestWriter.java
+++ b/javagen/src/main/java/com/azure/autorest/template/example/ProtocolTestWriter.java
@@ -51,7 +51,7 @@ public class ProtocolTestWriter {
                 OffsetDateTime.class.getName(),
                 Mono.class.getName(),
                 "com.azure.identity.DefaultAzureCredentialBuilder",
-                "com.azure.core.test.TestBase",
+                "com.azure.core.test.TestProxyTestBase",
                 "com.azure.core.test.TestMode",
 //                "com.azure.core.test.annotation.DoNotRecord",
                 "org.junit.jupiter.api.Disabled",

--- a/javagen/src/test/java/com/azure/autorest/template/TestProxyAssertsTemplateTests.java
+++ b/javagen/src/test/java/com/azure/autorest/template/TestProxyAssertsTemplateTests.java
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.autorest.template;
+
+import com.azure.autorest.MockUnitJavagen;
+import com.azure.autorest.model.projectmodel.Project;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestProxyAssertsTemplateTests {
+
+    private static class MockProject extends Project {
+        MockProject() {
+            serviceName = "OpenAI";
+            serviceDescription = "OpenAI Service";
+            namespace = "com.azure.ai.openai";
+            artifactId = "azure-ai-openai";
+            sdkRepositoryUri = "https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/openai/azure-ai-openai";
+        }
+    }
+
+    @Test
+    public void testAssertsTemplateWrite() throws JsonProcessingException {
+        MockUnitJavagen javagen = new MockUnitJavagen();
+
+        Project project = new MockProject();
+
+        String output = new TestProxyAssetsTemplate().write(project);
+
+        JsonNode jsonNode = TestProxyAssetsTemplate.OBJECT_MAPPER.readTree(output);
+        Assert.assertEquals("Azure/azure-sdk-assets", jsonNode.get("AssetsRepo").asText());
+        Assert.assertEquals("java", jsonNode.get("AssetsRepoPrefixPath").asText());
+        Assert.assertEquals("java/openai/azure-ai-openai", jsonNode.get("TagPrefix").asText());
+        Assert.assertNotNull(jsonNode.get("Tag").asText());
+    }
+}

--- a/protocol-sdk-integration-tests/test.py
+++ b/protocol-sdk-integration-tests/test.py
@@ -58,6 +58,7 @@ def run(script_path: str, output_folder: str, json_path: str, namespace: str,
         '-Djacoco.skip',
         '-Drevapi.skip',
         '-Dmaven.javadoc.skip',
+        '-Dmaven.test.skip',
         '--no-transfer-progress'
     ]
     subprocess.check_call(cmd, cwd=output_folder)


### PR DESCRIPTION
fix https://github.com/Azure/autorest.java/issues/2180

The `assets.json` is only generated on option `--sdk-integration`, which is usually the first-time user generate an SDK (via sdk automation, or via python script).
Hence follow-up generate (e.g. via call to `autorest`) will not overwrite the file.

For TypeSpec, this option is enabled if no `src` folder found in output folder (again, usually the first-time codegen).

sample change (assets.json and ContentSafetyClientTestBase.java)
https://github.com/weidongxu-microsoft/azure-sdk-for-java/commit/d9a21c4804040d04fb6c001d3685d73ba95b5cc7
(I am reusing a ContentSafety sample PR https://github.com/Azure/azure-sdk-for-java/pull/35372)