### PR TITLE
mgmt, set null-byte-array-maps-to-empty-array to true

### DIFF
--- a/fluentnamer/readme.md
+++ b/fluentnamer/readme.md
@@ -62,5 +62,6 @@ client-logger: true
 generate-client-interfaces: true
 required-parameter-client-methods: true
 client-flattened-annotation-target: none
+null-byte-array-maps-to-empty-array: true
 graal-vm-config: true
 ```


### PR DESCRIPTION
```java
    public byte[] data() {
        if (this.data == null) {
            return null;
        }
        return this.data.decodedBytes();
    }
```

```
[ERROR] Low: Should com.azure.resourcemanager.keyvault.generated.models.KeyReleasePolicy.data() return a zero length array rather than null? [com.azure.resourcemanager.keyvault.generated.models.KeyReleasePolicy] At KeyReleasePolicy.java:[line 58] PZLA_PREFER_ZERO_LENGTH_ARRAYS
[ERROR] Low: Should com.azure.resourcemanager.keyvault.generated.models.ManagedHsmKeyReleasePolicy.data() return a zero length array rather than null? [com.azure.resourcemanager.keyvault.generated.models.ManagedHsmKeyReleasePolicy] At ManagedHsmKeyReleasePolicy.java:[line 58] PZLA_PREFER_ZERO_LENGTH_ARRAYS
```

ref change https://github.com/Azure/autorest.java/pull/2317