### PR TITLE
Add test cases for tsp, cadl-ranch Type/Property/Optional

### DIFF
--- a/typespec-tests/src/test/java/com/type/property/optional/BooleanLiteralClientTests.java
+++ b/typespec-tests/src/test/java/com/type/property/optional/BooleanLiteralClientTests.java
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.type.property.optional;
+
+import com.type.property.optional.models.BooleanLiteralProperty;
+import com.type.property.optional.models.BooleanLiteralProperty1;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class BooleanLiteralClientTests {
+    BooleanLiteralClient client = new OptionalClientBuilder().buildBooleanLiteralClient();
+
+    @Test
+    void getAll() {
+        BooleanLiteralProperty booleanLiteralProperty = client.getAll();
+        Assertions.assertEquals(BooleanLiteralProperty1.TRUE, booleanLiteralProperty.getProperty());
+    }
+
+    @Test
+    void getDefault() {
+        BooleanLiteralProperty booleanLiteralProperty = client.getDefault();
+        Assertions.assertNull(booleanLiteralProperty.getProperty());
+    }
+
+    @Test
+    void putAll() {
+        BooleanLiteralProperty booleanLiteralProperty = new BooleanLiteralProperty();
+        booleanLiteralProperty.setProperty(BooleanLiteralProperty1.TRUE);
+        client.putAll(booleanLiteralProperty);
+    }
+
+    @Test
+    void putDefault() {
+        BooleanLiteralProperty booleanLiteralProperty = new BooleanLiteralProperty();
+        client.putDefault(booleanLiteralProperty);
+    }
+}

--- a/typespec-tests/src/test/java/com/type/property/optional/BooleanLiteralClientTests.java
+++ b/typespec-tests/src/test/java/com/type/property/optional/BooleanLiteralClientTests.java
@@ -8,30 +8,30 @@ import com.type.property.optional.models.BooleanLiteralProperty1;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-class BooleanLiteralClientTests {
-    BooleanLiteralClient client = new OptionalClientBuilder().buildBooleanLiteralClient();
+public class BooleanLiteralClientTests {
+    private final BooleanLiteralClient client = new OptionalClientBuilder().buildBooleanLiteralClient();
 
     @Test
-    void getAll() {
+    public void getAll() {
         BooleanLiteralProperty booleanLiteralProperty = client.getAll();
         Assertions.assertEquals(BooleanLiteralProperty1.TRUE, booleanLiteralProperty.getProperty());
     }
 
     @Test
-    void getDefault() {
+    public void getDefault() {
         BooleanLiteralProperty booleanLiteralProperty = client.getDefault();
         Assertions.assertNull(booleanLiteralProperty.getProperty());
     }
 
     @Test
-    void putAll() {
+    public void putAll() {
         BooleanLiteralProperty booleanLiteralProperty = new BooleanLiteralProperty();
         booleanLiteralProperty.setProperty(BooleanLiteralProperty1.TRUE);
         client.putAll(booleanLiteralProperty);
     }
 
     @Test
-    void putDefault() {
+    public void putDefault() {
         BooleanLiteralProperty booleanLiteralProperty = new BooleanLiteralProperty();
         client.putDefault(booleanLiteralProperty);
     }

--- a/typespec-tests/src/test/java/com/type/property/optional/FloatLiteralClientTests.java
+++ b/typespec-tests/src/test/java/com/type/property/optional/FloatLiteralClientTests.java
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.type.property.optional;
+
+import com.type.property.optional.models.FloatLiteralProperty;
+import com.type.property.optional.models.FloatLiteralProperty1;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class FloatLiteralClientTests {
+    FloatLiteralClient client = new OptionalClientBuilder().buildFloatLiteralClient();
+
+    @Test
+    void getAll() {
+        FloatLiteralProperty floatLiteralProperty = client.getAll();
+        Assertions.assertEquals(FloatLiteralProperty1.ONE_TWO, floatLiteralProperty.getProperty());
+    }
+
+    @Test
+    void getDefault() {
+        FloatLiteralProperty floatLiteralProperty = client.getDefault();
+        Assertions.assertNull(floatLiteralProperty.getProperty());
+    }
+
+    @Test
+    void putAll() {
+        FloatLiteralProperty floatLiteralProperty = new FloatLiteralProperty();
+        floatLiteralProperty.setProperty(FloatLiteralProperty1.ONE_TWO);
+        client.putAll(floatLiteralProperty);
+    }
+
+    @Test
+    void putDefault() {
+        FloatLiteralProperty floatLiteralProperty = new FloatLiteralProperty();
+        client.putDefault(floatLiteralProperty);
+    }
+}

--- a/typespec-tests/src/test/java/com/type/property/optional/FloatLiteralClientTests.java
+++ b/typespec-tests/src/test/java/com/type/property/optional/FloatLiteralClientTests.java
@@ -9,23 +9,23 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-class FloatLiteralClientTests {
-    FloatLiteralClient client = new OptionalClientBuilder().buildFloatLiteralClient();
+public class FloatLiteralClientTests {
+    private final FloatLiteralClient client = new OptionalClientBuilder().buildFloatLiteralClient();
 
     @Test
-    void getAll() {
+    public void getAll() {
         FloatLiteralProperty floatLiteralProperty = client.getAll();
         Assertions.assertEquals(FloatLiteralProperty1.ONE_TWO, floatLiteralProperty.getProperty());
     }
 
     @Test
-    void getDefault() {
+    public void getDefault() {
         FloatLiteralProperty floatLiteralProperty = client.getDefault();
         Assertions.assertNull(floatLiteralProperty.getProperty());
     }
 
     @Test
-    void putAll() {
+    public void putAll() {
         FloatLiteralProperty floatLiteralProperty = new FloatLiteralProperty();
         floatLiteralProperty.setProperty(FloatLiteralProperty1.ONE_TWO);
         client.putAll(floatLiteralProperty);
@@ -33,7 +33,7 @@ class FloatLiteralClientTests {
 
     @Test
     @Disabled("NullPointer Cannot invoke \"java.lang.Double.doubleValue()\"")
-    void putDefault() {
+    public void putDefault() {
         FloatLiteralProperty floatLiteralProperty = new FloatLiteralProperty();
         client.putDefault(floatLiteralProperty);
     }

--- a/typespec-tests/src/test/java/com/type/property/optional/FloatLiteralClientTests.java
+++ b/typespec-tests/src/test/java/com/type/property/optional/FloatLiteralClientTests.java
@@ -6,6 +6,7 @@ package com.type.property.optional;
 import com.type.property.optional.models.FloatLiteralProperty;
 import com.type.property.optional.models.FloatLiteralProperty1;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class FloatLiteralClientTests {
@@ -31,6 +32,7 @@ class FloatLiteralClientTests {
     }
 
     @Test
+    @Disabled("NullPointer Cannot invoke \"java.lang.Double.doubleValue()\"")
     void putDefault() {
         FloatLiteralProperty floatLiteralProperty = new FloatLiteralProperty();
         client.putDefault(floatLiteralProperty);

--- a/typespec-tests/src/test/java/com/type/property/optional/IntLiteralClientTests.java
+++ b/typespec-tests/src/test/java/com/type/property/optional/IntLiteralClientTests.java
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.type.property.optional;
+
+import com.type.property.optional.models.IntLiteralProperty;
+import com.type.property.optional.models.IntLiteralProperty1;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class IntLiteralClientTests {
+    IntLiteralClient client = new OptionalClientBuilder().buildIntLiteralClient();
+
+    @Test
+    void getAll() {
+        IntLiteralProperty intLiteralProperty = client.getAll();
+        Assertions.assertEquals(IntLiteralProperty1.ONE, intLiteralProperty.getProperty());
+    }
+
+    @Test
+    void getDefault() {
+        IntLiteralProperty intLiteralProperty = client.getDefault();
+        Assertions.assertNull(intLiteralProperty.getProperty());
+    }
+
+    @Test
+    void putAll() {
+        IntLiteralProperty intLiteralProperty = new IntLiteralProperty();
+        intLiteralProperty.setProperty(IntLiteralProperty1.ONE);
+        client.putAll(intLiteralProperty);
+    }
+
+    @Test
+    void putDefault() {
+        IntLiteralProperty intLiteralProperty = new IntLiteralProperty();
+        client.putDefault(intLiteralProperty);
+    }
+}

--- a/typespec-tests/src/test/java/com/type/property/optional/IntLiteralClientTests.java
+++ b/typespec-tests/src/test/java/com/type/property/optional/IntLiteralClientTests.java
@@ -6,6 +6,7 @@ package com.type.property.optional;
 import com.type.property.optional.models.IntLiteralProperty;
 import com.type.property.optional.models.IntLiteralProperty1;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class IntLiteralClientTests {
@@ -31,6 +32,7 @@ class IntLiteralClientTests {
     }
 
     @Test
+    @Disabled("NullPointer Cannot invoke \"java.lang.Long.longValue()\"")
     void putDefault() {
         IntLiteralProperty intLiteralProperty = new IntLiteralProperty();
         client.putDefault(intLiteralProperty);

--- a/typespec-tests/src/test/java/com/type/property/optional/IntLiteralClientTests.java
+++ b/typespec-tests/src/test/java/com/type/property/optional/IntLiteralClientTests.java
@@ -9,23 +9,23 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-class IntLiteralClientTests {
-    IntLiteralClient client = new OptionalClientBuilder().buildIntLiteralClient();
+public class IntLiteralClientTests {
+    private final IntLiteralClient client = new OptionalClientBuilder().buildIntLiteralClient();
 
     @Test
-    void getAll() {
+    public void getAll() {
         IntLiteralProperty intLiteralProperty = client.getAll();
         Assertions.assertEquals(IntLiteralProperty1.ONE, intLiteralProperty.getProperty());
     }
 
     @Test
-    void getDefault() {
+    public void getDefault() {
         IntLiteralProperty intLiteralProperty = client.getDefault();
         Assertions.assertNull(intLiteralProperty.getProperty());
     }
 
     @Test
-    void putAll() {
+    public void putAll() {
         IntLiteralProperty intLiteralProperty = new IntLiteralProperty();
         intLiteralProperty.setProperty(IntLiteralProperty1.ONE);
         client.putAll(intLiteralProperty);
@@ -33,7 +33,7 @@ class IntLiteralClientTests {
 
     @Test
     @Disabled("NullPointer Cannot invoke \"java.lang.Long.longValue()\"")
-    void putDefault() {
+    public void putDefault() {
         IntLiteralProperty intLiteralProperty = new IntLiteralProperty();
         client.putDefault(intLiteralProperty);
     }

--- a/typespec-tests/src/test/java/com/type/property/optional/StringLiteralClientTests.java
+++ b/typespec-tests/src/test/java/com/type/property/optional/StringLiteralClientTests.java
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.type.property.optional;
+
+import com.type.property.optional.models.StringLiteralProperty;
+import com.type.property.optional.models.StringLiteralProperty1;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class StringLiteralClientTests {
+    StringLiteralClient client = new OptionalClientBuilder().buildStringLiteralClient();
+
+    @Test
+    void getAll() {
+        StringLiteralProperty stringLiteralProperty = client.getAll();
+        Assertions.assertEquals(StringLiteralProperty1.HELLO, stringLiteralProperty.getProperty());
+    }
+
+    @Test
+    void getDefault() {
+        StringLiteralProperty stringLiteralProperty = client.getDefault();
+        Assertions.assertNull(stringLiteralProperty.getProperty());
+    }
+
+    @Test
+    void putAll() {
+        StringLiteralProperty stringLiteralProperty = new StringLiteralProperty();
+        stringLiteralProperty.setProperty(StringLiteralProperty1.HELLO);
+        client.putAll(stringLiteralProperty);
+    }
+
+    @Test
+    void putDefault() {
+        StringLiteralProperty stringLiteralProperty = new StringLiteralProperty();
+        client.putDefault(stringLiteralProperty);
+    }
+}

--- a/typespec-tests/src/test/java/com/type/property/optional/StringLiteralClientTests.java
+++ b/typespec-tests/src/test/java/com/type/property/optional/StringLiteralClientTests.java
@@ -8,30 +8,30 @@ import com.type.property.optional.models.StringLiteralProperty1;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-class StringLiteralClientTests {
-    StringLiteralClient client = new OptionalClientBuilder().buildStringLiteralClient();
+public class StringLiteralClientTests {
+    private final StringLiteralClient client = new OptionalClientBuilder().buildStringLiteralClient();
 
     @Test
-    void getAll() {
+    public void getAll() {
         StringLiteralProperty stringLiteralProperty = client.getAll();
         Assertions.assertEquals(StringLiteralProperty1.HELLO, stringLiteralProperty.getProperty());
     }
 
     @Test
-    void getDefault() {
+    public void getDefault() {
         StringLiteralProperty stringLiteralProperty = client.getDefault();
         Assertions.assertNull(stringLiteralProperty.getProperty());
     }
 
     @Test
-    void putAll() {
+    public void putAll() {
         StringLiteralProperty stringLiteralProperty = new StringLiteralProperty();
         stringLiteralProperty.setProperty(StringLiteralProperty1.HELLO);
         client.putAll(stringLiteralProperty);
     }
 
     @Test
-    void putDefault() {
+    public void putDefault() {
         StringLiteralProperty stringLiteralProperty = new StringLiteralProperty();
         client.putDefault(stringLiteralProperty);
     }

--- a/typespec-tests/src/test/java/com/type/property/optional/UnionFloatLiteralClientTests.java
+++ b/typespec-tests/src/test/java/com/type/property/optional/UnionFloatLiteralClientTests.java
@@ -9,23 +9,23 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-class UnionFloatLiteralClientTests {
-    UnionFloatLiteralClient client = new OptionalClientBuilder().buildUnionFloatLiteralClient();
+public class UnionFloatLiteralClientTests {
+    private final UnionFloatLiteralClient client = new OptionalClientBuilder().buildUnionFloatLiteralClient();
 
     @Test
-    void getAll() {
+    public void getAll() {
         UnionFloatLiteralProperty unionFloatLiteralProperty = client.getAll();
         Assertions.assertEquals(UnionFloatLiteralPropertyProperty.TWO3, unionFloatLiteralProperty.getProperty());
     }
 
     @Test
-    void getDefault() {
+    public void getDefault() {
         UnionFloatLiteralProperty unionFloatLiteralProperty = client.getDefault();
         Assertions.assertNull(unionFloatLiteralProperty.getProperty());
     }
 
     @Test
-    void putAll() {
+    public void putAll() {
         UnionFloatLiteralProperty unionFloatLiteralProperty = new UnionFloatLiteralProperty();
         unionFloatLiteralProperty.setProperty(UnionFloatLiteralPropertyProperty.TWO3);
         client.putAll(unionFloatLiteralProperty);
@@ -33,7 +33,7 @@ class UnionFloatLiteralClientTests {
 
     @Test
     @Disabled("NullPointer Cannot invoke \"java.lang.Double.doubleValue()\"")
-    void putDefault() {
+    public void putDefault() {
         UnionFloatLiteralProperty unionFloatLiteralProperty = new UnionFloatLiteralProperty();
         client.putDefault(unionFloatLiteralProperty);
     }

--- a/typespec-tests/src/test/java/com/type/property/optional/UnionFloatLiteralClientTests.java
+++ b/typespec-tests/src/test/java/com/type/property/optional/UnionFloatLiteralClientTests.java
@@ -6,6 +6,7 @@ package com.type.property.optional;
 import com.type.property.optional.models.UnionFloatLiteralProperty;
 import com.type.property.optional.models.UnionFloatLiteralPropertyProperty;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class UnionFloatLiteralClientTests {
@@ -31,6 +32,7 @@ class UnionFloatLiteralClientTests {
     }
 
     @Test
+    @Disabled("NullPointer Cannot invoke \"java.lang.Double.doubleValue()\"")
     void putDefault() {
         UnionFloatLiteralProperty unionFloatLiteralProperty = new UnionFloatLiteralProperty();
         client.putDefault(unionFloatLiteralProperty);

--- a/typespec-tests/src/test/java/com/type/property/optional/UnionFloatLiteralClientTests.java
+++ b/typespec-tests/src/test/java/com/type/property/optional/UnionFloatLiteralClientTests.java
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.type.property.optional;
+
+import com.type.property.optional.models.UnionFloatLiteralProperty;
+import com.type.property.optional.models.UnionFloatLiteralPropertyProperty;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class UnionFloatLiteralClientTests {
+    UnionFloatLiteralClient client = new OptionalClientBuilder().buildUnionFloatLiteralClient();
+
+    @Test
+    void getAll() {
+        UnionFloatLiteralProperty unionFloatLiteralProperty = client.getAll();
+        Assertions.assertEquals(UnionFloatLiteralPropertyProperty.TWO3, unionFloatLiteralProperty.getProperty());
+    }
+
+    @Test
+    void getDefault() {
+        UnionFloatLiteralProperty unionFloatLiteralProperty = client.getDefault();
+        Assertions.assertNull(unionFloatLiteralProperty.getProperty());
+    }
+
+    @Test
+    void putAll() {
+        UnionFloatLiteralProperty unionFloatLiteralProperty = new UnionFloatLiteralProperty();
+        unionFloatLiteralProperty.setProperty(UnionFloatLiteralPropertyProperty.TWO3);
+        client.putAll(unionFloatLiteralProperty);
+    }
+
+    @Test
+    void putDefault() {
+        UnionFloatLiteralProperty unionFloatLiteralProperty = new UnionFloatLiteralProperty();
+        client.putDefault(unionFloatLiteralProperty);
+    }
+}

--- a/typespec-tests/src/test/java/com/type/property/optional/UnionIntLiteralClientTests.java
+++ b/typespec-tests/src/test/java/com/type/property/optional/UnionIntLiteralClientTests.java
@@ -6,6 +6,7 @@ package com.type.property.optional;
 import com.type.property.optional.models.UnionIntLiteralProperty;
 import com.type.property.optional.models.UnionIntLiteralPropertyProperty;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class UnionIntLiteralClientTests {
@@ -31,6 +32,7 @@ class UnionIntLiteralClientTests {
     }
 
     @Test
+    @Disabled("NullPointer Cannot invoke \"java.lang.Long.longValue()\"")
     void putDefault() {
         UnionIntLiteralProperty unionIntLiteralProperty = new UnionIntLiteralProperty();
         client.putDefault(unionIntLiteralProperty);

--- a/typespec-tests/src/test/java/com/type/property/optional/UnionIntLiteralClientTests.java
+++ b/typespec-tests/src/test/java/com/type/property/optional/UnionIntLiteralClientTests.java
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.type.property.optional;
+
+import com.type.property.optional.models.UnionIntLiteralProperty;
+import com.type.property.optional.models.UnionIntLiteralPropertyProperty;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class UnionIntLiteralClientTests {
+    UnionIntLiteralClient client = new OptionalClientBuilder().buildUnionIntLiteralClient();
+
+    @Test
+    void getAll() {
+        UnionIntLiteralProperty unionIntLiteralProperty = client.getAll();
+        Assertions.assertEquals(UnionIntLiteralPropertyProperty.TWO, unionIntLiteralProperty.getProperty());
+    }
+
+    @Test
+    void getDefault() {
+        UnionIntLiteralProperty unionIntLiteralProperty = client.getDefault();
+        Assertions.assertNull(unionIntLiteralProperty.getProperty());
+    }
+
+    @Test
+    void putAll() {
+        UnionIntLiteralProperty unionIntLiteralProperty = new UnionIntLiteralProperty();
+        unionIntLiteralProperty.setProperty(UnionIntLiteralPropertyProperty.TWO);
+        client.putAll(unionIntLiteralProperty);
+    }
+
+    @Test
+    void putDefault() {
+        UnionIntLiteralProperty unionIntLiteralProperty = new UnionIntLiteralProperty();
+        client.putDefault(unionIntLiteralProperty);
+    }
+}

--- a/typespec-tests/src/test/java/com/type/property/optional/UnionIntLiteralClientTests.java
+++ b/typespec-tests/src/test/java/com/type/property/optional/UnionIntLiteralClientTests.java
@@ -9,23 +9,23 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-class UnionIntLiteralClientTests {
-    UnionIntLiteralClient client = new OptionalClientBuilder().buildUnionIntLiteralClient();
+public class UnionIntLiteralClientTests {
+    private final UnionIntLiteralClient client = new OptionalClientBuilder().buildUnionIntLiteralClient();
 
     @Test
-    void getAll() {
+    public void getAll() {
         UnionIntLiteralProperty unionIntLiteralProperty = client.getAll();
         Assertions.assertEquals(UnionIntLiteralPropertyProperty.TWO, unionIntLiteralProperty.getProperty());
     }
 
     @Test
-    void getDefault() {
+    public void getDefault() {
         UnionIntLiteralProperty unionIntLiteralProperty = client.getDefault();
         Assertions.assertNull(unionIntLiteralProperty.getProperty());
     }
 
     @Test
-    void putAll() {
+    public void putAll() {
         UnionIntLiteralProperty unionIntLiteralProperty = new UnionIntLiteralProperty();
         unionIntLiteralProperty.setProperty(UnionIntLiteralPropertyProperty.TWO);
         client.putAll(unionIntLiteralProperty);
@@ -33,7 +33,7 @@ class UnionIntLiteralClientTests {
 
     @Test
     @Disabled("NullPointer Cannot invoke \"java.lang.Long.longValue()\"")
-    void putDefault() {
+    public void putDefault() {
         UnionIntLiteralProperty unionIntLiteralProperty = new UnionIntLiteralProperty();
         client.putDefault(unionIntLiteralProperty);
     }

--- a/typespec-tests/src/test/java/com/type/property/optional/UnionStringLiteralClientTests.java
+++ b/typespec-tests/src/test/java/com/type/property/optional/UnionStringLiteralClientTests.java
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.type.property.optional;
+
+import com.type.property.optional.models.UnionStringLiteralProperty;
+import com.type.property.optional.models.UnionStringLiteralPropertyProperty;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class UnionStringLiteralClientTests {
+    UnionStringLiteralClient client = new OptionalClientBuilder().buildUnionStringLiteralClient();
+
+    @Test
+    void getAll() {
+        UnionStringLiteralProperty unionStringLiteralProperty = client.getAll();
+        Assertions.assertEquals(UnionStringLiteralPropertyProperty.WORLD, unionStringLiteralProperty.getProperty());
+    }
+
+    @Test
+    void getDefault() {
+        UnionStringLiteralProperty unionStringLiteralProperty = client.getDefault();
+        Assertions.assertNull(unionStringLiteralProperty.getProperty());
+    }
+
+    @Test
+    void putAll() {
+        UnionStringLiteralProperty unionStringLiteralProperty = new UnionStringLiteralProperty();
+        unionStringLiteralProperty.setProperty(UnionStringLiteralPropertyProperty.WORLD);
+        client.putAll(unionStringLiteralProperty);
+    }
+
+    @Test
+    void putDefault() {
+        UnionStringLiteralProperty unionStringLiteralProperty = new UnionStringLiteralProperty();
+        client.putDefault(unionStringLiteralProperty);
+    }
+}

--- a/typespec-tests/src/test/java/com/type/property/optional/UnionStringLiteralClientTests.java
+++ b/typespec-tests/src/test/java/com/type/property/optional/UnionStringLiteralClientTests.java
@@ -8,30 +8,30 @@ import com.type.property.optional.models.UnionStringLiteralPropertyProperty;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-class UnionStringLiteralClientTests {
-    UnionStringLiteralClient client = new OptionalClientBuilder().buildUnionStringLiteralClient();
+public class UnionStringLiteralClientTests {
+    private final UnionStringLiteralClient client = new OptionalClientBuilder().buildUnionStringLiteralClient();
 
     @Test
-    void getAll() {
+    public void getAll() {
         UnionStringLiteralProperty unionStringLiteralProperty = client.getAll();
         Assertions.assertEquals(UnionStringLiteralPropertyProperty.WORLD, unionStringLiteralProperty.getProperty());
     }
 
     @Test
-    void getDefault() {
+    public void getDefault() {
         UnionStringLiteralProperty unionStringLiteralProperty = client.getDefault();
         Assertions.assertNull(unionStringLiteralProperty.getProperty());
     }
 
     @Test
-    void putAll() {
+    public void putAll() {
         UnionStringLiteralProperty unionStringLiteralProperty = new UnionStringLiteralProperty();
         unionStringLiteralProperty.setProperty(UnionStringLiteralPropertyProperty.WORLD);
         client.putAll(unionStringLiteralProperty);
     }
 
     @Test
-    void putDefault() {
+    public void putDefault() {
         UnionStringLiteralProperty unionStringLiteralProperty = new UnionStringLiteralProperty();
         client.putDefault(unionStringLiteralProperty);
     }


### PR DESCRIPTION
1. Add test cases for fix [issues#2436](https://github.com/Azure/autorest.java/issues/2436).
2. Now there are four test cases that are not working due to `NullPointer` exception occurs. 
   The detail info following as : 
![image](https://github.com/Azure/autorest.java/assets/74638143/1d312696-65c5-4e12-a902-9d9f25c71120)
3. Disabled not working test cases, the tag is `NullPointer Cannot invoke "java.lang.Long.longValue()"`.
