### PR TITLE
Fixed the not working test case for PR#2445

### DIFF
--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/ExtendsModelArrayAdditionalProperties.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/ExtendsModelArrayAdditionalProperties.java
@@ -11,7 +11,6 @@ import com.azure.json.JsonSerializable;
 import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -90,13 +89,8 @@ public final class ExtendsModelArrayAdditionalProperties
                     additionalProperties = new LinkedHashMap<>();
                 }
 
-                additionalProperties.put(fieldName, null);
-                if (reader.currentToken() == JsonToken.START_ARRAY) {
-                    additionalProperties.replace(fieldName, new ArrayList<>());
-                    while (reader.nextToken() != JsonToken.END_ARRAY) {
-                        additionalProperties.get(fieldName).add(ModelForRecord.fromJson(reader));
-                    }
-                }
+                additionalProperties.put(fieldName, reader.readArray(ModelForRecord::fromJson));
+
             }
             deserializedExtendsModelArrayAdditionalProperties.additionalProperties = additionalProperties;
             return deserializedExtendsModelArrayAdditionalProperties;

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/ExtendsModelArrayAdditionalProperties.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/ExtendsModelArrayAdditionalProperties.java
@@ -11,6 +11,7 @@ import com.azure.json.JsonSerializable;
 import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -90,9 +91,14 @@ public final class ExtendsModelArrayAdditionalProperties
                 }
 
                 additionalProperties.put(fieldName, null);
+                if (reader.currentToken() == JsonToken.START_ARRAY) {
+                    additionalProperties.replace(fieldName, new ArrayList<>());
+                    while (reader.nextToken() != JsonToken.END_ARRAY) {
+                        additionalProperties.get(fieldName).add(ModelForRecord.fromJson(reader));
+                    }
+                }
             }
             deserializedExtendsModelArrayAdditionalProperties.additionalProperties = additionalProperties;
-
             return deserializedExtendsModelArrayAdditionalProperties;
         });
     }

--- a/typespec-tests/src/test/java/com/type/property/additionalproperties/ExtendsTests.java
+++ b/typespec-tests/src/test/java/com/type/property/additionalproperties/ExtendsTests.java
@@ -1,7 +1,6 @@
 package com.type.property.additionalproperties;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.type.property.additionalproperties.models.ExtendsFloatAdditionalProperties;
@@ -39,7 +38,6 @@ public class ExtendsTests {
     }
 
     @Test
-    @Disabled("The 'Get' request did not respond for a long time.")
     public void testExtendsModelArrayClient() {
         Map<String, List<ModelForRecord>> propertyMap = new LinkedHashMap<>();
         propertyMap.put("prop", Arrays.asList(new ModelForRecord("ok"), new ModelForRecord("ok")));


### PR DESCRIPTION
1. The JsonTokes in the record from `ExtendsModelArrayClient.getWithResponse` are following as:
`START_OBJECT`,`FIELD_NAME`,`START_ARRAY`,`START_OBJECT`,`FIELD_NAME`,`STRING`,`END_OBJECT`,`END_ARRAY`,`END_OBJECT`
According to the logic of `ExtendsModelArrayAdditionalProperties#fromJson`
```
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();

                 if (additionalProperties == null) {
                     additionalProperties = new LinkedHashMap<>();
                 }

                 additionalProperties.put(fieldName, null);
             }
```
The values of `reader.nextToken()` in the while statement evaluates expression are `FIELD_NAME`,`START_OBJECT`,`STRING`and `END_ARRAY`, so the while loop becomes an infinite loop.

2. `ExtendsModelArrayAdditionalProperties#fromJson` also does not complete the encapsulation of the `Array` section.

3. Please replace 
```
                 additionalProperties.put(fieldName, null);
```` 
with
```
                additionalProperties.put(fieldName, reader.readArray(ModelForRecord::fromJson));
```