### PR TITLE
tsp, warning for method with convenience API disabled

### DIFF
--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Language.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Language.java
@@ -36,6 +36,8 @@ public class Language {
 
     private String namespace;
 
+    private String comment;
+
     /**
      * name used in actual implementation
      * (Required)
@@ -94,6 +96,14 @@ public class Language {
 
     public void setNamespace(String namespace) {
         this.namespace = namespace;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
     }
 
     @Override

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -184,6 +184,12 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
             builder.description(SchemaUtil.mergeSummaryWithDescription(summary, description));
         }
 
+        // API comment
+        ImplementationDetails.Builder implDetailsBuilder = null;
+        if (operation.getLanguage().getJava() != null && !CoreUtils.isNullOrEmpty(operation.getLanguage().getJava().getComment())) {
+            implDetailsBuilder = new ImplementationDetails.Builder().comment(operation.getLanguage().getJava().getComment());
+            builder.implementationDetails(implDetailsBuilder.build());
+        }
 
         // map externalDocs property
         if (operation.getExternalDocs() != null) {
@@ -438,7 +444,10 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                         // additional LRO method for data-plane, with intermediate/final type, for convenience of grow-up
                         // it is public in implementation, but not exposed in wrapper client
 
-                        ImplementationDetails.Builder implDetailsBuilder = new ImplementationDetails.Builder().implementationOnly(true);
+                        if (implDetailsBuilder == null) {
+                            implDetailsBuilder = new ImplementationDetails.Builder();
+                        }
+                        implDetailsBuilder.implementationOnly(true);
 
                         builder = builder.implementationDetails(implDetailsBuilder.build());
 

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ImplementationDetails.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ImplementationDetails.java
@@ -95,6 +95,8 @@ public class ImplementationDetails {
 
     private final Set<Usage> usages;
 
+    private final String comment;
+
     /**
      * Usually on a method, that it is only required in implementation class (FooClientImpl),
      * but not in public class (FooClient).
@@ -131,14 +133,23 @@ public class ImplementationDetails {
         return usages.contains(Usage.EXCEPTION);
     }
 
-    protected ImplementationDetails(boolean implementationOnly, Set<Usage> usages) {
+    /**
+     * @return API comment.
+     */
+    public String getComment() {
+        return comment;
+    }
+
+    protected ImplementationDetails(boolean implementationOnly, Set<Usage> usages, String comment) {
         this.implementationOnly = implementationOnly;
         this.usages = usages;
+        this.comment = comment;
     }
 
     public static final class Builder {
         private boolean implementationOnly = false;
         private Set<Usage> usages = new HashSet<>();
+        private String comment;
 
         public Builder() {
         }
@@ -153,8 +164,13 @@ public class ImplementationDetails {
             return this;
         }
 
+        public Builder comment(String comment) {
+            this.comment = comment;
+            return this;
+        }
+
         public ImplementationDetails build() {
-            return new ImplementationDetails(implementationOnly, usages);
+            return new ImplementationDetails(implementationOnly, usages, comment);
         }
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/template/WrapperClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/WrapperClientMethodTemplate.java
@@ -16,6 +16,7 @@ import com.azure.autorest.model.javamodel.JavaType;
 import com.azure.autorest.model.javamodel.JavaVisibility;
 import com.azure.autorest.util.TemplateUtil;
 import com.azure.core.annotation.Generated;
+import com.azure.core.util.CoreUtils;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -62,6 +63,11 @@ public class WrapperClientMethodTemplate extends ClientMethodTemplateBase {
 
         String declaration = String.format("%1$s %2$s(%3$s)", clientMethod.getReturnValue().getType(), methodName, clientMethod.getParametersDeclaration());
         Consumer<JavaBlock> method = function -> {
+
+            // API comment
+            if (clientMethod.getImplementationDetails() != null && !CoreUtils.isNullOrEmpty(clientMethod.getImplementationDetails().getComment())) {
+                function.line("// " + clientMethod.getImplementationDetails().getComment());
+            }
 
             boolean shouldReturn = true;
             if (clientMethod.getReturnValue() != null && clientMethod.getReturnValue().getType() instanceof PrimitiveType) {

--- a/typespec-extension/src/type-utils.ts
+++ b/typespec-extension/src/type-utils.ts
@@ -133,7 +133,7 @@ export function hasScalarAsBase(type: Scalar, scalarName: IntrinsicScalarName): 
   return false;
 }
 
-export function unionReferedByType(
+export function unionReferredByType(
   program: Program,
   type: Type,
   cache: Map<Type, Union | null | undefined>,
@@ -153,7 +153,7 @@ export function unionReferedByType(
     const nonNullVariants = Array.from(type.variants.values()).filter((it) => !isNullType(it.type));
     if (nonNullVariants.length === 1) {
       // Type | null, follow that Type
-      const ret = unionReferedByType(program, nonNullVariants[0], cache);
+      const ret = unionReferredByType(program, nonNullVariants[0], cache);
       if (ret) {
         cache.set(type, ret);
         return ret;
@@ -170,7 +170,7 @@ export function unionReferedByType(
   } else if (type.kind === "Model") {
     if (type.indexer) {
       // follow indexer (for Array/Record)
-      const ret = unionReferedByType(program, type.indexer.value, cache);
+      const ret = unionReferredByType(program, type.indexer.value, cache);
       if (ret) {
         cache.set(type, ret);
         return ret;
@@ -178,7 +178,7 @@ export function unionReferedByType(
     }
     // follow properties
     for (const property of type.properties.values()) {
-      const ret = unionReferedByType(program, property.type, cache);
+      const ret = unionReferredByType(program, property.type, cache);
       if (ret) {
         cache.set(type, ret);
         return ret;

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/basic/BasicAsyncClient.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/basic/BasicAsyncClient.java
@@ -93,6 +93,7 @@ public final class BasicAsyncClient {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<BinaryData>> createOrUpdateWithResponse(
             int id, BinaryData resource, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'createOrUpdate' is 'application/merge-patch+json'
         return this.serviceClient.createOrUpdateWithResponseAsync(id, resource, requestOptions);
     }
 

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/basic/BasicClient.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/basic/BasicClient.java
@@ -86,6 +86,7 @@ public final class BasicClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<BinaryData> createOrUpdateWithResponse(int id, BinaryData resource, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'createOrUpdate' is 'application/merge-patch+json'
         return this.serviceClient.createOrUpdateWithResponse(id, resource, requestOptions);
     }
 

--- a/typespec-tests/src/main/java/com/cadl/multicontenttypes/MultiContentTypesAsyncClient.java
+++ b/typespec-tests/src/main/java/com/cadl/multicontenttypes/MultiContentTypesAsyncClient.java
@@ -58,6 +58,7 @@ public final class MultiContentTypesAsyncClient {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> uploadWithOverloadWithResponse(
             String contentType, BinaryData data, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'uploadWithOverload' is multiple content-type
         return this.serviceClient.uploadWithOverloadWithResponseAsync(contentType, data, requestOptions);
     }
 
@@ -130,6 +131,8 @@ public final class MultiContentTypesAsyncClient {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> uploadBytesWithSingleBodyTypeForMultiContentTypesWithResponse(
             String contentType, BinaryData data, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'uploadBytesWithSingleBodyTypeForMultiContentTypes' is
+        // multiple content-type
         return this.serviceClient.uploadBytesWithSingleBodyTypeForMultiContentTypesWithResponseAsync(
                 contentType, data, requestOptions);
     }
@@ -157,6 +160,8 @@ public final class MultiContentTypesAsyncClient {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> uploadBytesWithMultiBodyTypesForMultiContentTypesWithResponse(
             String contentType, BinaryData data, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'uploadBytesWithMultiBodyTypesForMultiContentTypes' is
+        // multiple content-type
         return this.serviceClient.uploadBytesWithMultiBodyTypesForMultiContentTypesWithResponseAsync(
                 contentType, data, requestOptions);
     }
@@ -212,6 +217,8 @@ public final class MultiContentTypesAsyncClient {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> uploadJsonOrBytesWithMultiBodyTypesForMultiContentTypesWithResponse(
             String contentType, BinaryData data, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'uploadJsonOrBytesWithMultiBodyTypesForMultiContentTypes' is
+        // multiple content-type
         return this.serviceClient.uploadJsonOrBytesWithMultiBodyTypesForMultiContentTypesWithResponseAsync(
                 contentType, data, requestOptions);
     }

--- a/typespec-tests/src/main/java/com/cadl/multicontenttypes/MultiContentTypesClient.java
+++ b/typespec-tests/src/main/java/com/cadl/multicontenttypes/MultiContentTypesClient.java
@@ -56,6 +56,7 @@ public final class MultiContentTypesClient {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> uploadWithOverloadWithResponse(
             String contentType, BinaryData data, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'uploadWithOverload' is multiple content-type
         return this.serviceClient.uploadWithOverloadWithResponse(contentType, data, requestOptions);
     }
 
@@ -127,6 +128,8 @@ public final class MultiContentTypesClient {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> uploadBytesWithSingleBodyTypeForMultiContentTypesWithResponse(
             String contentType, BinaryData data, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'uploadBytesWithSingleBodyTypeForMultiContentTypes' is
+        // multiple content-type
         return this.serviceClient.uploadBytesWithSingleBodyTypeForMultiContentTypesWithResponse(
                 contentType, data, requestOptions);
     }
@@ -154,6 +157,8 @@ public final class MultiContentTypesClient {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> uploadBytesWithMultiBodyTypesForMultiContentTypesWithResponse(
             String contentType, BinaryData data, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'uploadBytesWithMultiBodyTypesForMultiContentTypes' is
+        // multiple content-type
         return this.serviceClient.uploadBytesWithMultiBodyTypesForMultiContentTypesWithResponse(
                 contentType, data, requestOptions);
     }
@@ -208,6 +213,8 @@ public final class MultiContentTypesClient {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> uploadJsonOrBytesWithMultiBodyTypesForMultiContentTypesWithResponse(
             String contentType, BinaryData data, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'uploadJsonOrBytesWithMultiBodyTypesForMultiContentTypes' is
+        // multiple content-type
         return this.serviceClient.uploadJsonOrBytesWithMultiBodyTypesForMultiContentTypesWithResponse(
                 contentType, data, requestOptions);
     }

--- a/typespec-tests/src/main/java/com/cadl/patch/PatchAsyncClient.java
+++ b/typespec-tests/src/main/java/com/cadl/patch/PatchAsyncClient.java
@@ -71,6 +71,7 @@ public final class PatchAsyncClient {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<BinaryData>> createOrUpdateWithResponse(
             String name, BinaryData body, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'createOrUpdate' is 'application/merge-patch+json'
         return this.serviceClient.createOrUpdateWithResponseAsync(name, body, requestOptions);
     }
 }

--- a/typespec-tests/src/main/java/com/cadl/patch/PatchClient.java
+++ b/typespec-tests/src/main/java/com/cadl/patch/PatchClient.java
@@ -70,6 +70,7 @@ public final class PatchClient {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<BinaryData> createOrUpdateWithResponse(
             String name, BinaryData body, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'createOrUpdate' is 'application/merge-patch+json'
         return this.serviceClient.createOrUpdateWithResponse(name, body, requestOptions);
     }
 }

--- a/typespec-tests/src/main/java/com/cadl/specialheaders/SpecialHeadersAsyncClient.java
+++ b/typespec-tests/src/main/java/com/cadl/specialheaders/SpecialHeadersAsyncClient.java
@@ -208,6 +208,7 @@ public final class SpecialHeadersAsyncClient {
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
     public PollerFlux<BinaryData, BinaryData> beginCreateLro(
             String name, BinaryData resource, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'createLro' is 'application/merge-patch+json'
         return this.serviceClient.beginCreateLroAsync(name, resource, requestOptions);
     }
 

--- a/typespec-tests/src/main/java/com/cadl/specialheaders/SpecialHeadersClient.java
+++ b/typespec-tests/src/main/java/com/cadl/specialheaders/SpecialHeadersClient.java
@@ -206,6 +206,7 @@ public final class SpecialHeadersClient {
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
     public SyncPoller<BinaryData, BinaryData> beginCreateLro(
             String name, BinaryData resource, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'createLro' is 'application/merge-patch+json'
         return this.serviceClient.beginCreateLro(name, resource, requestOptions);
     }
 

--- a/typespec-tests/src/main/java/com/cadl/union/UnionAsyncClient.java
+++ b/typespec-tests/src/main/java/com/cadl/union/UnionAsyncClient.java
@@ -60,6 +60,8 @@ public final class UnionAsyncClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> sendWithResponse(String id, BinaryData request, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'send' refers Union 'string | string[] | integer[] |
+        // integer[][]'
         return this.serviceClient.sendWithResponseAsync(id, request, requestOptions);
     }
 
@@ -103,6 +105,8 @@ public final class UnionAsyncClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> sendLongWithResponse(String id, BinaryData request, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'sendLong' refers Union 'string | ArrayData | bytes |
+        // utcDateTime'
         return this.serviceClient.sendLongWithResponseAsync(id, request, requestOptions);
     }
 
@@ -129,6 +133,7 @@ public final class UnionAsyncClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getWithResponse(RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'get' refers Union 'url | bytes'
         return this.serviceClient.getWithResponseAsync(requestOptions);
     }
 
@@ -162,6 +167,7 @@ public final class UnionAsyncClient {
     @Generated
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
     public PollerFlux<BinaryData, BinaryData> beginGenerate(RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'generate' refers Union 'bytes | Result'
         return this.serviceClient.beginGenerateAsync(requestOptions);
     }
 }

--- a/typespec-tests/src/main/java/com/cadl/union/UnionClient.java
+++ b/typespec-tests/src/main/java/com/cadl/union/UnionClient.java
@@ -59,6 +59,8 @@ public final class UnionClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> sendWithResponse(String id, BinaryData request, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'send' refers Union 'string | string[] | integer[] |
+        // integer[][]'
         return this.serviceClient.sendWithResponse(id, request, requestOptions);
     }
 
@@ -102,6 +104,8 @@ public final class UnionClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> sendLongWithResponse(String id, BinaryData request, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'sendLong' refers Union 'string | ArrayData | bytes |
+        // utcDateTime'
         return this.serviceClient.sendLongWithResponse(id, request, requestOptions);
     }
 
@@ -128,6 +132,7 @@ public final class UnionClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> getWithResponse(RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'get' refers Union 'url | bytes'
         return this.serviceClient.getWithResponse(requestOptions);
     }
 
@@ -161,6 +166,7 @@ public final class UnionClient {
     @Generated
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
     public SyncPoller<BinaryData, BinaryData> beginGenerate(RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'generate' refers Union 'bytes | Result'
         return this.serviceClient.beginGenerate(requestOptions);
     }
 }

--- a/typespec-tests/src/main/java/com/type/property/nullable/BytesAsyncClient.java
+++ b/typespec-tests/src/main/java/com/type/property/nullable/BytesAsyncClient.java
@@ -111,6 +111,7 @@ public final class BytesAsyncClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> patchNonNullWithResponse(BinaryData body, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'patchNonNull' is 'application/merge-patch+json'
         return this.serviceClient.patchNonNullWithResponseAsync(body, requestOptions);
     }
 
@@ -138,6 +139,7 @@ public final class BytesAsyncClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> patchNullWithResponse(BinaryData body, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'patchNull' is 'application/merge-patch+json'
         return this.serviceClient.patchNullWithResponseAsync(body, requestOptions);
     }
 

--- a/typespec-tests/src/main/java/com/type/property/nullable/BytesClient.java
+++ b/typespec-tests/src/main/java/com/type/property/nullable/BytesClient.java
@@ -107,6 +107,7 @@ public final class BytesClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> patchNonNullWithResponse(BinaryData body, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'patchNonNull' is 'application/merge-patch+json'
         return this.serviceClient.patchNonNullWithResponse(body, requestOptions);
     }
 
@@ -134,6 +135,7 @@ public final class BytesClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> patchNullWithResponse(BinaryData body, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'patchNull' is 'application/merge-patch+json'
         return this.serviceClient.patchNullWithResponse(body, requestOptions);
     }
 

--- a/typespec-tests/src/main/java/com/type/property/nullable/CollectionsByteAsyncClient.java
+++ b/typespec-tests/src/main/java/com/type/property/nullable/CollectionsByteAsyncClient.java
@@ -116,6 +116,7 @@ public final class CollectionsByteAsyncClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> patchNonNullWithResponse(BinaryData body, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'patchNonNull' is 'application/merge-patch+json'
         return this.serviceClient.patchNonNullWithResponseAsync(body, requestOptions);
     }
 
@@ -144,6 +145,7 @@ public final class CollectionsByteAsyncClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> patchNullWithResponse(BinaryData body, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'patchNull' is 'application/merge-patch+json'
         return this.serviceClient.patchNullWithResponseAsync(body, requestOptions);
     }
 

--- a/typespec-tests/src/main/java/com/type/property/nullable/CollectionsByteClient.java
+++ b/typespec-tests/src/main/java/com/type/property/nullable/CollectionsByteClient.java
@@ -112,6 +112,7 @@ public final class CollectionsByteClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> patchNonNullWithResponse(BinaryData body, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'patchNonNull' is 'application/merge-patch+json'
         return this.serviceClient.patchNonNullWithResponse(body, requestOptions);
     }
 
@@ -140,6 +141,7 @@ public final class CollectionsByteClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> patchNullWithResponse(BinaryData body, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'patchNull' is 'application/merge-patch+json'
         return this.serviceClient.patchNullWithResponse(body, requestOptions);
     }
 

--- a/typespec-tests/src/main/java/com/type/property/nullable/CollectionsModelAsyncClient.java
+++ b/typespec-tests/src/main/java/com/type/property/nullable/CollectionsModelAsyncClient.java
@@ -122,6 +122,7 @@ public final class CollectionsModelAsyncClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> patchNonNullWithResponse(BinaryData body, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'patchNonNull' is 'application/merge-patch+json'
         return this.serviceClient.patchNonNullWithResponseAsync(body, requestOptions);
     }
 
@@ -152,6 +153,7 @@ public final class CollectionsModelAsyncClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> patchNullWithResponse(BinaryData body, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'patchNull' is 'application/merge-patch+json'
         return this.serviceClient.patchNullWithResponseAsync(body, requestOptions);
     }
 

--- a/typespec-tests/src/main/java/com/type/property/nullable/CollectionsModelClient.java
+++ b/typespec-tests/src/main/java/com/type/property/nullable/CollectionsModelClient.java
@@ -118,6 +118,7 @@ public final class CollectionsModelClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> patchNonNullWithResponse(BinaryData body, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'patchNonNull' is 'application/merge-patch+json'
         return this.serviceClient.patchNonNullWithResponse(body, requestOptions);
     }
 
@@ -148,6 +149,7 @@ public final class CollectionsModelClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> patchNullWithResponse(BinaryData body, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'patchNull' is 'application/merge-patch+json'
         return this.serviceClient.patchNullWithResponse(body, requestOptions);
     }
 

--- a/typespec-tests/src/main/java/com/type/property/nullable/DatetimeOperationAsyncClient.java
+++ b/typespec-tests/src/main/java/com/type/property/nullable/DatetimeOperationAsyncClient.java
@@ -110,6 +110,7 @@ public final class DatetimeOperationAsyncClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> patchNonNullWithResponse(BinaryData body, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'patchNonNull' is 'application/merge-patch+json'
         return this.serviceClient.patchNonNullWithResponseAsync(body, requestOptions);
     }
 
@@ -136,6 +137,7 @@ public final class DatetimeOperationAsyncClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> patchNullWithResponse(BinaryData body, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'patchNull' is 'application/merge-patch+json'
         return this.serviceClient.patchNullWithResponseAsync(body, requestOptions);
     }
 

--- a/typespec-tests/src/main/java/com/type/property/nullable/DatetimeOperationClient.java
+++ b/typespec-tests/src/main/java/com/type/property/nullable/DatetimeOperationClient.java
@@ -106,6 +106,7 @@ public final class DatetimeOperationClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> patchNonNullWithResponse(BinaryData body, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'patchNonNull' is 'application/merge-patch+json'
         return this.serviceClient.patchNonNullWithResponse(body, requestOptions);
     }
 
@@ -132,6 +133,7 @@ public final class DatetimeOperationClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> patchNullWithResponse(BinaryData body, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'patchNull' is 'application/merge-patch+json'
         return this.serviceClient.patchNullWithResponse(body, requestOptions);
     }
 

--- a/typespec-tests/src/main/java/com/type/property/nullable/DurationOperationAsyncClient.java
+++ b/typespec-tests/src/main/java/com/type/property/nullable/DurationOperationAsyncClient.java
@@ -110,6 +110,7 @@ public final class DurationOperationAsyncClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> patchNonNullWithResponse(BinaryData body, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'patchNonNull' is 'application/merge-patch+json'
         return this.serviceClient.patchNonNullWithResponseAsync(body, requestOptions);
     }
 
@@ -136,6 +137,7 @@ public final class DurationOperationAsyncClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> patchNullWithResponse(BinaryData body, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'patchNull' is 'application/merge-patch+json'
         return this.serviceClient.patchNullWithResponseAsync(body, requestOptions);
     }
 

--- a/typespec-tests/src/main/java/com/type/property/nullable/DurationOperationClient.java
+++ b/typespec-tests/src/main/java/com/type/property/nullable/DurationOperationClient.java
@@ -106,6 +106,7 @@ public final class DurationOperationClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> patchNonNullWithResponse(BinaryData body, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'patchNonNull' is 'application/merge-patch+json'
         return this.serviceClient.patchNonNullWithResponse(body, requestOptions);
     }
 
@@ -132,6 +133,7 @@ public final class DurationOperationClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> patchNullWithResponse(BinaryData body, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'patchNull' is 'application/merge-patch+json'
         return this.serviceClient.patchNullWithResponse(body, requestOptions);
     }
 

--- a/typespec-tests/src/main/java/com/type/property/nullable/StringOperationAsyncClient.java
+++ b/typespec-tests/src/main/java/com/type/property/nullable/StringOperationAsyncClient.java
@@ -111,6 +111,7 @@ public final class StringOperationAsyncClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> patchNonNullWithResponse(BinaryData body, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'patchNonNull' is 'application/merge-patch+json'
         return this.serviceClient.patchNonNullWithResponseAsync(body, requestOptions);
     }
 
@@ -138,6 +139,7 @@ public final class StringOperationAsyncClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> patchNullWithResponse(BinaryData body, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'patchNull' is 'application/merge-patch+json'
         return this.serviceClient.patchNullWithResponseAsync(body, requestOptions);
     }
 

--- a/typespec-tests/src/main/java/com/type/property/nullable/StringOperationClient.java
+++ b/typespec-tests/src/main/java/com/type/property/nullable/StringOperationClient.java
@@ -107,6 +107,7 @@ public final class StringOperationClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> patchNonNullWithResponse(BinaryData body, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'patchNonNull' is 'application/merge-patch+json'
         return this.serviceClient.patchNonNullWithResponse(body, requestOptions);
     }
 
@@ -134,6 +135,7 @@ public final class StringOperationClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> patchNullWithResponse(BinaryData body, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'patchNull' is 'application/merge-patch+json'
         return this.serviceClient.patchNullWithResponse(body, requestOptions);
     }
 

--- a/typespec-tests/src/main/java/com/type/union/UnionAsyncClient.java
+++ b/typespec-tests/src/main/java/com/type/union/UnionAsyncClient.java
@@ -55,6 +55,7 @@ public final class UnionAsyncClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> sendIntWithResponse(BinaryData input, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'sendInt' refers Union 'int32 | int32[]'
         return this.serviceClient.sendIntWithResponseAsync(input, requestOptions);
     }
 
@@ -80,6 +81,7 @@ public final class UnionAsyncClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> sendIntArrayWithResponse(BinaryData input, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'sendIntArray' refers Union 'int32 | int32[]'
         return this.serviceClient.sendIntArrayWithResponseAsync(input, requestOptions);
     }
 
@@ -105,6 +107,7 @@ public final class UnionAsyncClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> sendFirstNamedUnionValueWithResponse(BinaryData input, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'sendFirstNamedUnionValue' refers Union 'MyNamedUnion'
         return this.serviceClient.sendFirstNamedUnionValueWithResponseAsync(input, requestOptions);
     }
 
@@ -130,6 +133,7 @@ public final class UnionAsyncClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> sendSecondNamedUnionValueWithResponse(BinaryData input, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'sendSecondNamedUnionValue' refers Union 'MyNamedUnion'
         return this.serviceClient.sendSecondNamedUnionValueWithResponseAsync(input, requestOptions);
     }
 }

--- a/typespec-tests/src/main/java/com/type/union/UnionClient.java
+++ b/typespec-tests/src/main/java/com/type/union/UnionClient.java
@@ -54,6 +54,7 @@ public final class UnionClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> sendIntWithResponse(BinaryData input, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'sendInt' refers Union 'int32 | int32[]'
         return this.serviceClient.sendIntWithResponse(input, requestOptions);
     }
 
@@ -79,6 +80,7 @@ public final class UnionClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> sendIntArrayWithResponse(BinaryData input, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'sendIntArray' refers Union 'int32 | int32[]'
         return this.serviceClient.sendIntArrayWithResponse(input, requestOptions);
     }
 
@@ -104,6 +106,7 @@ public final class UnionClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> sendFirstNamedUnionValueWithResponse(BinaryData input, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'sendFirstNamedUnionValue' refers Union 'MyNamedUnion'
         return this.serviceClient.sendFirstNamedUnionValueWithResponse(input, requestOptions);
     }
 
@@ -129,6 +132,7 @@ public final class UnionClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> sendSecondNamedUnionValueWithResponse(BinaryData input, RequestOptions requestOptions) {
+        // Convenience API is not generated, as operation 'sendSecondNamedUnionValue' refers Union 'MyNamedUnion'
         return this.serviceClient.sendSecondNamedUnionValueWithResponse(input, requestOptions);
     }
 }

--- a/typespec-tests/tsp/builtin.tsp
+++ b/typespec-tests/tsp/builtin.tsp
@@ -63,19 +63,19 @@ model Encoded {
 
   timeInSecondsFraction?: myDuration;
 
-  @encode(DateTimeKnownEncoding.rfc3339, string)
+  @encode(DateTimeKnownEncoding.rfc3339)
   dateTime?: utcDateTime;
 
-  @encode(DateTimeKnownEncoding.rfc7231, string)
+  @encode(DateTimeKnownEncoding.rfc7231)
   dateTimeRfc7231?: utcDateTime;
 
   @encode(DateTimeKnownEncoding.unixTimestamp, int64)
   unixTimestamp?: utcDateTime;
 
-  @encode(BytesKnownEncoding.base64, string)
+  @encode(BytesKnownEncoding.base64)
   base64?: bytes;
 
-  @encode(BytesKnownEncoding.base64url, string)
+  @encode(BytesKnownEncoding.base64url)
   base64url?: bytes;
 }
 


### PR DESCRIPTION
emitter warning e.g.

```
warning typespec-java: Convenience API is not generated, as operation 'createOrUpdate' is 'application/merge-patch+json'

warning typespec-java: Convenience API is not generated, as operation 'uploadWithOverload' is multiple content-type

warning typespec-java: Convenience API is not generated, as operation 'generate' refers Union 'bytes | Result'
```

As well as a line comment in protocol API.