### PR TITLE
XML stream-style serialization fixes and cleanup

### DIFF
--- a/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/ArtifactManifestPropertiesInternal.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/ArtifactManifestPropertiesInternal.java
@@ -22,8 +22,6 @@ import java.util.List;
  */
 @Fluent
 public class ArtifactManifestPropertiesInternal implements JsonSerializable<ArtifactManifestPropertiesInternal> {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /*
      * Registry login server name. This is likely to be similar to {registry-name}.azurecr.io.
      */
@@ -396,9 +394,10 @@ public class ArtifactManifestPropertiesInternal implements JsonSerializable<Arti
             jsonWriter.writeStartObject("manifest");
             jsonWriter.writeStringField("digest", this.digest);
             jsonWriter.writeNumberField("imageSize", this.sizeInBytes);
-            jsonWriter.writeStringField("createdTime", this.createdOn == null ? null : ISO_8601.format(this.createdOn));
+            jsonWriter.writeStringField("createdTime",
+                this.createdOn == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.createdOn));
             jsonWriter.writeStringField("lastUpdateTime",
-                this.lastUpdatedOn == null ? null : ISO_8601.format(this.lastUpdatedOn));
+                this.lastUpdatedOn == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.lastUpdatedOn));
             jsonWriter.writeStringField("architecture",
                 this.architecture == null ? null : this.architecture.toString());
             jsonWriter.writeStringField("os", this.operatingSystem == null ? null : this.operatingSystem.toString());

--- a/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/ArtifactTagPropertiesInternal.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/ArtifactTagPropertiesInternal.java
@@ -18,8 +18,6 @@ import java.time.format.DateTimeFormatter;
  */
 @Fluent
 public class ArtifactTagPropertiesInternal implements JsonSerializable<ArtifactTagPropertiesInternal> {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /*
      * Registry login server name. This is likely to be similar to {registry-name}.azurecr.io.
      */
@@ -288,9 +286,10 @@ public class ArtifactTagPropertiesInternal implements JsonSerializable<ArtifactT
             jsonWriter.writeStartObject("tag");
             jsonWriter.writeStringField("name", this.name);
             jsonWriter.writeStringField("digest", this.digest);
-            jsonWriter.writeStringField("createdTime", this.createdOn == null ? null : ISO_8601.format(this.createdOn));
+            jsonWriter.writeStringField("createdTime",
+                this.createdOn == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.createdOn));
             jsonWriter.writeStringField("lastUpdateTime",
-                this.lastUpdatedOn == null ? null : ISO_8601.format(this.lastUpdatedOn));
+                this.lastUpdatedOn == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.lastUpdatedOn));
             if (deleteEnabled != null || writeEnabled != null || listEnabled != null || readEnabled != null) {
                 jsonWriter.writeStartObject("changeableAttributes");
                 jsonWriter.writeBooleanField("deleteEnabled", this.deleteEnabled);

--- a/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/ManifestAttributesBase.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/ManifestAttributesBase.java
@@ -22,8 +22,6 @@ import java.util.List;
  */
 @Fluent
 public class ManifestAttributesBase implements JsonSerializable<ManifestAttributesBase> {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /*
      * Manifest
      */
@@ -337,9 +335,10 @@ public class ManifestAttributesBase implements JsonSerializable<ManifestAttribut
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeStringField("digest", this.digest);
-        jsonWriter.writeStringField("createdTime", this.createdOn == null ? null : ISO_8601.format(this.createdOn));
+        jsonWriter.writeStringField("createdTime",
+            this.createdOn == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.createdOn));
         jsonWriter.writeStringField("lastUpdateTime",
-            this.lastUpdatedOn == null ? null : ISO_8601.format(this.lastUpdatedOn));
+            this.lastUpdatedOn == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.lastUpdatedOn));
         jsonWriter.writeNumberField("imageSize", this.sizeInBytes);
         jsonWriter.writeStringField("architecture", this.architecture == null ? null : this.architecture.toString());
         jsonWriter.writeStringField("os", this.operatingSystem == null ? null : this.operatingSystem.toString());

--- a/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/TagAttributesBase.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/TagAttributesBase.java
@@ -18,8 +18,6 @@ import java.time.format.DateTimeFormatter;
  */
 @Fluent
 public class TagAttributesBase implements JsonSerializable<TagAttributesBase> {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /*
      * Tag name
      */
@@ -231,9 +229,10 @@ public class TagAttributesBase implements JsonSerializable<TagAttributesBase> {
         jsonWriter.writeStartObject();
         jsonWriter.writeStringField("name", this.name);
         jsonWriter.writeStringField("digest", this.digest);
-        jsonWriter.writeStringField("createdTime", this.createdOn == null ? null : ISO_8601.format(this.createdOn));
+        jsonWriter.writeStringField("createdTime",
+            this.createdOn == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.createdOn));
         jsonWriter.writeStringField("lastUpdateTime",
-            this.lastUpdatedOn == null ? null : ISO_8601.format(this.lastUpdatedOn));
+            this.lastUpdatedOn == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.lastUpdatedOn));
         if (deleteEnabled != null || writeEnabled != null || listEnabled != null || readEnabled != null) {
             jsonWriter.writeStartObject("changeableAttributes");
             jsonWriter.writeBooleanField("deleteEnabled", this.deleteEnabled);

--- a/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/models/ContainerRepositoryProperties.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/models/ContainerRepositoryProperties.java
@@ -11,15 +11,12 @@ import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
 import java.io.IOException;
 import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
 
 /**
  * Properties of this repository.
  */
 @Fluent
 public class ContainerRepositoryProperties implements JsonSerializable<ContainerRepositoryProperties> {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /*
      * Registry login server name. This is likely to be similar to {registry-name}.azurecr.io.
      */

--- a/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/models/OciAnnotations.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/models/OciAnnotations.java
@@ -20,8 +20,6 @@ import java.util.Map;
  */
 @Fluent
 public final class OciAnnotations implements JsonSerializable<OciAnnotations> {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /*
      * Date and time on which the image was built (string, date-time as defined by
      * https://tools.ietf.org/html/rfc3339#section-5.6)
@@ -365,7 +363,7 @@ public final class OciAnnotations implements JsonSerializable<OciAnnotations> {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeStringField("org.opencontainers.image.created",
-            this.createdOn == null ? null : ISO_8601.format(this.createdOn));
+            this.createdOn == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.createdOn));
         jsonWriter.writeStringField("org.opencontainers.image.authors", this.authors);
         jsonWriter.writeStringField("org.opencontainers.image.url", this.url);
         jsonWriter.writeStringField("org.opencontainers.image.documentation", this.documentation);

--- a/javagen/src/main/java/com/azure/autorest/implementation/ClientModelPropertiesManager.java
+++ b/javagen/src/main/java/com/azure/autorest/implementation/ClientModelPropertiesManager.java
@@ -15,6 +15,7 @@ import com.azure.xml.XmlSerializable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -73,7 +74,8 @@ public final class ClientModelPropertiesManager {
     private final List<ClientModelProperty> xmlTexts;
     private final List<ClientModelProperty> superXmlElements;
     private final List<ClientModelProperty> xmlElements;
-    private final Map<String, String> xmlNameSpaceWithPrefix;
+    private final Map<String, String> xmlNamespaceWithPrefix;
+    private final Map<String, String> xmlNamespaceToConstantMapping;
 
     /**
      * Creates a new instance of {@link ClientModelPropertiesManager}.
@@ -100,7 +102,7 @@ public final class ClientModelPropertiesManager {
         superReadOnlyProperties = new ArrayList<>();
         boolean hasXmlElements = false;
         boolean hasXmlTexts = false;
-        xmlNameSpaceWithPrefix = new LinkedHashMap<>();
+        xmlNamespaceWithPrefix = new LinkedHashMap<>();
         superXmlAttributes = new ArrayList<>();
         xmlAttributes = new ArrayList<>();
         superXmlTexts = new ArrayList<>();
@@ -167,7 +169,7 @@ public final class ClientModelPropertiesManager {
             }
 
             if (!CoreUtils.isNullOrEmpty(property.getXmlPrefix())) {
-                xmlNameSpaceWithPrefix.put(property.getXmlPrefix(), property.getXmlNamespace());
+                xmlNamespaceWithPrefix.put(property.getXmlPrefix(), property.getXmlNamespace());
             }
         }
 
@@ -221,7 +223,7 @@ public final class ClientModelPropertiesManager {
             }
 
             if (!CoreUtils.isNullOrEmpty(property.getXmlPrefix())) {
-                xmlNameSpaceWithPrefix.put(property.getXmlPrefix(), property.getXmlNamespace());
+                xmlNamespaceWithPrefix.put(property.getXmlPrefix(), property.getXmlNamespace());
             }
         }
 
@@ -258,6 +260,9 @@ public final class ClientModelPropertiesManager {
             throw new IllegalStateException("Model properties exhausted all possible XmlReader name variables. "
                 + "Add additional possible XmlReader name variables to resolve this issue.");
         }
+
+        this.xmlNamespaceToConstantMapping = model.getXmlName() == null
+            ? Collections.emptyMap() : ClientModelUtil.xmlNamespaceToConstantMapping(model);
     }
 
     /**
@@ -539,7 +544,7 @@ public final class ClientModelPropertiesManager {
      * @param consumer XML namespace with prefix consumer.
      */
     public void forEachXmlNamespaceWithPrefix(BiConsumer<String, String> consumer) {
-        xmlNameSpaceWithPrefix.forEach(consumer);
+        xmlNamespaceWithPrefix.forEach(consumer);
     }
 
     /**
@@ -597,6 +602,16 @@ public final class ClientModelPropertiesManager {
      */
     public void forEachXmlElement(Consumer<ClientModelProperty> consumer) {
         xmlElements.forEach(consumer);
+    }
+
+    /**
+     * Gets the XML namespace constant for the given XML namespace.
+     *
+     * @param xmlNamespace The XML namespace.
+     * @return The XML namespace constant.
+     */
+    public String getXmlNamespaceConstant(String xmlNamespace) {
+        return xmlNamespaceToConstantMapping.get(xmlNamespace);
     }
 
     /**

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ArrayType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ArrayType.java
@@ -115,21 +115,24 @@ public class ArrayType implements IType {
     }
 
     @Override
-    public String xmlDeserializationMethod(String xmlReaderName, String attributeName, String attributeNamespace) {
+    public String xmlDeserializationMethod(String xmlReaderName, String attributeName, String attributeNamespace,
+        boolean namespaceIsConstant) {
         if (attributeName == null) {
             return xmlReaderName + ".getBinaryElement()";
+        } else if (attributeNamespace == null) {
+            return xmlReaderName + ".getBinaryAttribute(null, \"" + attributeName + "\")";
         } else {
-            return (attributeNamespace == null)
-                ? xmlReaderName + ".getBinaryAttribute(null, \"" + attributeName + "\")"
+            return namespaceIsConstant
+                ? xmlReaderName + ".getBinaryAttribute(" + attributeNamespace + ", \"" + attributeName + "\")"
                 : xmlReaderName + ".getBinaryAttribute(\"" + attributeNamespace + "\", \"" + attributeName + "\")";
         }
     }
 
     @Override
     public String xmlSerializationMethodCall(String xmlWriterName, String attributeOrElementName, String namespaceUri,
-        String valueGetter, boolean isAttribute, boolean nameIsVariable) {
+        String valueGetter, boolean isAttribute, boolean nameIsVariable, boolean namespaceIsConstant) {
         return ClassType.xmlSerializationCallHelper(xmlWriterName, "writeBinary", attributeOrElementName, namespaceUri,
-            valueGetter, isAttribute, nameIsVariable);
+            valueGetter, isAttribute, nameIsVariable, namespaceIsConstant);
     }
 
     @Override

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/EnumType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/EnumType.java
@@ -188,18 +188,19 @@ public class EnumType implements IType {
     }
 
     @Override
-    public String xmlDeserializationMethod(String xmlReaderName, String attributeName, String attributeNamespace) {
+    public String xmlDeserializationMethod(String xmlReaderName, String attributeName, String attributeNamespace,
+        boolean namespaceIsConstant) {
         String elementTypeXmlDeserialization = elementType.xmlDeserializationMethod(xmlReaderName, attributeName,
-            attributeNamespace);
+            attributeNamespace, namespaceIsConstant);
         return name + "." + getFromMethodName() + "(" + elementTypeXmlDeserialization + ")";
     }
 
     @Override
     public String xmlSerializationMethodCall(String xmlWriterName, String attributeOrElementName, String namespaceUri,
-        String valueGetter, boolean isAttribute, boolean nameIsVariable) {
+        String valueGetter, boolean isAttribute, boolean nameIsVariable, boolean namespaceIsConstant) {
         String actualValueGetter = valueGetter + " == null ? null : " + valueGetter + "." + getToMethodName() + "()";
         return elementType.xmlSerializationMethodCall(xmlWriterName, attributeOrElementName, namespaceUri,
-            actualValueGetter, isAttribute, nameIsVariable);
+            actualValueGetter, isAttribute, nameIsVariable, namespaceIsConstant);
     }
 
     @Override

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/GenericType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/GenericType.java
@@ -303,13 +303,14 @@ public class GenericType implements IType {
     }
 
     @Override
-    public final String xmlDeserializationMethod(String xmlReaderName, String attributeName, String attributeNamespace) {
+    public final String xmlDeserializationMethod(String xmlReaderName, String attributeName, String attributeNamespace,
+        boolean namespaceIsConstant) {
         return null;
     }
 
     @Override
     public final String xmlSerializationMethodCall(String xmlWriterName, String attributeOrElementName,
-        String namespaceUri, String valueGetter, boolean isAttribute, boolean nameIsVariable) {
+        String namespaceUri, String valueGetter, boolean isAttribute, boolean nameIsVariable, boolean namespaceIsConstant) {
         return null;
     }
 

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/IType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/IType.java
@@ -153,9 +153,11 @@ public interface IType {
      * @param xmlReaderName The name of the {@link com.azure.xml.XmlReader} performing deserialization.
      * @param attributeName The attribute name, if null this is considered to be an element call.
      * @param attributeNamespace The attribute namespace, optional, ignored if {@code attributeName} is null.
+     * @param namespaceIsConstant Whether the {@code attributeNamespace} is a constant instead of a string.
      * @return The XML deserialization method, or null i it isn't supported directly.
      */
-    String xmlDeserializationMethod(String xmlReaderName, String attributeName, String attributeNamespace);
+    String xmlDeserializationMethod(String xmlReaderName, String attributeName, String attributeNamespace,
+        boolean namespaceIsConstant);
 
     /**
      * Gets the method call that will handle XML serialization.
@@ -171,10 +173,11 @@ public interface IType {
      * @param valueGetter The value getter.
      * @param isAttribute Whether an attribute is being written, if true {@code attributeOrElementName} must be set.
      * @param nameIsVariable Whether the {@code attributeOrElementName} is a variable instead of a string.
+     * @param namespaceIsConstant Whether the {@code namespaceUri} is a constant instead of a string.
      * @return The method call that will handle XML serialization, or null if it isn't supported directly.
      */
     String xmlSerializationMethodCall(String xmlWriterName, String attributeOrElementName, String namespaceUri,
-        String valueGetter, boolean isAttribute, boolean nameIsVariable);
+        String valueGetter, boolean isAttribute, boolean nameIsVariable, boolean namespaceIsConstant);
 
     /**
      * Whether the type is used with XML serialization.

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/PrimitiveType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/PrimitiveType.java
@@ -225,9 +225,9 @@ public class PrimitiveType implements IType {
         if (this == PrimitiveType.UNIX_TIME_LONG) {
             expression = String.format("OffsetDateTime.ofInstant(Instant.ofEpochSecond(%1$s), ZoneOffset.UTC)", expression);
         } else if (this == PrimitiveType.DURATION_LONG) {
-            expression = java.lang.String.format("Duration.ofSeconds(%s)", expression);
+            expression = String.format("Duration.ofSeconds(%s)", expression);
         } else if (this == PrimitiveType.DURATION_DOUBLE) {
-            expression = java.lang.String.format("Duration.ofNanos((long) (%s * 1000_000_000L))", expression);
+            expression = String.format("Duration.ofNanos((long) (%s * 1000_000_000L))", expression);
         }
         return expression;
     }
@@ -241,9 +241,9 @@ public class PrimitiveType implements IType {
         if (this == PrimitiveType.UNIX_TIME_LONG) {
             expression = String.format("%1$s.toEpochSecond()", expression);
         } else if (this == PrimitiveType.DURATION_LONG) {
-            expression = java.lang.String.format("%s.getSeconds()", expression);
+            expression = String.format("%s.getSeconds()", expression);
         } else if (this == PrimitiveType.DURATION_DOUBLE) {
-            expression = java.lang.String.format("(double) %s.toNanos() / 1000_000_000L", expression);
+            expression = String.format("(double) %s.toNanos() / 1000_000_000L", expression);
         }
         return expression;
     }
@@ -268,42 +268,42 @@ public class PrimitiveType implements IType {
     }
 
     @Override
-    public java.lang.String jsonSerializationMethodCall(java.lang.String jsonWriterName, java.lang.String fieldName,
-        java.lang.String valueGetter) {
+    public String jsonSerializationMethodCall(String jsonWriterName, String fieldName, String valueGetter) {
         if (wrapSerializationWithObjectsToString) {
             return fieldName == null
-                ? java.lang.String.format("%s.%s(Objects.toString(%s, null))", jsonWriterName,
-                serializationMethodBase, valueGetter)
-                : java.lang.String.format("%s.%sField(\"%s\", Objects.toString(%s, null))", jsonWriterName,
-                serializationMethodBase, fieldName, valueGetter);
+                ? String.format("%s.%s(Objects.toString(%s, null))", jsonWriterName, serializationMethodBase, valueGetter)
+                : String.format("%s.%sField(\"%s\", Objects.toString(%s, null))", jsonWriterName,
+                    serializationMethodBase, fieldName, valueGetter);
         }
 
         return fieldName == null
-            ? java.lang.String.format("%s.%s(%s)", jsonWriterName, serializationMethodBase, valueGetter)
-            : java.lang.String.format("%s.%sField(\"%s\", %s)", jsonWriterName, serializationMethodBase, fieldName,
-            valueGetter);
+            ? String.format("%s.%s(%s)", jsonWriterName, serializationMethodBase, valueGetter)
+            : String.format("%s.%sField(\"%s\", %s)", jsonWriterName, serializationMethodBase, fieldName, valueGetter);
     }
 
     @Override
-    public String xmlDeserializationMethod(String xmlReaderName, String attributeName, String attributeNamespace) {
+    public String xmlDeserializationMethod(String xmlReaderName, String attributeName, String attributeNamespace,
+        boolean namespaceIsConstant) {
         if (attributeName == null) {
             return xmlReaderName + "." + xmlElementDeserializationMethod;
+        } else if (attributeNamespace == null) {
+            return String.format(xmlAttributeDeserializationTemplate, xmlReaderName, "null",
+                "\"" + attributeName + "\"");
         } else {
-            String namespace = attributeNamespace == null ? "null" : "\"" + attributeNamespace + "\"";
+            String namespace = namespaceIsConstant ? attributeNamespace : "\"" + attributeNamespace + "\"";
             return String.format(xmlAttributeDeserializationTemplate, xmlReaderName, namespace,
                 "\"" + attributeName + "\"");
         }
     }
 
     @Override
-    public java.lang.String xmlSerializationMethodCall(java.lang.String xmlWriterName,
-        java.lang.String attributeOrElementName, java.lang.String namespaceUri, java.lang.String valueGetter,
-        boolean isAttribute, boolean nameIsVariable) {
+    public String xmlSerializationMethodCall(String xmlWriterName, String attributeOrElementName, String namespaceUri,
+        String valueGetter, boolean isAttribute, boolean nameIsVariable, boolean namespaceIsConstant) {
         String value = wrapSerializationWithObjectsToString
             ? "Objects.toString(" + valueGetter + ", null)" : valueGetter;
 
         return ClassType.xmlSerializationCallHelper(xmlWriterName, serializationMethodBase, attributeOrElementName,
-            namespaceUri, value, isAttribute, nameIsVariable);
+            namespaceUri, value, isAttribute, nameIsVariable, namespaceIsConstant);
     }
 
     @Override

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -139,9 +139,8 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                 classBlock.privateStaticFinalVariable("byte[] EMPTY_BYTE_ARRAY = new byte[0]");
             }
 
-            if (isStreamStyleWithIso8601DateTime(model, settings)) {
-                classBlock.privateStaticFinalVariable("DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern(\"yyyy-MM-dd'T'HH:mm:ss.SSSX\")");
-            }
+            // XML namespace constants
+            addXmlNamespaceConstants(model, classBlock);
 
             // properties
             addProperties(model, classBlock, settings);
@@ -497,6 +496,10 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
         return classSignature;
     }
 
+    protected void addXmlNamespaceConstants(ClientModel model, JavaClass classBlock) {
+        // no-op as this is an entry point for subclasses of ModelTemplate that provide more specific code generation.
+    }
+
     /**
      * Adds the property fields to a class.
      *
@@ -515,12 +518,16 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
 
             String fieldSignature;
             if (model.isUsedInXml()) {
-                if (property.isXmlWrapper() && !settings.isStreamStyleSerialization()) {
-                    String xmlWrapperClassName = getPropertyXmlWrapperClassName(property);
-                    classBlock.staticFinalClass(JavaVisibility.PackagePrivate, xmlWrapperClassName,
-                        innerClass -> addXmlWrapperClass(innerClass, property, xmlWrapperClassName, settings));
+                if (property.isXmlWrapper()) {
+                    if (!settings.isStreamStyleSerialization()) {
+                        String xmlWrapperClassName = getPropertyXmlWrapperClassName(property);
+                        classBlock.staticFinalClass(JavaVisibility.PackagePrivate, xmlWrapperClassName,
+                            innerClass -> addXmlWrapperClass(innerClass, property, xmlWrapperClassName, settings));
 
-                    fieldSignature = xmlWrapperClassName + " " + propertyName;
+                        fieldSignature = xmlWrapperClassName + " " + propertyName;
+                    } else {
+                        fieldSignature = propertyType + " " + propertyName;
+                    }
                 } else if (propertyType instanceof ListType) {
                     fieldSignature = propertyType + " " + propertyName + " = new ArrayList<>()";
                 } else {
@@ -1093,15 +1100,6 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
         }
 
         return ret;
-    }
-
-    private static boolean isStreamStyleWithIso8601DateTime(ClientModel model, JavaSettings settings) {
-        if (!settings.isStreamStyleSerialization()) {
-            return false;
-        }
-
-        return model.getProperties().stream().anyMatch(property -> property.getWireType() == ClassType.DATE_TIME)
-            || ClientModelUtil.getParentProperties(model).stream().anyMatch(p -> p.getWireType() == ClassType.DATE_TIME);
     }
 
     /**

--- a/javagen/src/main/java/com/azure/autorest/template/StreamSerializationModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/StreamSerializationModelTemplate.java
@@ -19,6 +19,7 @@ import com.azure.autorest.model.javamodel.JavaClass;
 import com.azure.autorest.model.javamodel.JavaFile;
 import com.azure.autorest.model.javamodel.JavaIfBlock;
 import com.azure.autorest.model.javamodel.JavaVisibility;
+import com.azure.autorest.util.ClientModelUtil;
 import com.azure.core.util.CoreUtils;
 import com.azure.xml.XmlReader;
 import com.azure.xml.XmlSerializable;
@@ -78,7 +79,6 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
             ClassType.JSON_WRITER.addImportsTo(imports, false);
             ClassType.JSON_READER.addImportsTo(imports, false);
             ClassType.JSON_TOKEN.addImportsTo(imports, false);
-            imports.add(settings.getPackage(settings.getImplementationSubpackage()) + ".CoreToCodegenBridgeUtils");
         }
 
         ClassType.CORE_UTILS.addImportsTo(imports, false);
@@ -88,6 +88,7 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
         imports.add(LinkedHashMap.class.getName());
         imports.add(List.class.getName());
         imports.add(Objects.class.getName());
+        imports.add(settings.getPackage(settings.getImplementationSubpackage()) + ".CoreToCodegenBridgeUtils");
     }
 
     @Override
@@ -114,6 +115,18 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
         return classSignature + " implements " + interfaceName + "<" + model.getName() + ">";
     }
 
+    @Override
+    protected void addXmlNamespaceConstants(ClientModel model, JavaClass classBlock) {
+        if (model.getXmlName() == null) {
+            return;
+        }
+
+        Map<String, String> constantMap = ClientModelUtil.xmlNamespaceToConstantMapping(model);
+        for (Map.Entry<String, String> constant : constantMap.entrySet()) {
+            classBlock.privateStaticFinalVariable("String " + constant.getValue() + " = \"" + constant.getKey() + "\"");
+        }
+    }
+
     static void xmlWrapperClassXmlSerializableImplementation(JavaClass classBlock, String wrapperClassName,
         IType iterableType, String xmlRootElementName, String xmlRootElementNamespace, String xmlListElementName,
         String xmlElementNameCamelCase, String xmlListElementNamespace) {
@@ -133,7 +146,7 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
 
             writerMethod.ifBlock(xmlElementNameCamelCase + " != null", ifAction -> {
                 String xmlWrite = elementType.xmlSerializationMethodCall("xmlWriter", xmlListElementName,
-                    xmlListElementNamespace, "element", false, false);
+                    xmlListElementNamespace, "element", false, false, false);
                 ifAction.line("for (%s element : %s) {", elementType, xmlElementNameCamelCase);
                 ifAction.indent(() -> ifAction.line(xmlWrite + ";"));
                 ifAction.line("}");
@@ -158,7 +171,7 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
                 readerMethod.line("while (reader.nextElement() != XmlToken.END_ELEMENT) {");
                 readerMethod.indent(() -> {
                     readerMethod.line("QName elementName = reader.getElementName();");
-                    String condition = getXmlNameConditional(xmlListElementName, xmlListElementNamespace, "elementName");
+                    String condition = getXmlNameConditional(xmlListElementName, xmlListElementNamespace, "elementName", false);
                     readerMethod.line();
                     readerMethod.ifBlock(condition, ifBlock -> {
                         ifBlock.ifBlock("items == null", ifBlock2 -> ifBlock2.line("items = new ArrayList<>();"));
@@ -166,7 +179,7 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
 
                         // TODO (alzimmer): Insert XML object reading logic.
                         ifBlock.line("items.add(" + getSimpleXmlDeserialization(elementType, "reader", null, null,
-                                null) + ");");
+                                null, false) + ");");
                     }).elseBlock(elseBlock -> elseBlock.line("reader.nextElement();"));
                 });
                 readerMethod.line("}");
@@ -1343,23 +1356,23 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
 
             String modelXmlNamespace = propertiesManager.getXmlRootElementNamespace();
             if (modelXmlNamespace != null) {
-                methodBlock.line("xmlWriter.writeNamespace(\"" + modelXmlNamespace + "\");");
+                methodBlock.line("xmlWriter.writeNamespace(" + propertiesManager.getXmlNamespaceConstant(modelXmlNamespace) + ");");
             }
 
             propertiesManager.forEachXmlNamespaceWithPrefix((prefix, namespace) ->
-                methodBlock.line("xmlWriter.writeNamespace(\"" + prefix + "\", \"" + namespace + "\");"));
+                methodBlock.line("xmlWriter.writeNamespace(\"" + prefix + "\", " + propertiesManager.getXmlNamespaceConstant(namespace) + ");"));
 
             String modelName = propertiesManager.getModel().getName();
-            propertiesManager.forEachSuperXmlAttribute(property -> serializeXml(methodBlock, property, true, modelName));
-            propertiesManager.forEachXmlAttribute(property -> serializeXml(methodBlock, property, false, modelName));
+            propertiesManager.forEachSuperXmlAttribute(property -> serializeXml(methodBlock, property, true, modelName, propertiesManager));
+            propertiesManager.forEachXmlAttribute(property -> serializeXml(methodBlock, property, false, modelName, propertiesManager));
 
             // Valid XML should only either have elements or text.
             if (propertiesManager.hasXmlElements()) {
-                propertiesManager.forEachSuperXmlElement(property -> serializeXml(methodBlock, property, true, modelName));
-                propertiesManager.forEachXmlElement(property -> serializeXml(methodBlock, property, false, modelName));
+                propertiesManager.forEachSuperXmlElement(property -> serializeXml(methodBlock, property, true, modelName, propertiesManager));
+                propertiesManager.forEachXmlElement(property -> serializeXml(methodBlock, property, false, modelName, propertiesManager));
             } else {
-                propertiesManager.forEachSuperXmlText(property -> serializeXml(methodBlock, property, true, modelName));
-                propertiesManager.forEachXmlText(property -> serializeXml(methodBlock, property, false, modelName));
+                propertiesManager.forEachSuperXmlText(property -> serializeXml(methodBlock, property, true, modelName, propertiesManager));
+                propertiesManager.forEachXmlText(property -> serializeXml(methodBlock, property, false, modelName, propertiesManager));
             }
 
             methodBlock.methodReturn("xmlWriter.writeEndElement()");
@@ -1374,7 +1387,7 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
      * @param fromSuperType Whether the property is defined in the super type.
      */
     private static void serializeXml(JavaBlock methodBlock, ClientModelProperty element, boolean fromSuperType,
-        String modelName) {
+        String modelName, ClientModelPropertiesManager propertiesManager) {
         IType clientType = element.getClientType();
         IType wireType = element.getWireType();
         String propertyValueGetter;
@@ -1396,7 +1409,8 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
         // Attempt to determine whether the wire type is simple serialization.
         // This is primitives, boxed primitives, a small set of string based models, and other ClientModels.
         String xmlSerializationMethodCall = wireType.xmlSerializationMethodCall("xmlWriter", element.getXmlName(),
-            element.getXmlNamespace(), propertyValueGetter, element.isXmlAttribute(), false);
+            propertiesManager.getXmlNamespaceConstant(element.getXmlNamespace()), propertyValueGetter,
+            element.isXmlAttribute(), false, true);
         if (xmlSerializationMethodCall != null) {
             Consumer<JavaBlock> serializationLogic = javaBlock -> {
                 // XML text has special handling.
@@ -1424,12 +1438,13 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
                 if (!sameNames) {
                     String writeStartElement = element.getXmlNamespace() == null
                         ? "xmlWriter.writeStartElement(\"" + element.getXmlName() + "\");"
-                        : "xmlWriter.writeStartElement(\"" + element.getXmlNamespace() + "\", \"" + element.getXmlName() + "\");";
+                        : "xmlWriter.writeStartElement(" + propertiesManager.getXmlNamespaceConstant(element.getXmlNamespace()) + ", \"" + element.getXmlName() + "\");";
                     ifAction.line(writeStartElement);
                 }
 
                 String xmlWrite = elementType.xmlSerializationMethodCall("xmlWriter", element.getXmlListElementName(),
-                    element.getXmlListElementNamespace(), "element", false, false);
+                    propertiesManager.getXmlNamespaceConstant(element.getXmlListElementNamespace()), "element", false,
+                    false, true);
                 ifAction.line("for (%s element : %s) {", elementType, propertyValueGetter);
                 ifAction.indent(() -> ifAction.line(xmlWrite + ";"));
                 ifAction.line("}");
@@ -1448,7 +1463,7 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
 
                 if (valueType instanceof ClassType && ((ClassType) valueType).isSwaggerType()) {
                     String writeStartElement = (element.getXmlNamespace() != null)
-                        ? "xmlWriter.writeStartElement(\"" + element.getXmlNamespace() + "\", key);"
+                        ? "xmlWriter.writeStartElement(" + propertiesManager.getXmlNamespaceConstant(element.getXmlNamespace()) + ", key);"
                         : "xmlWriter.writeStartElement(key);";
 
                     ifAction.line("for (Map.Entry<String, %s> entry : %s.entrySet()) {", valueType, propertyValueGetter);
@@ -1460,7 +1475,8 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
                     ifAction.line("}");
                 } else {
                     String xmlWrite = valueType.xmlSerializationMethodCall("xmlWriter", "entry.getKey()",
-                        element.getXmlNamespace(), "entry.getValue()", false, true);
+                        propertiesManager.getXmlNamespaceConstant(element.getXmlNamespace()), "entry.getValue()", false,
+                        true, true);
 
                     ifAction.line("for (Map.Entry<String, %s> entry : %s.entrySet()) {", valueType, propertyValueGetter);
                     ifAction.indent(() -> ifAction.line(xmlWrite + ";"));
@@ -1507,7 +1523,7 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
             methodBlock.line("// Get the XML discriminator attribute.");
             if (discriminatorProperty.getXmlNamespace() != null) {
                 methodBlock.line("String discriminatorValue = reader.getStringAttribute("
-                    + "\"" + discriminatorProperty.getXmlNamespace() + "\", "
+                    + propertiesManager.getXmlNamespaceConstant(discriminatorProperty.getXmlNamespace()) + ", "
                     + "\"" + discriminatorProperty.getSerializedName() + "\");");
             } else {
                 methodBlock.line("String discriminatorValue = reader.getStringAttribute("
@@ -1613,7 +1629,7 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
             methodBlock.line("String finalRootElementName = CoreUtils.isNullOrEmpty(rootElementName) ? "
                 + "\"" + requiredElementName + "\" : rootElementName;");
             if (requiredNamespace != null) {
-                methodBlock.line("return xmlReader.readObject(\"" + requiredNamespace + "\", finalRootElementName, reader -> {");
+                methodBlock.line("return xmlReader.readObject(" + propertiesManager.getXmlNamespaceConstant(requiredNamespace) + ", finalRootElementName, reader -> {");
             } else {
                 methodBlock.line("return xmlReader.readObject(finalRootElementName, reader -> {");
             }
@@ -1747,7 +1763,7 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
     private static void deserializeXmlAttribute(JavaBlock methodBlock, ClientModelProperty attribute,
         ClientModelPropertiesManager propertiesManager, boolean fromSuper) {
         String xmlAttributeDeserialization = getSimpleXmlDeserialization(attribute.getWireType(), "reader", null,
-                attribute.getXmlName(), attribute.getXmlNamespace());
+                attribute.getXmlName(), propertiesManager.getXmlNamespaceConstant(attribute.getXmlNamespace()), true);
 
         if (attribute.isPolymorphicDiscriminator()) {
             methodBlock.line("String discriminatorValue = " + xmlAttributeDeserialization + ";");
@@ -1770,7 +1786,7 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
 
     private static void deserializeXmlText(JavaBlock methodBlock, ClientModelProperty text,
         ClientModelPropertiesManager propertiesManager, boolean fromSuper) {
-        String xmlTextDeserialization = getSimpleXmlDeserialization(text.getWireType(), "reader", null, null, null);
+        String xmlTextDeserialization = getSimpleXmlDeserialization(text.getWireType(), "reader", null, null, null, false);
         if (propertiesManager.hasConstructorArguments()) {
             methodBlock.line("%s %s = %s;", text.getClientType(), text.getName(), xmlTextDeserialization);
         } else {
@@ -1799,13 +1815,13 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
         JavaIfBlock ifBlock, String fieldNameVariableName, ClientModelPropertiesManager propertiesManager,
         boolean fromSuper, JavaSettings settings) {
         String xmlElementName = property.getXmlName();
-        String xmlNamespace = property.getXmlNamespace();
+        String xmlNamespace = propertiesManager.getXmlNamespaceConstant(property.getXmlNamespace());
 
         if (CoreUtils.isNullOrEmpty(xmlElementName)) {
             return ifBlock;
         }
 
-        String condition = getXmlNameConditional(xmlElementName, xmlNamespace, fieldNameVariableName);
+        String condition = getXmlNameConditional(xmlElementName, xmlNamespace, fieldNameVariableName, true);
         return ifOrElseIf(methodBlock, ifBlock, condition,
             deserializationBlock -> generateXmlDeserializationLogic(deserializationBlock, property, propertiesManager,
                 fromSuper, settings));
@@ -1818,7 +1834,7 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
         // Attempt to determine whether the wire type is simple deserialization.
         // This is primitives, boxed primitives, a small set of string based models, and other ClientModels.
         String simpleDeserialization = getSimpleXmlDeserialization(wireType, "reader", property.getXmlName(), null,
-                null);
+                null, false);
         if (simpleDeserialization != null) {
             if (propertiesManager.hasConstructorArguments()) {
                 deserializationBlock.line(property.getName() + " = " + simpleDeserialization + ";");
@@ -1830,7 +1846,7 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
             IType elementType = ((IterableType) wireType).getElementType();
             boolean sameNames = Objects.equals(property.getXmlName(), property.getXmlListElementName());
             String elementDeserialization = getSimpleXmlDeserialization(elementType, "reader",
-                sameNames ? property.getXmlName() : property.getXmlListElementName(), null, null);
+                sameNames ? property.getXmlName() : property.getXmlListElementName(), null, null, false);
             String fieldAccess;
             if (propertiesManager.hasConstructorArguments()) {
                 // Cases with constructor arguments will have a local variable based on the name of the property.
@@ -1843,24 +1859,27 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
                 fieldAccess = propertiesManager.getDeserializedModelName() + "." + property.getName();
             }
 
-            // TODO (alzimmer): Handle nested container types when needed.
-            deserializationBlock.ifBlock(fieldAccess + " == null", ifStatement -> {
-                if (fromSuper) {
-                    ifStatement.line(propertiesManager.getDeserializedModelName() + "." + property.getSetterName()
-                        + "(new ArrayList<>());");
-                } else {
-                    ifStatement.line(fieldAccess + " = new ArrayList<>();");
-                }
-            });
-
             if (sameNames) {
                 deserializationBlock.line(fieldAccess + ".add(" + elementDeserialization + ");");
             } else {
                 deserializationBlock.block("while (reader.nextElement() != XmlToken.END_ELEMENT)", whileBlock -> {
                     whileBlock.line("elementName = reader.getElementName();");
                     String condition = getXmlNameConditional(property.getXmlListElementName(),
-                        property.getXmlListElementNamespace(), "elementName");
-                    whileBlock.ifBlock(condition, ifBlock -> ifBlock.line(fieldAccess + ".add(" + elementDeserialization + ");"))
+                        propertiesManager.getXmlNamespaceConstant(property.getXmlListElementNamespace()), "elementName",
+                        true);
+                    whileBlock.ifBlock(condition, ifBlock -> {
+                            // TODO (alzimmer): Handle nested container types when needed.
+                            ifBlock.ifBlock(fieldAccess + " == null", ifStatement -> {
+                                if (fromSuper) {
+                                    ifStatement.line(propertiesManager.getDeserializedModelName() + "." + property.getSetterName()
+                                        + "(new ArrayList<>());");
+                                } else {
+                                    ifStatement.line(fieldAccess + " = new ArrayList<>();");
+                                }
+                            });
+
+                            ifBlock.line(fieldAccess + ".add(" + elementDeserialization + ");");
+                        })
                         .elseBlock(elseBlock -> elseBlock.line("reader.skipElement();"));
                 });
             }
@@ -1870,16 +1889,17 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
                 ? property.getName()
                 : propertiesManager.getDeserializedModelName() + "." + property.getName();
 
-            // TODO (alzimmer): Handle nested container types when needed.
-            // Assumption is that the key type for the Map is a String. This may not always hold true and when that
-            // becomes reality this will need to be reworked to handle that case.
-            deserializationBlock.ifBlock(fieldAccess + " == null",
-                ifStatement -> ifStatement.line(fieldAccess + " = new LinkedHashMap<>();"));
-
             String valueDeserialization = getSimpleXmlDeserialization(valueType, "reader", property.getXmlName(), null,
-                    null);
-            deserializationBlock.block("while (reader.nextElement() != XmlToken.END_ELEMENT)", whileBlock -> whileBlock
-                .line(fieldAccess + ".put(reader.getElementName().getLocalPart(), " + valueDeserialization + ");"));
+                    null, false);
+            deserializationBlock.block("while (reader.nextElement() != XmlToken.END_ELEMENT)", whileBlock -> {
+                // TODO (alzimmer): Handle nested container types when needed.
+                // Assumption is that the key type for the Map is a String. This may not always hold true and when that
+                // becomes reality this will need to be reworked to handle that case.
+                whileBlock.ifBlock(fieldAccess + " == null",
+                    ifStatement -> ifStatement.line(fieldAccess + " = new LinkedHashMap<>();"));
+
+                whileBlock.line(fieldAccess + ".put(reader.getElementName().getLocalPart(), " + valueDeserialization + ");");
+            });
         } else {
             // TODO (alzimmer): Resolve this as deserialization logic generation needs to handle all cases.
             throw new RuntimeException("Unknown wire type " + wireType + ". Need to add support for it.");
@@ -1907,7 +1927,7 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
                 } else {
                     // Another assumption, the additional properties value type is simple.
                     javaBlock.line(additionalProperties.getName() + ".put(" + fieldNameVariableName + ", "
-                        + getSimpleXmlDeserialization(valueType, "reader", null, null, null) + ");");
+                        + getSimpleXmlDeserialization(valueType, "reader", null, null, null, false) + ");");
                 }
             } else {
                 javaBlock.line("reader.skipElement();");
@@ -1922,17 +1942,14 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
     }
 
     private static String getSimpleXmlDeserialization(IType wireType, String readerName, String elementName,
-                                                      String attributeName, String attributeNamespace) {
-        String wireTypeDeserialization = null;
+        String attributeName, String attributeNamespace, boolean namespaceIsConstant) {
         if (wireType instanceof ClassType && ((ClassType) wireType).isSwaggerType()) {
-            wireTypeDeserialization = CoreUtils.isNullOrEmpty(elementName)
+            return CoreUtils.isNullOrEmpty(elementName)
                 ? wireType + ".fromXml(" + readerName + ")"
                 : wireType + ".fromXml(" + readerName + ", \"" + elementName + "\")";
         } else {
-            wireTypeDeserialization = wireType.xmlDeserializationMethod(readerName, attributeName, attributeNamespace);
+            return wireType.xmlDeserializationMethod(readerName, attributeName, attributeNamespace, namespaceIsConstant);
         }
-
-        return wireTypeDeserialization;
     }
 
     private static List<ClientModelPropertyWithMetadata> getClientModelPropertiesInJsonTree(
@@ -1950,10 +1967,15 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
         }
     }
 
-    private static String getXmlNameConditional(String localPart, String namespace, String elementName) {
+    private static String getXmlNameConditional(String localPart, String namespace, String elementName,
+        boolean namespaceIsConstant) {
         String condition = "\"" + localPart + "\".equals(" + elementName + ".getLocalPart())";
         if (!CoreUtils.isNullOrEmpty(namespace)) {
-            condition += " && \"" + namespace + "\".equals(" + elementName + ".getNamespaceURI())";
+            if (namespaceIsConstant) {
+                condition += " && " + namespace + ".equals(" + elementName + ".getNamespaceURI())";
+            } else {
+                condition += " && \"" + namespace + "\".equals(" + elementName + ".getNamespaceURI())";
+            }
         }
 
         return condition;

--- a/typespec-tests/src/main/java/com/cadl/builtin/models/Builtin.java
+++ b/typespec-tests/src/main/java/com/cadl/builtin/models/Builtin.java
@@ -26,8 +26,6 @@ import java.util.Objects;
  */
 @Immutable
 public final class Builtin implements JsonSerializable<Builtin> {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /*
      * The boolean property.
      */
@@ -359,7 +357,8 @@ public final class Builtin implements JsonSerializable<Builtin> {
         jsonWriter.writeDoubleField("double", this.doubleProperty);
         jsonWriter.writeStringField("duration", CoreToCodegenBridgeUtils.durationToStringWithDays(this.duration));
         jsonWriter.writeStringField("date", Objects.toString(this.date, null));
-        jsonWriter.writeStringField("dateTime", this.dateTime == null ? null : ISO_8601.format(this.dateTime));
+        jsonWriter.writeStringField("dateTime",
+            this.dateTime == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.dateTime));
         jsonWriter.writeArrayField("stringList", this.stringList, (writer, element) -> writer.writeString(element));
         jsonWriter.writeMapField("bytesDict", this.bytesDict, (writer, element) -> writer.writeBinary(element));
         jsonWriter.writeStringField("url", this.url);

--- a/typespec-tests/src/main/java/com/cadl/builtin/models/Encoded.java
+++ b/typespec-tests/src/main/java/com/cadl/builtin/models/Encoded.java
@@ -26,8 +26,6 @@ import java.util.Objects;
  */
 @Fluent
 public final class Encoded implements JsonSerializable<Encoded> {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /*
      * The timeInSeconds property.
      */
@@ -271,7 +269,8 @@ public final class Encoded implements JsonSerializable<Encoded> {
         jsonWriter.writeStartObject();
         jsonWriter.writeNumberField("timeInSeconds", this.timeInSeconds);
         jsonWriter.writeNumberField("timeInSecondsFraction", this.timeInSecondsFraction);
-        jsonWriter.writeStringField("dateTime", this.dateTime == null ? null : ISO_8601.format(this.dateTime));
+        jsonWriter.writeStringField("dateTime",
+            this.dateTime == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.dateTime));
         jsonWriter.writeStringField("dateTimeRfc7231", Objects.toString(this.dateTimeRfc7231, null));
         jsonWriter.writeNumberField("unixTimestamp", this.unixTimestamp);
         jsonWriter.writeBinaryField("base64", this.base64);

--- a/typespec-tests/src/main/java/com/cadl/optional/models/AllPropertiesOptional.java
+++ b/typespec-tests/src/main/java/com/cadl/optional/models/AllPropertiesOptional.java
@@ -24,8 +24,6 @@ import java.util.Map;
  */
 @Immutable
 public final class AllPropertiesOptional implements JsonSerializable<AllPropertiesOptional> {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /*
      * The boolean property.
      */
@@ -338,7 +336,8 @@ public final class AllPropertiesOptional implements JsonSerializable<AllProperti
         jsonWriter.writeNumberField("float", this.floatProperty);
         jsonWriter.writeNumberField("double", this.doubleProperty);
         jsonWriter.writeStringField("duration", CoreToCodegenBridgeUtils.durationToStringWithDays(this.duration));
-        jsonWriter.writeStringField("dateTime", this.dateTime == null ? null : ISO_8601.format(this.dateTime));
+        jsonWriter.writeStringField("dateTime",
+            this.dateTime == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.dateTime));
         jsonWriter.writeArrayField("stringList", this.stringList, (writer, element) -> writer.writeString(element));
         jsonWriter.writeMapField("bytesDict", this.bytesDict, (writer, element) -> writer.writeBinary(element));
         jsonWriter.writeJsonField("immutable", this.immutable);

--- a/typespec-tests/src/main/java/com/cadl/optional/models/Optional.java
+++ b/typespec-tests/src/main/java/com/cadl/optional/models/Optional.java
@@ -24,8 +24,6 @@ import java.util.Map;
  */
 @Fluent
 public final class Optional implements JsonSerializable<Optional> {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /*
      * The boolean property.
      */
@@ -488,7 +486,8 @@ public final class Optional implements JsonSerializable<Optional> {
         jsonWriter.writeNumberField("float", this.floatProperty);
         jsonWriter.writeNumberField("double", this.doubleProperty);
         jsonWriter.writeStringField("duration", CoreToCodegenBridgeUtils.durationToStringWithDays(this.duration));
-        jsonWriter.writeStringField("dateTime", this.dateTime == null ? null : ISO_8601.format(this.dateTime));
+        jsonWriter.writeStringField("dateTime",
+            this.dateTime == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.dateTime));
         jsonWriter.writeArrayField("stringList", this.stringList, (writer, element) -> writer.writeString(element));
         jsonWriter.writeMapField("bytesDict", this.bytesDict, (writer, element) -> writer.writeBinary(element));
         return jsonWriter.writeEndObject();

--- a/typespec-tests/src/main/java/com/cadl/wiretype/models/SubClass.java
+++ b/typespec-tests/src/main/java/com/cadl/wiretype/models/SubClass.java
@@ -20,8 +20,6 @@ import java.util.Objects;
  */
 @Immutable
 public final class SubClass extends SuperClassMismatch {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /*
      * The dateTime property.
      */
@@ -57,7 +55,8 @@ public final class SubClass extends SuperClassMismatch {
             jsonWriter.writeStringField("dateTimeRfc7231",
                 Objects.toString(new DateTimeRfc1123(getDateTimeRfc7231()), null));
         }
-        jsonWriter.writeStringField("dateTime", this.dateTime == null ? null : ISO_8601.format(this.dateTime));
+        jsonWriter.writeStringField("dateTime",
+            this.dateTime == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.dateTime));
         return jsonWriter.writeEndObject();
     }
 

--- a/typespec-tests/src/main/java/com/cadl/wiretype/models/SubClassMismatch.java
+++ b/typespec-tests/src/main/java/com/cadl/wiretype/models/SubClassMismatch.java
@@ -20,8 +20,6 @@ import java.util.Objects;
  */
 @Immutable
 public final class SubClassMismatch extends SuperClass {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /*
      * The dateTimeRfc7231 property.
      */
@@ -56,7 +54,8 @@ public final class SubClassMismatch extends SuperClass {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("dateTime", getDateTime() == null ? null : ISO_8601.format(getDateTime()));
+        jsonWriter.writeStringField("dateTime",
+            getDateTime() == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(getDateTime()));
         jsonWriter.writeStringField("dateTimeRfc7231", Objects.toString(this.dateTimeRfc7231, null));
         return jsonWriter.writeEndObject();
     }

--- a/typespec-tests/src/main/java/com/cadl/wiretype/models/SuperClass.java
+++ b/typespec-tests/src/main/java/com/cadl/wiretype/models/SuperClass.java
@@ -19,8 +19,6 @@ import java.time.format.DateTimeFormatter;
  */
 @Immutable
 public class SuperClass implements JsonSerializable<SuperClass> {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /*
      * The dateTime property.
      */
@@ -50,7 +48,8 @@ public class SuperClass implements JsonSerializable<SuperClass> {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("dateTime", this.dateTime == null ? null : ISO_8601.format(this.dateTime));
+        jsonWriter.writeStringField("dateTime",
+            this.dateTime == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.dateTime));
         return jsonWriter.writeEndObject();
     }
 

--- a/typespec-tests/src/main/java/com/encode/datetime/models/DefaultDatetimeProperty.java
+++ b/typespec-tests/src/main/java/com/encode/datetime/models/DefaultDatetimeProperty.java
@@ -19,8 +19,6 @@ import java.time.format.DateTimeFormatter;
  */
 @Immutable
 public final class DefaultDatetimeProperty implements JsonSerializable<DefaultDatetimeProperty> {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /*
      * The value property.
      */
@@ -50,7 +48,8 @@ public final class DefaultDatetimeProperty implements JsonSerializable<DefaultDa
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("value", this.value == null ? null : ISO_8601.format(this.value));
+        jsonWriter.writeStringField("value",
+            this.value == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.value));
         return jsonWriter.writeEndObject();
     }
 

--- a/typespec-tests/src/main/java/com/encode/datetime/models/Rfc3339DatetimeProperty.java
+++ b/typespec-tests/src/main/java/com/encode/datetime/models/Rfc3339DatetimeProperty.java
@@ -19,8 +19,6 @@ import java.time.format.DateTimeFormatter;
  */
 @Immutable
 public final class Rfc3339DatetimeProperty implements JsonSerializable<Rfc3339DatetimeProperty> {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /*
      * The value property.
      */
@@ -50,7 +48,8 @@ public final class Rfc3339DatetimeProperty implements JsonSerializable<Rfc3339Da
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("value", this.value == null ? null : ISO_8601.format(this.value));
+        jsonWriter.writeStringField("value",
+            this.value == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.value));
         return jsonWriter.writeEndObject();
     }
 

--- a/typespec-tests/src/main/java/com/type/property/nullable/models/DatetimeProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/nullable/models/DatetimeProperty.java
@@ -19,8 +19,6 @@ import java.time.format.DateTimeFormatter;
  */
 @Immutable
 public final class DatetimeProperty implements JsonSerializable<DatetimeProperty> {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /*
      * Required property
      */
@@ -69,8 +67,8 @@ public final class DatetimeProperty implements JsonSerializable<DatetimeProperty
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeStringField("requiredProperty", this.requiredProperty);
-        jsonWriter.writeStringField("nullableProperty",
-            this.nullableProperty == null ? null : ISO_8601.format(this.nullableProperty));
+        jsonWriter.writeStringField("nullableProperty", this.nullableProperty == null ? null
+            : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.nullableProperty));
         return jsonWriter.writeEndObject();
     }
 

--- a/typespec-tests/src/main/java/com/type/property/optional/models/DatetimeProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/optional/models/DatetimeProperty.java
@@ -19,8 +19,6 @@ import java.time.format.DateTimeFormatter;
  */
 @Fluent
 public final class DatetimeProperty implements JsonSerializable<DatetimeProperty> {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /*
      * Property
      */
@@ -59,7 +57,8 @@ public final class DatetimeProperty implements JsonSerializable<DatetimeProperty
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("property", this.property == null ? null : ISO_8601.format(this.property));
+        jsonWriter.writeStringField("property",
+            this.property == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.property));
         return jsonWriter.writeEndObject();
     }
 

--- a/typespec-tests/src/main/java/com/type/property/valuetypes/models/DatetimeProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/valuetypes/models/DatetimeProperty.java
@@ -19,8 +19,6 @@ import java.time.format.DateTimeFormatter;
  */
 @Immutable
 public final class DatetimeProperty implements JsonSerializable<DatetimeProperty> {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /*
      * Property
      */
@@ -50,7 +48,8 @@ public final class DatetimeProperty implements JsonSerializable<DatetimeProperty
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("property", this.property == null ? null : ISO_8601.format(this.property));
+        jsonWriter.writeStringField("property",
+            this.property == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.property));
         return jsonWriter.writeEndObject();
     }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Cookiecuttershark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Cookiecuttershark.java
@@ -18,8 +18,6 @@ import java.util.List;
  */
 @Fluent
 public final class Cookiecuttershark extends Shark {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /**
      * Creates an instance of Cookiecuttershark class.
      */
@@ -86,7 +84,8 @@ public final class Cookiecuttershark extends Shark {
         jsonWriter.writeStartObject();
         jsonWriter.writeStringField("fishtype", "cookiecuttershark");
         jsonWriter.writeFloatField("length", getLength());
-        jsonWriter.writeStringField("birthday", getBirthday() == null ? null : ISO_8601.format(getBirthday()));
+        jsonWriter.writeStringField("birthday",
+            getBirthday() == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(getBirthday()));
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeNumberField("age", getAge());

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/DatetimeWrapper.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/DatetimeWrapper.java
@@ -18,8 +18,6 @@ import java.time.format.DateTimeFormatter;
  */
 @Fluent
 public final class DatetimeWrapper implements JsonSerializable<DatetimeWrapper> {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /*
      * The field property.
      */
@@ -87,8 +85,10 @@ public final class DatetimeWrapper implements JsonSerializable<DatetimeWrapper> 
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("field", this.field == null ? null : ISO_8601.format(this.field));
-        jsonWriter.writeStringField("now", this.now == null ? null : ISO_8601.format(this.now));
+        jsonWriter.writeStringField("field",
+            this.field == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.field));
+        jsonWriter.writeStringField("now",
+            this.now == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.now));
         return jsonWriter.writeEndObject();
     }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Goblinshark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Goblinshark.java
@@ -18,8 +18,6 @@ import java.util.List;
  */
 @Fluent
 public final class Goblinshark extends Shark {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /*
      * The jawsize property.
      */
@@ -136,7 +134,8 @@ public final class Goblinshark extends Shark {
         jsonWriter.writeStartObject();
         jsonWriter.writeStringField("fishtype", "goblin");
         jsonWriter.writeFloatField("length", getLength());
-        jsonWriter.writeStringField("birthday", getBirthday() == null ? null : ISO_8601.format(getBirthday()));
+        jsonWriter.writeStringField("birthday",
+            getBirthday() == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(getBirthday()));
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeNumberField("age", getAge());

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Sawshark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Sawshark.java
@@ -19,8 +19,6 @@ import java.util.List;
  */
 @Fluent
 public final class Sawshark extends Shark {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /*
      * The picture property.
      */
@@ -112,7 +110,8 @@ public final class Sawshark extends Shark {
         jsonWriter.writeStartObject();
         jsonWriter.writeStringField("fishtype", "sawshark");
         jsonWriter.writeFloatField("length", getLength());
-        jsonWriter.writeStringField("birthday", getBirthday() == null ? null : ISO_8601.format(getBirthday()));
+        jsonWriter.writeStringField("birthday",
+            getBirthday() == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(getBirthday()));
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeNumberField("age", getAge());

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Shark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Shark.java
@@ -19,8 +19,6 @@ import java.util.List;
  */
 @Fluent
 public class Shark extends Fish {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /*
      * The age property.
      */
@@ -127,7 +125,8 @@ public class Shark extends Fish {
         jsonWriter.writeFloatField("length", getLength());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
-        jsonWriter.writeStringField("birthday", this.birthday == null ? null : ISO_8601.format(this.birthday));
+        jsonWriter.writeStringField("birthday",
+            this.birthday == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.birthday));
         jsonWriter.writeNumberField("age", this.age);
         return jsonWriter.writeEndObject();
     }

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Cookiecuttershark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Cookiecuttershark.java
@@ -19,8 +19,6 @@ import java.util.List;
  */
 @Fluent
 public final class Cookiecuttershark extends Shark {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /**
      * Creates an instance of Cookiecuttershark class.
      * 
@@ -73,7 +71,8 @@ public final class Cookiecuttershark extends Shark {
         jsonWriter.writeStartObject();
         jsonWriter.writeStringField("fishtype", "cookiecuttershark");
         jsonWriter.writeFloatField("length", getLength());
-        jsonWriter.writeStringField("birthday", getBirthday() == null ? null : ISO_8601.format(getBirthday()));
+        jsonWriter.writeStringField("birthday",
+            getBirthday() == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(getBirthday()));
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeNumberField("age", getAge());

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/DatetimeWrapper.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/DatetimeWrapper.java
@@ -18,8 +18,6 @@ import java.time.format.DateTimeFormatter;
  */
 @Fluent
 public final class DatetimeWrapper implements JsonSerializable<DatetimeWrapper> {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /*
      * The field property.
      */
@@ -87,8 +85,10 @@ public final class DatetimeWrapper implements JsonSerializable<DatetimeWrapper> 
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("field", this.field == null ? null : ISO_8601.format(this.field));
-        jsonWriter.writeStringField("now", this.now == null ? null : ISO_8601.format(this.now));
+        jsonWriter.writeStringField("field",
+            this.field == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.field));
+        jsonWriter.writeStringField("now",
+            this.now == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.now));
         return jsonWriter.writeEndObject();
     }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Goblinshark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Goblinshark.java
@@ -19,8 +19,6 @@ import java.util.List;
  */
 @Fluent
 public final class Goblinshark extends Shark {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /*
      * The jawsize property.
      */
@@ -123,7 +121,8 @@ public final class Goblinshark extends Shark {
         jsonWriter.writeStartObject();
         jsonWriter.writeStringField("fishtype", "goblin");
         jsonWriter.writeFloatField("length", getLength());
-        jsonWriter.writeStringField("birthday", getBirthday() == null ? null : ISO_8601.format(getBirthday()));
+        jsonWriter.writeStringField("birthday",
+            getBirthday() == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(getBirthday()));
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeNumberField("age", getAge());

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Sawshark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Sawshark.java
@@ -20,8 +20,6 @@ import java.util.List;
  */
 @Fluent
 public final class Sawshark extends Shark {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /*
      * The picture property.
      */
@@ -99,7 +97,8 @@ public final class Sawshark extends Shark {
         jsonWriter.writeStartObject();
         jsonWriter.writeStringField("fishtype", "sawshark");
         jsonWriter.writeFloatField("length", getLength());
-        jsonWriter.writeStringField("birthday", getBirthday() == null ? null : ISO_8601.format(getBirthday()));
+        jsonWriter.writeStringField("birthday",
+            getBirthday() == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(getBirthday()));
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeNumberField("age", getAge());

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Shark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Shark.java
@@ -20,8 +20,6 @@ import java.util.List;
  */
 @Fluent
 public class Shark extends Fish {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /*
      * The age property.
      */
@@ -113,7 +111,8 @@ public class Shark extends Fish {
         jsonWriter.writeFloatField("length", getLength());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
-        jsonWriter.writeStringField("birthday", this.birthday == null ? null : ISO_8601.format(this.birthday));
+        jsonWriter.writeStringField("birthday",
+            this.birthday == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.birthday));
         jsonWriter.writeNumberField("age", this.age);
         return jsonWriter.writeEndObject();
     }

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/AccessPolicy.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/AccessPolicy.java
@@ -20,8 +20,6 @@ import javax.xml.stream.XMLStreamException;
  */
 @Fluent
 public final class AccessPolicy implements XmlSerializable<AccessPolicy> {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /*
      * the date-time the policy is active
      */
@@ -129,8 +127,10 @@ public final class AccessPolicy implements XmlSerializable<AccessPolicy> {
     public XmlWriter toXml(XmlWriter xmlWriter, String rootElementName) throws XMLStreamException {
         rootElementName = CoreUtils.isNullOrEmpty(rootElementName) ? "AccessPolicy" : rootElementName;
         xmlWriter.writeStartElement(rootElementName);
-        xmlWriter.writeStringElement("Start", this.start == null ? null : ISO_8601.format(this.start));
-        xmlWriter.writeStringElement("Expiry", this.expiry == null ? null : ISO_8601.format(this.expiry));
+        xmlWriter.writeStringElement("Start",
+            this.start == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.start));
+        xmlWriter.writeStringElement("Expiry",
+            this.expiry == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.expiry));
         xmlWriter.writeStringElement("Permission", this.permission);
         return xmlWriter.writeEndElement();
     }

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/AppleBarrel.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/AppleBarrel.java
@@ -23,12 +23,12 @@ public final class AppleBarrel implements XmlSerializable<AppleBarrel> {
     /*
      * The GoodApples property.
      */
-    private List<String> goodApples = new ArrayList<>();
+    private List<String> goodApples;
 
     /*
      * The BadApples property.
      */
-    private List<String> badApples = new ArrayList<>();
+    private List<String> badApples;
 
     /**
      * Creates an instance of AppleBarrel class.
@@ -146,24 +146,24 @@ public final class AppleBarrel implements XmlSerializable<AppleBarrel> {
                 QName elementName = reader.getElementName();
 
                 if ("GoodApples".equals(elementName.getLocalPart())) {
-                    if (deserializedAppleBarrel.goodApples == null) {
-                        deserializedAppleBarrel.goodApples = new ArrayList<>();
-                    }
                     while (reader.nextElement() != XmlToken.END_ELEMENT) {
                         elementName = reader.getElementName();
                         if ("Apple".equals(elementName.getLocalPart())) {
+                            if (deserializedAppleBarrel.goodApples == null) {
+                                deserializedAppleBarrel.goodApples = new ArrayList<>();
+                            }
                             deserializedAppleBarrel.goodApples.add(reader.getStringElement());
                         } else {
                             reader.skipElement();
                         }
                     }
                 } else if ("BadApples".equals(elementName.getLocalPart())) {
-                    if (deserializedAppleBarrel.badApples == null) {
-                        deserializedAppleBarrel.badApples = new ArrayList<>();
-                    }
                     while (reader.nextElement() != XmlToken.END_ELEMENT) {
                         elementName = reader.getElementName();
                         if ("Apple".equals(elementName.getLocalPart())) {
+                            if (deserializedAppleBarrel.badApples == null) {
+                                deserializedAppleBarrel.badApples = new ArrayList<>();
+                            }
                             deserializedAppleBarrel.badApples.add(reader.getStringElement());
                         } else {
                             reader.skipElement();

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/Banana.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/Banana.java
@@ -20,8 +20,6 @@ import javax.xml.stream.XMLStreamException;
  */
 @Fluent
 public final class Banana implements XmlSerializable<Banana> {
-    private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-
     /*
      * The name property.
      */
@@ -122,7 +120,8 @@ public final class Banana implements XmlSerializable<Banana> {
         xmlWriter.writeStartElement(rootElementName);
         xmlWriter.writeStringElement("name", this.name);
         xmlWriter.writeStringElement("flavor", this.flavor);
-        xmlWriter.writeStringElement("expiration", this.expiration == null ? null : ISO_8601.format(this.expiration));
+        xmlWriter.writeStringElement("expiration",
+            this.expiration == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.expiration));
         return xmlWriter.writeEndElement();
     }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/Blob.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/Blob.java
@@ -233,10 +233,10 @@ public final class Blob implements XmlSerializable<Blob> {
                 } else if ("Properties".equals(elementName.getLocalPart())) {
                     deserializedBlob.properties = BlobProperties.fromXml(reader, "Properties");
                 } else if ("Metadata".equals(elementName.getLocalPart())) {
-                    if (deserializedBlob.metadata == null) {
-                        deserializedBlob.metadata = new LinkedHashMap<>();
-                    }
                     while (reader.nextElement() != XmlToken.END_ELEMENT) {
+                        if (deserializedBlob.metadata == null) {
+                            deserializedBlob.metadata = new LinkedHashMap<>();
+                        }
                         deserializedBlob.metadata.put(reader.getElementName().getLocalPart(),
                             reader.getStringElement());
                     }

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/Blobs.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/Blobs.java
@@ -142,14 +142,8 @@ public final class Blobs implements XmlSerializable<Blobs> {
                 QName elementName = reader.getElementName();
 
                 if ("BlobPrefix".equals(elementName.getLocalPart())) {
-                    if (deserializedBlobs.blobPrefix == null) {
-                        deserializedBlobs.blobPrefix = new ArrayList<>();
-                    }
                     deserializedBlobs.blobPrefix.add(BlobPrefix.fromXml(reader, "BlobPrefix"));
                 } else if ("Blob".equals(elementName.getLocalPart())) {
-                    if (deserializedBlobs.blob == null) {
-                        deserializedBlobs.blob = new ArrayList<>();
-                    }
                     deserializedBlobs.blob.add(Blob.fromXml(reader, "Blob"));
                 } else {
                     reader.skipElement();

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/Container.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/Container.java
@@ -174,10 +174,10 @@ public final class Container implements XmlSerializable<Container> {
                 } else if ("Properties".equals(elementName.getLocalPart())) {
                     deserializedContainer.properties = ContainerProperties.fromXml(reader, "Properties");
                 } else if ("Metadata".equals(elementName.getLocalPart())) {
-                    if (deserializedContainer.metadata == null) {
-                        deserializedContainer.metadata = new LinkedHashMap<>();
-                    }
                     while (reader.nextElement() != XmlToken.END_ELEMENT) {
+                        if (deserializedContainer.metadata == null) {
+                            deserializedContainer.metadata = new LinkedHashMap<>();
+                        }
                         deserializedContainer.metadata.put(reader.getElementName().getLocalPart(),
                             reader.getStringElement());
                     }

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/ListContainersResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/ListContainersResponse.java
@@ -43,7 +43,7 @@ public final class ListContainersResponse implements XmlSerializable<ListContain
     /*
      * The Containers property.
      */
-    private List<Container> containers = new ArrayList<>();
+    private List<Container> containers;
 
     /*
      * The NextMarker property.
@@ -264,12 +264,12 @@ public final class ListContainersResponse implements XmlSerializable<ListContain
                 } else if ("MaxResults".equals(elementName.getLocalPart())) {
                     deserializedListContainersResponse.maxResults = reader.getIntElement();
                 } else if ("Containers".equals(elementName.getLocalPart())) {
-                    if (deserializedListContainersResponse.containers == null) {
-                        deserializedListContainersResponse.containers = new ArrayList<>();
-                    }
                     while (reader.nextElement() != XmlToken.END_ELEMENT) {
                         elementName = reader.getElementName();
                         if ("Container".equals(elementName.getLocalPart())) {
+                            if (deserializedListContainersResponse.containers == null) {
+                                deserializedListContainersResponse.containers = new ArrayList<>();
+                            }
                             deserializedListContainersResponse.containers.add(Container.fromXml(reader, "Container"));
                         } else {
                             reader.skipElement();

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/Slide.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/Slide.java
@@ -163,12 +163,12 @@ public final class Slide implements XmlSerializable<Slide> {
                 if ("title".equals(elementName.getLocalPart())) {
                     deserializedSlide.title = reader.getStringElement();
                 } else if ("items".equals(elementName.getLocalPart())) {
-                    if (deserializedSlide.items == null) {
-                        deserializedSlide.items = new ArrayList<>();
-                    }
                     while (reader.nextElement() != XmlToken.END_ELEMENT) {
                         elementName = reader.getElementName();
                         if ("item".equals(elementName.getLocalPart())) {
+                            if (deserializedSlide.items == null) {
+                                deserializedSlide.items = new ArrayList<>();
+                            }
                             deserializedSlide.items.add(reader.getStringElement());
                         } else {
                             reader.skipElement();

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/Slideshow.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/Slideshow.java
@@ -192,12 +192,12 @@ public final class Slideshow implements XmlSerializable<Slideshow> {
                 QName elementName = reader.getElementName();
 
                 if ("slides".equals(elementName.getLocalPart())) {
-                    if (deserializedSlideshow.slides == null) {
-                        deserializedSlideshow.slides = new ArrayList<>();
-                    }
                     while (reader.nextElement() != XmlToken.END_ELEMENT) {
                         elementName = reader.getElementName();
                         if ("slide".equals(elementName.getLocalPart())) {
+                            if (deserializedSlideshow.slides == null) {
+                                deserializedSlideshow.slides = new ArrayList<>();
+                            }
                             deserializedSlideshow.slides.add(Slide.fromXml(reader, "slide"));
                         } else {
                             reader.skipElement();

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/StorageServiceProperties.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/StorageServiceProperties.java
@@ -38,7 +38,7 @@ public final class StorageServiceProperties implements XmlSerializable<StorageSe
     /*
      * The set of CORS rules.
      */
-    private List<CorsRule> cors = new ArrayList<>();
+    private List<CorsRule> cors;
 
     /*
      * The default version to use for requests to the Blob service if an incoming request's version is not specified.
@@ -269,12 +269,12 @@ public final class StorageServiceProperties implements XmlSerializable<StorageSe
                 } else if ("MinuteMetrics".equals(elementName.getLocalPart())) {
                     deserializedStorageServiceProperties.minuteMetrics = Metrics.fromXml(reader, "MinuteMetrics");
                 } else if ("Cors".equals(elementName.getLocalPart())) {
-                    if (deserializedStorageServiceProperties.cors == null) {
-                        deserializedStorageServiceProperties.cors = new ArrayList<>();
-                    }
                     while (reader.nextElement() != XmlToken.END_ELEMENT) {
                         elementName = reader.getElementName();
                         if ("CorsRule".equals(elementName.getLocalPart())) {
+                            if (deserializedStorageServiceProperties.cors == null) {
+                                deserializedStorageServiceProperties.cors = new ArrayList<>();
+                            }
                             deserializedStorageServiceProperties.cors.add(CorsRule.fromXml(reader, "CorsRule"));
                         } else {
                             reader.skipElement();


### PR DESCRIPTION
- Replace custom `DateTimeFormatter` `ISO_8601` with `DateTimeFormatter.ISO_OFFSET_DATE_TIME`
- Add XML namespace to constant mapping to cleanup XML with namespaces
- Remove `new ArrayList<>()` during instantiation for wrapped XML element lists
- Pushed down `new ArrayList<>()` creation when deserializing XML element lists to match Jackson behavior of treating empty elements as null
- 