### PR TITLE
client, readme.md include impression pixel

### DIFF
--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/ReadmeTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/ReadmeTemplate.java
@@ -9,10 +9,6 @@ import com.azure.autorest.fluent.model.projectmodel.FluentProject;
 import com.azure.autorest.fluent.util.FluentUtils;
 import com.azure.autorest.util.TemplateUtil;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-
 public class ReadmeTemplate extends com.azure.autorest.template.ReadmeTemplate {
 
     public String write(FluentProject project) {
@@ -31,17 +27,6 @@ public class ReadmeTemplate extends com.azure.autorest.template.ReadmeTemplate {
                     .append("\n");
         }
 
-        String impression = "";
-        if (project.getSdkRepositoryPath().isPresent()) {
-            try {
-                impression = "![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/"
-                        + URLEncoder.encode("azure-sdk-for-java/" + project.getSdkRepositoryPath().get() + "/README.png", StandardCharsets.UTF_8.name())
-                        + ")";
-            } catch (UnsupportedEncodingException e) {
-                // NOOP
-            }
-        }
-
         return FluentUtils.loadTextFromResource("Readme.txt",
                 TemplateUtil.SERVICE_NAME, project.getServiceName(),
                 TemplateUtil.SERVICE_DESCRIPTION, project.getServiceDescriptionForMarkdown(),
@@ -50,7 +35,7 @@ public class ReadmeTemplate extends com.azure.autorest.template.ReadmeTemplate {
                 TemplateUtil.ARTIFACT_VERSION, project.getVersion(),
                 TemplateUtil.MANAGER_CLASS, FluentStatic.getFluentManager().getType().getName(),
                 TemplateUtil.SAMPLE_CODES, sampleCodesBuilder.toString(),
-                TemplateUtil.IMPRESSION_PIXEL, impression
+                TemplateUtil.IMPRESSION_PIXEL, getImpression(project)
         );
     }
 }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/ReadmeTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/ReadmeTemplate.java
@@ -9,6 +9,10 @@ import com.azure.autorest.fluent.model.projectmodel.FluentProject;
 import com.azure.autorest.fluent.util.FluentUtils;
 import com.azure.autorest.util.TemplateUtil;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 public class ReadmeTemplate extends com.azure.autorest.template.ReadmeTemplate {
 
     public String write(FluentProject project) {
@@ -27,6 +31,17 @@ public class ReadmeTemplate extends com.azure.autorest.template.ReadmeTemplate {
                     .append("\n");
         }
 
+        String impression = "";
+        if (project.getSdkRepositoryPath().isPresent()) {
+            try {
+                impression = "![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/"
+                        + URLEncoder.encode("azure-sdk-for-java/" + project.getSdkRepositoryPath().get() + "/README.png", StandardCharsets.UTF_8.name())
+                        + ")";
+            } catch (UnsupportedEncodingException e) {
+                // NOOP
+            }
+        }
+
         return FluentUtils.loadTextFromResource("Readme.txt",
                 TemplateUtil.SERVICE_NAME, project.getServiceName(),
                 TemplateUtil.SERVICE_DESCRIPTION, project.getServiceDescriptionForMarkdown(),
@@ -34,7 +49,8 @@ public class ReadmeTemplate extends com.azure.autorest.template.ReadmeTemplate {
                 TemplateUtil.ARTIFACT_ID, project.getArtifactId(),
                 TemplateUtil.ARTIFACT_VERSION, project.getVersion(),
                 TemplateUtil.MANAGER_CLASS, FluentStatic.getFluentManager().getType().getName(),
-                TemplateUtil.SAMPLE_CODES, sampleCodesBuilder.toString()
+                TemplateUtil.SAMPLE_CODES, sampleCodesBuilder.toString(),
+                TemplateUtil.IMPRESSION_PIXEL, impression
         );
     }
 }

--- a/fluentgen/src/main/resources/Readme.txt
+++ b/fluentgen/src/main/resources/Readme.txt
@@ -102,3 +102,5 @@ This project has adopted the [Microsoft Open Source Code of Conduct][coc]. For m
 [cg]: https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md
 [coc]: https://opensource.microsoft.com/codeofconduct/
 [coc_faq]: https://opensource.microsoft.com/codeofconduct/faq/
+
+{{impression-pixel}}

--- a/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
+++ b/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
@@ -47,7 +47,7 @@ public class Project {
     protected String artifactId;
     protected String version = "1.0.0-beta.1";
     protected final List<String> pomDependencyIdentifiers = new ArrayList<>();
-    protected String sdkRepositoryUri;
+    protected String sdkRepositoryPath;
 
     private List<String> apiVersions;
 
@@ -172,8 +172,8 @@ public class Project {
             }
             if (path != null) {
                 Collections.reverse(pathSegment);
-                sdkRepositoryUri = "https://github.com/Azure/azure-sdk-for-java/blob/main/" + String.join("/", pathSegment);
-                LOGGER.info("Repository URI '{}' deduced from 'output-folder' parameter", sdkRepositoryUri);
+                sdkRepositoryPath = String.join("/", pathSegment);
+                LOGGER.info("Repository path '{}' deduced from 'output-folder' parameter", sdkRepositoryPath);
             }
         }
     }
@@ -400,7 +400,11 @@ public class Project {
     }
 
     public Optional<String> getSdkRepositoryUri() {
-        return Optional.ofNullable(sdkRepositoryUri);
+        return Optional.ofNullable(sdkRepositoryPath == null ? null : ("https://github.com/Azure/azure-sdk-for-java/blob/main/" + sdkRepositoryPath));
+    }
+
+    public Optional<String> getSdkRepositoryPath() {
+        return Optional.ofNullable(sdkRepositoryPath);
     }
 
     public boolean isIntegratedWithSdk() {

--- a/javagen/src/main/java/com/azure/autorest/template/ReadmeTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ReadmeTemplate.java
@@ -13,6 +13,18 @@ import java.nio.charset.StandardCharsets;
 public class ReadmeTemplate {
 
     public String write(Project project) {
+        return TemplateUtil.loadTextFromResource("Readme_protocol.txt",
+                TemplateUtil.SERVICE_NAME, project.getServiceName(),
+                TemplateUtil.SERVICE_DESCRIPTION, project.getServiceDescriptionForMarkdown(),
+                TemplateUtil.GROUP_ID, project.getGroupId(),
+                TemplateUtil.ARTIFACT_ID, project.getArtifactId(),
+                TemplateUtil.ARTIFACT_VERSION, project.getVersion(),
+                TemplateUtil.PACKAGE_NAME, project.getNamespace(),
+                TemplateUtil.IMPRESSION_PIXEL, getImpression(project)
+        );
+    }
+
+    protected static String getImpression(Project project) {
         String impression = "";
         if (project.getSdkRepositoryPath().isPresent()) {
             try {
@@ -23,15 +35,6 @@ public class ReadmeTemplate {
                 // NOOP
             }
         }
-
-        return TemplateUtil.loadTextFromResource("Readme_protocol.txt",
-                TemplateUtil.SERVICE_NAME, project.getServiceName(),
-                TemplateUtil.SERVICE_DESCRIPTION, project.getServiceDescriptionForMarkdown(),
-                TemplateUtil.GROUP_ID, project.getGroupId(),
-                TemplateUtil.ARTIFACT_ID, project.getArtifactId(),
-                TemplateUtil.ARTIFACT_VERSION, project.getVersion(),
-                TemplateUtil.PACKAGE_NAME, project.getNamespace(),
-                TemplateUtil.IMPRESSION_PIXEL, impression
-        );
+        return impression;
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/template/ReadmeTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ReadmeTemplate.java
@@ -6,16 +6,32 @@ package com.azure.autorest.template;
 import com.azure.autorest.model.projectmodel.Project;
 import com.azure.autorest.util.TemplateUtil;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 public class ReadmeTemplate {
 
     public String write(Project project) {
+        String impression = "";
+        if (project.getSdkRepositoryPath().isPresent()) {
+            try {
+                impression = "![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/"
+                        + URLEncoder.encode("azure-sdk-for-java/" + project.getSdkRepositoryPath().get() + "/README.png", StandardCharsets.UTF_8.name())
+                        + ")";
+            } catch (UnsupportedEncodingException e) {
+                // NOOP
+            }
+        }
+
         return TemplateUtil.loadTextFromResource("Readme_protocol.txt",
                 TemplateUtil.SERVICE_NAME, project.getServiceName(),
                 TemplateUtil.SERVICE_DESCRIPTION, project.getServiceDescriptionForMarkdown(),
                 TemplateUtil.GROUP_ID, project.getGroupId(),
                 TemplateUtil.ARTIFACT_ID, project.getArtifactId(),
                 TemplateUtil.ARTIFACT_VERSION, project.getVersion(),
-                TemplateUtil.PACKAGE_NAME, project.getNamespace()
+                TemplateUtil.PACKAGE_NAME, project.getNamespace(),
+                TemplateUtil.IMPRESSION_PIXEL, impression
         );
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/util/TemplateUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/TemplateUtil.java
@@ -45,6 +45,7 @@ public class TemplateUtil {
     public static final String ARTIFACT_ID = "artifact-id";
     public static final String ARTIFACT_VERSION = "artifact-version";
     public static final String PACKAGE_NAME = "package-name";
+    public static final String IMPRESSION_PIXEL = "impression-pixel";
 
     public static final String MANAGER_CLASS = "manager-class";
 

--- a/javagen/src/main/resources/Readme_protocol.txt
+++ b/javagen/src/main/resources/Readme_protocol.txt
@@ -61,3 +61,5 @@ For details on contributing to this repository, see the [contributing guide](htt
 [jdk]: https://docs.microsoft.com/java/azure/jdk/
 [azure_subscription]: https://azure.microsoft.com/free/
 [azure_identity]: https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/identity/azure-identity
+
+{{impression-pixel}}


### PR DESCRIPTION
fix https://github.com/Azure/autorest.java/issues/2070

e.g. end of readme.md
```
![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-java%2Fsdk%2Fdatafactory%2Fazure-resourcemanager-datafactory%2FREADME.png)
```

Above would be empty if we cannot find the path ("sdk/datafatory/azure-resourcemanager-datafactory").