### PR TITLE
bug on pass-discriminator-to-child-deserialization

### DIFF
--- a/vanilla-tests/src/main/java/fixtures/inheritance/passdiscriminator/models/MetricAlertSingleResourceMultipleMetricCriteria.java
+++ b/vanilla-tests/src/main/java/fixtures/inheritance/passdiscriminator/models/MetricAlertSingleResourceMultipleMetricCriteria.java
@@ -27,9 +27,8 @@ public class MetricAlertSingleResourceMultipleMetricCriteria extends MetricAlert
     /*
      * specifies the type of the alert criteria.
      */
-    @JsonTypeId
     @JsonProperty(value = "odata\\.type", required = true)
-    private static final Odatatype ODATA_TYPE
+    private Odatatype ODATA_TYPE
         = Odatatype.MICROSOFT_AZURE_MONITOR_SINGLE_RESOURCE_MULTIPLE_METRIC_CRITERIA;
 
     /*

--- a/vanilla-tests/src/test/java/fixtures/Bug.java
+++ b/vanilla-tests/src/test/java/fixtures/Bug.java
@@ -16,5 +16,11 @@ public class Bug {
         MetricAlertCriteria criteria = new MetricAlertSingleResourceMultipleMetricCriteria();
         String json = BinaryData.fromObject(criteria).toString();
         Assertions.assertTrue(json.contains("SingleResourceMultipleMetricCriteria"));
+
+        criteria = BinaryData.fromString(json).toObject(MetricAlertCriteria.class);
+        Assertions.assertTrue(criteria instanceof MetricAlertCriteria);
+
+        json = "{\"odata.type\": \"invalid\"}";
+        criteria = BinaryData.fromString(json).toObject(MetricAlertCriteria.class);
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/Bug.java
+++ b/vanilla-tests/src/test/java/fixtures/Bug.java
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package fixtures;
+
+import com.azure.core.util.BinaryData;
+import fixtures.inheritance.passdiscriminator.models.MetricAlertCriteria;
+import fixtures.inheritance.passdiscriminator.models.MetricAlertSingleResourceMultipleMetricCriteria;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class Bug {
+
+    @Test
+    public void testSerialization() {
+        MetricAlertCriteria criteria = new MetricAlertSingleResourceMultipleMetricCriteria();
+        String json = BinaryData.fromObject(criteria).toString();
+        Assertions.assertTrue(json.contains("SingleResourceMultipleMetricCriteria"));
+    }
+}


### PR DESCRIPTION
Current generated code seems get confused around

- JsonTypeId https://fasterxml.github.io/jackson-annotations/javadoc/2.9/com/fasterxml/jackson/annotation/JsonTypeId.html
- JsonTypeInfo.As.EXISTING_PROPERTY https://fasterxml.github.io/jackson-annotations/javadoc/2.9/com/fasterxml/jackson/annotation/JsonTypeInfo.As.html
- static var