### PR TITLE
tsp, fix regression on BinaryData serialization

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
@@ -467,6 +467,7 @@ public class ClassType implements IType {
 
     public static final ClassType BINARY_DATA = getClassTypeBuilder(BinaryData.class)
         .defaultValueExpressionConverter(defaultValueExpression -> "BinaryData.fromObject(\"" + defaultValueExpression + "\")")
+        // do not use the "writeUntyped(nullableVar)", because some backend would fail the request on "null" value
 //        .serializationMethodBase("writeUntyped")
 //        .serializationValueGetterModifier(valueGetter -> valueGetter + " == null ? null : " + valueGetter + ".toObject(Object.class)")
         .jsonDeserializationMethod("getNullable(nonNullReader -> BinaryData.fromObject(nonNullReader.readUntyped()))")

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
@@ -467,8 +467,8 @@ public class ClassType implements IType {
 
     public static final ClassType BINARY_DATA = getClassTypeBuilder(BinaryData.class)
         .defaultValueExpressionConverter(defaultValueExpression -> "BinaryData.fromObject(\"" + defaultValueExpression + "\")")
-        .serializationMethodBase("writeUntyped")
-        .serializationValueGetterModifier(valueGetter -> valueGetter + " == null ? null : " + valueGetter + ".toObject(Object.class)")
+//        .serializationMethodBase("writeUntyped")
+//        .serializationValueGetterModifier(valueGetter -> valueGetter + " == null ? null : " + valueGetter + ".toObject(Object.class)")
         .jsonDeserializationMethod("getNullable(nonNullReader -> BinaryData.fromObject(nonNullReader.readUntyped()))")
         .xmlElementDeserializationMethod("getNullableElement(BinaryData::fromObject)")
         .xmlAttributeDeserializationTemplate("%s.getNullableAttribute(%s, %s, BinaryData::fromObject)")

--- a/javagen/src/main/java/com/azure/autorest/template/StreamSerializationModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/StreamSerializationModelTemplate.java
@@ -315,6 +315,15 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
             }
         } else if (wireType == ClassType.OBJECT) {
             methodBlock.line("jsonWriter.writeUntypedField(\"" + serializedName + "\", " + propertyValueGetter + ");");
+        } else if (wireType == ClassType.BINARY_DATA) {
+            String writeBinaryDataExpr = "jsonWriter.writeUntypedField(\"" + serializedName + "\", " + propertyValueGetter + ".toObject(Object.class));";
+            if (!property.isRequired()) {
+                methodBlock.ifBlock(propertyValueGetter + " != null", ifAction -> {
+                    ifAction.line(writeBinaryDataExpr);
+                });
+            } else {
+                methodBlock.line(writeBinaryDataExpr);
+            }
         } else if (wireType instanceof IterableType) {
             serializeJsonContainerProperty(methodBlock, "writeArrayField", wireType, ((IterableType) wireType).getElementType(),
                 serializedName, propertyValueGetter, 0);

--- a/typespec-tests/src/main/java/com/cadl/internal/implementation/models/StandAloneUnion.java
+++ b/typespec-tests/src/main/java/com/cadl/internal/implementation/models/StandAloneUnion.java
@@ -47,7 +47,7 @@ public final class StandAloneUnion implements JsonSerializable<StandAloneUnion> 
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeUntypedField("data", this.data == null ? null : this.data.toObject(Object.class));
+        jsonWriter.writeUntypedField("data", this.data.toObject(Object.class));
         return jsonWriter.writeEndObject();
     }
 

--- a/typespec-tests/src/main/java/com/cadl/multipart/models/FormData.java
+++ b/typespec-tests/src/main/java/com/cadl/multipart/models/FormData.java
@@ -151,7 +151,7 @@ public final class FormData implements JsonSerializable<FormData> {
         jsonWriter.writeIntField("resolution", this.resolution);
         jsonWriter.writeStringField("type", this.type == null ? null : this.type.toString());
         jsonWriter.writeJsonField("size", this.size);
-        jsonWriter.writeUntypedField("image", this.image == null ? null : this.image.toObject(Object.class));
+        jsonWriter.writeUntypedField("image", this.image.toObject(Object.class));
         jsonWriter.writeStringField("image", this.imageFilename);
         return jsonWriter.writeEndObject();
     }

--- a/typespec-tests/src/main/java/com/cadl/union/models/Result.java
+++ b/typespec-tests/src/main/java/com/cadl/union/models/Result.java
@@ -94,7 +94,7 @@ public class Result implements JsonSerializable<Result> {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeStringField("name", this.name);
-        jsonWriter.writeUntypedField("data", this.data == null ? null : this.data.toObject(Object.class));
+        jsonWriter.writeUntypedField("data", this.data.toObject(Object.class));
         jsonWriter.writeJsonField("result", this.result);
         return jsonWriter.writeEndObject();
     }

--- a/typespec-tests/src/main/java/com/cadl/union/models/SendLongOptions.java
+++ b/typespec-tests/src/main/java/com/cadl/union/models/SendLongOptions.java
@@ -228,8 +228,9 @@ public final class SendLongOptions implements JsonSerializable<SendLongOptions> 
         jsonWriter.writeIntField("dataInt", this.dataInt);
         jsonWriter.writeStringField("filter", this.filter);
         jsonWriter.writeJsonField("user", this.user);
-        jsonWriter.writeUntypedField("dataUnion",
-            this.dataUnion == null ? null : this.dataUnion.toObject(Object.class));
+        if (this.dataUnion != null) {
+            jsonWriter.writeUntypedField("dataUnion", this.dataUnion.toObject(Object.class));
+        }
         jsonWriter.writeNumberField("dataLong", this.dataLong);
         jsonWriter.writeNumberField("data_float", this.dataFloat);
         return jsonWriter.writeEndObject();

--- a/typespec-tests/src/main/java/com/cadl/union/models/SubResult.java
+++ b/typespec-tests/src/main/java/com/cadl/union/models/SubResult.java
@@ -98,11 +98,12 @@ public final class SubResult extends Result {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeStringField("name", getName());
-        jsonWriter.writeUntypedField("data", getData() == null ? null : getData().toObject(Object.class));
+        jsonWriter.writeUntypedField("data", getData().toObject(Object.class));
         jsonWriter.writeJsonField("result", getResult());
         jsonWriter.writeStringField("text", this.text);
-        jsonWriter.writeUntypedField("arrayData",
-            this.arrayData == null ? null : this.arrayData.toObject(Object.class));
+        if (this.arrayData != null) {
+            jsonWriter.writeUntypedField("arrayData", this.arrayData.toObject(Object.class));
+        }
         return jsonWriter.writeEndObject();
     }
 

--- a/typespec-tests/src/main/java/com/payload/multipart/models/MultiPartRequest.java
+++ b/typespec-tests/src/main/java/com/payload/multipart/models/MultiPartRequest.java
@@ -94,8 +94,7 @@ public final class MultiPartRequest implements JsonSerializable<MultiPartRequest
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeStringField("id", this.id);
-        jsonWriter.writeUntypedField("profileImage",
-            this.profileImage == null ? null : this.profileImage.toObject(Object.class));
+        jsonWriter.writeUntypedField("profileImage", this.profileImage.toObject(Object.class));
         jsonWriter.writeStringField("profileImage", this.profileImageFilename);
         return jsonWriter.writeEndObject();
     }

--- a/typespec-tests/src/main/java/com/type/union/models/EnumsOnlyCases.java
+++ b/typespec-tests/src/main/java/com/type/union/models/EnumsOnlyCases.java
@@ -65,8 +65,8 @@ public final class EnumsOnlyCases implements JsonSerializable<EnumsOnlyCases> {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeUntypedField("lr", this.lr == null ? null : this.lr.toObject(Object.class));
-        jsonWriter.writeUntypedField("ud", this.ud == null ? null : this.ud.toObject(Object.class));
+        jsonWriter.writeUntypedField("lr", this.lr.toObject(Object.class));
+        jsonWriter.writeUntypedField("ud", this.ud.toObject(Object.class));
         return jsonWriter.writeEndObject();
     }
 

--- a/typespec-tests/src/main/java/com/type/union/models/GetResponse5.java
+++ b/typespec-tests/src/main/java/com/type/union/models/GetResponse5.java
@@ -47,7 +47,7 @@ public final class GetResponse5 implements JsonSerializable<GetResponse5> {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeUntypedField("prop", this.prop == null ? null : this.prop.toObject(Object.class));
+        jsonWriter.writeUntypedField("prop", this.prop.toObject(Object.class));
         return jsonWriter.writeEndObject();
     }
 

--- a/typespec-tests/src/main/java/com/type/union/models/MixedLiteralsCases.java
+++ b/typespec-tests/src/main/java/com/type/union/models/MixedLiteralsCases.java
@@ -102,14 +102,10 @@ public final class MixedLiteralsCases implements JsonSerializable<MixedLiteralsC
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeUntypedField("stringLiteral",
-            this.stringLiteral == null ? null : this.stringLiteral.toObject(Object.class));
-        jsonWriter.writeUntypedField("intLiteral",
-            this.intLiteral == null ? null : this.intLiteral.toObject(Object.class));
-        jsonWriter.writeUntypedField("floatLiteral",
-            this.floatLiteral == null ? null : this.floatLiteral.toObject(Object.class));
-        jsonWriter.writeUntypedField("booleanLiteral",
-            this.booleanLiteral == null ? null : this.booleanLiteral.toObject(Object.class));
+        jsonWriter.writeUntypedField("stringLiteral", this.stringLiteral.toObject(Object.class));
+        jsonWriter.writeUntypedField("intLiteral", this.intLiteral.toObject(Object.class));
+        jsonWriter.writeUntypedField("floatLiteral", this.floatLiteral.toObject(Object.class));
+        jsonWriter.writeUntypedField("booleanLiteral", this.booleanLiteral.toObject(Object.class));
         return jsonWriter.writeEndObject();
     }
 

--- a/typespec-tests/src/main/java/com/type/union/models/MixedTypesCases.java
+++ b/typespec-tests/src/main/java/com/type/union/models/MixedTypesCases.java
@@ -101,11 +101,10 @@ public final class MixedTypesCases implements JsonSerializable<MixedTypesCases> 
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeUntypedField("model", this.model == null ? null : this.model.toObject(Object.class));
-        jsonWriter.writeUntypedField("literal", this.literal == null ? null : this.literal.toObject(Object.class));
-        jsonWriter.writeUntypedField("int", this.intProperty == null ? null : this.intProperty.toObject(Object.class));
-        jsonWriter.writeUntypedField("boolean",
-            this.booleanProperty == null ? null : this.booleanProperty.toObject(Object.class));
+        jsonWriter.writeUntypedField("model", this.model.toObject(Object.class));
+        jsonWriter.writeUntypedField("literal", this.literal.toObject(Object.class));
+        jsonWriter.writeUntypedField("int", this.intProperty.toObject(Object.class));
+        jsonWriter.writeUntypedField("boolean", this.booleanProperty.toObject(Object.class));
         return jsonWriter.writeEndObject();
     }
 

--- a/typespec-tests/src/main/java/com/type/union/models/StringAndArrayCases.java
+++ b/typespec-tests/src/main/java/com/type/union/models/StringAndArrayCases.java
@@ -65,8 +65,8 @@ public final class StringAndArrayCases implements JsonSerializable<StringAndArra
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeUntypedField("string", this.string == null ? null : this.string.toObject(Object.class));
-        jsonWriter.writeUntypedField("array", this.array == null ? null : this.array.toObject(Object.class));
+        jsonWriter.writeUntypedField("string", this.string.toObject(Object.class));
+        jsonWriter.writeUntypedField("array", this.array.toObject(Object.class));
         return jsonWriter.writeEndObject();
     }
 


### PR DESCRIPTION
fix a regression introduced in https://github.com/Azure/autorest.java/pull/2466

test case https://github.com/Azure/autorest.java/commit/8a26a51ada8ce256a718d15a7581622612d52901

remembered the reason I wrote the null protection logic -- the non-azure OpenAI fails the chat completion request upon "function: null"...