### PR TITLE
tsp, add missing decimal test for cadl-ranch

### DIFF
--- a/typespec-tests/src/test/java/com/type/property/valuetypes/DecimalTests.java
+++ b/typespec-tests/src/test/java/com/type/property/valuetypes/DecimalTests.java
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.type.property.valuetypes;
+
+import org.junit.jupiter.api.Test;
+
+public class DecimalTests {
+
+    private final DecimalClient client1 = new ValueTypesClientBuilder().buildDecimalClient();
+    private final Decimal128Client client2 = new ValueTypesClientBuilder().buildDecimal128Client();
+
+    @Test
+    public void test() {
+        client1.put(client1.get());
+
+        client2.put(client2.get());
+    }
+}

--- a/typespec-tests/src/test/java/com/type/scalar/DecimalTests.java
+++ b/typespec-tests/src/test/java/com/type/scalar/DecimalTests.java
@@ -3,98 +3,69 @@
 
 package com.type.scalar;
 
+import com.azure.core.annotation.Immutable;
 import com.azure.core.util.BinaryData;
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonToken;
-import com.azure.json.JsonWriter;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.type.property.valuetypes.models.DecimalProperty;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.io.IOException;
 import java.math.BigDecimal;
 
 public class DecimalTests {
 
-    public interface Getter {
-        BigDecimal getProperty();
-    }
-
-    public static class DecimalStream implements JsonSerializable<DecimalStream>, Getter {
-        private BigDecimal property;
-
-        public BigDecimal getProperty() {
-            return property;
-        }
-
-        public DecimalStream setProperty(BigDecimal property) {
-            this.property = property;
-            return this;
-        }
-
-        @Override
-        public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-            jsonWriter.writeStartObject();
-            jsonWriter.writeNumberField("property", this.property == null ? null : this.property);
-            return jsonWriter.writeEndObject();
-        }
-
-        public static DecimalStream fromJson(JsonReader jsonReader) throws IOException {
-            return jsonReader.readObject(reader -> {
-                DecimalStream decimalProperty = new DecimalStream();
-                while (reader.nextToken() != JsonToken.END_OBJECT) {
-                    String fieldName = reader.getFieldName();
-                    reader.nextToken();
-
-                    if ("property".equals(fieldName)) {
-                        BigDecimal property = reader.getNullable(nonNullReader -> new BigDecimal(nonNullReader.getString()));
-                        decimalProperty.setProperty(property);
-                    } else {
-                        reader.skipChildren();
-                    }
-                }
-                return decimalProperty;
-            });
-        }
-    }
-
-    public static class DecimalJackson implements Getter {
+    @Immutable
+    public static class DecimalJackson {
         @JsonProperty("property")
         private BigDecimal property;
 
-        @Override
-        public BigDecimal getProperty() {
-            return property;
+        public DecimalJackson(@JsonProperty("property") BigDecimal property) {
+            this.property = property;
         }
 
-        public void setProperty(BigDecimal property) {
-            this.property = property;
+        public BigDecimal getProperty() {
+            return property;
         }
     }
 
     @ParameterizedTest
-    @ValueSource(classes = {DecimalStream.class, DecimalJackson.class})
-    public <T extends Getter> void testBigDecimal(Class<T> clazz) {
+    @ValueSource(classes = {DecimalProperty.class, DecimalJackson.class})
+    public <T> void testBigDecimal(Class<T> clazz) {
         // precision larger than double
         BigDecimal value = new BigDecimal("12345678901234567890.1234567890");
-        String json = BinaryData.fromObject(new DecimalStream().setProperty(value)).toString();
+        String json = BinaryData.fromObject(newInstance(clazz, value)).toString();
         var test = BinaryData.fromString(json).toObject(clazz);
-        Assertions.assertEquals(value, test.getProperty());
+        Assertions.assertEquals(value, getProperty(clazz, test));
 
         // make sure precision difference would cause NotEquals
         Assertions.assertNotEquals(value, new BigDecimal("12345678901234567890.123456789"));
 
         // scientific
         value = new BigDecimal("1.2345678901234567890E23");
-        json = BinaryData.fromObject(new DecimalStream().setProperty(value)).toString();
+        json = BinaryData.fromObject(newInstance(clazz, value)).toString();
         test = BinaryData.fromString(json).toObject(clazz);
-        Assertions.assertEquals(value, test.getProperty());
+        Assertions.assertEquals(value, getProperty(clazz, test));
 
         value = new BigDecimal("-1.2345678901234567890e-105");
-        json = BinaryData.fromObject(new DecimalStream().setProperty(value)).toString();
+        json = BinaryData.fromObject(newInstance(clazz, value)).toString();
         test = BinaryData.fromString(json).toObject(clazz);
-        Assertions.assertEquals(value, test.getProperty());
+        Assertions.assertEquals(value, getProperty(clazz, test));
+    }
+
+    private static <T> T newInstance(Class<T> clazz, BigDecimal value) {
+        try {
+            return clazz.getDeclaredConstructor(BigDecimal.class).newInstance(value);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static <T> BigDecimal getProperty(Class<T> clazz, T obj) {
+        try {
+            return (BigDecimal) clazz.getDeclaredMethod("getProperty").invoke(obj);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
wasn't aware there is another decimal test case under type/property/valuetypes