### PR TITLE
tsp, bug fix for response as primitive type

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/template/ConvenienceAsyncMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ConvenienceAsyncMethodTemplate.java
@@ -147,7 +147,7 @@ public class ConvenienceAsyncMethodTemplate extends ConvenienceMethodTemplateBas
             mapExpression = null;
         } else if (isModelOrBuiltin(responseBodyType)) {
             // class
-            mapExpression = String.format("protocolMethodData -> protocolMethodData.toObject(%1$s.class)", responseBodyType);
+            mapExpression = String.format("protocolMethodData -> protocolMethodData.toObject(%1$s.class)", responseBodyType.asNullable());
         } else if (responseBodyType == ArrayType.BYTE_ARRAY) {
             // byte[]
             if (rawType == ClassType.Base64Url) {

--- a/javagen/src/main/java/com/azure/autorest/template/ConvenienceAsyncMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ConvenienceAsyncMethodTemplate.java
@@ -15,6 +15,7 @@ import com.azure.autorest.model.javamodel.JavaBlock;
 import com.azure.autorest.util.TemplateUtil;
 import com.azure.core.http.rest.PagedResponse;
 import com.azure.core.http.rest.PagedResponseBase;
+import com.azure.core.http.rest.Response;
 import com.azure.core.util.CoreUtils;
 import com.azure.core.util.FluxUtil;
 import reactor.core.publisher.Flux;
@@ -69,9 +70,8 @@ public class ConvenienceAsyncMethodTemplate extends ConvenienceMethodTemplateBas
         ClientMethodType methodType = protocolMethod.getType();
 
         IType responseBodyType = getResponseBodyType(convenienceMethod);
+        IType protocolResponseBodyType = getResponseBodyType(protocolMethod);
         IType rawResponseBodyType = convenienceMethod.getProxyMethod().getRawResponseBodyType();
-
-        String returnTypeConversionExpression = expressionConvertFromBinaryData(responseBodyType, rawResponseBodyType, typeReferenceStaticClasses);
 
         if (methodType == ClientMethodType.PagingAsync) {
             String expressionMapFromBinaryData = expressionMapFromBinaryData(responseBodyType, rawResponseBodyType, typeReferenceStaticClasses);
@@ -99,6 +99,11 @@ public class ConvenienceAsyncMethodTemplate extends ConvenienceMethodTemplateBas
             String methodName = protocolMethod.getName();
             methodBlock.methodReturn(String.format("serviceClient.%1$s(%2$s)", methodName, invocationExpression));
         } else {
+            String returnTypeConversionExpression = "";
+            if (protocolResponseBodyType == ClassType.BinaryData) {
+                returnTypeConversionExpression = expressionConvertFromBinaryData(responseBodyType, rawResponseBodyType, typeReferenceStaticClasses);
+            }
+
             methodBlock.methodReturn(
                     String.format("%1$s(%2$s).flatMap(FluxUtil::toMono)%3$s",
                             getMethodName(protocolMethod),
@@ -119,8 +124,14 @@ public class ConvenienceAsyncMethodTemplate extends ConvenienceMethodTemplateBas
     }
 
     private IType getResponseBodyType(ClientMethod method) {
-        // Mono<T>
-        return ((GenericType) method.getReturnValue().getType()).getTypeArguments()[0];
+        // no need to care about LRO
+        // Mono<T> / PagedFlux<T>
+        IType type = ((GenericType) method.getReturnValue().getType()).getTypeArguments()[0];
+        if (type instanceof GenericType && Response.class.getSimpleName().equals(((GenericType) type).getName())) {
+            // Mono<Response<T>>
+            type = ((GenericType) type).getTypeArguments()[0];
+        }
+        return type;
     }
 
     private String expressionConvertFromBinaryData(IType responseBodyType, IType rawType, Set<GenericType> typeReferenceStaticClasses) {

--- a/javagen/src/main/java/com/azure/autorest/template/ConvenienceMethodTemplateBase.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ConvenienceMethodTemplateBase.java
@@ -357,7 +357,13 @@ abstract class ConvenienceMethodTemplateBase {
 
     protected boolean isModelOrBuiltin(IType type) {
         // TODO: other built-in types
-        return type == ClassType.String || ClientModelUtil.isClientModel(type);
+        return type ==
+                // string
+                ClassType.String
+                // boolean, int, float, etc.
+                || (type instanceof PrimitiveType && type.asNullable() != ClassType.Void)
+                // client model
+                || ClientModelUtil.isClientModel(type);
     }
 
     private static String expressionConvertToBinaryData(String name, IType type) {

--- a/javagen/src/main/java/com/azure/autorest/template/ConvenienceSyncMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ConvenienceSyncMethodTemplate.java
@@ -208,7 +208,7 @@ public class ConvenienceSyncMethodTemplate extends ConvenienceMethodTemplateBase
             return invocationExpression;
         } else if (isModelOrBuiltin(responseBodyType)) {
             // class
-            return String.format("%2$s.toObject(%1$s.class)", responseBodyType, invocationExpression);
+            return String.format("%2$s.toObject(%1$s.class)", responseBodyType.asNullable(), invocationExpression);
         } else if (responseBodyType == ArrayType.BYTE_ARRAY) {
             // byte[]
             if (rawType == ClassType.Base64Url) {

--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ Settings can be provided on the command line through `--name:value` or in a READ
 |`--client-type-prefix=STRING`|The prefix that will be added to each generated client type.|
 |`--service-interface-as-public`|Indicates whether to generate service interfaces as public. This resolves `SecurityManager` issues to prevent reflectively access non-public APIs. Default is true.|
 |`--require-x-ms-flattened-to-flatten`|Indicates whether `x-ms-flattened` is required to annotated a class with `@JsonFlatten` if the discriminator has `.` in its name. Default is false.|
-|`--client-flattened-annotation-target=TYPE,FIELD,NONE`|Indicates the target of `@JsonFlatten` annotation for `x-ms-client-flatten`. Default is `TYPE`. If value is `FIELD`, it implies `require-x-ms-flattened-to-flatten=true`.|
+|`--client-flattened-annotation-target=TYPE,FIELD,NONE,DISABLED`|Indicates the target of `@JsonFlatten` annotation for `x-ms-client-flatten`. Default is `TYPE`. If value is `FIELD`, it implies `require-x-ms-flattened-to-flatten=true`.|
 |`--disable-client-builder`|Indicates whether to disable generating the `ClientBuilder` class. This is for SDK that already contains a hand-written `ClientBuilder` class. Default is false.|
 |`--skip-formatting`|Indicates whether to skip formatting Java file. Default is false.|
 |`--polling`|Configures how to generate long running operations. See [Polling Configuration](#polling-configuration) to see more details on how to use this flag.|
@@ -377,7 +377,7 @@ help-content:
         description: The prefix that will be added to each generated client type.
       - key: client-flattened-annotation-target
         type: string
-        description: \[TYPE,FIELD] Indicates the target of `@JsonFlatten` annotation for `x-ms-client-flatten`. Default is `TYPE`. If value is `FIELD`, it implies `require-x-ms-flattened-to-flatten=true`.
+        description: \[TYPE,FIELD,NONE,DISABLED] Indicates the target of `@JsonFlatten` annotation for `x-ms-client-flatten`. Default is `TYPE`. If value is `FIELD`, it implies `require-x-ms-flattened-to-flatten=true`.
       - key: disable-client-builder
         type: bool
         description: Indicates whether to disable generating the `ClientBuilder` class. This is for SDK that already contains a hand-written `ClientBuilder` class. Default is false.


### PR DESCRIPTION
For cases that response body is not a JSON object, only a JSON string or JSON boolean etc.

Crystal has a pending cadl-ranch test.