### PR TITLE
tsp, fix bug that azure-core-experimental missing from pom/module-info

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/Javagen.java
+++ b/javagen/src/main/java/com/azure/autorest/Javagen.java
@@ -275,8 +275,8 @@ public class Javagen extends NewPlugin {
                 project.integrateWithSdk();
             }
 
-            client.getModuleInfo().checkForAdditionalDependencies(client.getModels());
-            project.checkForAdditionalDependencies(client.getModels());
+            client.getModuleInfo().checkForAdditionalDependencies(client.getModels(), codeModel);
+            project.checkForAdditionalDependencies(client.getModels(), codeModel);
 
             // Module-info
             javaPackage.addModuleInfo(client.getModuleInfo());

--- a/javagen/src/main/java/com/azure/autorest/Javagen.java
+++ b/javagen/src/main/java/com/azure/autorest/Javagen.java
@@ -52,6 +52,7 @@ import org.yaml.snakeyaml.representer.Representer;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class Javagen extends NewPlugin {
@@ -275,8 +276,9 @@ public class Javagen extends NewPlugin {
                 project.integrateWithSdk();
             }
 
-            client.getModuleInfo().checkForAdditionalDependencies(client.getModels(), codeModel);
-            project.checkForAdditionalDependencies(client.getModels(), codeModel);
+            Set<String> externalPackageNames = ClientModelUtil.getExternalPackageNamesUsedInClient(client.getModels(), codeModel);
+            client.getModuleInfo().checkForAdditionalDependencies(externalPackageNames);
+            project.checkForAdditionalDependencies(externalPackageNames);
 
             // Module-info
             javaPackage.addModuleInfo(client.getModuleInfo());

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ModuleInfo.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ModuleInfo.java
@@ -3,11 +3,13 @@
 
 package com.azure.autorest.model.clientmodel;
 
+import com.azure.autorest.extension.base.model.codemodel.CodeModel;
+import com.azure.autorest.util.ClientModelUtil;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class ModuleInfo {
     private final String moduleName;
@@ -137,12 +139,8 @@ public class ModuleInfo {
     }
 
     // TODO (weidxu): this method likely will get refactored when we support external model (hence external package)
-    public void checkForAdditionalDependencies(List<ClientModel> models) {
-        Set<String> externalPackageNames = models.stream()
-                .filter(m -> m.getImplementationDetails() != null && m.getImplementationDetails().getUsages() != null
-                        && m.getImplementationDetails().getUsages().contains(ImplementationDetails.Usage.EXTERNAL))
-                .map(ClientModel::getPackage)
-                .collect(Collectors.toSet());
+    public void checkForAdditionalDependencies(List<ClientModel> models, CodeModel codeModel) {
+        Set<String> externalPackageNames = ClientModelUtil.getExternalPackageNamesUsedInClient(models, codeModel);
 
         // currently, only check for azure-core-experimental
         if (externalPackageNames.stream().anyMatch(p -> p.startsWith("com.azure.core.experimental"))) {

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ModuleInfo.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ModuleInfo.java
@@ -3,9 +3,6 @@
 
 package com.azure.autorest.model.clientmodel;
 
-import com.azure.autorest.extension.base.model.codemodel.CodeModel;
-import com.azure.autorest.util.ClientModelUtil;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -139,9 +136,7 @@ public class ModuleInfo {
     }
 
     // TODO (weidxu): this method likely will get refactored when we support external model (hence external package)
-    public void checkForAdditionalDependencies(List<ClientModel> models, CodeModel codeModel) {
-        Set<String> externalPackageNames = ClientModelUtil.getExternalPackageNamesUsedInClient(models, codeModel);
-
+    public void checkForAdditionalDependencies(Set<String> externalPackageNames) {
         // currently, only check for azure-core-experimental
         if (externalPackageNames.stream().anyMatch(p -> p.startsWith("com.azure.core.experimental"))) {
             getRequireModules().add(new ModuleInfo.RequireModule("com.azure.core.experimental", true));

--- a/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
+++ b/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
@@ -4,11 +4,9 @@
 package com.azure.autorest.model.projectmodel;
 
 import com.azure.autorest.Javagen;
-import com.azure.autorest.extension.base.model.codemodel.CodeModel;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.extension.base.plugin.PluginLogger;
 import com.azure.autorest.model.clientmodel.Client;
-import com.azure.autorest.model.clientmodel.ClientModel;
 import com.azure.autorest.model.clientmodel.ExternalPackage;
 import com.azure.autorest.template.TemplateHelper;
 import com.azure.autorest.util.ClientModelUtil;
@@ -128,9 +126,7 @@ public class Project {
     }
 
     // TODO (weidxu): this method likely will get refactored when we support external model (hence external package)
-    public void checkForAdditionalDependencies(List<ClientModel> models, CodeModel codeModel) {
-        Set<String> externalPackageNames = ClientModelUtil.getExternalPackageNamesUsedInClient(models, codeModel);
-
+    public void checkForAdditionalDependencies(Set<String> externalPackageNames) {
         // currently, only check for azure-core-experimental
         if (externalPackageNames.stream().anyMatch(p -> p.startsWith("com.azure.core.experimental"))) {
             // add to pomDependencyIdentifiers is not already there

--- a/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
+++ b/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
@@ -4,12 +4,12 @@
 package com.azure.autorest.model.projectmodel;
 
 import com.azure.autorest.Javagen;
+import com.azure.autorest.extension.base.model.codemodel.CodeModel;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.extension.base.plugin.PluginLogger;
 import com.azure.autorest.model.clientmodel.Client;
 import com.azure.autorest.model.clientmodel.ClientModel;
 import com.azure.autorest.model.clientmodel.ExternalPackage;
-import com.azure.autorest.model.clientmodel.ImplementationDetails;
 import com.azure.autorest.template.TemplateHelper;
 import com.azure.autorest.util.ClientModelUtil;
 import com.azure.core.util.CoreUtils;
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 public class Project {
 
@@ -129,12 +128,8 @@ public class Project {
     }
 
     // TODO (weidxu): this method likely will get refactored when we support external model (hence external package)
-    public void checkForAdditionalDependencies(List<ClientModel> models) {
-        Set<String> externalPackageNames = models.stream()
-                .filter(m -> m.getImplementationDetails() != null && m.getImplementationDetails().getUsages() != null
-                        && m.getImplementationDetails().getUsages().contains(ImplementationDetails.Usage.EXTERNAL))
-                .map(ClientModel::getPackage)
-                .collect(Collectors.toSet());
+    public void checkForAdditionalDependencies(List<ClientModel> models, CodeModel codeModel) {
+        Set<String> externalPackageNames = ClientModelUtil.getExternalPackageNamesUsedInClient(models, codeModel);
 
         // currently, only check for azure-core-experimental
         if (externalPackageNames.stream().anyMatch(p -> p.startsWith("com.azure.core.experimental"))) {


### PR DESCRIPTION
Previously we rely on the model in azure-core-experimental to figure out whether the generated SDK requires experimental lib.

However, we moved that model into azure-core.

Code is not great. We don't have final design on external lib/model. Maybe future we don't need this code (e.g. the PollingStrategy get moved to azure-core as well); maybe we are going to improve it.