### PR TITLE
tsp, generic core, sync-only for sync-methods option

### DIFF
--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -741,6 +741,16 @@ public class JavaSettings {
         return syncMethods;
     }
 
+    public final boolean isGenerateAsyncMethods() {
+        SyncMethodsGeneration syncMethodsGeneration = getSyncMethods();
+        return syncMethodsGeneration == SyncMethodsGeneration.ALL || syncMethodsGeneration == SyncMethodsGeneration.ESSENTIAL;
+    }
+
+    public final boolean isGenerateSyncMethods() {
+        SyncMethodsGeneration syncMethodsGeneration = getSyncMethods();
+        return syncMethodsGeneration == SyncMethodsGeneration.ALL || syncMethodsGeneration == SyncMethodsGeneration.SYNC_ONLY;
+    }
+
     private final boolean requiredFieldsAsConstructorArgs;
 
     public boolean isRequiredFieldsAsConstructorArgs() {
@@ -756,6 +766,7 @@ public class JavaSettings {
     public enum SyncMethodsGeneration {
         ALL,
         ESSENTIAL,
+        SYNC_ONLY,  // SYNC_ONLY requires "enable-sync-stack"
         NONE;
 
         public static SyncMethodsGeneration fromValue(String value) {
@@ -767,6 +778,8 @@ public class JavaSettings {
                 return ESSENTIAL;
             } else if (value.equals("none")) {
                 return NONE;
+            } else if (value.equals("sync-only")) {
+                return SYNC_ONLY;
             }
             return null;
         }

--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
@@ -263,8 +263,12 @@ public class ProxyMethodMapper implements IMapper<Operation, Map<Request, List<P
                         asyncRestResponseReturnType, proxyMethods);
             }
 
+            final List<ProxyMethod> asyncProxyMethods = new ArrayList<>(proxyMethods);
             if (settings.isSyncStackEnabled()) {
                 addSyncProxyMethods(proxyMethods);
+            }
+            if (settings.getSyncMethods() == JavaSettings.SyncMethodsGeneration.SYNC_ONLY) {
+                proxyMethods.removeAll(asyncProxyMethods);
             }
             result.put(request, proxyMethods);
             parsed.put(request, proxyMethods);

--- a/javagen/src/main/java/com/azure/autorest/util/ClientModelUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/ClientModelUtil.java
@@ -57,8 +57,8 @@ public class ClientModelUtil {
     public static void getAsyncSyncClients(Client client, ServiceClient serviceClient,
                                            List<AsyncSyncClient> asyncClients, List<AsyncSyncClient> syncClients) {
         String packageName = getAsyncSyncClientPackageName(serviceClient);
-        boolean generateSyncMethods = JavaSettings.SyncMethodsGeneration.ALL
-            .equals(JavaSettings.getInstance().getSyncMethods());
+        boolean generateAsyncMethods = JavaSettings.getInstance().isGenerateAsyncMethods();
+        boolean generateSyncMethods = JavaSettings.getInstance().isGenerateSyncMethods();
 
         if (serviceClient.getProxy() != null) {
             AsyncSyncClient.Builder builder = new AsyncSyncClient.Builder()
@@ -72,8 +72,10 @@ public class ClientModelUtil {
                     .orElse(Collections.emptyList());
             builder.convenienceMethods(convenienceMethods);
 
-            String asyncClassName = clientNameToAsyncClientName(serviceClient.getClientBaseName());
-            asyncClients.add(builder.className(asyncClassName).build());
+            if (generateAsyncMethods) {
+                String asyncClassName = clientNameToAsyncClientName(serviceClient.getClientBaseName());
+                asyncClients.add(builder.className(asyncClassName).build());
+            }
 
             if (generateSyncMethods) {
                 String syncClassName =
@@ -101,8 +103,10 @@ public class ClientModelUtil {
             if (count == 1) {
                 // if it is the only method group, use service client name as base.
 
-                String asyncClassName = clientNameToAsyncClientName(serviceClient.getClientBaseName());
-                asyncClients.add(builder.className(asyncClassName).build());
+                if (generateAsyncMethods) {
+                    String asyncClassName = clientNameToAsyncClientName(serviceClient.getClientBaseName());
+                    asyncClients.add(builder.className(asyncClassName).build());
+                }
 
                 if (generateSyncMethods) {
                     String syncClassName =
@@ -112,8 +116,10 @@ public class ClientModelUtil {
                     syncClients.add(builder.className(syncClassName).build());
                 }
             } else {
-                String asyncClassName = clientNameToAsyncClientName(methodGroupClient.getClassBaseName());
-                asyncClients.add(builder.className(asyncClassName).build());
+                if (generateAsyncMethods) {
+                    String asyncClassName = clientNameToAsyncClientName(methodGroupClient.getClassBaseName());
+                    asyncClients.add(builder.className(asyncClassName).build());
+                }
 
                 if (generateSyncMethods) {
                     String syncClassName =


### PR DESCRIPTION
fix https://github.com/Azure/autorest.java/issues/2348

`sync-methods=sync-only`

Use `isGenerateAsyncMethods()` and `isGenerateSyncMethods()` for most cases (except for one case of NONE which still generate `SimpleAsyncRestResponse` type; but `SYNC_ONLY` won't).

If `SYNC_ONLY`, do not generate Async proxy methods.

---

tested locally for simple API and pageable API