### PR TITLE
mpg, support lro

### DIFF
--- a/typespec-extension/package.json
+++ b/typespec-extension/package.json
@@ -50,9 +50,7 @@
     "@typespec/openapi": ">=0.50.0 <1.0.0",
     "@typespec/versioning": ">=0.50.0 <1.0.0",
     "@azure-tools/typespec-azure-core": ">=0.36.0 <1.0.0",
-    "@azure-tools/typespec-providerhub": ">=0.36.0 <1.0.0",
-    "@azure-tools/typespec-client-generator-core": ">=0.36.0 <1.0.0",
-    "@azure-tools/typespec-azure-resource-manager": ">=0.36.0 <1.0.0"
+    "@azure-tools/typespec-client-generator-core": ">=0.36.0 <1.0.0"
   },
   "dependencies": {
     "@autorest/codemodel": "~4.19.3",

--- a/typespec-extension/src/common/code-model.ts
+++ b/typespec-extension/src/common/code-model.ts
@@ -20,7 +20,7 @@ export interface CodeModel extends Metadata {
 
   clients: Array<Client>;
 
-  arm: boolean;
+  arm?: boolean;
 }
 
 export class CodeModel extends Metadata implements CodeModel {

--- a/typespec-extension/src/common/code-model.ts
+++ b/typespec-extension/src/common/code-model.ts
@@ -19,6 +19,8 @@ export interface CodeModel extends Metadata {
   security: Security;
 
   clients: Array<Client>;
+
+  arm: boolean;
 }
 
 export class CodeModel extends Metadata implements CodeModel {

--- a/typespec-extension/src/emitter.ts
+++ b/typespec-extension/src/emitter.ts
@@ -37,7 +37,7 @@ export interface EmitterOptions {
   "custom-types-subpackage"?: string;
   "customization-class"?: string;
 
-  "fluent"?: string;
+  "arm"?: boolean;
 
   "dev-options"?: DevOptions;
 }
@@ -81,7 +81,7 @@ const EmitterOptionsSchema: JSONSchemaType<EmitterOptions> = {
     "custom-types-subpackage": { type: "string", nullable: true },
     "customization-class": { type: "string", nullable: true },
 
-    "fluent": { type: "string", nullable: true },
+    "arm": { type: "boolean", nullable: true },
 
     "dev-options": { type: "object", additionalProperties: true, nullable: true },
   },
@@ -108,6 +108,8 @@ export async function $onEmit(context: EmitContext<EmitterOptions>) {
 
     const outputPath = options["output-dir"] ?? context.emitterOutputDir;
     options["output-dir"] = getNormalizedAbsolutePath(outputPath, undefined);
+
+    options["arm"] = codeModel.arm;
 
     const codeModelFileName = resolvePath(outputPath, "./code-model.yaml");
 

--- a/typespec-extension/src/main/java/com/azure/autorest/fluent/TypeSpecFluentPlugin.java
+++ b/typespec-extension/src/main/java/com/azure/autorest/fluent/TypeSpecFluentPlugin.java
@@ -46,8 +46,8 @@ public class TypeSpecFluentPlugin extends FluentGen {
         if (emitterOptions.getGenerateTests() != null) {
             SETTINGS_MAP.put("generate-tests", emitterOptions.getGenerateTests());
         }
-        if (emitterOptions.getFluent() != null) {
-            SETTINGS_MAP.put("fluent", emitterOptions.getFluent());
+        if (emitterOptions.getArm()) {
+            SETTINGS_MAP.put("fluent", "lite");
         }
         SETTINGS_MAP.put("sdk-integration", sdkIntegration);
 

--- a/typespec-extension/src/main/java/com/azure/typespec/Main.java
+++ b/typespec-extension/src/main/java/com/azure/typespec/Main.java
@@ -87,10 +87,10 @@ public class Main {
             }
         }
 
-        if (emitterOptions.getFluent() == null) {
-            handleDPG(codeModel, emitterOptions, sdkIntegration, outputDir);
-        } else {
+        if (emitterOptions.getArm()) {
             handleFluent(codeModel, emitterOptions, sdkIntegration);
+        } else {
+            handleDPG(codeModel, emitterOptions, sdkIntegration, outputDir);
         }
     }
 

--- a/typespec-extension/src/main/java/com/azure/typespec/model/EmitterOptions.java
+++ b/typespec-extension/src/main/java/com/azure/typespec/model/EmitterOptions.java
@@ -55,8 +55,8 @@ public class EmitterOptions {
     @JsonProperty(value="customization-class")
     private String customizationClass;
 
-    @JsonProperty(value = "fluent")
-    private String fluent;
+    @JsonProperty(value = "arm")
+    private Boolean arm = false;
 
     public String getNamespace() {
         return namespace;
@@ -120,8 +120,8 @@ public class EmitterOptions {
         return branded;
     }
 
-    public String getFluent() {
-        return fluent;
+    public Boolean getArm() {
+        return arm;
     }
 
     public static class EmptyStringToNullDeserializer extends JsonDeserializer<String> {


### PR DESCRIPTION
1. When @extension("x-ms-long-running-operation") is present on operation, add x-ms-long-running-operation to operation code model.
2. Switch `fluent` to `arm` in `EmitterOptions`.
3. Remove `typespec-azure-resource-manager` and `typespec-providerhub` from dependencies.

generated LRO method: 
```java
@ServiceMethod(returns = ReturnType.SINGLE)
    private Mono<TrackedResourceAssociationPropertiesInner> createOrUpdateAsync(String subscriptionId,
        String resourceGroupName, String trafficControllerName, String associationName, AssociationInner resource) {
        return beginCreateOrUpdateAsync(subscriptionId, resourceGroupName, trafficControllerName, associationName,
            resource).last().flatMap(this::getLroFinalResultOrError);
    }

```
