### PR TITLE
eng, fix tsp nightly ci

### DIFF
--- a/eng/pipelines/ci-typespec-java-dev-nightly.yaml
+++ b/eng/pipelines/ci-typespec-java-dev-nightly.yaml
@@ -51,6 +51,11 @@ jobs:
           cat typespec-tests/package.json
         displayName: 'Bump TypeSpec Dependencies to dev'
 
+      - script: |
+          npm install
+        displayName: 'Install dev TypeSpec Dependencies'
+        workingDirectory: ./typespec-extension
+
       - task: PowerShell@2
         displayName: 'Generate Code'
         inputs:


### PR DESCRIPTION
after Patrick switch to `npm ci`, now after update package.json, CI need to run `npm install` first (to generate the new package-lock.json).