### PR TITLE
tsp, fix javadoc for alias/flatten

### DIFF
--- a/typespec-extension/src/code-model-builder.ts
+++ b/typespec-extension/src/code-model-builder.ts
@@ -1057,6 +1057,9 @@ export class CodeModelBuilder {
     if (!schema.language.default.name && schema instanceof ObjectSchema) {
       // anonymous model
 
+      // name the schema for documentation
+      schema.language.default.name = op.language.default.name + "Request";
+
       if (!parameter.language.default.name) {
         // name the parameter for documentation
         parameter.language.default.name = "request";

--- a/typespec-tests/src/main/java/com/cadl/flatten/FlattenAsyncClient.java
+++ b/typespec-tests/src/main/java/com/cadl/flatten/FlattenAsyncClient.java
@@ -88,6 +88,10 @@ public final class FlattenAsyncClient {
      *         user: String (Required)
      *     }
      *     input: String (Required)
+     *     dataInt: int (Required)
+     *     dataIntOptional: Integer (Optional)
+     *     dataLong: Long (Optional)
+     *     data_float: Double (Optional)
      * }
      * }</pre>
      *

--- a/typespec-tests/src/main/java/com/cadl/flatten/FlattenClient.java
+++ b/typespec-tests/src/main/java/com/cadl/flatten/FlattenClient.java
@@ -86,6 +86,10 @@ public final class FlattenClient {
      *         user: String (Required)
      *     }
      *     input: String (Required)
+     *     dataInt: int (Required)
+     *     dataIntOptional: Integer (Optional)
+     *     dataLong: Long (Optional)
+     *     data_float: Double (Optional)
      * }
      * }</pre>
      *

--- a/typespec-tests/src/main/java/com/cadl/flatten/implementation/FlattenClientImpl.java
+++ b/typespec-tests/src/main/java/com/cadl/flatten/implementation/FlattenClientImpl.java
@@ -318,6 +318,10 @@ public final class FlattenClientImpl {
      *         user: String (Required)
      *     }
      *     input: String (Required)
+     *     dataInt: int (Required)
+     *     dataIntOptional: Integer (Optional)
+     *     dataLong: Long (Optional)
+     *     data_float: Double (Optional)
      * }
      * }</pre>
      *
@@ -367,6 +371,10 @@ public final class FlattenClientImpl {
      *         user: String (Required)
      *     }
      *     input: String (Required)
+     *     dataInt: int (Required)
+     *     dataIntOptional: Integer (Optional)
+     *     dataLong: Long (Optional)
+     *     data_float: Double (Optional)
      * }
      * }</pre>
      *

--- a/typespec-tests/src/main/java/com/cadl/union/UnionAsyncClient.java
+++ b/typespec-tests/src/main/java/com/cadl/union/UnionAsyncClient.java
@@ -83,7 +83,11 @@ public final class UnionAsyncClient {
      *     user (Optional): {
      *         user: String (Required)
      *     }
-     *     input: InputModelBase (Required)
+     *     input: String (Required)
+     *     dataInt: int (Required)
+     *     dataUnion: DataUnionModelBase (Optional)
+     *     dataLong: Long (Optional)
+     *     data_float: Double (Optional)
      * }
      * }</pre>
      *

--- a/typespec-tests/src/main/java/com/cadl/union/UnionClient.java
+++ b/typespec-tests/src/main/java/com/cadl/union/UnionClient.java
@@ -82,7 +82,11 @@ public final class UnionClient {
      *     user (Optional): {
      *         user: String (Required)
      *     }
-     *     input: InputModelBase (Required)
+     *     input: String (Required)
+     *     dataInt: int (Required)
+     *     dataUnion: DataUnionModelBase (Optional)
+     *     dataLong: Long (Optional)
+     *     data_float: Double (Optional)
      * }
      * }</pre>
      *

--- a/typespec-tests/src/main/java/com/cadl/union/implementation/UnionClientImpl.java
+++ b/typespec-tests/src/main/java/com/cadl/union/implementation/UnionClientImpl.java
@@ -399,7 +399,11 @@ public final class UnionClientImpl {
      *     user (Optional): {
      *         user: String (Required)
      *     }
-     *     input: InputModelBase (Required)
+     *     input: String (Required)
+     *     dataInt: int (Required)
+     *     dataUnion: DataUnionModelBase (Optional)
+     *     dataLong: Long (Optional)
+     *     data_float: Double (Optional)
      * }
      * }</pre>
      *
@@ -448,7 +452,11 @@ public final class UnionClientImpl {
      *     user (Optional): {
      *         user: String (Required)
      *     }
-     *     input: InputModelBase (Required)
+     *     input: String (Required)
+     *     dataInt: int (Required)
+     *     dataUnion: DataUnionModelBase (Optional)
+     *     dataLong: Long (Optional)
+     *     data_float: Double (Optional)
      * }
      * }</pre>
      *

--- a/typespec-tests/src/main/java/com/parameters/spread/AliasAsyncClient.java
+++ b/typespec-tests/src/main/java/com/parameters/spread/AliasAsyncClient.java
@@ -97,7 +97,12 @@ public final class AliasAsyncClient {
      *
      * <pre>{@code
      * {
-     *     name: String (Required)
+     *     prop1: String (Required)
+     *     prop2: String (Required)
+     *     prop3: String (Required)
+     *     prop4: String (Required)
+     *     prop5: String (Required)
+     *     prop6: String (Required)
      * }
      * }</pre>
      *

--- a/typespec-tests/src/main/java/com/parameters/spread/AliasClient.java
+++ b/typespec-tests/src/main/java/com/parameters/spread/AliasClient.java
@@ -95,7 +95,12 @@ public final class AliasClient {
      *
      * <pre>{@code
      * {
-     *     name: String (Required)
+     *     prop1: String (Required)
+     *     prop2: String (Required)
+     *     prop3: String (Required)
+     *     prop4: String (Required)
+     *     prop5: String (Required)
+     *     prop6: String (Required)
      * }
      * }</pre>
      *

--- a/typespec-tests/src/main/java/com/parameters/spread/implementation/AliasImpl.java
+++ b/typespec-tests/src/main/java/com/parameters/spread/implementation/AliasImpl.java
@@ -284,7 +284,12 @@ public final class AliasImpl {
      *
      * <pre>{@code
      * {
-     *     name: String (Required)
+     *     prop1: String (Required)
+     *     prop2: String (Required)
+     *     prop3: String (Required)
+     *     prop4: String (Required)
+     *     prop5: String (Required)
+     *     prop6: String (Required)
      * }
      * }</pre>
      *
@@ -315,7 +320,12 @@ public final class AliasImpl {
      *
      * <pre>{@code
      * {
-     *     name: String (Required)
+     *     prop1: String (Required)
+     *     prop2: String (Required)
+     *     prop3: String (Required)
+     *     prop4: String (Required)
+     *     prop5: String (Required)
+     *     prop6: String (Required)
      * }
      * }</pre>
      *


### PR DESCRIPTION
Provide a name for model of alias, so that during generateJavadoc, it can find the correct request body model.

Without a name, all model that get flattened would be named as `""`, which causes problem when find the correct one.