### PR TITLE
client, fix bug on constant property in stream style

### DIFF
--- a/azure-tests/src/main/java/fixtures/azureparametergrouping/models/Grouper.java
+++ b/azure-tests/src/main/java/fixtures/azureparametergrouping/models/Grouper.java
@@ -23,9 +23,7 @@ public final class Grouper {
     private String groupedParameter;
 
     /** Creates an instance of Grouper class. */
-    public Grouper() {
-        groupedConstant = "foo";
-    }
+    public Grouper() {}
 
     /**
      * Get the groupedConstant property: A grouped parameter that is a constant.

--- a/azure-tests/src/main/java/fixtures/azurespecials/models/Error.java
+++ b/azure-tests/src/main/java/fixtures/azurespecials/models/Error.java
@@ -29,9 +29,7 @@ public final class Error {
     private String message;
 
     /** Creates an instance of Error class. */
-    public Error() {
-        constantId = 1;
-    }
+    public Error() {}
 
     /**
      * Get the status property: The status property.

--- a/javagen/src/main/java/com/azure/autorest/implementation/ClientModelPropertiesManager.java
+++ b/javagen/src/main/java/com/azure/autorest/implementation/ClientModelPropertiesManager.java
@@ -168,10 +168,12 @@ public final class ClientModelPropertiesManager {
                 hasRequiredProperties = true;
                 requiredProperties.add(property);
 
-                if (ClientModelUtil.includePropertyInConstructor(property, settings)) {
-                    constructorProperties.add(property);
-                } else {
-                    readOnlyProperties.add(property);
+                if (!property.isConstant()) {
+                    if (ClientModelUtil.includePropertyInConstructor(property, settings)) {
+                        constructorProperties.add(property);
+                    } else {
+                        readOnlyProperties.add(property);
+                    }
                 }
             } else if (property.isAdditionalProperties()) {
                 // Extract the additionalProperties property as this will need to be passed into all deserialization

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -562,7 +562,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
 
             if (property.isPolymorphicDiscriminator()) {
                 classBlock.privateStaticFinalVariable(fieldSignature);
-            } else if ((ClientModelUtil.includePropertyInConstructor(property, settings) && settings.isStreamStyleSerialization())) {
+            } else if (ClientModelUtil.includePropertyInConstructor(property, settings) && settings.isStreamStyleSerialization()) {
                 classBlock.privateFinalMemberVariable(fieldSignature);
             } else {
                 classBlock.privateMemberVariable(fieldSignature);
@@ -768,10 +768,11 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                 constructor.line("super(" + superProperties + ");");
             }
 
-            // Then, add all constant properties.
-            for (ClientModelProperty property : constantProperties) {
-                constructor.line(property.getName() + " = " + property.getDefaultValue() + ";");
-            }
+            // constant properties should already be initialized in class variable definition
+//            // Then, add all constant properties.
+//            for (ClientModelProperty property : constantProperties) {
+//                constructor.line(property.getName() + " = " + property.getDefaultValue() + ";");
+//            }
 
             // Finally, add all required properties.
             if (settings.isRequiredFieldsAsConstructorArgs()) {

--- a/typespec-tests/src/main/java/com/cadl/enumservice/models/Operation.java
+++ b/typespec-tests/src/main/java/com/cadl/enumservice/models/Operation.java
@@ -81,11 +81,6 @@ public final class Operation {
             @JsonProperty(value = "name") OperationName name,
             @JsonProperty(value = "priority") Priority priority,
             @JsonProperty(value = "color") ColorModel color) {
-        best = true;
-        age = 50L;
-        priorityValue = Priority.LOW;
-        colorValue = Color.GREEN;
-        colorModelValue = ColorModel.BLUE;
         this.name = name;
         this.priority = priority;
         this.color = color;

--- a/typespec-tests/src/main/java/com/cadl/literalservice/models/Model.java
+++ b/typespec-tests/src/main/java/com/cadl/literalservice/models/Model.java
@@ -27,9 +27,7 @@ public final class Model {
 
     /** Creates an instance of Model class. */
     @Generated
-    public Model() {
-        literal = "literal";
-    }
+    public Model() {}
 
     /**
      * Get the literal property: The literal property.

--- a/vanilla-tests/src/main/java/fixtures/bodyformdataurlencoded/models/PathsPvivzlFormsdataurlencodedPartialconstantbodyPostRequestbodyContentApplicationXWwwFormUrlencodedSchema.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyformdataurlencoded/models/PathsPvivzlFormsdataurlencodedPartialconstantbodyPostRequestbodyContentApplicationXWwwFormUrlencodedSchema.java
@@ -36,9 +36,7 @@ class PathsPvivzlFormsdataurlencodedPartialconstantbodyPostRequestbodyContentApp
      * PathsPvivzlFormsdataurlencodedPartialconstantbodyPostRequestbodyContentApplicationXWwwFormUrlencodedSchema class.
      */
     public
-    PathsPvivzlFormsdataurlencodedPartialconstantbodyPostRequestbodyContentApplicationXWwwFormUrlencodedSchema() {
-        grantType = "access_token";
-    }
+    PathsPvivzlFormsdataurlencodedPartialconstantbodyPostRequestbodyContentApplicationXWwwFormUrlencodedSchema() {}
 
     /**
      * Get the grantType property: Constant part of a formdata body.

--- a/vanilla-tests/src/main/java/fixtures/bodystring/models/RefColorConstant.java
+++ b/vanilla-tests/src/main/java/fixtures/bodystring/models/RefColorConstant.java
@@ -23,9 +23,7 @@ public final class RefColorConstant {
     private String field1;
 
     /** Creates an instance of RefColorConstant class. */
-    public RefColorConstant() {
-        colorConstant = "green-color";
-    }
+    public RefColorConstant() {}
 
     /**
      * Get the colorConstant property: Referenced Color Constant Description.

--- a/vanilla-tests/src/main/java/fixtures/constants/models/NoModelAsStringNoRequiredOneValueDefault.java
+++ b/vanilla-tests/src/main/java/fixtures/constants/models/NoModelAsStringNoRequiredOneValueDefault.java
@@ -17,9 +17,7 @@ public final class NoModelAsStringNoRequiredOneValueDefault {
     private String parameter = "value1";
 
     /** Creates an instance of NoModelAsStringNoRequiredOneValueDefault class. */
-    public NoModelAsStringNoRequiredOneValueDefault() {
-        parameter = "value1";
-    }
+    public NoModelAsStringNoRequiredOneValueDefault() {}
 
     /**
      * Get the parameter property: The parameter property.

--- a/vanilla-tests/src/main/java/fixtures/constants/models/NoModelAsStringNoRequiredOneValueNoDefault.java
+++ b/vanilla-tests/src/main/java/fixtures/constants/models/NoModelAsStringNoRequiredOneValueNoDefault.java
@@ -17,9 +17,7 @@ public final class NoModelAsStringNoRequiredOneValueNoDefault {
     private String parameter = "value1";
 
     /** Creates an instance of NoModelAsStringNoRequiredOneValueNoDefault class. */
-    public NoModelAsStringNoRequiredOneValueNoDefault() {
-        parameter = "value1";
-    }
+    public NoModelAsStringNoRequiredOneValueNoDefault() {}
 
     /**
      * Get the parameter property: The parameter property.

--- a/vanilla-tests/src/main/java/fixtures/constants/models/NoModelAsStringRequiredOneValueDefault.java
+++ b/vanilla-tests/src/main/java/fixtures/constants/models/NoModelAsStringRequiredOneValueDefault.java
@@ -17,9 +17,7 @@ public final class NoModelAsStringRequiredOneValueDefault {
     private String parameter = "value1";
 
     /** Creates an instance of NoModelAsStringRequiredOneValueDefault class. */
-    public NoModelAsStringRequiredOneValueDefault() {
-        parameter = "value1";
-    }
+    public NoModelAsStringRequiredOneValueDefault() {}
 
     /**
      * Get the parameter property: The parameter property.

--- a/vanilla-tests/src/main/java/fixtures/constants/models/NoModelAsStringRequiredOneValueNoDefault.java
+++ b/vanilla-tests/src/main/java/fixtures/constants/models/NoModelAsStringRequiredOneValueNoDefault.java
@@ -17,9 +17,7 @@ public final class NoModelAsStringRequiredOneValueNoDefault {
     private String parameter = "value1";
 
     /** Creates an instance of NoModelAsStringRequiredOneValueNoDefault class. */
-    public NoModelAsStringRequiredOneValueNoDefault() {
-        parameter = "value1";
-    }
+    public NoModelAsStringRequiredOneValueNoDefault() {}
 
     /**
      * Get the parameter property: The parameter property.

--- a/vanilla-tests/src/main/java/fixtures/validation/models/ChildProduct.java
+++ b/vanilla-tests/src/main/java/fixtures/validation/models/ChildProduct.java
@@ -23,9 +23,7 @@ public final class ChildProduct {
     private Integer count;
 
     /** Creates an instance of ChildProduct class. */
-    public ChildProduct() {
-        constProperty = "constant";
-    }
+    public ChildProduct() {}
 
     /**
      * Get the constProperty property: Constant string.

--- a/vanilla-tests/src/main/java/fixtures/validation/models/ConstantProduct.java
+++ b/vanilla-tests/src/main/java/fixtures/validation/models/ConstantProduct.java
@@ -23,10 +23,7 @@ public final class ConstantProduct {
     private String constProperty2 = "constant2";
 
     /** Creates an instance of ConstantProduct class. */
-    public ConstantProduct() {
-        constProperty = "constant";
-        constProperty2 = "constant2";
-    }
+    public ConstantProduct() {}
 
     /**
      * Get the constProperty property: Constant string.

--- a/vanilla-tests/src/main/java/fixtures/validation/models/Product.java
+++ b/vanilla-tests/src/main/java/fixtures/validation/models/Product.java
@@ -60,11 +60,7 @@ public final class Product {
     private String constStringAsEnum = "constant_string_as_enum";
 
     /** Creates an instance of Product class. */
-    public Product() {
-        constInt = 0;
-        constString = "constant";
-        constStringAsEnum = "constant_string_as_enum";
-    }
+    public Product() {}
 
     /**
      * Get the displayNames property: Non required array of unique items from 0 to 6 elements.


### PR DESCRIPTION
fix below case

model https://github.com/bterlson/openai-in-typespec/blob/main/fine-tuning/models.tsp#L4-L44

```java
public final class FineTune implements JsonSerializable<FineTune> {
    /*
     * The object identifier, which can be referenced in the API endpoints.
     */
    @Generated private final String id;

    /*
     * The object type, which is always "fine-tune".
     */
    @Generated private final String object = "fine-tune";

    ...

    private FineTune(
            String id,
            OffsetDateTime createdAt,
            OffsetDateTime updatedAt,
            ...
            List<OpenAiFile> resultFiles) {
        object = "fine-tune";
        ...
    }

    public static FineTune fromJson(JsonReader jsonReader) throws IOException {
        ...
                                new FineTune(
                                        id,
                                        object,
                                        createdAt,
                                        updatedAt,
        ...
    }
```

The `object` is a constant, so it should not appear in ctor nor in the place invoking ctor.

This may not be a complete fix for the general case of `final` var in ctor, but let us handle it case by case.