### PR TITLE
mgmt, bug fix on Error used both in exception and output

### DIFF
--- a/fluent-tests/prepare-tests.bat
+++ b/fluent-tests/prepare-tests.bat
@@ -67,6 +67,10 @@ REM swagger customized Resource and ProxyResource
 CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENT_ARGUMENTS% --input-file=https://github.com/Azure/azure-rest-api-specs/blob/main/specification/trafficmanager/resource-manager/Microsoft.Network/stable/2018-08-01/trafficmanager.json --namespace=com.azure.mgmttest.trafficmanager
 if %errorlevel% neq 0 exit /b %errorlevel%
 
+REM customized ErrorDetails
+CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENT_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/8fa9b5051129dd4808c9be1f5b753af226b044db/specification/iothub/resource-manager/Microsoft.Devices/stable/2023-06-30/iothub.json --namespace=com.azure.mgmttest.iothub
+if %errorlevel% neq 0 exit /b %errorlevel%
+
 REM fluent lite
 CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENTLITE_ARGUMENTS% --pom-file=pom_generated_resources.xml https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/resources/resource-manager/readme.md --tag=package-resources-2021-01 --java.namespace=com.azure.mgmtlitetest.resources
 if %errorlevel% neq 0 exit /b %errorlevel%

--- a/fluent-tests/prepare-tests.bat
+++ b/fluent-tests/prepare-tests.bat
@@ -63,6 +63,10 @@ REM flatten the empty model which has non-empty parent model
 CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENT_ARGUMENTS% --input-file=https://github.com/Azure/azure-rest-api-specs/blob/main/specification/monitor/resource-manager/Microsoft.Insights/preview/2021-09-01-preview/dataCollectionRules_API.json --namespace=com.azure.mgmttest.monitor
 if %errorlevel% neq 0 exit /b %errorlevel%
 
+REM extract systemData from Resource
+CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENT_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/29f3116d3ce31f2125d1e2cfb92d6511fcb01c41/specification/postgresqlhsc/resource-manager/Microsoft.DBforPostgreSQL/stable/2022-11-08/postgresqlhsc.json --java.namespace=com.azure.mgmttest.postgresqlhsc
+if %errorlevel% neq 0 exit /b %errorlevel%
+
 REM swagger customized Resource and ProxyResource
 CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENT_ARGUMENTS% --input-file=https://github.com/Azure/azure-rest-api-specs/blob/main/specification/trafficmanager/resource-manager/Microsoft.Network/stable/2018-08-01/trafficmanager.json --namespace=com.azure.mgmttest.trafficmanager
 if %errorlevel% neq 0 exit /b %errorlevel%
@@ -98,10 +102,6 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 
 REM model inherit ErrorResponse
 CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENTLITE_ARGUMENTS% --regenerate-pom=false --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/196886564583ff59186bd0ef44d923120aaf3f78/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/stable/2023-06-15/NetworkFabrics.json --java.namespace=com.azure.mgmtlitetest.managednetworkfabric
-if %errorlevel% neq 0 exit /b %errorlevel%
-
-REM extract systemData from Resource
-CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENTLITE_ARGUMENTS% --regenerate-pom=false --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/29f3116d3ce31f2125d1e2cfb92d6511fcb01c41/specification/postgresqlhsc/resource-manager/Microsoft.DBforPostgreSQL/stable/2022-11-08/postgresqlhsc.json --java.namespace=com.azure.mgmtlitetest.postgresqlhsc
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 REM schema clean-up

--- a/fluent-tests/prepare-tests.bat
+++ b/fluent-tests/prepare-tests.bat
@@ -71,7 +71,7 @@ REM swagger customized Resource and ProxyResource
 CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENT_ARGUMENTS% --input-file=https://github.com/Azure/azure-rest-api-specs/blob/main/specification/trafficmanager/resource-manager/Microsoft.Network/stable/2018-08-01/trafficmanager.json --namespace=com.azure.mgmttest.trafficmanager
 if %errorlevel% neq 0 exit /b %errorlevel%
 
-REM customized ErrorDetails
+REM ErrorDetails shared in exception and output
 CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENT_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/8fa9b5051129dd4808c9be1f5b753af226b044db/specification/iothub/resource-manager/Microsoft.Devices/stable/2023-06-30/iothub.json --namespace=com.azure.mgmttest.iothub
 if %errorlevel% neq 0 exit /b %errorlevel%
 

--- a/fluent-tests/src/test/java/com/azure/mgmttest/CompilationTests.java
+++ b/fluent-tests/src/test/java/com/azure/mgmttest/CompilationTests.java
@@ -4,6 +4,7 @@
 package com.azure.mgmttest;
 
 import com.azure.core.management.Resource;
+import com.azure.core.management.SystemData;
 import com.azure.core.management.exception.ManagementError;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.mgmttest.appservice.fluent.WebSiteManagementClient;
@@ -22,6 +23,7 @@ import com.azure.mgmttest.network.fluent.NetworkInterfacesClient;
 import com.azure.mgmttest.network.fluent.models.NetworkInterfaceInner;
 import com.azure.mgmttest.network.fluent.models.NetworkSecurityGroupInner;
 import com.azure.mgmttest.networkwatcher.fluent.models.PacketCaptureResultInner;
+import com.azure.mgmttest.postgresqlhsc.fluent.models.ServerConfigurationInner;
 import com.azure.mgmttest.resources.fluent.DeploymentsClient;
 import com.azure.mgmttest.resources.fluent.models.DeploymentExtendedInner;
 import com.azure.mgmttest.resources.fluent.models.ResourceGroupInner;
@@ -145,5 +147,11 @@ public class CompilationTests {
 
         GraphErrorException graphException = new GraphErrorException(anyString(), null);
         GraphError graphError = graphException.getValue();
+    }
+
+    public void testPropertyExtractFromResource() {
+        ServerConfigurationInner serverConfiguration = mock(ServerConfigurationInner.class);
+        // systemData from ProxyResource > Resource
+        SystemData systemData = serverConfiguration.systemData();
     }
 }

--- a/fluent-tests/src/test/java/com/azure/mgmttest/CompilationTests.java
+++ b/fluent-tests/src/test/java/com/azure/mgmttest/CompilationTests.java
@@ -18,6 +18,7 @@ import com.azure.mgmttest.cosmos.models.SqlDatabaseGetPropertiesResource;
 import com.azure.mgmttest.hybridnetwork.fluent.models.DeviceInner;
 import com.azure.mgmttest.hybridnetwork.models.AzureStackEdgeFormat;
 import com.azure.mgmttest.hybridnetwork.models.DevicePropertiesFormat;
+import com.azure.mgmttest.iothub.models.ErrorDetails;
 import com.azure.mgmttest.monitor.fluent.models.DataCollectionRuleResourceInner;
 import com.azure.mgmttest.network.fluent.NetworkInterfacesClient;
 import com.azure.mgmttest.network.fluent.models.NetworkInterfaceInner;
@@ -153,5 +154,10 @@ public class CompilationTests {
         ServerConfigurationInner serverConfiguration = mock(ServerConfigurationInner.class);
         // systemData from ProxyResource > Resource
         SystemData systemData = serverConfiguration.systemData();
+    }
+
+    public void testSharedError() {
+        ErrorDetails errorDetails = mock(ErrorDetails.class);
+        errorDetails.getHttpStatusCode();
     }
 }

--- a/fluent-tests/src/test/java/com/azure/mgmttest/LiteCompilationTests.java
+++ b/fluent-tests/src/test/java/com/azure/mgmttest/LiteCompilationTests.java
@@ -12,16 +12,16 @@ import com.azure.core.http.policy.HttpLogOptions;
 import com.azure.core.http.rest.PagedIterable;
 import com.azure.core.management.AzureEnvironment;
 import com.azure.core.management.Region;
-import com.azure.core.management.SystemData;
+import com.azure.core.management.exception.ManagementError;
 import com.azure.core.management.profile.AzureProfile;
 import com.azure.core.util.Context;
 import com.azure.identity.EnvironmentCredentialBuilder;
 import com.azure.mgmtlitetest.containerregistrylite.ContainerRegistryManager;
+import com.azure.mgmtlitetest.managednetworkfabric.models.CommonPostActionResponseForStateUpdate;
 import com.azure.mgmtlitetest.mediaservices.MediaServicesManager;
 import com.azure.mgmtlitetest.mediaservices.models.LiveEventStatus;
 import com.azure.mgmtlitetest.mediaservices.models.MediaService;
 import com.azure.mgmtlitetest.mediaservices.models.SyncStorageKeysInput;
-import com.azure.mgmtlitetest.postgresqlhsc.models.ServerConfiguration;
 import com.azure.mgmtlitetest.resources.ResourceManager;
 import com.azure.mgmtlitetest.resources.models.ResourceGroup;
 import com.azure.mgmtlitetest.storage.StorageManager;
@@ -193,9 +193,8 @@ public class LiteCompilationTests {
         PagedIterable<LiveEventStatus> eventStatuses = manager.liveEvents().listGetStatus(anyString(), anyString(), anyString());
     }
 
-    public void testPropertyExtractFromResource() {
-        ServerConfiguration serverConfiguration = mock(ServerConfiguration.class);
-        // systemData from ProxyResource > Resource
-        SystemData systemData = serverConfiguration.systemData();
+    public void testModelExtendsErrorResponse() {
+        CommonPostActionResponseForStateUpdate actionResponse = mock(CommonPostActionResponseForStateUpdate.class);
+        ManagementError error = actionResponse.error();
     }
 }

--- a/fluent-tests/src/test/java/com/azure/mgmttest/LiteCompilationTests.java
+++ b/fluent-tests/src/test/java/com/azure/mgmttest/LiteCompilationTests.java
@@ -196,5 +196,6 @@ public class LiteCompilationTests {
     public void testModelExtendsErrorResponse() {
         CommonPostActionResponseForStateUpdate actionResponse = mock(CommonPostActionResponseForStateUpdate.class);
         ManagementError error = actionResponse.error();
+        error = actionResponse.innerModel().error();
     }
 }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentModelTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentModelTemplate.java
@@ -77,19 +77,25 @@ public class FluentModelTemplate extends ModelTemplate {
         if (FluentType.ManagementError.getName().equals(model.getParentModelName())) {
             // subclass of ManagementError
 
-            if (model.getImplementationDetails() != null
-                    && model.getImplementationDetails().isException()
-                    && !model.getImplementationDetails().isOutput()
-                    && !model.getImplementationDetails().isInput()) {
-                // model used in Exception, also not in any non-Exception input or output
-
-                if (modelNamer == null) {
-                    modelNamer = new ModelNamer();
-                }
-                return modelNamer.modelPropertyGetterName(property);
-            } else {
-                return super.getGetterName(model, property);
+            if (modelNamer == null) {
+                modelNamer = new ModelNamer();
             }
+            return modelNamer.modelPropertyGetterName(property);
+
+            // disabled for now, as e.g. https://github.com/Azure/azure-rest-api-specs/blob/8fa9b5051129dd4808c9be1f5b753af226b044db/specification/iothub/resource-manager/Microsoft.Devices/stable/2023-06-30/iothub.json#L298-L303 makes it usage=output
+//            if (model.getImplementationDetails() != null
+//                    && model.getImplementationDetails().isException()
+//                    && !model.getImplementationDetails().isOutput()
+//                    && !model.getImplementationDetails().isInput()) {
+//                // model used in Exception, also not in any non-Exception input or output
+//
+//                if (modelNamer == null) {
+//                    modelNamer = new ModelNamer();
+//                }
+//                return modelNamer.modelPropertyGetterName(property);
+//            } else {
+//                return super.getGetterName(model, property);
+//            }
         } else {
             return super.getGetterName(model, property);
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/java",
-  "version": "4.1.20",
+  "version": "4.1.21",
   "description": "The Java extension for classic generators in AutoRest.",
   "scripts": {
     "autorest": "autorest",


### PR DESCRIPTION
cause: ErrorDetails shared in exception and output
https://github.com/Azure/azure-rest-api-specs/blob/8fa9b5051129dd4808c9be1f5b753af226b044db/specification/iothub/resource-manager/Microsoft.Devices/stable/2023-06-30/iothub.json#L298-L303

It likely a bug that 404 does not have x-ms-error-response...

It reverted change in https://github.com/Azure/autorest.java/pull/2235, as later it uses another solution (composition instead of inheritance).
Origin issue: https://github.com/Azure/autorest.java/issues/2241