### PR TITLE
tsp, update one test customization code for stream-serialization

### DIFF
--- a/typespec-tests/customization/src/main/java/CustomizationEncodeBytes.java
+++ b/typespec-tests/customization/src/main/java/CustomizationEncodeBytes.java
@@ -24,11 +24,12 @@ public class CustomizationEncodeBytes extends Customization {
 
         classCustomization.getProperty("value").setModifier(Modifier.PRIVATE);
 
-        ConstructorCustomization constructorCustomization = classCustomization.getConstructor("Base64UrlArrayBytesProperty");
-        constructorCustomization.removeAnnotation("JsonCreator");
-        constructorCustomization = classCustomization.getConstructor("Base64UrlArrayBytesProperty");
-        constructorCustomization.addAnnotation("JsonCreator(mode=JsonCreator.Mode.DISABLED)");
-
-        classCustomization.addConstructor("@Generated private Base64UrlArrayBytesProperty() {}");
+        // as stream-serialization, we no longer need these Jackson annotations
+//        ConstructorCustomization constructorCustomization = classCustomization.getConstructor("Base64UrlArrayBytesProperty");
+//        constructorCustomization.removeAnnotation("JsonCreator");
+//        constructorCustomization = classCustomization.getConstructor("Base64UrlArrayBytesProperty");
+//        constructorCustomization.addAnnotation("JsonCreator(mode=JsonCreator.Mode.DISABLED)");
+//
+//        classCustomization.addConstructor("@Generated private Base64UrlArrayBytesProperty() {}");
     }
 }

--- a/typespec-tests/src/main/java/com/encode/bytes/models/Base64UrlArrayBytesProperty.java
+++ b/typespec-tests/src/main/java/com/encode/bytes/models/Base64UrlArrayBytesProperty.java
@@ -11,7 +11,6 @@ import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
 import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
-import com.fasterxml.jackson.annotation.JsonCreator;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
@@ -33,13 +32,8 @@ public final class Base64UrlArrayBytesProperty implements JsonSerializable<Base6
      * @param value the value value to set.
      */
     @Generated
-    @JsonCreator(mode = JsonCreator.Mode.DISABLED)
     public Base64UrlArrayBytesProperty(List<byte[]> value) {
         this.value = value.stream().map(el -> Base64Url.encode(el)).collect(java.util.stream.Collectors.toList());
-    }
-
-    @Generated
-    private Base64UrlArrayBytesProperty() {
     }
 
     /**


### PR DESCRIPTION
In stream-serialization, we don't need the JsonCreator annotations.