### PR TITLE
Fix regression where single page paging API generates invalid code

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -829,7 +829,7 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
                 addOptionalVariables(function, clientMethod);
                 function.line("return new PagedIterable<>(");
                 function.indent(() -> {
-                    function.line("%s,", this.getPagingSinglePageExpression(
+                    function.line("%s);", this.getPagingSinglePageExpression(
                             clientMethod,
                             clientMethod.getProxyMethod().getPagingSinglePageMethodName(),
                             effectiveFirstPageArgs,


### PR DESCRIPTION
Single page pageable didn't produce proper Java code and was missing a closing `);`.