### PR TITLE
Return null by default for byte[] getters

### DIFF
--- a/Generate.ps1
+++ b/Generate.ps1
@@ -136,7 +136,7 @@ singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/xml-
 singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/xml-tag-with-attribute-and-value.json --namespace=fixtures.complexstreamstylexmlserialization --stream-style-serialization --enable-xml"
 singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/security-info.json --namespace=fixtures.securityinfo --use-key-credential"
 singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/special-header.json --namespace=fixtures.specialheader"
-singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/required-fields-as-ctor-args-transformation.json --namespace=fixtures.requiredfieldsascotrargstransformation --required-fields-as-ctor-args=true --output-model-immutable"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/required-fields-as-ctor-args-transformation.json --namespace=fixtures.requiredfieldsascotrargstransformation --required-fields-as-ctor-args=true --output-model-immutable --default-byte-array-returns-empty-array"
 
 # Azure Data Plane
 if (Test-Path ./azure-dataplane-tests/src/main) {

--- a/Generate.ps1
+++ b/Generate.ps1
@@ -136,7 +136,7 @@ singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/xml-
 singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/xml-tag-with-attribute-and-value.json --namespace=fixtures.complexstreamstylexmlserialization --stream-style-serialization --enable-xml"
 singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/security-info.json --namespace=fixtures.securityinfo --use-key-credential"
 singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/special-header.json --namespace=fixtures.specialheader"
-singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/required-fields-as-ctor-args-transformation.json --namespace=fixtures.requiredfieldsascotrargstransformation --required-fields-as-ctor-args=true --output-model-immutable --default-byte-array-returns-empty-array"
+singleThreadGenerate "$VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/required-fields-as-ctor-args-transformation.json --namespace=fixtures.requiredfieldsascotrargstransformation --required-fields-as-ctor-args=true --output-model-immutable --null-byte-array-maps-to-empty-array"
 
 # Azure Data Plane
 if (Test-Path ./azure-dataplane-tests/src/main) {

--- a/androidgen/src/main/java/com/azure/autorest/android/mapper/AndroidPrimitiveMapper.java
+++ b/androidgen/src/main/java/com/azure/autorest/android/mapper/AndroidPrimitiveMapper.java
@@ -34,7 +34,7 @@ public class AndroidPrimitiveMapper extends PrimitiveMapper {
                 if (byteArraySchema.getFormat() == ByteArraySchema.Format.BASE_64_URL) {
                     return ClassType.AndroidBase64Url;
                 } else {
-                    return ArrayType.ByteArray;
+                    return ArrayType.BYTE_ARRAY;
                 }
             case DATE_TIME:
                 DateTimeSchema dateTimeSchema = (DateTimeSchema) primaryType;

--- a/androidgen/src/main/java/com/azure/autorest/android/model/clientmodel/AndroidProxyMethodParameter.java
+++ b/androidgen/src/main/java/com/azure/autorest/android/model/clientmodel/AndroidProxyMethodParameter.java
@@ -75,7 +75,7 @@ public class AndroidProxyMethodParameter extends ProxyMethodParameter {
             imports.add(String.format("com.azure.android.core.rest.annotation.%1$sParam", CodeNamer.toPascalCase(getRequestParameterLocation().toString())));
         }
         if (getRequestParameterLocation() != RequestParameterLocation.BODY) {
-            if (getClientType() == com.azure.autorest.model.clientmodel.ArrayType.ByteArray) {
+            if (getClientType() == com.azure.autorest.model.clientmodel.ArrayType.BYTE_ARRAY) {
                 imports.add("com.azure.android.core.util.Base64Util");
             }
         }

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -170,7 +170,7 @@ public class JavaSettings {
                 getBooleanValue(host, "disable-required-property-annotation", false),
                 getBooleanValue(host, "enable-page-size", false),
                 getBooleanValue(host, "use-key-credential", false),
-                getBooleanValue(host, "default-byte-array-returns-empty-array", false)
+                getBooleanValue(host, "null-byte-array-maps-to-empty-array", false)
             );
         }
         return instance;
@@ -259,7 +259,7 @@ public class JavaSettings {
      * previously read-only required were included in constructors.
      * @param urlAsString This generates all URLs as String type. This is enabled by default as required by the Java
      * design guidelines. For backward compatability, this can be set to false.
-     * @param defaultByteArrayReturnsEmptyArray If set to true, {@code ArrayType.BYTE_ARRAY} will return an empty array
+     * @param nullByteArrayMapsToEmptyArray If set to true, {@code ArrayType.BYTE_ARRAY} will return an empty array
      * instead of null when the default value expression is null.
      */
     private JavaSettings(AutorestSettings autorestSettings,
@@ -326,7 +326,7 @@ public class JavaSettings {
         boolean disableRequiredPropertyAnnotation,
         boolean pageSizeEnabled,
         boolean useKeyCredential,
-        boolean defaultByteArrayReturnsEmptyArray) {
+        boolean nullByteArrayMapsToEmptyArray) {
 
         this.autorestSettings = autorestSettings;
         this.modelerSettings = new ModelerSettings(modelerSettings);
@@ -424,7 +424,7 @@ public class JavaSettings {
         this.disableRequiredJsonAnnotation = disableRequiredPropertyAnnotation;
         this.pageSizeEnabled = pageSizeEnabled;
         this.useKeyCredential = useKeyCredential;
-        this.defaultByteArrayReturnsEmptyArray = defaultByteArrayReturnsEmptyArray;
+        this.nullByteArrayMapsToEmptyArray = nullByteArrayMapsToEmptyArray;
     }
 
 
@@ -1088,7 +1088,7 @@ public class JavaSettings {
         return this.useKeyCredential;
     }
 
-    private final boolean defaultByteArrayReturnsEmptyArray;
+    private final boolean nullByteArrayMapsToEmptyArray;
 
     /**
      * Whether {@code ArrayType.BYTE_ARRAY} will return an empty array instead of null when the default value expression
@@ -1099,8 +1099,8 @@ public class JavaSettings {
      * @return Whether {@code ArrayType.BYTE_ARRAY} will return an empty array instead of null when the default value
      * expression is null.
      */
-    public boolean isDefaultByteArrayReturnsEmptyArray() {
-        return defaultByteArrayReturnsEmptyArray;
+    public boolean isNullByteArrayMapsToEmptyArray() {
+        return nullByteArrayMapsToEmptyArray;
     }
 
     private static final String DEFAULT_CODE_GENERATION_HEADER = String.join("\r\n",

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -34,7 +34,7 @@ public class JavaSettings {
 
     private static Logger logger;
     private final boolean useKeyCredential;
-    private boolean noCustomHeaders;
+    private final boolean noCustomHeaders;
     static void setHeader(String value) {
         if ("MICROSOFT_MIT".equals(value)) {
             header = MICROSOFT_MIT_LICENSE_HEADER + "\n" + String.format(DEFAULT_CODE_GENERATION_HEADER, VERSION);
@@ -169,7 +169,8 @@ public class JavaSettings {
                 // were generated with required = true set in JsonProperty annotation
                 getBooleanValue(host, "disable-required-property-annotation", false),
                 getBooleanValue(host, "enable-page-size", false),
-                getBooleanValue(host, "use-key-credential", false)
+                getBooleanValue(host, "use-key-credential", false),
+                getBooleanValue(host, "default-byte-array-returns-empty-array", false)
             );
         }
         return instance;
@@ -258,6 +259,8 @@ public class JavaSettings {
      * previously read-only required were included in constructors.
      * @param urlAsString This generates all URLs as String type. This is enabled by default as required by the Java
      * design guidelines. For backward compatability, this can be set to false.
+     * @param defaultByteArrayReturnsEmptyArray If set to true, {@code ArrayType.BYTE_ARRAY} will return an empty array
+     * instead of null when the default value expression is null.
      */
     private JavaSettings(AutorestSettings autorestSettings,
         Map<String, Object> modelerSettings,
@@ -322,7 +325,8 @@ public class JavaSettings {
         boolean urlAsString,
         boolean disableRequiredPropertyAnnotation,
         boolean pageSizeEnabled,
-        boolean useKeyCredential) {
+        boolean useKeyCredential,
+        boolean defaultByteArrayReturnsEmptyArray) {
 
         this.autorestSettings = autorestSettings;
         this.modelerSettings = new ModelerSettings(modelerSettings);
@@ -420,10 +424,11 @@ public class JavaSettings {
         this.disableRequiredJsonAnnotation = disableRequiredPropertyAnnotation;
         this.pageSizeEnabled = pageSizeEnabled;
         this.useKeyCredential = useKeyCredential;
+        this.defaultByteArrayReturnsEmptyArray = defaultByteArrayReturnsEmptyArray;
     }
 
 
-    private String keyCredentialHeaderName;
+    private final String keyCredentialHeaderName;
     public String getKeyCredentialHeaderName() {
         return this.keyCredentialHeaderName;
     }
@@ -441,13 +446,13 @@ public class JavaSettings {
     }
 
 
-    private boolean azure;
+    private final boolean azure;
     public final boolean isAzure() {
         return azure;
     }
 
 
-    private String artifactId;
+    private final String artifactId;
     public String getArtifactId() {
         return artifactId;
     }
@@ -457,7 +462,7 @@ public class JavaSettings {
     }
 
 
-    private boolean urlAsString;
+    private final boolean urlAsString;
     public boolean urlAsString() {
         return urlAsString;
     }
@@ -505,7 +510,7 @@ public class JavaSettings {
     }
 
     public static class ModelerSettings {
-        private Map<String, Object> settings;
+        private final Map<String, Object> settings;
 
         public ModelerSettings(Map<String, Object> settings) {
             this.settings = settings == null ? Collections.emptyMap() : settings;
@@ -518,10 +523,10 @@ public class JavaSettings {
         /**
          * If false, use client-flattened-annotation-target = TYPE for no flatten; client-flattened-annotation-target =
          * NONE for flatten at getter/setter methods via codegen.
-         *
+         * <p>
          * If true, use client-flattened-annotation-target = TYPE for <code>@JsonFlatten</code> on type (i.e. on class);
          * client-flattened-annotation-target = FIELD for <code>@JsonFlatten</code> on field.
-         *
+         * <p>
          * modelerfour.flatten-models = false and client-flattened-annotation-target = NONE would require
          * modelerfour.flatten-payloads = false.
          *
@@ -554,31 +559,31 @@ public class JavaSettings {
         return sdkIntegration;
     }
 
-    private boolean regeneratePom;
+    private final boolean regeneratePom;
 
     public final boolean isRegeneratePom() {
         return regeneratePom;
     }
 
-    private String fileHeaderText;
+    private final String fileHeaderText;
 
     public final String getFileHeaderText() {
         return fileHeaderText;
     }
 
-    private int maximumJavadocCommentWidth;
+    private final int maximumJavadocCommentWidth;
 
     public final int getMaximumJavadocCommentWidth() {
         return maximumJavadocCommentWidth;
     }
 
-    private String serviceName;
+    private final String serviceName;
 
     public final String getServiceName() {
         return serviceName;
     }
 
-    private String packageName;
+    private final String packageName;
 
     public final String getPackage() {
         return packageName;
@@ -611,7 +616,7 @@ public class JavaSettings {
         return packageBuilder.toString();
     }
 
-    private boolean shouldGenerateXmlSerialization;
+    private final boolean shouldGenerateXmlSerialization;
 
     public final boolean isGenerateXmlSerialization() {
         return shouldGenerateXmlSerialization;
@@ -620,13 +625,13 @@ public class JavaSettings {
     /**
      * Whether to add the @NotNull annotation to required parameters in client methods.
      */
-    private boolean nonNullAnnotations;
+    private final boolean nonNullAnnotations;
 
     public final boolean isNonNullAnnotations() {
         return nonNullAnnotations;
     }
 
-    private boolean clientSideValidations;
+    private final boolean clientSideValidations;
 
     public final boolean isClientSideValidations() {
         return clientSideValidations;
@@ -635,7 +640,7 @@ public class JavaSettings {
     /**
      * The prefix that will be added to each generated client type.
      */
-    private String clientTypePrefix;
+    private final String clientTypePrefix;
 
     public final String getClientTypePrefix() {
         return clientTypePrefix;
@@ -644,7 +649,7 @@ public class JavaSettings {
     /**
      * Whether interfaces will be generated for Service and Method Group clients.
      */
-    private boolean generateClientInterfaces;
+    private final boolean generateClientInterfaces;
 
     public final boolean isGenerateClientInterfaces() {
         return generateClientInterfaces;
@@ -653,7 +658,7 @@ public class JavaSettings {
     /**
      * Whether interfaces will be generated for Service and Method Group clients.
      */
-    private boolean generateClientAsImpl;
+    private final boolean generateClientAsImpl;
 
     public final boolean isGenerateClientAsImpl() {
         return generateClientAsImpl;
@@ -662,7 +667,7 @@ public class JavaSettings {
     /**
      * The sub-package that the Service and Method Group client implementation classes will be put into.
      */
-    private String implementationSubpackage;
+    private final String implementationSubpackage;
 
     public final String getImplementationSubpackage() {
         return implementationSubpackage;
@@ -671,13 +676,13 @@ public class JavaSettings {
     /**
      * The sub-package that Enums, Exceptions, and Model types will be put into.
      */
-    private String modelsSubpackage;
+    private final String modelsSubpackage;
 
     public final String getModelsSubpackage() {
         return modelsSubpackage;
     }
 
-    private String fluentSubpackage;
+    private final String fluentSubpackage;
 
     /**
      * @return The sub-package for Fluent SDK, that contains Client and Builder types, which is not recommended to be
@@ -702,13 +707,13 @@ public class JavaSettings {
     /**
      * Whether Service and Method Group client method overloads that omit optional parameters will be created.
      */
-    private boolean requiredParameterClientMethods;
+    private final boolean requiredParameterClientMethods;
 
     public final boolean isRequiredParameterClientMethods() {
         return requiredParameterClientMethods;
     }
 
-    private boolean generateSyncAsyncClients;
+    private final boolean generateSyncAsyncClients;
 
     public final boolean isGenerateSyncAsyncClients() {
         return generateSyncAsyncClients;
@@ -724,13 +729,13 @@ public class JavaSettings {
         return syncMethods;
     }
 
-    private boolean requiredFieldsAsConstructorArgs;
+    private final boolean requiredFieldsAsConstructorArgs;
 
     public boolean isRequiredFieldsAsConstructorArgs() {
         return requiredFieldsAsConstructorArgs;
     }
 
-    private boolean serviceInterfaceAsPublic;
+    private final boolean serviceInterfaceAsPublic;
 
     public boolean isServiceInterfaceAsPublic() {
         return serviceInterfaceAsPublic;
@@ -755,7 +760,7 @@ public class JavaSettings {
         }
     }
 
-    private List<String> customTypes;
+    private final List<String> customTypes;
 
     public List<String> getCustomTypes() {
         return customTypes;
@@ -765,7 +770,7 @@ public class JavaSettings {
         return customTypes.contains(typeName);
     }
 
-    private String customTypesSubpackage;
+    private final String customTypesSubpackage;
 
     public final String getCustomTypesSubpackage() {
         return customTypesSubpackage;
@@ -790,19 +795,19 @@ public class JavaSettings {
         }
     }
 
-    private boolean clientLogger;
+    private final boolean clientLogger;
 
     public final boolean isUseClientLogger() {
         return clientLogger;
     }
 
-    private String customizationJarPath;
+    private final String customizationJarPath;
 
     public final String getCustomizationJarPath() {
         return customizationJarPath;
     }
 
-    private String customizationClass;
+    private final String customizationClass;
 
     public final String getCustomizationClass() {
         return customizationClass;
@@ -1081,6 +1086,21 @@ public class JavaSettings {
 
     public boolean isUseKeyCredential() {
         return this.useKeyCredential;
+    }
+
+    private final boolean defaultByteArrayReturnsEmptyArray;
+
+    /**
+     * Whether {@code ArrayType.BYTE_ARRAY} will return an empty array instead of null when the default value expression
+     * is null.
+     * <p>
+     * Set this to true to ensure backwards compatibility with previous versions of the Java generator.
+     *
+     * @return Whether {@code ArrayType.BYTE_ARRAY} will return an empty array instead of null when the default value
+     * expression is null.
+     */
+    public boolean isDefaultByteArrayReturnsEmptyArray() {
+        return defaultByteArrayReturnsEmptyArray;
     }
 
     private static final String DEFAULT_CODE_GENERATION_HEADER = String.join("\r\n",

--- a/javagen/src/main/java/com/azure/autorest/mapper/CustomProxyParameterMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/CustomProxyParameterMapper.java
@@ -84,7 +84,7 @@ public class CustomProxyParameterMapper implements IMapper<Parameter, ProxyMetho
                 .name(modelTypeName + "Wrapper")
                 .usedInXml(true)
                 .build();
-        } else if (wireType == ArrayType.ByteArray) {
+        } else if (wireType == ArrayType.BYTE_ARRAY) {
             if (parameterRequestLocation != RequestParameterLocation.BODY /*&& parameterRequestLocation != RequestParameterLocation.FormData*/) {
                 wireType = ClassType.String;
             }

--- a/javagen/src/main/java/com/azure/autorest/mapper/PrimitiveMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/PrimitiveMapper.java
@@ -56,7 +56,7 @@ public class PrimitiveMapper implements IMapper<PrimitiveSchema, IType> {
                 ByteArraySchema byteArraySchema = (ByteArraySchema) primaryType;
                 return (byteArraySchema.getFormat() == ByteArraySchema.Format.BASE_64_URL)
                     ? ClassType.Base64Url
-                    : ArrayType.ByteArray;
+                    : ArrayType.BYTE_ARRAY;
             case CHAR: return PrimitiveType.Char;
             case DATE: return isLowLevelClient ? ClassType.String : ClassType.LocalDate;
             case DATE_TIME:

--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyParameterMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyParameterMapper.java
@@ -84,7 +84,7 @@ public class ProxyParameterMapper implements IMapper<Parameter, ProxyMethodParam
                 .name(modelTypeName + "Wrapper")
                 .usedInXml(true)
                 .build();
-        } else if (wireType == ArrayType.ByteArray) {
+        } else if (wireType == ArrayType.BYTE_ARRAY) {
             if (parameterRequestLocation != RequestParameterLocation.BODY /*&& parameterRequestLocation != RequestParameterLocation.FormData*/) {
                 wireType = ClassType.String;
             } else if (settings.isDataPlaneClient()) {

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ArrayType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ArrayType.java
@@ -3,6 +3,8 @@
 
 package com.azure.autorest.model.clientmodel;
 
+import com.azure.autorest.extension.base.plugin.JavaSettings;
+
 import java.util.Set;
 import java.util.function.Function;
 
@@ -14,10 +16,14 @@ public class ArrayType implements IType {
     /**
      * The {@code byte[]} type.
      */
-    public static final ArrayType ByteArray = new ArrayType(PrimitiveType.Byte,
-        defaultValueExpression -> defaultValueExpression == null
-            ? "new byte[0]" // TODO (alzimmer): Should this be new byte[0] or null?
-            : String.format("\"%1$s\".getBytes()", defaultValueExpression));
+    public static final ArrayType BYTE_ARRAY = new ArrayType(PrimitiveType.Byte,
+        defaultValueExpression -> {
+            if (defaultValueExpression != null) {
+                return String.format("\"%1$s\".getBytes()", defaultValueExpression);
+            } else {
+                return JavaSettings.getInstance().isDefaultByteArrayReturnsEmptyArray() ? "EMPTY_BYTE_ARRAY" : "null";
+            }
+        });
 
     private final String toStringValue;
     private final IType elementType;

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ArrayType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ArrayType.java
@@ -21,7 +21,7 @@ public class ArrayType implements IType {
             if (defaultValueExpression != null) {
                 return String.format("\"%1$s\".getBytes()", defaultValueExpression);
             } else {
-                return JavaSettings.getInstance().isDefaultByteArrayReturnsEmptyArray() ? "EMPTY_BYTE_ARRAY" : "null";
+                return JavaSettings.getInstance().isNullByteArrayMapsToEmptyArray() ? "EMPTY_BYTE_ARRAY" : "null";
             }
         });
 

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
@@ -522,7 +522,7 @@ public class ClassType implements IType {
         } else if (this == ClassType.UnixTimeLong) {
             clientType = ClassType.DateTime;
         } else if (this == ClassType.Base64Url) {
-            clientType = ArrayType.ByteArray;
+            clientType = ArrayType.BYTE_ARRAY;
         } else if (this == ClassType.DurationLong) {
             clientType = ClassType.Duration;
         } else if (this == ClassType.DurationDouble) {

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModelProperty.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModelProperty.java
@@ -313,7 +313,7 @@ public class ClientModelProperty implements ClientModelPropertyAccess {
         }
         getClientType().addImportsTo(imports, false);
 
-        if (getClientType().equals(ArrayType.ByteArray)) {
+        if (getClientType().equals(ArrayType.BYTE_ARRAY)) {
             imports.add(CoreUtils.class.getName());
         }
 

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodParameter.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodParameter.java
@@ -176,7 +176,7 @@ public class ProxyMethodParameter extends MethodParameter {
             imports.add(String.format("com.azure.core.annotation.%1$sParam", CodeNamer.toPascalCase(getRequestParameterLocation().toString())));
         }
         if (getRequestParameterLocation() != RequestParameterLocation.BODY) {
-            if (getClientType() == ArrayType.ByteArray) {
+            if (getClientType() == ArrayType.BYTE_ARRAY) {
                 imports.add("com.azure.core.util.Base64Util");
             } else if (getClientType() instanceof ListType && !getExplode()) {
                 imports.add("com.azure.core.util.serializer.CollectionFormat");

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -363,7 +363,7 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
                 //parameterLocation != RequestParameterLocation.FormData &&
                 (parameterClientType instanceof ArrayType || parameterClientType instanceof IterableType)) {
 
-                if (parameterClientType == ArrayType.ByteArray) {
+                if (parameterClientType == ArrayType.BYTE_ARRAY) {
                     String expression = "null";
                     if (!alwaysNull) {
                         expression = String.format("%s(%s)",

--- a/javagen/src/main/java/com/azure/autorest/template/ConvenienceAsyncMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ConvenienceAsyncMethodTemplate.java
@@ -148,7 +148,7 @@ public class ConvenienceAsyncMethodTemplate extends ConvenienceMethodTemplateBas
         } else if (isModelOrBuiltin(responseBodyType)) {
             // class
             mapExpression = String.format("protocolMethodData -> protocolMethodData.toObject(%1$s.class)", responseBodyType);
-        } else if (responseBodyType == ArrayType.ByteArray) {
+        } else if (responseBodyType == ArrayType.BYTE_ARRAY) {
             // byte[]
             if (rawType == ClassType.Base64Url) {
                 return "protocolMethodData -> protocolMethodData.toObject(Base64Url.class).decodedBytes()";

--- a/javagen/src/main/java/com/azure/autorest/template/ConvenienceSyncMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ConvenienceSyncMethodTemplate.java
@@ -209,7 +209,7 @@ public class ConvenienceSyncMethodTemplate extends ConvenienceMethodTemplateBase
         } else if (isModelOrBuiltin(responseBodyType)) {
             // class
             return String.format("%2$s.toObject(%1$s.class)", responseBodyType, invocationExpression);
-        } else if (responseBodyType == ArrayType.ByteArray) {
+        } else if (responseBodyType == ArrayType.BYTE_ARRAY) {
             // byte[]
             if (rawType == ClassType.Base64Url) {
                 return String.format("%1$s.toObject(Base64Url.class).decodedBytes()", invocationExpression);

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -135,7 +135,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
             // If code is being generated with the behavior to return an empty byte array when the default value
             // expression is null and the model has any array types that will need conversion within getter methods
             // generate a static byte[] that will be returned instead of creating a new instance each get.
-            if (settings.isDefaultByteArrayReturnsEmptyArray()
+            if (settings.isNullByteArrayMapsToEmptyArray()
                 && model.getProperties().stream().anyMatch(property -> property.getClientType() instanceof ArrayType
                     && property.getWireType() != property.getClientType())) {
                 classBlock.privateStaticFinalVariable("byte[] EMPTY_BYTE_ARRAY = new byte[0]");

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -132,6 +132,15 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                 classBlock.privateStaticFinalVariable("Pattern KEY_ESCAPER = Pattern.compile(\"\\\\.\");");
             }
 
+            // If code is being generated with the behavior to return an empty byte array when the default value
+            // expression is null and the model has any array types that will need conversion within getter methods
+            // generate a static byte[] that will be returned instead of creating a new instance each get.
+            if (settings.isDefaultByteArrayReturnsEmptyArray()
+                && model.getProperties().stream().anyMatch(property -> property.getClientType() instanceof ArrayType
+                    && property.getWireType() != property.getClientType())) {
+                classBlock.privateStaticFinalVariable("byte[] EMPTY_BYTE_ARRAY = new byte[0]");
+            }
+
             // properties
             addProperties(model, classBlock, settings);
 
@@ -867,7 +876,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
         String expression = property.isPolymorphicDiscriminator()
             ? CodeNamer.getEnumMemberName(property.getName())
             : "this." + property.getName();
-        if (propertyWireType.equals(ArrayType.ByteArray)) {
+        if (propertyWireType.equals(ArrayType.BYTE_ARRAY)) {
             expression = String.format("CoreUtils.clone(%s)", expression);
         }
 
@@ -913,7 +922,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
      */
     private static void addSetterMethod(IType propertyWireType, IType propertyClientType, ClientModelProperty property,
         boolean treatAsXml, JavaBlock methodBlock, JavaSettings settings) {
-        String expression = (propertyClientType.equals(ArrayType.ByteArray))
+        String expression = (propertyClientType.equals(ArrayType.BYTE_ARRAY))
             ? "CoreUtils.clone(" + property.getName() + ")"
             : property.getName();
 

--- a/javagen/src/main/java/com/azure/autorest/template/PatchModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/PatchModelTemplate.java
@@ -133,7 +133,7 @@ public class PatchModelTemplate implements IJavaTemplate<ClientModel, JavaFile> 
                                     patchClassNameWithBaseType, property.getSetterName(), setterPropertyOptionType, property.getName()),
                             (methodBlock) -> {
                                 String expression;
-                                if (propertyClientType.equals(ArrayType.ByteArray)) {
+                                if (propertyClientType.equals(ArrayType.BYTE_ARRAY)) {
                                     expression = String.format("CoreUtils.clone(%s)", property.getName());
                                 } else {
                                     expression = property.getName();

--- a/javagen/src/main/java/com/azure/autorest/template/util/ModelTemplateHeaderHelper.java
+++ b/javagen/src/main/java/com/azure/autorest/template/util/ModelTemplateHeaderHelper.java
@@ -168,7 +168,7 @@ public final class ModelTemplateHeaderHelper {
             setter = String.format("Integer.parseInt(%s)", rawHeaderAccess);
         } else if (wireType == PrimitiveType.Long || wireType == ClassType.Long) {
             setter = String.format("Long.parseLong(%s)", rawHeaderAccess);
-        } else if (wireType == ArrayType.ByteArray) {
+        } else if (wireType == ArrayType.BYTE_ARRAY) {
             setter = String.format("Base64.getDecoder().decode(%s)", rawHeaderAccess);
         } else if (wireType == ClassType.String) {
             setter = rawHeaderAccess;

--- a/typespec-tests/src/main/java/com/cadl/builtin/models/Encoded.java
+++ b/typespec-tests/src/main/java/com/cadl/builtin/models/Encoded.java
@@ -239,7 +239,7 @@ public final class Encoded {
     @Generated
     public byte[] getBase64Url() {
         if (this.base64Url == null) {
-            return new byte[0];
+            return null;
         }
         return this.base64Url.decodedBytes();
     }

--- a/typespec-tests/src/main/java/com/cadl/wiretype/models/SubClassBothMismatch.java
+++ b/typespec-tests/src/main/java/com/cadl/wiretype/models/SubClassBothMismatch.java
@@ -50,7 +50,7 @@ public final class SubClassBothMismatch extends SuperClassMismatch {
     @Generated
     public byte[] getBase64Url() {
         if (this.base64Url == null) {
-            return new byte[0];
+            return null;
         }
         return this.base64Url.decodedBytes();
     }

--- a/typespec-tests/src/main/java/com/encode/bytes/models/Base64UrlBytesProperty.java
+++ b/typespec-tests/src/main/java/com/encode/bytes/models/Base64UrlBytesProperty.java
@@ -44,7 +44,7 @@ public final class Base64UrlBytesProperty {
     @Generated
     public byte[] getValue() {
         if (this.value == null) {
-            return new byte[0];
+            return null;
         }
         return this.value.decodedBytes();
     }

--- a/vanilla-tests/src/main/java/fixtures/requiredfieldsascotrargstransformation/models/TransformationAsRequiredFields.java
+++ b/vanilla-tests/src/main/java/fixtures/requiredfieldsascotrargstransformation/models/TransformationAsRequiredFields.java
@@ -16,6 +16,8 @@ import java.time.ZoneOffset;
 /** The TransformationAsRequiredFields model. */
 @Immutable
 public class TransformationAsRequiredFields {
+    private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
+
     /*
      * The rfc1123NonRequired property.
      */
@@ -130,7 +132,7 @@ public class TransformationAsRequiredFields {
      */
     public byte[] getUrlBase64EncodedRequired() {
         if (this.urlBase64EncodedRequired == null) {
-            return new byte[0];
+            return EMPTY_BYTE_ARRAY;
         }
         return this.urlBase64EncodedRequired.decodedBytes();
     }

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Sawshark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Sawshark.java
@@ -122,7 +122,7 @@ public final class Sawshark extends Shark {
                     String species = null;
                     List<Fish> siblings = null;
                     Integer age = null;
-                    byte[] picture = new byte[0];
+                    byte[] picture = null;
                     while (reader.nextToken() != JsonToken.END_OBJECT) {
                         String fieldName = reader.getFieldName();
                         reader.nextToken();

--- a/vanilla-tests/src/main/java/fixtures/url/Queries.java
+++ b/vanilla-tests/src/main/java/fixtures/url/Queries.java
@@ -2589,7 +2589,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> byteMultiByteAsync() {
-        final byte[] byteQuery = new byte[0];
+        final byte[] byteQuery = null;
         return byteMultiByteWithResponseAsync(byteQuery).flatMap(ignored -> Mono.empty());
     }
 
@@ -2644,7 +2644,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void byteMultiByte() {
-        final byte[] byteQuery = new byte[0];
+        final byte[] byteQuery = null;
         byteMultiByteWithResponse(byteQuery, Context.NONE);
     }
 
@@ -2807,7 +2807,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> byteNullAsync() {
-        final byte[] byteQuery = new byte[0];
+        final byte[] byteQuery = null;
         return byteNullWithResponseAsync(byteQuery).flatMap(ignored -> Mono.empty());
     }
 
@@ -2862,7 +2862,7 @@ public final class Queries {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void byteNull() {
-        final byte[] byteQuery = new byte[0];
+        final byte[] byteQuery = null;
         byteNullWithResponse(byteQuery, Context.NONE);
     }
 


### PR DESCRIPTION
Changes the default behavior in `ArrayType` to return `null` instead of `new byte[0]` when the `defaultValueExpression` is null. To provide a way for backwards compatibility a new configuration `default-byte-array-returns-empty-array` has been added to `JavaSettings`. Additionally, the previous behavior has a minor improvement by reusing a static singleton for the empty byte array instead of creating a new instance on each get call.