### PR TITLE
client, fallback to "body" for request body

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/util/ModelExampleUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/ModelExampleUtil.java
@@ -285,6 +285,12 @@ public class ModelExampleUtil {
                     parameterValue = findParameter(example, serializedName);
                 }
             }
+
+            // fallback, "body" is commonly used in example JSON for request body
+            if (parameterValue == null) {
+                serializedName = "body";
+                parameterValue = findParameter(example, serializedName);
+            }
         }
 
         Object exampleValue = parameterValue;


### PR DESCRIPTION
Mostly for typespec. 

Even I don't know what will be the body parameter name, after all these templates.
So have "body" as fallback.

Effect https://github.com/Azure/azure-sdk-for-java/pull/35372/commits/03a94311b3481fc7e13538ab73a3613697fa9c9a#diff-675194c20c2981ba3865b41512445e449629a1963a0b0f3308d9b45c38a211bf