### PR TITLE
tsp, mitigate lro use of property other than "result"

### DIFF
--- a/typespec-extension/src/code-model-builder.ts
+++ b/typespec-extension/src/code-model-builder.ts
@@ -792,7 +792,19 @@ export class CodeModelBuilder {
 
       // finalSchema
       if (verb !== "delete" && lroMetadata.logicalResult) {
-        const finalType = this.findResponseBody(lroMetadata.logicalResult);
+        let finalResult = lroMetadata.logicalResult;
+        if (
+          verb === "post" &&
+          lroMetadata.finalStep &&
+          lroMetadata.finalStep.kind === "pollingSuccessProperty" &&
+          lroMetadata.finalStep.target.name !== "result" &&
+          lroMetadata.logicalResult !== lroMetadata.envelopeResult
+        ) {
+          // fix the case that @lroResult is not "result" property
+          finalResult = lroMetadata.envelopeResult;
+        }
+
+        const finalType = this.findResponseBody(finalResult);
         finalSchema = this.processSchema(finalType, "finalResult");
       }
 


### PR DESCRIPTION
https://github.com/Azure/azure-rest-api-specs-pr/blob/feature/documentintelligence-tsp/specification/cognitiveservices/DocumentIntelligence/models.tsp#L304-L306 uses "analyzeResult"

However, the extraction logic is built-in core-experimental, it can only handle "result" https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/core/azure-core-experimental/src/main/java/com/azure/core/experimental/util/polling/implementation/PostPollResult.java#L9-L17

Maybe we need to make the "result" in core-experimental configurable.