### PR TITLE
tsp, unbranded, remove Trait, Policy, SerializerAdapter

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMapper.java
@@ -435,6 +435,10 @@ public class ClientMapper implements IMapper<CodeModel, Client> {
     }
 
     private void addBuilderTraits(ClientBuilder clientBuilder, ServiceClient serviceClient) {
+        if (!JavaSettings.getInstance().isBranded()) {
+            return;
+        }
+
         clientBuilder.addBuilderTrait(ClientBuilderTrait.HTTP_TRAIT);
         clientBuilder.addBuilderTrait(ClientBuilderTrait.CONFIGURATION_TRAIT);
         if (serviceClient.getSecurityInfo().getSecurityTypes().contains(Scheme.SecuritySchemeType.OAUTH2)) {

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
@@ -47,6 +47,7 @@ public class ClassType implements IType {
 //    private static final Map<Class<?>, ClassDetails> CLASS_TYPE_MAPPING = new HashMap<Class<?>, ClassDetails>() {{
 //        put(com.azure.core.http.rest.RestProxy.class, new ClassDetails(com.azure.core.http.rest.RestProxy.class, com.generic.core.http.RestProxy.class));
 //        put(com.azure.core.http.HttpPipeline.class, new ClassDetails(com.azure.core.http.HttpPipeline.class, com.generic.core.http.pipeline.HttpPipeline.class));
+//        put(com.azure.core.http.HttpPipelineBuilder.class, new ClassDetails(com.azure.core.http.HttpPipelineBuilder.class, com.generic.core.http.pipeline.HttpPipelineBuilder.class));
 //        put(com.azure.core.util.Context.class, new ClassDetails(com.azure.core.util.Context.class, com.generic.core.models.Context.class));
 //        put(com.azure.core.http.HttpClient.class, new ClassDetails(com.azure.core.http.HttpClient.class, com.generic.core.http.client.HttpClient.class));
 //        put(com.azure.core.http.policy.HttpLogOptions.class, new ClassDetails(com.azure.core.http.policy.HttpLogOptions.class, com.generic.core.http.policy.logging.HttpLogOptions.class));
@@ -87,6 +88,7 @@ public class ClassType implements IType {
     private static final Map<Class<?>, ClassDetails> CLASS_TYPE_MAPPING = new HashMap<Class<?>, ClassDetails>() {{
         put(com.azure.core.http.rest.RestProxy.class, new ClassDetails(com.azure.core.http.rest.RestProxy.class, "com.generic.core.http.RestProxy"));
         put(com.azure.core.http.HttpPipeline.class, new ClassDetails(com.azure.core.http.HttpPipeline.class, "com.generic.core.http.pipeline.HttpPipeline"));
+        put(com.azure.core.http.HttpPipelineBuilder.class, new ClassDetails(com.azure.core.http.HttpPipelineBuilder.class, "com.generic.core.http.pipeline.HttpPipelineBuilder"));
         put(com.azure.core.util.Context.class, new ClassDetails(com.azure.core.util.Context.class, "com.generic.core.models.Context"));
         put(com.azure.core.http.HttpClient.class, new ClassDetails(com.azure.core.http.HttpClient.class, "com.generic.core.http.client.HttpClient"));
         put(com.azure.core.http.policy.HttpLogOptions.class, new ClassDetails(com.azure.core.http.policy.HttpLogOptions.class, "com.generic.core.http.policy.logging.HttpLogOptions"));
@@ -477,6 +479,9 @@ public class ClassType implements IType {
         .build();
 
     public static final ClassType ExpandableStringEnum = getClassTypeBuilder(com.azure.core.util.ExpandableStringEnum.class)
+        .build();
+
+    public static final ClassType HttpPipelineBuilder = getClassTypeBuilder(com.azure.core.http.HttpPipelineBuilder.class)
         .build();
 
     public static final ClassType JsonSerializable = getClassTypeBuilder(com.azure.json.JsonSerializable.class)

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ServiceClient.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ServiceClient.java
@@ -275,9 +275,7 @@ public class ServiceClient {
     }
 
     protected void addPipelineBuilderImport(Set<String> imports) {
-        if (JavaSettings.getInstance().isBranded()) {
-            imports.add("com.azure.core.http.HttpPipelineBuilder");
-        }
+        ClassType.HttpPipelineBuilder.addImportsTo(imports, false);
     }
 
     public static class Builder {

--- a/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
@@ -144,7 +144,9 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ClientBuilder
                     .map(trait -> trait.getTraitInterfaceName() + serviceClientBuilderGeneric)
                     .collect(Collectors.joining(", "));
 
-            classDefinition = serviceClientBuilderName + " implements " + interfaces;
+            if (!interfaces.isEmpty()) {
+                classDefinition = serviceClientBuilderName + " implements " + interfaces;
+            }
         }
 
         javaFile.publicFinalClass(classDefinition, classBlock ->
@@ -519,7 +521,7 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ClientBuilder
                     settings.isFluent() ? "SerializerFactory.createDefaultManagementSerializerAdapter()" : JACKSON_SERIALIZER));
         }
 
-        if (!settings.isAzureOrFluent()) {
+        if (!settings.isAzureOrFluent() && settings.isBranded()) {
             commonProperties.add(new ServiceClientProperty("The retry policy that will attempt to retry failed "
                     + "requests, if applicable.", ClassType.RetryPolicy, "retryPolicy", false, null));
         }

--- a/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
@@ -168,24 +168,31 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ClientBuilder
                             String.join(", ", scopes)));
                 }
 
-                // properties for sdk name and version
-                String propertiesValue = "new HashMap<>()";
-                String artifactId = ClientModelUtil.getArtifactId();
-                if (!CoreUtils.isNullOrEmpty(artifactId)) {
-                    propertiesValue = "CoreUtils.getProperties" + "(\"" + artifactId + ".properties\")";
+                if (settings.isBranded()) {
+                    // properties for sdk name and version
+                    String propertiesValue = "new HashMap<>()";
+                    String artifactId = ClientModelUtil.getArtifactId();
+                    if (!CoreUtils.isNullOrEmpty(artifactId)) {
+                        propertiesValue = "CoreUtils.getProperties" + "(\"" + artifactId + ".properties\")";
+                    }
+                    addGeneratedAnnotation(classBlock);
+                    classBlock.privateStaticFinalVariable(String.format("Map<String, String> PROPERTIES = %s", propertiesValue));
+
+                    addGeneratedAnnotation(classBlock);
+                    classBlock.privateFinalMemberVariable("List<HttpPipelinePolicy>", "pipelinePolicies");
+
+                    // constructor
+                    classBlock.javadocComment(String.format("Create an instance of the %s.", serviceClientBuilderName));
+                    addGeneratedAnnotation(classBlock);
+                    classBlock.publicConstructor(String.format("%1$s()", serviceClientBuilderName), javaBlock -> {
+                        javaBlock.line("this.pipelinePolicies = new ArrayList<>();");
+                    });
+                } else {
+                    classBlock.javadocComment(String.format("Create an instance of the %s.", serviceClientBuilderName));
+                    addGeneratedAnnotation(classBlock);
+                    classBlock.publicConstructor(String.format("%1$s()", serviceClientBuilderName), javaBlock -> {
+                    });
                 }
-                addGeneratedAnnotation(classBlock);
-                classBlock.privateStaticFinalVariable(String.format("Map<String, String> PROPERTIES = %s", propertiesValue));
-
-                addGeneratedAnnotation(classBlock);
-                classBlock.privateFinalMemberVariable("List<HttpPipelinePolicy>", "pipelinePolicies");
-
-                // constructor
-                classBlock.javadocComment(String.format("Create an instance of the %s.", serviceClientBuilderName));
-                addGeneratedAnnotation(classBlock);
-                classBlock.publicConstructor(String.format("%1$s()", serviceClientBuilderName), javaBlock -> {
-                    javaBlock.line("this.pipelinePolicies = new ArrayList<>();");
-                });
             }
 
             Stream<ServiceClientProperty> serviceClientPropertyStream = serviceClient.getProperties().stream()
@@ -291,7 +298,9 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ClientBuilder
                     serializerExpression = getLocalBuildVariableName(getSerializerMemberName());
                 }
 
-                if (settings.isFluent()) {
+                if (!settings.isBranded()) {
+                    function.line(String.format("%1$s client = new %1$s(%2$s);", serviceClient.getClassName(), "this.createHttpPipeline()"));
+                } else if (settings.isFluent()) {
                     function.line(String.format("%1$s client = new %2$s(%3$s, %4$s, %5$s, %6$s%7$s);",
                             serviceClient.getClassName(),
                             serviceClient.getClassName(),
@@ -500,8 +509,6 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ClientBuilder
             TemplateHelper.createHttpPipelineMethod(settings, defaultCredentialScopes, securityInfo, pipelinePolicyDetails, function);
         });
     }
-
-
 
     protected ArrayList<ServiceClientProperty> addCommonClientProperties(JavaSettings settings, SecurityInfo securityInfo) {
         ArrayList<ServiceClientProperty> commonProperties = new ArrayList<ServiceClientProperty>();

--- a/javagen/src/main/java/com/azure/autorest/template/TemplateHelper.java
+++ b/javagen/src/main/java/com/azure/autorest/template/TemplateHelper.java
@@ -153,7 +153,7 @@ public final class TemplateHelper {
 
     public static void createRestProxyInstance(ServiceClientTemplate template, ServiceClient serviceClient, JavaBlock constructorBlock) {
         if (!JavaSettings.getInstance().isBranded()) {
-            constructorBlock.line("this.service = %s.create(%s.class, this.httpPipeline, %s);", ClassType.RestProxy.getName(), serviceClient.getProxy().getName(), "JsonSerializerProvider.createInstance()");
+            constructorBlock.line("this.service = %s.create(%s.class, this.httpPipeline, %s);", ClassType.RestProxy.getName(), serviceClient.getProxy().getName(), "null");
         } else {
             constructorBlock.line("this.service = %s.create(%s.class, this.httpPipeline, %s);", ClassType.RestProxy.getName(), serviceClient.getProxy().getName(), template.getSerializerPhrase());
         }


### PR DESCRIPTION
may add them back, if they appear again in generic-core

https://github.com/Azure/autorest.java/issues/2322

now we had 1 error in ClientBuilder, no error in ClientImpl, 2 types of errors in Client


sample

ClientBuilder
```java
    @Generated
    private OpenAiClientImpl buildInnerClient() {
        OpenAiClientImpl client = new OpenAiClientImpl(this.createHttpPipeline());
        return client;
    }

    @Generated
    private HttpPipeline createHttpPipeline() {
        HttpPipeline httpPipeline = HttpPipelineBuilder.createDefaultPipeline();
        return httpPipeline;
    }

    /**
     * Builds an instance of OpenAiClient class.
     *
     * @return an instance of OpenAiClient.
     */
    @Generated
    public OpenAiClient buildClient() {
        return new OpenAiClient(buildInnerClient());
    }
```

ClientImpl
```java
    public OpenAiClientImpl(HttpPipeline httpPipeline) {
        this.httpPipeline = httpPipeline;
        this.service = RestProxy.create(OpenAiClientService.class, this.httpPipeline, null);
    }
```
(that `null` may not be there)