### PR TITLE
Move Eclipse language server to download during runtime

### DIFF
--- a/customization-base/pom.xml
+++ b/customization-base/pom.xml
@@ -55,6 +55,11 @@
       <artifactId>javaparser-symbol-solver-core</artifactId>
       <version>3.25.2</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.ant</groupId>
+      <artifactId>ant</artifactId>
+      <version>1.10.14</version>
+    </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/customization-base/src/main/java/com/azure/autorest/customization/implementation/ls/EclipseLanguageServerFacade.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/implementation/ls/EclipseLanguageServerFacade.java
@@ -4,16 +4,17 @@
 package com.azure.autorest.customization.implementation.ls;
 
 import com.azure.autorest.customization.implementation.Utils;
+import org.apache.tools.tar.TarEntry;
+import org.apache.tools.tar.TarInputStream;
 
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
+import java.util.zip.GZIPInputStream;
 
 public class EclipseLanguageServerFacade {
     private final Process server;
@@ -25,9 +26,9 @@ public class EclipseLanguageServerFacade {
     public EclipseLanguageServerFacade(String pathToLanguageServerPlugin, int port) {
         Runtime.getRuntime().addShutdownHook(new Thread(this::shutdown));
         try {
-            if (pathToLanguageServerPlugin == null) {
-                pathToLanguageServerPlugin = unzipLanguageServer();
-            }
+            Path languageServerPath = (pathToLanguageServerPlugin == null)
+                ? getLanguageServerDirectory()
+                : Paths.get(pathToLanguageServerPlugin).resolve("jdt-language-server");
 
             String command = "java -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=1044 " +
                 "-Declipse.application=org.eclipse.jdt.ls.core.id1 -Dosgi.bundles.defaultStartLevel=4 " +
@@ -44,35 +45,65 @@ public class EclipseLanguageServerFacade {
             } else {
                 command += "-configuration ./config_linux";
             }
+
             server = Runtime.getRuntime().exec(command, new String[]{"CLIENT_PORT=" + port},
-                Paths.get(pathToLanguageServerPlugin, "jdt-language-server").toFile());
+                languageServerPath.toFile());
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
-    private String unzipLanguageServer() throws IOException {
-        Path languageServerDirectory = Files.createTempDirectory("tmpjdt");
-        InputStream resourceAsStream = EclipseLanguageServerFacade.class.getClassLoader().getResourceAsStream("jdt-language-server.zip");
-        ZipInputStream zipInputStream = new ZipInputStream(resourceAsStream);
-        ZipEntry zipEntry = zipInputStream.getNextEntry();
-        byte[] buffer = new byte[2048];
-        while (zipEntry != null) {
-            if (zipEntry.isDirectory()) {
-                File currentDir = new File(languageServerDirectory.toString(), zipEntry.getName());
-                currentDir.mkdirs();
-            } else {
-                File file = new File(languageServerDirectory.toString(), zipEntry.getName());
-                try (FileOutputStream outputStream = new FileOutputStream(file)) {
-                    int length;
-                    while ((length = zipInputStream.read(buffer)) > 0) {
-                        outputStream.write(buffer, 0, length);
-                    }
+    private static Path getLanguageServerDirectory() throws IOException {
+        Path tmp = Paths.get(System.getProperty("java.io.tmpdir"));
+        Path autorestLanguageServer = tmp.resolve("autorest-java-language-server");
+
+        int javaVersion = Runtime.version().feature();
+        URL downloadUrl;
+        Path languageServerPath;
+        if (javaVersion < 17) {
+            // Eclipse JDT language server version 1.12.0 is the last version that supports Java 11, which is
+            // autorest.java's baseline.
+            downloadUrl = URI.create("https://www.eclipse.org/downloads/download.php?file=/jdtls/milestones/1.12.0/jdt-language-server-1.12.0-202206011637.tar.gz")
+                .toURL();
+            languageServerPath = autorestLanguageServer.resolve("1.12.0");
+        } else {
+            // Eclipse JDT language server version 1.29.0 is the latest version that supports Java 17.
+            // In the future this else statement may need to be replaced with an else if as newer versions of
+            // Eclipse JDT language server may baseline on Java 21 (or later).
+            downloadUrl = URI.create("https://www.eclipse.org/downloads/download.php?file=/jdtls/milestones/1.29.0/jdt-language-server-1.29.0-202310261436.tar.gz")
+                .toURL();
+            languageServerPath = autorestLanguageServer.resolve("1.29.0");
+        }
+
+        Path languageServer = languageServerPath.resolve("jdt-language-server");
+        if (!Files.exists(languageServerPath) || !Files.exists(languageServer)) {
+            Files.createDirectories(languageServerPath);
+            Path zipPath = languageServerPath.resolve("jdt-language-server.tar.gz");
+            try (InputStream in = downloadUrl.openStream()) {
+                Files.copy(in, zipPath);
+            }
+
+            return unzipLanguageServer(zipPath);
+        }
+
+        return languageServer;
+    }
+
+    private static Path unzipLanguageServer(Path zipPath) throws IOException {
+        try (TarInputStream tar = new TarInputStream(new GZIPInputStream(Files.newInputStream(zipPath)))) {
+            Path languageServerDirectory = zipPath.getParent().resolve("jdt-language-server");
+            Files.createDirectory(languageServerDirectory);
+            TarEntry entry;
+            while ((entry = tar.getNextEntry()) != null) {
+                if (entry.isDirectory()) {
+                    Files.createDirectories(languageServerDirectory.resolve(entry.getName()));
+                } else {
+                    Files.copy(tar, languageServerDirectory.resolve(entry.getName()));
                 }
             }
-            zipEntry = zipInputStream.getNextEntry();
+
+            return languageServerDirectory;
         }
-        return languageServerDirectory.toString();
     }
 
     public InputStream getOutput() {


### PR DESCRIPTION
Externalizes the Eclipse language server to download during runtime instead of being bundled into the uber JARs. The language server will be downloaded to a well-known path in the temp directory, `/<temp directory>/autorest-java-language-server`. Since the language server is no longer bundled it allows for different versions to be selected based on the JVM running code generation, right now there is two choices of `1.12.0` while using Java [11, 17) and `1.29.0` when using Java[17,). In the future this may change when there is a new version of Eclipse language server that requires Java 21+.