### PR TITLE
mgmt, add graalvm-config-suffix option

### DIFF
--- a/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
@@ -274,7 +274,11 @@ public class FluentGen extends Javagen {
 
         // GraalVM config
         if (javaSettings.isGenerateGraalVmConfig()) {
-            javaPackage.addGraalVmConfig("com.azure.resourcemanager", FluentUtils.getArtifactId(), client.getGraalVmConfig());
+            String artifactId = FluentUtils.getArtifactId();
+            if (fluentJavaSettings.getGraalVmConfigSuffix().isPresent()) {
+                artifactId = artifactId + "_" + fluentJavaSettings.getGraalVmConfigSuffix().get();
+            }
+            javaPackage.addGraalVmConfig("com.azure.resourcemanager", artifactId, client.getGraalVmConfig());
         }
 
         // Samples

--- a/fluentnamer/src/main/java/com/azure/autorest/fluent/util/FluentJavaSettings.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluent/util/FluentJavaSettings.java
@@ -81,6 +81,8 @@ public class FluentJavaSettings {
 
     private SampleGeneration generateSamples = SampleGeneration.NONE;
 
+    private String graalVmConfigSuffix = null;
+
     private boolean sdkIntegration = false;
 
     private enum SampleGeneration {
@@ -165,6 +167,10 @@ public class FluentJavaSettings {
         return generateSamples != SampleGeneration.NONE;
     }
 
+    public Optional<String> getGraalVmConfigSuffix() {
+        return Optional.ofNullable(graalVmConfigSuffix);
+    }
+
     public boolean isSdkIntegration() {
         return sdkIntegration;
     }
@@ -226,6 +232,8 @@ public class FluentJavaSettings {
         loadBooleanSetting("generate-async-methods", s -> generateAsyncMethods = s);
 
         loadBooleanSetting("generate-samples", s -> generateSamples = (s ? SampleGeneration.AGGREGATED : SampleGeneration.NONE));
+
+        loadStringSetting("graalvm-config-suffix", s -> graalVmConfigSuffix = s);
 
         loadBooleanSetting("sdk-integration", b -> sdkIntegration = b);
 

--- a/typespec-extension/src/main/java/com/azure/autorest/TypeSpecPlugin.java
+++ b/typespec-extension/src/main/java/com/azure/autorest/TypeSpecPlugin.java
@@ -123,7 +123,7 @@ public class TypeSpecPlugin extends Javagen {
         SETTINGS_MAP.put("generate-client-as-impl", true);
         SETTINGS_MAP.put("generate-sync-async-clients", true);
         SETTINGS_MAP.put("generate-builder-per-client", false);
-        SETTINGS_MAP.put("sync-methods", "sync-only");
+        SETTINGS_MAP.put("sync-methods", "all");
         SETTINGS_MAP.put("enable-sync-stack", true);
         SETTINGS_MAP.put("enable-page-size", true);
 

--- a/typespec-extension/src/main/java/com/azure/autorest/TypeSpecPlugin.java
+++ b/typespec-extension/src/main/java/com/azure/autorest/TypeSpecPlugin.java
@@ -123,7 +123,7 @@ public class TypeSpecPlugin extends Javagen {
         SETTINGS_MAP.put("generate-client-as-impl", true);
         SETTINGS_MAP.put("generate-sync-async-clients", true);
         SETTINGS_MAP.put("generate-builder-per-client", false);
-        SETTINGS_MAP.put("sync-methods", "all");
+        SETTINGS_MAP.put("sync-methods", "sync-only");
         SETTINGS_MAP.put("enable-sync-stack", true);
         SETTINGS_MAP.put("enable-page-size", true);
 


### PR DESCRIPTION
Alternative is to do a merge of json files from different tag, e.g. resources + subscriptions + policy + features. But it is unnecessarily complicated.

A bit of hack to generate
```
azure-resourcemanager-resources/src/main/resources/META-INF/native-image/com.azure.resourcemanager/azure-resourcemanager-resources_subscription
```
for `subscriptions`.

instead of
```
azure-resourcemanager-resources/src/main/resources/META-INF/native-image/com.azure.resourcemanager/azure-resourcemanager-resources
```

ref https://github.com/Azure/azure-sdk-for-java/pull/37195