### PR TITLE
tsp, drop PollResult from core-experimental, use PollOperationDetails in core

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
@@ -494,6 +494,9 @@ public class ClassType implements IType {
     public static final ClassType KeyCredentialTrait = getClassTypeBuilder(com.azure.core.client.traits.KeyCredentialTrait.class)
         .build();
 
+    public static final ClassType PollOperationDetails = getClassTypeBuilder(com.azure.core.util.polling.PollOperationDetails.class)
+        .build();
+
     public static final ClassType JsonSerializable = getClassTypeBuilder(com.azure.json.JsonSerializable.class)
         .build();
 

--- a/javagen/src/main/java/com/azure/autorest/util/SchemaUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/SchemaUtil.java
@@ -267,18 +267,14 @@ public class SchemaUtil {
                         && compositeType.getLanguage().getJava().getNamespace() != null) {
 
                     // https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/core/azure-core-experimental/src/main/java/com/azure/core/experimental/models/PollResult.java
-                    if ("PollResult".equals(name)
-                        && compositeType.getLanguage().getJava().getNamespace().startsWith("com.azure.core")) {
-                        classType = new ClassType.Builder()
-                            .name(name)
-                            .packageName(compositeType.getLanguage().getJava().getNamespace())
-                            .usedInXml(treatAsXml(compositeType))
-                            .build();
+                    if (ClassType.PollOperationDetails.getName().equals(name)
+                        && Objects.equals(compositeType.getLanguage().getJava().getNamespace(), ClassType.PollOperationDetails.getPackage())) {
+                        classType = ClassType.PollOperationDetails;
                     } else if (Objects.equals(name, ClassType.RequestConditions.getName())
-                            && Objects.equals(compositeType.getLanguage().getJava().getNamespace(), "com.azure.core.http")) {
+                        && Objects.equals(compositeType.getLanguage().getJava().getNamespace(), ClassType.RequestConditions.getPackage())) {
                         classType = ClassType.RequestConditions;
                     } else if (Objects.equals(name, ClassType.MatchConditions.getName())
-                            && Objects.equals(compositeType.getLanguage().getJava().getNamespace(), "com.azure.core.http")) {
+                        && Objects.equals(compositeType.getLanguage().getJava().getNamespace(), ClassType.RequestConditions.getPackage())) {
                         classType = ClassType.MatchConditions;
                     }
                 }

--- a/javagen/src/main/java/com/azure/autorest/util/SchemaUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/SchemaUtil.java
@@ -267,7 +267,7 @@ public class SchemaUtil {
                         && compositeType.getLanguage().getJava().getNamespace() != null) {
 
                     // https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/core/azure-core-experimental/src/main/java/com/azure/core/experimental/models/PollResult.java
-                    if (ClassType.PollOperationDetails.getName().equals(name)
+                    if (Objects.equals(name, ClassType.PollOperationDetails.getName())
                         && Objects.equals(compositeType.getLanguage().getJava().getNamespace(), ClassType.PollOperationDetails.getPackage())) {
                         classType = ClassType.PollOperationDetails;
                     } else if (Objects.equals(name, ClassType.RequestConditions.getName())

--- a/typespec-extension/src/code-model-builder.ts
+++ b/typespec-extension/src/code-model-builder.ts
@@ -123,7 +123,7 @@ import { LongRunningMetadata } from "./common/long-running-metadata.js";
 import { DurationSchema } from "./common/schemas/time.js";
 import { PreNamer } from "./prenamer/prenamer.js";
 import { EmitterOptions } from "./emitter.js";
-import { createPollResultSchema } from "./external-schemas.js";
+import { createPollOperationDetailsSchema } from "./external-schemas.js";
 import { ClientContext } from "./models.js";
 import {
   stringArrayContainsIgnoreCase,
@@ -2459,7 +2459,7 @@ export class CodeModelBuilder {
   get pollResultSchema(): ObjectSchema {
     return (
       this._pollResultSchema ??
-      (this._pollResultSchema = createPollResultSchema(this.codeModel.schemas, this.stringSchema))
+      (this._pollResultSchema = createPollOperationDetailsSchema(this.codeModel.schemas, this.stringSchema))
     );
   }
 

--- a/typespec-extension/src/external-schemas.ts
+++ b/typespec-extension/src/external-schemas.ts
@@ -55,19 +55,23 @@ export function createResponseErrorSchema(schemas: Schemas, stringSchema: String
   return responseErrorSchema;
 }
 
-export function createPollResultSchema(schemas: Schemas, stringSchema: StringSchema): ObjectSchema {
-  const pollResultSchema = new ObjectSchema("PollResult", "Status details for long running operations", {
-    language: {
-      default: {
-        namespace: "Azure.Core.Foundations",
-      },
-      java: {
-        namespace: "com.azure.core.experimental.models",
+export function createPollOperationDetailsSchema(schemas: Schemas, stringSchema: StringSchema): ObjectSchema {
+  const pollOperationDetailsSchema = new ObjectSchema(
+    "PollOperationDetails",
+    "Status details for long running operations",
+    {
+      language: {
+        default: {
+          namespace: "Azure.Core.Foundations",
+        },
+        java: {
+          namespace: "com.azure.core.util.polling",
+        },
       },
     },
-  });
-  schemas.add(pollResultSchema);
-  pollResultSchema.addProperty(
+  );
+  schemas.add(pollOperationDetailsSchema);
+  pollOperationDetailsSchema.addProperty(
     new Property("operationId", "The unique ID of the operation.", stringSchema, {
       serializedName: "id",
       required: true,
@@ -75,7 +79,7 @@ export function createPollResultSchema(schemas: Schemas, stringSchema: StringSch
       readOnly: true,
     }),
   );
-  pollResultSchema.addProperty(
+  pollOperationDetailsSchema.addProperty(
     new Property("status", "The status of the operation.", stringSchema, {
       serializedName: "status",
       required: true,
@@ -84,7 +88,7 @@ export function createPollResultSchema(schemas: Schemas, stringSchema: StringSch
     }),
   );
   const responseErrorSchema = createResponseErrorSchema(schemas, stringSchema);
-  pollResultSchema.addProperty(
+  pollOperationDetailsSchema.addProperty(
     new Property("error", 'Error object that describes the error when status is "Failed".', responseErrorSchema, {
       serializedName: "error",
       required: false,
@@ -97,5 +101,5 @@ export function createPollResultSchema(schemas: Schemas, stringSchema: StringSch
       },
     }),
   );
-  return pollResultSchema;
+  return pollOperationDetailsSchema;
 }

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/lro/rpc/RpcAsyncClient.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/lro/rpc/RpcAsyncClient.java
@@ -15,9 +15,9 @@ import com.azure.core.exception.ClientAuthenticationException;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
-import com.azure.core.experimental.models.PollResult;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.polling.PollOperationDetails;
 import com.azure.core.util.polling.PollerFlux;
 
 /**
@@ -95,7 +95,7 @@ public final class RpcAsyncClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public PollerFlux<PollResult, GenerationResult> beginLongRunningRpc(GenerationOptions generationOptions) {
+    public PollerFlux<PollOperationDetails, GenerationResult> beginLongRunningRpc(GenerationOptions generationOptions) {
         // Generated convenience method for beginLongRunningRpcWithModel
         RequestOptions requestOptions = new RequestOptions();
         return serviceClient.beginLongRunningRpcWithModelAsync(BinaryData.fromObject(generationOptions),

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/lro/rpc/RpcClient.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/lro/rpc/RpcClient.java
@@ -15,9 +15,9 @@ import com.azure.core.exception.ClientAuthenticationException;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
-import com.azure.core.experimental.models.PollResult;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.polling.PollOperationDetails;
 import com.azure.core.util.polling.SyncPoller;
 
 /**
@@ -95,7 +95,7 @@ public final class RpcClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<PollResult, GenerationResult> beginLongRunningRpc(GenerationOptions generationOptions) {
+    public SyncPoller<PollOperationDetails, GenerationResult> beginLongRunningRpc(GenerationOptions generationOptions) {
         // Generated convenience method for beginLongRunningRpcWithModel
         RequestOptions requestOptions = new RequestOptions();
         return serviceClient.beginLongRunningRpcWithModel(BinaryData.fromObject(generationOptions), requestOptions);

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/lro/rpc/implementation/RpcClientImpl.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/lro/rpc/implementation/RpcClientImpl.java
@@ -20,7 +20,6 @@ import com.azure.core.exception.ClientAuthenticationException;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
-import com.azure.core.experimental.models.PollResult;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.RetryPolicy;
@@ -31,6 +30,7 @@ import com.azure.core.http.rest.RestProxy;
 import com.azure.core.util.BinaryData;
 import com.azure.core.util.Context;
 import com.azure.core.util.FluxUtil;
+import com.azure.core.util.polling.PollOperationDetails;
 import com.azure.core.util.polling.PollerFlux;
 import com.azure.core.util.polling.PollingStrategyOptions;
 import com.azure.core.util.polling.SyncPoller;
@@ -379,8 +379,8 @@ public final class RpcClientImpl {
      * @return the {@link PollerFlux} for polling of status details for long running operations.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public PollerFlux<PollResult, GenerationResult> beginLongRunningRpcWithModelAsync(BinaryData generationOptions,
-        RequestOptions requestOptions) {
+    public PollerFlux<PollOperationDetails, GenerationResult>
+        beginLongRunningRpcWithModelAsync(BinaryData generationOptions, RequestOptions requestOptions) {
         return PollerFlux.create(Duration.ofSeconds(1),
             () -> this.longRunningRpcWithResponseAsync(generationOptions, requestOptions),
             new com.azure.core.experimental.util.polling.OperationLocationPollingStrategy<>(
@@ -389,7 +389,8 @@ public final class RpcClientImpl {
                     .setContext(requestOptions != null && requestOptions.getContext() != null
                         ? requestOptions.getContext() : Context.NONE)
                     .setServiceVersion(this.getServiceVersion().getVersion())),
-            TypeReference.createInstance(PollResult.class), TypeReference.createInstance(GenerationResult.class));
+            TypeReference.createInstance(PollOperationDetails.class),
+            TypeReference.createInstance(GenerationResult.class));
     }
 
     /**
@@ -429,7 +430,7 @@ public final class RpcClientImpl {
      * @return the {@link SyncPoller} for polling of status details for long running operations.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<PollResult, GenerationResult> beginLongRunningRpcWithModel(BinaryData generationOptions,
+    public SyncPoller<PollOperationDetails, GenerationResult> beginLongRunningRpcWithModel(BinaryData generationOptions,
         RequestOptions requestOptions) {
         return SyncPoller.createPoller(Duration.ofSeconds(1),
             () -> this.longRunningRpcWithResponse(generationOptions, requestOptions),
@@ -439,6 +440,7 @@ public final class RpcClientImpl {
                     .setContext(requestOptions != null && requestOptions.getContext() != null
                         ? requestOptions.getContext() : Context.NONE)
                     .setServiceVersion(this.getServiceVersion().getVersion())),
-            TypeReference.createInstance(PollResult.class), TypeReference.createInstance(GenerationResult.class));
+            TypeReference.createInstance(PollOperationDetails.class),
+            TypeReference.createInstance(GenerationResult.class));
     }
 }

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/lro/standard/StandardAsyncClient.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/lro/standard/StandardAsyncClient.java
@@ -15,9 +15,9 @@ import com.azure.core.exception.ClientAuthenticationException;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
-import com.azure.core.experimental.models.PollResult;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.polling.PollOperationDetails;
 import com.azure.core.util.polling.PollerFlux;
 
 /**
@@ -167,7 +167,7 @@ public final class StandardAsyncClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public PollerFlux<PollResult, User> beginCreateOrReplace(String name, User resource) {
+    public PollerFlux<PollOperationDetails, User> beginCreateOrReplace(String name, User resource) {
         // Generated convenience method for beginCreateOrReplaceWithModel
         RequestOptions requestOptions = new RequestOptions();
         return serviceClient.beginCreateOrReplaceWithModelAsync(name, BinaryData.fromObject(resource), requestOptions);
@@ -189,7 +189,7 @@ public final class StandardAsyncClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public PollerFlux<PollResult, Void> beginDelete(String name) {
+    public PollerFlux<PollOperationDetails, Void> beginDelete(String name) {
         // Generated convenience method for beginDeleteWithModel
         RequestOptions requestOptions = new RequestOptions();
         return serviceClient.beginDeleteWithModelAsync(name, requestOptions);
@@ -212,7 +212,7 @@ public final class StandardAsyncClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public PollerFlux<PollResult, ExportedUser> beginExport(String name, String format) {
+    public PollerFlux<PollOperationDetails, ExportedUser> beginExport(String name, String format) {
         // Generated convenience method for beginExportWithModel
         RequestOptions requestOptions = new RequestOptions();
         return serviceClient.beginExportWithModelAsync(name, format, requestOptions);

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/lro/standard/StandardClient.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/lro/standard/StandardClient.java
@@ -15,9 +15,9 @@ import com.azure.core.exception.ClientAuthenticationException;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
-import com.azure.core.experimental.models.PollResult;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.polling.PollOperationDetails;
 import com.azure.core.util.polling.SyncPoller;
 
 /**
@@ -167,7 +167,7 @@ public final class StandardClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<PollResult, User> beginCreateOrReplace(String name, User resource) {
+    public SyncPoller<PollOperationDetails, User> beginCreateOrReplace(String name, User resource) {
         // Generated convenience method for beginCreateOrReplaceWithModel
         RequestOptions requestOptions = new RequestOptions();
         return serviceClient.beginCreateOrReplaceWithModel(name, BinaryData.fromObject(resource), requestOptions);
@@ -189,7 +189,7 @@ public final class StandardClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<PollResult, Void> beginDelete(String name) {
+    public SyncPoller<PollOperationDetails, Void> beginDelete(String name) {
         // Generated convenience method for beginDeleteWithModel
         RequestOptions requestOptions = new RequestOptions();
         return serviceClient.beginDeleteWithModel(name, requestOptions);
@@ -212,7 +212,7 @@ public final class StandardClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<PollResult, ExportedUser> beginExport(String name, String format) {
+    public SyncPoller<PollOperationDetails, ExportedUser> beginExport(String name, String format) {
         // Generated convenience method for beginExportWithModel
         RequestOptions requestOptions = new RequestOptions();
         return serviceClient.beginExportWithModel(name, format, requestOptions);

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/lro/standard/implementation/StandardClientImpl.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/lro/standard/implementation/StandardClientImpl.java
@@ -24,7 +24,6 @@ import com.azure.core.exception.ClientAuthenticationException;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
-import com.azure.core.experimental.models.PollResult;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.RetryPolicy;
@@ -35,6 +34,7 @@ import com.azure.core.http.rest.RestProxy;
 import com.azure.core.util.BinaryData;
 import com.azure.core.util.Context;
 import com.azure.core.util.FluxUtil;
+import com.azure.core.util.polling.PollOperationDetails;
 import com.azure.core.util.polling.PollerFlux;
 import com.azure.core.util.polling.PollingStrategyOptions;
 import com.azure.core.util.polling.SyncPoller;
@@ -401,7 +401,7 @@ public final class StandardClientImpl {
      * @return the {@link PollerFlux} for polling of details about a user.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public PollerFlux<PollResult, User> beginCreateOrReplaceWithModelAsync(String name, BinaryData resource,
+    public PollerFlux<PollOperationDetails, User> beginCreateOrReplaceWithModelAsync(String name, BinaryData resource,
         RequestOptions requestOptions) {
         return PollerFlux.create(Duration.ofSeconds(1),
             () -> this.createOrReplaceWithResponseAsync(name, resource, requestOptions),
@@ -411,7 +411,7 @@ public final class StandardClientImpl {
                     .setContext(requestOptions != null && requestOptions.getContext() != null
                         ? requestOptions.getContext() : Context.NONE)
                     .setServiceVersion(this.getServiceVersion().getVersion())),
-            TypeReference.createInstance(PollResult.class), TypeReference.createInstance(User.class));
+            TypeReference.createInstance(PollOperationDetails.class), TypeReference.createInstance(User.class));
     }
 
     /**
@@ -447,7 +447,7 @@ public final class StandardClientImpl {
      * @return the {@link SyncPoller} for polling of details about a user.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<PollResult, User> beginCreateOrReplaceWithModel(String name, BinaryData resource,
+    public SyncPoller<PollOperationDetails, User> beginCreateOrReplaceWithModel(String name, BinaryData resource,
         RequestOptions requestOptions) {
         return SyncPoller.createPoller(Duration.ofSeconds(1),
             () -> this.createOrReplaceWithResponse(name, resource, requestOptions),
@@ -457,7 +457,7 @@ public final class StandardClientImpl {
                     .setContext(requestOptions != null && requestOptions.getContext() != null
                         ? requestOptions.getContext() : Context.NONE)
                     .setServiceVersion(this.getServiceVersion().getVersion())),
-            TypeReference.createInstance(PollResult.class), TypeReference.createInstance(User.class));
+            TypeReference.createInstance(PollOperationDetails.class), TypeReference.createInstance(User.class));
     }
 
     /**
@@ -649,7 +649,8 @@ public final class StandardClientImpl {
      * @return the {@link PollerFlux} for polling of provides status details for long running operations.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public PollerFlux<PollResult, Void> beginDeleteWithModelAsync(String name, RequestOptions requestOptions) {
+    public PollerFlux<PollOperationDetails, Void> beginDeleteWithModelAsync(String name,
+        RequestOptions requestOptions) {
         return PollerFlux.create(Duration.ofSeconds(1), () -> this.deleteWithResponseAsync(name, requestOptions),
             new com.azure.core.experimental.util.polling.OperationLocationPollingStrategy<>(
                 new PollingStrategyOptions(this.getHttpPipeline())
@@ -657,7 +658,7 @@ public final class StandardClientImpl {
                     .setContext(requestOptions != null && requestOptions.getContext() != null
                         ? requestOptions.getContext() : Context.NONE)
                     .setServiceVersion(this.getServiceVersion().getVersion())),
-            TypeReference.createInstance(PollResult.class), TypeReference.createInstance(Void.class));
+            TypeReference.createInstance(PollOperationDetails.class), TypeReference.createInstance(Void.class));
     }
 
     /**
@@ -691,7 +692,7 @@ public final class StandardClientImpl {
      * @return the {@link SyncPoller} for polling of provides status details for long running operations.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<PollResult, Void> beginDeleteWithModel(String name, RequestOptions requestOptions) {
+    public SyncPoller<PollOperationDetails, Void> beginDeleteWithModel(String name, RequestOptions requestOptions) {
         return SyncPoller.createPoller(Duration.ofSeconds(1), () -> this.deleteWithResponse(name, requestOptions),
             new com.azure.core.experimental.util.polling.SyncOperationLocationPollingStrategy<>(
                 new PollingStrategyOptions(this.getHttpPipeline())
@@ -699,7 +700,7 @@ public final class StandardClientImpl {
                     .setContext(requestOptions != null && requestOptions.getContext() != null
                         ? requestOptions.getContext() : Context.NONE)
                     .setServiceVersion(this.getServiceVersion().getVersion())),
-            TypeReference.createInstance(PollResult.class), TypeReference.createInstance(Void.class));
+            TypeReference.createInstance(PollOperationDetails.class), TypeReference.createInstance(Void.class));
     }
 
     /**
@@ -901,7 +902,7 @@ public final class StandardClientImpl {
      * @return the {@link PollerFlux} for polling of status details for long running operations.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public PollerFlux<PollResult, ExportedUser> beginExportWithModelAsync(String name, String format,
+    public PollerFlux<PollOperationDetails, ExportedUser> beginExportWithModelAsync(String name, String format,
         RequestOptions requestOptions) {
         return PollerFlux.create(Duration.ofSeconds(1),
             () -> this.exportWithResponseAsync(name, format, requestOptions),
@@ -911,7 +912,7 @@ public final class StandardClientImpl {
                     .setContext(requestOptions != null && requestOptions.getContext() != null
                         ? requestOptions.getContext() : Context.NONE)
                     .setServiceVersion(this.getServiceVersion().getVersion())),
-            TypeReference.createInstance(PollResult.class), TypeReference.createInstance(ExportedUser.class));
+            TypeReference.createInstance(PollOperationDetails.class), TypeReference.createInstance(ExportedUser.class));
     }
 
     /**
@@ -946,7 +947,7 @@ public final class StandardClientImpl {
      * @return the {@link SyncPoller} for polling of status details for long running operations.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<PollResult, ExportedUser> beginExportWithModel(String name, String format,
+    public SyncPoller<PollOperationDetails, ExportedUser> beginExportWithModel(String name, String format,
         RequestOptions requestOptions) {
         return SyncPoller.createPoller(Duration.ofSeconds(1),
             () -> this.exportWithResponse(name, format, requestOptions),
@@ -956,6 +957,6 @@ public final class StandardClientImpl {
                     .setContext(requestOptions != null && requestOptions.getContext() != null
                         ? requestOptions.getContext() : Context.NONE)
                     .setServiceVersion(this.getServiceVersion().getVersion())),
-            TypeReference.createInstance(PollResult.class), TypeReference.createInstance(ExportedUser.class));
+            TypeReference.createInstance(PollOperationDetails.class), TypeReference.createInstance(ExportedUser.class));
     }
 }

--- a/typespec-tests/src/main/java/com/cadl/protocolandconvenient/ProtocolAndConvenientAsyncClient.java
+++ b/typespec-tests/src/main/java/com/cadl/protocolandconvenient/ProtocolAndConvenientAsyncClient.java
@@ -12,7 +12,6 @@ import com.azure.core.exception.ClientAuthenticationException;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
-import com.azure.core.experimental.models.PollResult;
 import com.azure.core.http.rest.PagedFlux;
 import com.azure.core.http.rest.PagedResponse;
 import com.azure.core.http.rest.PagedResponseBase;
@@ -20,6 +19,7 @@ import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
 import com.azure.core.util.FluxUtil;
+import com.azure.core.util.polling.PollOperationDetails;
 import com.azure.core.util.polling.PollerFlux;
 import com.cadl.protocolandconvenient.implementation.ProtocolAndConvenientClientImpl;
 import com.cadl.protocolandconvenient.models.ResourceA;
@@ -334,7 +334,7 @@ public final class ProtocolAndConvenientAsyncClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public PollerFlux<PollResult, ResourceI> beginCreateOrReplace(String name, ResourceI resource) {
+    public PollerFlux<PollOperationDetails, ResourceI> beginCreateOrReplace(String name, ResourceI resource) {
         // Generated convenience method for beginCreateOrReplaceWithModel
         RequestOptions requestOptions = new RequestOptions();
         return serviceClient.beginCreateOrReplaceWithModelAsync(name, BinaryData.fromObject(resource), requestOptions);

--- a/typespec-tests/src/main/java/com/cadl/protocolandconvenient/ProtocolAndConvenientClient.java
+++ b/typespec-tests/src/main/java/com/cadl/protocolandconvenient/ProtocolAndConvenientClient.java
@@ -12,11 +12,11 @@ import com.azure.core.exception.ClientAuthenticationException;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
-import com.azure.core.experimental.models.PollResult;
 import com.azure.core.http.rest.PagedIterable;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.polling.PollOperationDetails;
 import com.azure.core.util.polling.SyncPoller;
 import com.cadl.protocolandconvenient.implementation.ProtocolAndConvenientClientImpl;
 import com.cadl.protocolandconvenient.models.ResourceA;
@@ -327,7 +327,7 @@ public final class ProtocolAndConvenientClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<PollResult, ResourceI> beginCreateOrReplace(String name, ResourceI resource) {
+    public SyncPoller<PollOperationDetails, ResourceI> beginCreateOrReplace(String name, ResourceI resource) {
         // Generated convenience method for beginCreateOrReplaceWithModel
         RequestOptions requestOptions = new RequestOptions();
         return serviceClient.beginCreateOrReplaceWithModel(name, BinaryData.fromObject(resource), requestOptions);

--- a/typespec-tests/src/main/java/com/cadl/protocolandconvenient/implementation/ProtocolAndConvenientClientImpl.java
+++ b/typespec-tests/src/main/java/com/cadl/protocolandconvenient/implementation/ProtocolAndConvenientClientImpl.java
@@ -22,7 +22,6 @@ import com.azure.core.exception.ClientAuthenticationException;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
-import com.azure.core.experimental.models.PollResult;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.RetryPolicy;
@@ -38,6 +37,7 @@ import com.azure.core.util.BinaryData;
 import com.azure.core.util.Context;
 import com.azure.core.util.FluxUtil;
 import com.azure.core.util.UrlBuilder;
+import com.azure.core.util.polling.PollOperationDetails;
 import com.azure.core.util.polling.PollerFlux;
 import com.azure.core.util.polling.PollingStrategyOptions;
 import com.azure.core.util.polling.SyncPoller;
@@ -800,8 +800,8 @@ public final class ProtocolAndConvenientClientImpl {
      * @return the {@link PollerFlux} for polling of long-running operation.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public PollerFlux<PollResult, ResourceI> beginCreateOrReplaceWithModelAsync(String name, BinaryData resource,
-        RequestOptions requestOptions) {
+    public PollerFlux<PollOperationDetails, ResourceI> beginCreateOrReplaceWithModelAsync(String name,
+        BinaryData resource, RequestOptions requestOptions) {
         return PollerFlux.create(Duration.ofSeconds(1),
             () -> this.createOrReplaceWithResponseAsync(name, resource, requestOptions),
             new com.azure.core.experimental.util.polling.OperationLocationPollingStrategy<>(
@@ -810,7 +810,7 @@ public final class ProtocolAndConvenientClientImpl {
                     .setContext(requestOptions != null && requestOptions.getContext() != null
                         ? requestOptions.getContext() : Context.NONE)
                     .setServiceVersion(this.getServiceVersion().getVersion())),
-            TypeReference.createInstance(PollResult.class), TypeReference.createInstance(ResourceI.class));
+            TypeReference.createInstance(PollOperationDetails.class), TypeReference.createInstance(ResourceI.class));
     }
 
     /**
@@ -846,7 +846,7 @@ public final class ProtocolAndConvenientClientImpl {
      * @return the {@link SyncPoller} for polling of long-running operation.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<PollResult, ResourceI> beginCreateOrReplaceWithModel(String name, BinaryData resource,
+    public SyncPoller<PollOperationDetails, ResourceI> beginCreateOrReplaceWithModel(String name, BinaryData resource,
         RequestOptions requestOptions) {
         return SyncPoller.createPoller(Duration.ofSeconds(1),
             () -> this.createOrReplaceWithResponse(name, resource, requestOptions),
@@ -856,7 +856,7 @@ public final class ProtocolAndConvenientClientImpl {
                     .setContext(requestOptions != null && requestOptions.getContext() != null
                         ? requestOptions.getContext() : Context.NONE)
                     .setServiceVersion(this.getServiceVersion().getVersion())),
-            TypeReference.createInstance(PollResult.class), TypeReference.createInstance(ResourceI.class));
+            TypeReference.createInstance(PollOperationDetails.class), TypeReference.createInstance(ResourceI.class));
     }
 
     /**

--- a/typespec-tests/src/main/java/com/cadl/union/UnionAsyncClient.java
+++ b/typespec-tests/src/main/java/com/cadl/union/UnionAsyncClient.java
@@ -12,11 +12,11 @@ import com.azure.core.exception.ClientAuthenticationException;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
-import com.azure.core.experimental.models.PollResult;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
 import com.azure.core.util.FluxUtil;
+import com.azure.core.util.polling.PollOperationDetails;
 import com.azure.core.util.polling.PollerFlux;
 import com.cadl.union.implementation.UnionClientImpl;
 import com.cadl.union.models.Result;
@@ -329,7 +329,7 @@ public final class UnionAsyncClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public PollerFlux<PollResult, Result> beginGenerate() {
+    public PollerFlux<PollOperationDetails, Result> beginGenerate() {
         // Generated convenience method for beginGenerateWithModel
         RequestOptions requestOptions = new RequestOptions();
         return serviceClient.beginGenerateWithModelAsync(requestOptions);

--- a/typespec-tests/src/main/java/com/cadl/union/UnionClient.java
+++ b/typespec-tests/src/main/java/com/cadl/union/UnionClient.java
@@ -12,10 +12,10 @@ import com.azure.core.exception.ClientAuthenticationException;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
-import com.azure.core.experimental.models.PollResult;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.polling.PollOperationDetails;
 import com.azure.core.util.polling.SyncPoller;
 import com.cadl.union.implementation.UnionClientImpl;
 import com.cadl.union.models.Result;
@@ -322,7 +322,7 @@ public final class UnionClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<PollResult, Result> beginGenerate() {
+    public SyncPoller<PollOperationDetails, Result> beginGenerate() {
         // Generated convenience method for beginGenerateWithModel
         RequestOptions requestOptions = new RequestOptions();
         return serviceClient.beginGenerateWithModel(requestOptions);

--- a/typespec-tests/src/main/java/com/cadl/union/implementation/UnionClientImpl.java
+++ b/typespec-tests/src/main/java/com/cadl/union/implementation/UnionClientImpl.java
@@ -20,7 +20,6 @@ import com.azure.core.exception.ClientAuthenticationException;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
-import com.azure.core.experimental.models.PollResult;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.RetryPolicy;
@@ -31,6 +30,7 @@ import com.azure.core.http.rest.RestProxy;
 import com.azure.core.util.BinaryData;
 import com.azure.core.util.Context;
 import com.azure.core.util.FluxUtil;
+import com.azure.core.util.polling.PollOperationDetails;
 import com.azure.core.util.polling.PollerFlux;
 import com.azure.core.util.polling.PollingStrategyOptions;
 import com.azure.core.util.polling.SyncPoller;
@@ -642,7 +642,7 @@ public final class UnionClientImpl {
      * @return the {@link PollerFlux} for polling of status details for long running operations.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public PollerFlux<PollResult, Result> beginGenerateWithModelAsync(RequestOptions requestOptions) {
+    public PollerFlux<PollOperationDetails, Result> beginGenerateWithModelAsync(RequestOptions requestOptions) {
         return PollerFlux.create(Duration.ofSeconds(1), () -> this.generateWithResponseAsync(requestOptions),
             new com.azure.core.experimental.util.polling.OperationLocationPollingStrategy<>(
                 new PollingStrategyOptions(this.getHttpPipeline())
@@ -650,7 +650,7 @@ public final class UnionClientImpl {
                     .setContext(requestOptions != null && requestOptions.getContext() != null
                         ? requestOptions.getContext() : Context.NONE)
                     .setServiceVersion(this.getServiceVersion().getVersion())),
-            TypeReference.createInstance(PollResult.class), TypeReference.createInstance(Result.class));
+            TypeReference.createInstance(PollOperationDetails.class), TypeReference.createInstance(Result.class));
     }
 
     /**
@@ -681,7 +681,7 @@ public final class UnionClientImpl {
      * @return the {@link SyncPoller} for polling of status details for long running operations.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<PollResult, Result> beginGenerateWithModel(RequestOptions requestOptions) {
+    public SyncPoller<PollOperationDetails, Result> beginGenerateWithModel(RequestOptions requestOptions) {
         return SyncPoller.createPoller(Duration.ofSeconds(1), () -> this.generateWithResponse(requestOptions),
             new com.azure.core.experimental.util.polling.SyncOperationLocationPollingStrategy<>(
                 new PollingStrategyOptions(this.getHttpPipeline())
@@ -689,6 +689,6 @@ public final class UnionClientImpl {
                     .setContext(requestOptions != null && requestOptions.getContext() != null
                         ? requestOptions.getContext() : Context.NONE)
                     .setServiceVersion(this.getServiceVersion().getVersion())),
-            TypeReference.createInstance(PollResult.class), TypeReference.createInstance(Result.class));
+            TypeReference.createInstance(PollOperationDetails.class), TypeReference.createInstance(Result.class));
     }
 }

--- a/typespec-tests/src/main/java/com/cadl/versioning/VersioningAsyncClient.java
+++ b/typespec-tests/src/main/java/com/cadl/versioning/VersioningAsyncClient.java
@@ -12,12 +12,12 @@ import com.azure.core.exception.ClientAuthenticationException;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
-import com.azure.core.experimental.models.PollResult;
 import com.azure.core.http.rest.PagedFlux;
 import com.azure.core.http.rest.PagedResponse;
 import com.azure.core.http.rest.PagedResponseBase;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.polling.PollOperationDetails;
 import com.azure.core.util.polling.PollerFlux;
 import com.cadl.versioning.implementation.VersioningClientImpl;
 import com.cadl.versioning.models.ExportedResource;
@@ -172,7 +172,7 @@ public final class VersioningAsyncClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public PollerFlux<PollResult, ExportedResource> beginExport(String name, String projectFileVersion,
+    public PollerFlux<PollOperationDetails, ExportedResource> beginExport(String name, String projectFileVersion,
         String projectedFileFormat) {
         // Generated convenience method for beginExportWithModel
         RequestOptions requestOptions = new RequestOptions();
@@ -204,7 +204,7 @@ public final class VersioningAsyncClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public PollerFlux<PollResult, ExportedResource> beginExport(String name, String projectFileVersion) {
+    public PollerFlux<PollOperationDetails, ExportedResource> beginExport(String name, String projectFileVersion) {
         // Generated convenience method for beginExportWithModel
         RequestOptions requestOptions = new RequestOptions();
         if (projectFileVersion != null) {
@@ -227,7 +227,7 @@ public final class VersioningAsyncClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public PollerFlux<PollResult, ExportedResource> beginExport(String name) {
+    public PollerFlux<PollOperationDetails, ExportedResource> beginExport(String name) {
         // Generated convenience method for beginExportWithModel
         RequestOptions requestOptions = new RequestOptions();
         return serviceClient.beginExportWithModelAsync(name, requestOptions);

--- a/typespec-tests/src/main/java/com/cadl/versioning/VersioningClient.java
+++ b/typespec-tests/src/main/java/com/cadl/versioning/VersioningClient.java
@@ -12,11 +12,11 @@ import com.azure.core.exception.ClientAuthenticationException;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
-import com.azure.core.experimental.models.PollResult;
 import com.azure.core.http.rest.PagedIterable;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.util.BinaryData;
 import com.azure.core.util.logging.ClientLogger;
+import com.azure.core.util.polling.PollOperationDetails;
 import com.azure.core.util.polling.SyncPoller;
 import com.cadl.versioning.implementation.VersioningClientImpl;
 import com.cadl.versioning.models.ExportedResource;
@@ -169,7 +169,7 @@ public final class VersioningClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<PollResult, ExportedResource> beginExport(String name, String projectFileVersion,
+    public SyncPoller<PollOperationDetails, ExportedResource> beginExport(String name, String projectFileVersion,
         String projectedFileFormat) {
         // Generated convenience method for beginExportWithModel
         RequestOptions requestOptions = new RequestOptions();
@@ -201,7 +201,7 @@ public final class VersioningClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<PollResult, ExportedResource> beginExport(String name, String projectFileVersion) {
+    public SyncPoller<PollOperationDetails, ExportedResource> beginExport(String name, String projectFileVersion) {
         // Generated convenience method for beginExportWithModel
         RequestOptions requestOptions = new RequestOptions();
         if (projectFileVersion != null) {
@@ -224,7 +224,7 @@ public final class VersioningClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<PollResult, ExportedResource> beginExport(String name) {
+    public SyncPoller<PollOperationDetails, ExportedResource> beginExport(String name) {
         // Generated convenience method for beginExportWithModel
         RequestOptions requestOptions = new RequestOptions();
         return serviceClient.beginExportWithModel(name, requestOptions);

--- a/typespec-tests/src/main/java/com/cadl/versioning/implementation/VersioningClientImpl.java
+++ b/typespec-tests/src/main/java/com/cadl/versioning/implementation/VersioningClientImpl.java
@@ -20,7 +20,6 @@ import com.azure.core.exception.ClientAuthenticationException;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
-import com.azure.core.experimental.models.PollResult;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.RetryPolicy;
@@ -35,6 +34,7 @@ import com.azure.core.http.rest.RestProxy;
 import com.azure.core.util.BinaryData;
 import com.azure.core.util.Context;
 import com.azure.core.util.FluxUtil;
+import com.azure.core.util.polling.PollOperationDetails;
 import com.azure.core.util.polling.PollerFlux;
 import com.azure.core.util.polling.PollingStrategyOptions;
 import com.azure.core.util.polling.SyncPoller;
@@ -526,7 +526,7 @@ public final class VersioningClientImpl {
      * @return the {@link PollerFlux} for polling of status details for long running operations.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public PollerFlux<PollResult, ExportedResource> beginExportWithModelAsync(String name,
+    public PollerFlux<PollOperationDetails, ExportedResource> beginExportWithModelAsync(String name,
         RequestOptions requestOptions) {
         return PollerFlux.create(Duration.ofSeconds(1), () -> this.exportWithResponseAsync(name, requestOptions),
             new com.azure.core.experimental.util.polling.OperationLocationPollingStrategy<>(
@@ -535,7 +535,8 @@ public final class VersioningClientImpl {
                     .setContext(requestOptions != null && requestOptions.getContext() != null
                         ? requestOptions.getContext() : Context.NONE)
                     .setServiceVersion(this.getServiceVersion().getVersion())),
-            TypeReference.createInstance(PollResult.class), TypeReference.createInstance(ExportedResource.class));
+            TypeReference.createInstance(PollOperationDetails.class),
+            TypeReference.createInstance(ExportedResource.class));
     }
 
     /**
@@ -592,7 +593,8 @@ public final class VersioningClientImpl {
      * @return the {@link SyncPoller} for polling of status details for long running operations.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<PollResult, ExportedResource> beginExportWithModel(String name, RequestOptions requestOptions) {
+    public SyncPoller<PollOperationDetails, ExportedResource> beginExportWithModel(String name,
+        RequestOptions requestOptions) {
         return SyncPoller.createPoller(Duration.ofSeconds(1), () -> this.exportWithResponse(name, requestOptions),
             new com.azure.core.experimental.util.polling.SyncOperationLocationPollingStrategy<>(
                 new PollingStrategyOptions(this.getHttpPipeline())
@@ -600,7 +602,8 @@ public final class VersioningClientImpl {
                     .setContext(requestOptions != null && requestOptions.getContext() != null
                         ? requestOptions.getContext() : Context.NONE)
                     .setServiceVersion(this.getServiceVersion().getVersion())),
-            TypeReference.createInstance(PollResult.class), TypeReference.createInstance(ExportedResource.class));
+            TypeReference.createInstance(PollOperationDetails.class),
+            TypeReference.createInstance(ExportedResource.class));
     }
 
     /**

--- a/typespec-tests/src/test/java/com/_specs_/azure/core/lro/rpc/RpcTests.java
+++ b/typespec-tests/src/test/java/com/_specs_/azure/core/lro/rpc/RpcTests.java
@@ -5,10 +5,10 @@ package com._specs_.azure.core.lro.rpc;
 
 import com._specs_.azure.core.lro.rpc.models.GenerationOptions;
 import com._specs_.azure.core.lro.rpc.models.GenerationResult;
-import com.azure.core.experimental.models.PollResult;
 import com.azure.core.http.policy.HttpLogDetailLevel;
 import com.azure.core.http.policy.HttpLogOptions;
 import com.azure.core.util.polling.LongRunningOperationStatus;
+import com.azure.core.util.polling.PollOperationDetails;
 import com.azure.core.util.polling.PollResponse;
 import com.azure.core.util.polling.SyncPoller;
 import org.junit.jupiter.api.Assertions;
@@ -22,9 +22,9 @@ public class RpcTests {
 
     @Test
     public void testRpc() {
-        SyncPoller<PollResult, GenerationResult> poller = client.beginLongRunningRpc(new GenerationOptions("text"));
+        SyncPoller<PollOperationDetails, GenerationResult> poller = client.beginLongRunningRpc(new GenerationOptions("text"));
 
-        PollResponse<PollResult> response = poller.waitForCompletion();
+        PollResponse<PollOperationDetails> response = poller.waitForCompletion();
 
         Assertions.assertEquals(LongRunningOperationStatus.SUCCESSFULLY_COMPLETED, response.getStatus());
         Assertions.assertEquals("operation1", response.getValue().getOperationId());

--- a/typespec-tests/src/test/java/com/_specs_/azure/core/lro/standard/LroCoreTests.java
+++ b/typespec-tests/src/test/java/com/_specs_/azure/core/lro/standard/LroCoreTests.java
@@ -5,11 +5,11 @@ package com._specs_.azure.core.lro.standard;
 
 import com._specs_.azure.core.lro.standard.models.ExportedUser;
 import com._specs_.azure.core.lro.standard.models.User;
-import com.azure.core.experimental.models.PollResult;
 import com.azure.core.http.policy.HttpLogDetailLevel;
 import com.azure.core.http.policy.HttpLogOptions;
 import com.azure.core.util.BinaryData;
 import com.azure.core.util.polling.LongRunningOperationStatus;
+import com.azure.core.util.polling.PollOperationDetails;
 import com.azure.core.util.polling.PollResponse;
 import com.azure.core.util.polling.SyncPoller;
 
@@ -24,10 +24,10 @@ public class LroCoreTests {
 
     @Test
     public void testPut() {
-        SyncPoller<PollResult, User> poller = client.beginCreateOrReplace(
+        SyncPoller<PollOperationDetails, User> poller = client.beginCreateOrReplace(
                 "madge", new User("contributor"));
 
-        PollResponse<PollResult> response = poller.waitForCompletion();
+        PollResponse<PollOperationDetails> response = poller.waitForCompletion();
         Assertions.assertEquals(LongRunningOperationStatus.SUCCESSFULLY_COMPLETED, response.getStatus());
 
         User user = poller.getFinalResult();
@@ -49,18 +49,18 @@ public class LroCoreTests {
 
     @Test
     public void testDelete() {
-        SyncPoller<PollResult, Void> poller = client.beginDelete("madge");
+        SyncPoller<PollOperationDetails, Void> poller = client.beginDelete("madge");
 
-        PollResponse<PollResult> response = poller.waitForCompletion();
+        PollResponse<PollOperationDetails> response = poller.waitForCompletion();
         Assertions.assertEquals(LongRunningOperationStatus.SUCCESSFULLY_COMPLETED, response.getStatus());
     }
 
     @Test
     public void testPost() {
-        SyncPoller<PollResult, ExportedUser> poller = client.beginExport(
+        SyncPoller<PollOperationDetails, ExportedUser> poller = client.beginExport(
                 "madge", "json");
 
-        PollResponse<PollResult> response = poller.waitForCompletion();
+        PollResponse<PollOperationDetails> response = poller.waitForCompletion();
         Assertions.assertEquals(LongRunningOperationStatus.SUCCESSFULLY_COMPLETED, response.getStatus());
 
         ExportedUser finalResult = poller.getFinalResult();


### PR DESCRIPTION
`PollResult` moved to azure-core and get renamed to `PollOperationDetails`.