### PR TITLE
client, default namespace as com.mycompany.app

### DIFF
--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -106,7 +106,7 @@ public class JavaSettings {
                 header,
                 120,
                 getStringValue(host, "service-name"),
-                getStringValue(host, "namespace", "").toLowerCase(),
+                getStringValue(host, "namespace", "com.mycompany.app").toLowerCase(),
                 getBooleanValue(host, "enable-xml", false),
                 getBooleanValue(host, "non-null-annotations", false),
                 getBooleanValue(host, "client-side-validations", false),


### PR DESCRIPTION
link https://github.com/Azure/autorest.java/issues/2200

We've got a few queries on error when formatting output code, when namespace is not set.

Cause of the error is the code like `package .` or `import .models`.

I figure it be better provide a default namespace, if user does not provide one.

Currently, I use `com.mycompany.app` as https://maven.apache.org/guides/getting-started/maven-in-five-minutes.html