### PR TITLE
mgmt, fix for model inherit error, whether it is used in Exception

### DIFF
--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentModelTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentModelTemplate.java
@@ -77,10 +77,16 @@ public class FluentModelTemplate extends ModelTemplate {
         if (FluentType.ManagementError.getName().equals(model.getParentModelName())) {
             // subclass of ManagementError
 
-            if (modelNamer == null) {
-                modelNamer = new ModelNamer();
+            if (model.getImplementationDetails() != null && model.getImplementationDetails().isException()) {
+                // model used in Exception
+
+                if (modelNamer == null) {
+                    modelNamer = new ModelNamer();
+                }
+                return modelNamer.modelPropertyGetterName(property);
+            } else {
+                return super.getGetterName(model, property);
             }
-            return modelNamer.modelPropertyGetterName(property);
         } else {
             return super.getGetterName(model, property);
         }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentModelTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentModelTemplate.java
@@ -77,8 +77,11 @@ public class FluentModelTemplate extends ModelTemplate {
         if (FluentType.ManagementError.getName().equals(model.getParentModelName())) {
             // subclass of ManagementError
 
-            if (model.getImplementationDetails() != null && model.getImplementationDetails().isException()) {
-                // model used in Exception
+            if (model.getImplementationDetails() != null
+                    && model.getImplementationDetails().isException()
+                    && !model.getImplementationDetails().isOutput()
+                    && !model.getImplementationDetails().isInput()) {
+                // model used in Exception, also not in any non-Exception input or output
 
                 if (modelNamer == null) {
                     modelNamer = new ModelNamer();

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -584,7 +584,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                 returnTypeHolder.asyncReturnType = createAsyncVoidReturnType();
             }
             returnTypeHolder.syncReturnType = responseBodyType.getClientType();
-            if (responseBodyType == GenericType.FluxByteBuffer) {
+            if (responseBodyType == GenericType.FluxByteBuffer && !settings.isFluent()) {
                 returnTypeHolder.syncReturnType = ClassType.BinaryData;
             }
         }


### PR DESCRIPTION
problem: service got a model that inherit from `ErrorResponse`, but the model is not used in Error/Exception (its in 200/202).
https://github.com/Azure/azure-rest-api-specs/blob/1968865/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/stable/2023-06-15/common.json#L162-L193

This probably not a complete fix, as such model could be used both in success response and error response. But in practice, this case is already extreme rare.

--- 

Also fix of `BinaryData` in sync method return type. Mgmt still uses `Flux<ByteBuffer>`.