### PR TITLE
tsp, fix script and add override

### DIFF
--- a/.github/workflows/generate-test-code.yml
+++ b/.github/workflows/generate-test-code.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Build autorest-java, install modules
         run: |
-          mvn package install -f pom.xml -P local,tsp --no-transfer-progress
+          mvn install -f pom.xml -P local,tsp --no-transfer-progress
 
       - name: Generate test code for autorest-java
         if: ${{ inputs.scope == 'all' || inputs.scope == 'autorest' }}

--- a/typespec-tests/Setup.ps1
+++ b/typespec-tests/Setup.ps1
@@ -4,7 +4,7 @@ param (
 )
 
 if ($RebuildJar) {
-    mvn clean install package -f ../pom.xml -Plocal -Ptsp -DskipTests
+    mvn clean install -f ../pom.xml -P local,tsp -DskipTests "-Djacoco.skip"
     if ($LASTEXITCODE -ne 0) {
         exit $LASTEXITCODE
     }

--- a/typespec-tests/package.json
+++ b/typespec-tests/package.json
@@ -24,6 +24,7 @@
     "@typespec/http": ">=0.49.0 <1.0.0",
     "@typespec/rest": ">=0.49.0 <1.0.0",
     "@typespec/versioning": ">=0.49.0 <1.0.0",
+    "@typespec/openapi": ">=0.49.0 <1.0.0",
     "@azure-tools/typespec-azure-core": ">=0.35.0 <1.0.0",
     "@azure-tools/typespec-client-generator-core": ">=0.35.0 <1.0.0"
   },


### PR DESCRIPTION
The override on "@typespec/openapi" is for "@azure-tools/typespec-azure-resource-manager", which depends on openapi

@XiaofeiCao Do we really need "@azure-tools/typespec-azure-resource-manager" at present?