### PR TITLE
Fix polymorphic discriminator, use Linux for fluentgen CI

### DIFF
--- a/eng/pipelines/fluent_integration.yaml
+++ b/eng/pipelines/fluent_integration.yaml
@@ -22,8 +22,8 @@ jobs:
 - job: 'Build'
   timeoutInMinutes: 60
   pool:
-    name: azsdk-pool-mms-win-2022-general
-    vmImage: windows-2022
+    name: "azsdk-pool-mms-ubuntu-2004-general"
+    vmImage: "MMSUbuntu20.04"
 
   variables:
     - template: /eng/pipelines/variables/globals.yml

--- a/eng/pipelines/fluent_integration.yaml
+++ b/eng/pipelines/fluent_integration.yaml
@@ -22,8 +22,8 @@ jobs:
 - job: 'Build'
   timeoutInMinutes: 60
   pool:
-    name: "azsdk-pool-mms-ubuntu-2004-general"
-    vmImage: "MMSUbuntu20.04"
+    name: azsdk-pool-mms-win-2022-general
+    vmImage: windows-2022
 
   variables:
     - template: /eng/pipelines/variables/globals.yml

--- a/fluent-tests/Initialize-Tests.ps1
+++ b/fluent-tests/Initialize-Tests.ps1
@@ -1,0 +1,114 @@
+# Add Java 11 to path on DevOps
+Write-Host "java11 home dir: $env:JAVA_HOME_11_X64"
+Write-Host "add java11 to path"
+$env:PATH = "$env:JAVA_HOME_11_X64\bin;$env:PATH"
+
+# Print Java version
+Invoke-Expression -Command "java -version"
+
+# Regenerate code
+Remove-Item -Path ./src/main/java/com/azure/mgmttest -Recurse -Force | Out-Null
+Remove-Item -Path ./src/main/java/com/azure/mgmtlitetest -Recurse -Force | Out-Null
+Remove-Item -Path ./src/samples -Recurse -Force | Out-Null
+Remove-Item -Path ./src/test/java/com/azure/mgmtlitetest -Recurse -Force | Out-Null
+
+$AUTOREST_CORE_VERSION="3.9.7"
+$COMMON_ARGUMENTS="--java --use=../ --java.output-folder=./ --modelerfour.additional-checks=false --modelerfour.lenient-model-deduplication=true --azure-arm --java.license-header=MICROSOFT_MIT_SMALL"
+$FLUENT_ARGUMENTS="$COMMON_ARGUMENTS --fluent"
+$FLUENTLITE_ARGUMENTS="$COMMON_ARGUMENTS --fluent=lite --generate-samples --generate-tests"
+
+$ExitCode = 0
+function singleThreadGenerate($arguments) {
+    Write-Host "
+========================
+autorest $arguments
+========================
+    "
+    $generateOutput = Invoke-Expression "autorest $arguments"
+    $global:ExitCode = $global:ExitCode -bor $LASTEXITCODE
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host $([String]::Join("`n", $generateOutput))
+    } else {
+        Write-Host "SUCCEEDED"
+    }
+}
+
+# fluent premium
+singleThreadGenerate("--version=$AUTOREST_CORE_VERSION $FLUENT_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/resources/resource-manager/Microsoft.Resources/stable/2019-08-01/resources.json --namespace=com.azure.mgmttest.resources")
+
+singleThreadGenerate("--version=$AUTOREST_CORE_VERSION $FLUENT_ARGUMENTS ./swagger/readme.storage.md --namespace=com.azure.mgmttest.storage")
+
+singleThreadGenerate("--version=$AUTOREST_CORE_VERSION $FLUENT_ARGUMENTS ./swagger/readme.network.md --namespace=com.azure.mgmttest.network")
+
+# error response that is subclass of ManagementException
+singleThreadGenerate("--version=$AUTOREST_CORE_VERSION $FLUENT_ARGUMENTS ./swagger/readme.appservice.md --namespace=com.azure.mgmttest.appservice")
+
+# multiple inheritance
+singleThreadGenerate("--version=$AUTOREST_CORE_VERSION $FLUENT_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2019-12-12/cosmos-db.json --namespace=com.azure.mgmttest.cosmos")
+
+# flatten payload
+singleThreadGenerate("--version=$AUTOREST_CORE_VERSION $FLUENT_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/compute/resource-manager/Microsoft.Compute/CloudserviceRP/stable/2021-03-01/cloudService.json --namespace=com.azure.mgmttest.compute")
+
+# error response that not conform to ARM
+singleThreadGenerate("--version=$AUTOREST_CORE_VERSION $FLUENT_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/graphrbac/data-plane/Microsoft.GraphRbac/stable/1.6/graphrbac.json --namespace=com.azure.mgmttest.authorization")
+
+# client model flatten at autorest.java
+singleThreadGenerate("--version=$AUTOREST_CORE_VERSION $FLUENT_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/compute/resource-manager/Microsoft.Compute/GalleryRP/stable/2020-09-30/sharedGallery.json --namespace=com.azure.mgmttest.computegallery")
+
+singleThreadGenerate("--version=$AUTOREST_CORE_VERSION $FLUENT_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/network/resource-manager/Microsoft.Network/stable/2021-02-01/networkWatcher.json --namespace=com.azure.mgmttest.networkwatcher")
+
+singleThreadGenerate("--version=$AUTOREST_CORE_VERSION $FLUENT_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cdn/resource-manager/Microsoft.Cdn/stable/2020-09-01/afdx.json --namespace=com.azure.mgmttest.afdx")
+
+# nested x-ms-flatten from superclass in ExtendedProduct
+singleThreadGenerate("--version=$AUTOREST_CORE_VERSION $FLUENT_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/azurestack/resource-manager/Microsoft.AzureStack/preview/2020-06-01-preview/Product.json --namespace=com.azure.mgmttest.azurestack")
+
+# conflict property name from 2 x-ms-flatten in LabDetails and LabProperties
+singleThreadGenerate("--version=$AUTOREST_CORE_VERSION $FLUENT_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/education/resource-manager/Microsoft.Education/preview/2021-12-01-preview/education.json --namespace=com.azure.mgmttest.education")
+
+# do not flatten if polymorphic in DevicePropertiesFormat
+singleThreadGenerate("--version=$AUTOREST_CORE_VERSION $FLUENT_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/hybridnetwork/resource-manager/Microsoft.HybridNetwork/stable/2021-05-01/device.json --namespace=com.azure.mgmttest.hybridnetwork")
+
+# flatten the empty model which has non-empty parent model
+singleThreadGenerate("--version=$AUTOREST_CORE_VERSION $FLUENT_ARGUMENTS --input-file=https://github.com/Azure/azure-rest-api-specs/blob/main/specification/monitor/resource-manager/Microsoft.Insights/preview/2021-09-01-preview/dataCollectionRules_API.json --namespace=com.azure.mgmttest.monitor")
+
+# extract systemData from Resource
+singleThreadGenerate("--version=$AUTOREST_CORE_VERSION $FLUENT_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/29f3116d3ce31f2125d1e2cfb92d6511fcb01c41/specification/postgresqlhsc/resource-manager/Microsoft.DBforPostgreSQL/stable/2022-11-08/postgresqlhsc.json --java.namespace=com.azure.mgmttest.postgresqlhsc")
+
+# swagger customized Resource and ProxyResource
+singleThreadGenerate("--version=$AUTOREST_CORE_VERSION $FLUENT_ARGUMENTS --input-file=https://github.com/Azure/azure-rest-api-specs/blob/main/specification/trafficmanager/resource-manager/Microsoft.Network/stable/2018-08-01/trafficmanager.json --namespace=com.azure.mgmttest.trafficmanager")
+
+# ErrorDetails shared in exception and output
+singleThreadGenerate("--version=$AUTOREST_CORE_VERSION $FLUENT_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/8fa9b5051129dd4808c9be1f5b753af226b044db/specification/iothub/resource-manager/Microsoft.Devices/stable/2023-06-30/iothub.json --namespace=com.azure.mgmttest.iothub")
+
+# fluent lite
+singleThreadGenerate("--version=$AUTOREST_CORE_VERSION $FLUENTLITE_ARGUMENTS --pom-file=pom_generated_resources.xml https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/resources/resource-manager/readme.md --tag=package-resources-2021-01 --java.namespace=com.azure.mgmtlitetest.resources")
+
+singleThreadGenerate("--version=$AUTOREST_CORE_VERSION $FLUENTLITE_ARGUMENTS --regenerate-pom=false https://raw.githubusercontent.com/Azure/azure-rest-api-specs/da0cfefaa0e6c237e1e3819f1cb2e11d7606878d/specification/storage/resource-manager/readme.md --tag=package-2021-01 --java.namespace=com.azure.mgmtlitetest.storage")
+
+singleThreadGenerate("--version=$AUTOREST_CORE_VERSION $FLUENTLITE_ARGUMENTS --regenerate-pom=false https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/advisor/resource-manager/readme.md --tag=package-2020-01 --java.namespace=com.azure.mgmtlitetest.advisor")
+
+# pageable + LRO
+singleThreadGenerate("--version=$AUTOREST_CORE_VERSION $FLUENTLITE_ARGUMENTS --regenerate-pom=false https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/mediaservices/resource-manager/readme.md --tag=package-account-2023-01 --java.namespace=com.azure.mgmtlitetest.mediaservices")
+
+singleThreadGenerate("--version=$AUTOREST_CORE_VERSION $FLUENTLITE_ARGUMENTS --regenerate-pom=false https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/resources/resource-manager/readme.md --tag=package-policy-2020-09 --java.namespace=com.azure.mgmtlitetest.policy")
+
+# UUID subscriptionId
+singleThreadGenerate("--version=$AUTOREST_CORE_VERSION $FLUENTLITE_ARGUMENTS --regenerate-pom=false --input-file=https://github.com/Azure/azure-rest-api-specs/blob/0a2eb0d14f5132fcfd30222d584acf67713332ea/specification/containerregistry/resource-manager/Microsoft.ContainerRegistry/stable/2022-12-01/containerregistry.json --namespace=com.azure.mgmtlitetest.containerregistrylite")
+
+# multiple inheritance with conflict field
+singleThreadGenerate("--version=$AUTOREST_CORE_VERSION $FLUENTLITE_ARGUMENTS --regenerate-pom=false https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/botservice/resource-manager/readme.md --tag=package-preview-2021-05 --java.namespace=com.azure.mgmtlitetest.botservice")
+
+# model inherit ErrorResponse
+singleThreadGenerate("--version=$AUTOREST_CORE_VERSION $FLUENTLITE_ARGUMENTS --regenerate-pom=false --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/196886564583ff59186bd0ef44d923120aaf3f78/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/stable/2023-06-15/NetworkFabrics.json --java.namespace=com.azure.mgmtlitetest.managednetworkfabric")
+
+# schema clean-up
+singleThreadGenerate("--version=$AUTOREST_CORE_VERSION $FLUENTLITE_ARGUMENTS --regenerate-pom=false --input-file=./swagger/schema-cleanup.json --java.namespace=com.azure.mgmtlitetest.schemacleanup")
+
+# singleThreadGenerate("--version=$AUTOREST_CORE_VERSION $FLUENTLITE_ARGUMENTS --regenerate-pom=false https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/network/resource-manager/readme.md --tag=package-2020-06 --java.namespace=com.azure.mgmtlitetest.network")
+# singleThreadGenerate("--version=$AUTOREST_CORE_VERSION $FLUENTLITE_ARGUMENTS --regenerate-pom=false https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/compute/resource-manager/readme.md --tag=package-2020-06-30 --java.namespace=com.azure.mgmtlitetest.compute")
+
+# delete module-info as fluent-test is on java8
+Remove-Item -Path ./src/main/java/module-info.java -Force | Out-Null
+
+exit $ExitCode

--- a/fluent-tests/pom.xml
+++ b/fluent-tests/pom.xml
@@ -29,19 +29,13 @@
             <version>3.1.0</version>
             <executions>
               <execution>
-                <id>initialize-tests</id>
+                <id>prepare-tests</id>
                 <phase>generate-sources</phase>
                 <goals>
                   <goal>exec</goal>
                 </goals>
                 <configuration>
-                  <executable>powershell</executable>
-                  <arguments>
-                    <argument>-InputFormat</argument>
-                    <argument>None</argument>
-                    <argument>-File</argument>
-                    <argument>${basedir}/Initialize-Tests.ps1</argument>
-                  </arguments>
+                  <executable>${basedir}/prepare-tests.bat</executable>
                 </configuration>
               </execution>
             </executions>

--- a/fluent-tests/pom.xml
+++ b/fluent-tests/pom.xml
@@ -29,13 +29,13 @@
             <version>1.6.0</version>
             <executions>
               <execution>
-                <id>prepare-tests</id>
+                <id>initialize-tests</id>
                 <phase>generate-sources</phase>
                 <goals>
                   <goal>exec</goal>
                 </goals>
                 <configuration>
-                  <executable>${basedir}/prepare-tests.bat</executable>
+                  <executable>${basedir}/Initialize-Tests.ps1</executable>
                 </configuration>
               </execution>
             </executions>

--- a/fluent-tests/pom.xml
+++ b/fluent-tests/pom.xml
@@ -26,7 +26,7 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
-            <version>1.6.0</version>
+            <version>3.1.0</version>
             <executions>
               <execution>
                 <id>initialize-tests</id>
@@ -35,7 +35,13 @@
                   <goal>exec</goal>
                 </goals>
                 <configuration>
-                  <executable>${basedir}/Initialize-Tests.ps1</executable>
+                  <executable>powershell</executable>
+                  <arguments>
+                    <argument>-InputFormat</argument>
+                    <argument>None</argument>
+                    <argument>-File</argument>
+                    <argument>${basedir}/Initialize-Tests.ps1</argument>
+                  </arguments>
                 </configuration>
               </execution>
             </executions>

--- a/javagen/src/main/java/com/azure/autorest/template/StreamSerializationModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/StreamSerializationModelTemplate.java
@@ -206,8 +206,11 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
             methodBlock.line("jsonWriter.writeStartObject();");
 
             // If the model has a discriminator property serialize it first.
+            // Unless the polymorphic discriminator is also a property on the model, in which case it'll be handled
+            // later.
             if (propertiesManager.getDiscriminatorProperty() != null
-                && !CoreUtils.isNullOrEmpty(propertiesManager.getDiscriminatorProperty().getDefaultValue())) {
+                && !CoreUtils.isNullOrEmpty(propertiesManager.getDiscriminatorProperty().getDefaultValue())
+                && !propertiesManager.isDiscriminatorRequired()) {
                 ClientModelProperty discriminatorProperty = propertiesManager.getDiscriminatorProperty();
                 serializeJsonProperty(methodBlock, discriminatorProperty, discriminatorProperty.getSerializedName(),
                         false, true);

--- a/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/GoblinShark.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/GoblinShark.java
@@ -30,7 +30,6 @@ public final class GoblinShark extends Shark {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("sharktype", "goblin");
         jsonWriter.writeIntField("age", getAge());
         jsonWriter.writeStringField("sharktype", getSharktype());
         return jsonWriter.writeEndObject();

--- a/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/SawShark.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/SawShark.java
@@ -30,7 +30,6 @@ public final class SawShark extends Shark {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("sharktype", "saw");
         jsonWriter.writeIntField("age", getAge());
         jsonWriter.writeStringField("sharktype", getSharktype());
         return jsonWriter.writeEndObject();

--- a/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/Shark.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/Shark.java
@@ -47,7 +47,6 @@ public class Shark extends Fish {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("sharktype", "shark");
         jsonWriter.writeIntField("age", getAge());
         jsonWriter.writeStringField("sharktype", this.sharktype);
         return jsonWriter.writeEndObject();


### PR DESCRIPTION
Fixes a bug where models with polymorphic discriminator properties which are also required properties would serialize the polymorphic discriminator property twice. One value would be the constant defined in Swagger and the other would be the value passed during creation of the object. Now, only the property passed during creation of the object will be used.

fluentgen CI now uses Linux as the command script used to prepare test code was ported to PowerShell, now supporting all OSes.