### PR TITLE
Allow setting the working directory

### DIFF
--- a/customization-base/src/main/java/com/azure/autorest/customization/Customization.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/Customization.java
@@ -5,12 +5,12 @@ package com.azure.autorest.customization;
 
 import com.azure.autorest.customization.implementation.Utils;
 import com.azure.autorest.customization.implementation.ls.EclipseLanguageClient;
+import com.azure.autorest.extension.base.util.FileUtils;
 import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
@@ -31,7 +31,7 @@ public abstract class Customization {
         // Populate editor
         Editor editor;
         try {
-            tempDirWithPrefix = Files.createTempDirectory("temp");
+            tempDirWithPrefix = FileUtils.createTempDirectory("temp");
             editor = new Editor(files, tempDirWithPrefix);
             InputStream pomStream = Customization.class.getResourceAsStream("/pom.xml");
             byte[] buffer = new byte[pomStream.available()];

--- a/customization-base/src/test/java/com/azure/autorest/customization/AnnotationTests.java
+++ b/customization-base/src/test/java/com/azure/autorest/customization/AnnotationTests.java
@@ -4,6 +4,7 @@
 package com.azure.autorest.customization;
 
 import com.azure.autorest.customization.implementation.Utils;
+import com.azure.autorest.extension.base.util.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,7 +13,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.UUID;
@@ -32,7 +32,7 @@ public class AnnotationTests {
 
     @BeforeEach
     public void setup() throws IOException {
-        workingDir = Files.createTempDirectory("removeComplexAnnotation" + UUID.randomUUID());
+        workingDir = FileUtils.createTempDirectory("removeComplexAnnotation" + UUID.randomUUID());
     }
 
     @AfterEach

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/util/FileUtils.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/util/FileUtils.java
@@ -17,12 +17,12 @@ public final class FileUtils {
     /**
      * Creates a temporary directory.
      * <p>
-     * If the environment setting {@code autorest.java.temp.directory} is set, the directory will be created under the
+     * If the environment setting {@code codegen.java.temp.directory} is set, the directory will be created under the
      * specified path. Otherwise, the directory will be created under the system default temporary directory.
      * <p>
      * {@link System#getProperty(String)} is checked before {@link System#getenv(String)}.
      * <p>
-     * If {@code autorest.java.temp.directory} is set to a non-existent path, the directory will be created under the
+     * If {@code codegen.java.temp.directory} is set to a non-existent path, the directory will be created under the
      * system default temporary directory.
      *
      * @param prefix The prefix string to be used in generating the directory's name; may be {@code null}.
@@ -30,9 +30,9 @@ public final class FileUtils {
      * @throws IOException If an I/O error occurs.
      */
     public static Path createTempDirectory(String prefix) throws IOException {
-        String tempDirectory = System.getProperty("autorest.java.temp.directory");
+        String tempDirectory = System.getProperty("codegen.java.temp.directory");
         if (tempDirectory == null) {
-            tempDirectory = System.getenv("autorest.java.temp.directory");
+            tempDirectory = System.getenv("codegen.java.temp.directory");
         }
 
         if (tempDirectory != null) {

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/util/FileUtils.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/util/FileUtils.java
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.azure.autorest.extension.base.util;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Utility class for file operations.
+ */
+public final class FileUtils {
+    private FileUtils() {
+    }
+
+    /**
+     * Creates a temporary directory.
+     * <p>
+     * If the environment setting {@code autorest.java.temp.directory} is set, the directory will be created under the
+     * specified path. Otherwise, the directory will be created under the system default temporary directory.
+     * <p>
+     * {@link System#getProperty(String)} is checked before {@link System#getenv(String)}.
+     * <p>
+     * If {@code autorest.java.temp.directory} is set to a non-existent path, the directory will be created under the
+     * system default temporary directory.
+     *
+     * @param prefix The prefix string to be used in generating the directory's name; may be {@code null}.
+     * @return The path to the newly created directory.
+     * @throws IOException If an I/O error occurs.
+     */
+    public static Path createTempDirectory(String prefix) throws IOException {
+        String tempDirectory = System.getProperty("autorest.java.temp.directory");
+        if (tempDirectory == null) {
+            tempDirectory = System.getenv("autorest.java.temp.directory");
+        }
+
+        if (tempDirectory != null) {
+            Path tempDirectoryPath = Paths.get(tempDirectory);
+            if (Files.exists(tempDirectoryPath)) {
+                return Files.createTempDirectory(tempDirectoryPath, prefix);
+            }
+        }
+
+        return Files.createTempDirectory(prefix);
+    }
+}

--- a/fluentnamer/src/main/java/com/azure/autorest/fluentnamer/FluentNamer.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluentnamer/FluentNamer.java
@@ -8,6 +8,7 @@ import com.azure.autorest.extension.base.model.codemodel.CodeModel;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.extension.base.plugin.NewPlugin;
 import com.azure.autorest.extension.base.plugin.PluginLogger;
+import com.azure.autorest.extension.base.util.FileUtils;
 import com.azure.autorest.fluent.namer.FluentNamerFactory;
 import com.azure.autorest.fluent.transformer.FluentTransformer;
 import com.azure.autorest.fluent.util.FluentJavaSettings;
@@ -59,7 +60,7 @@ public class FluentNamer extends Preprocessor {
 
             Path codeModelFolder;
             try {
-                codeModelFolder = Files.createTempDirectory("code-model" + UUID.randomUUID());
+                codeModelFolder = FileUtils.createTempDirectory("code-model" + UUID.randomUUID());
                 logger.info("Created temp directory for code model: {}", codeModelFolder);
             } catch (IOException ex) {
                 logger.error("Failed to create temp directory for code model.", ex);

--- a/postprocessor/src/main/java/com/azure/autorest/postprocessor/Postprocessor.java
+++ b/postprocessor/src/main/java/com/azure/autorest/postprocessor/Postprocessor.java
@@ -8,6 +8,7 @@ import com.azure.autorest.customization.implementation.Utils;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.extension.base.plugin.NewPlugin;
 import com.azure.autorest.extension.base.plugin.PluginLogger;
+import com.azure.autorest.extension.base.util.FileUtils;
 import com.azure.autorest.partialupdate.util.PartialUpdateHandler;
 import org.slf4j.Logger;
 
@@ -119,7 +120,7 @@ public class Postprocessor {
         if (!settings.isSkipFormatting()) {
             Path tmpDir = null;
             try {
-                tmpDir = Files.createTempDirectory("spotless" + UUID.randomUUID());
+                tmpDir = FileUtils.createTempDirectory("spotless" + UUID.randomUUID());
 
                 for (Map.Entry<String, String> javaFile : javaFiles.entrySet()) {
                     Path file = tmpDir.resolve(javaFile.getKey());
@@ -212,7 +213,7 @@ public class Postprocessor {
     public static Class<? extends Customization> loadCustomizationClass(String className, String code) {
         Path customizationCompile = null;
         try {
-            customizationCompile = Files.createTempDirectory("customizationCompile" + UUID.randomUUID());
+            customizationCompile = FileUtils.createTempDirectory("customizationCompile" + UUID.randomUUID());
 
             Path pomPath = customizationCompile.resolve("compile-pom.xml");
             Files.copy(Postprocessor.class.getClassLoader().getResourceAsStream("readme/pom.xml"), pomPath);

--- a/preprocessor/src/main/java/com/azure/autorest/preprocessor/Preprocessor.java
+++ b/preprocessor/src/main/java/com/azure/autorest/preprocessor/Preprocessor.java
@@ -15,6 +15,7 @@ import com.azure.autorest.extension.base.model.codemodel.SealedChoiceSchema;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.extension.base.plugin.NewPlugin;
 import com.azure.autorest.extension.base.plugin.PluginLogger;
+import com.azure.autorest.extension.base.util.FileUtils;
 import com.azure.autorest.preprocessor.tranformer.Transformer;
 import org.slf4j.Logger;
 import org.yaml.snakeyaml.DumperOptions;
@@ -68,7 +69,7 @@ public class Preprocessor extends NewPlugin {
 
         Path codeModelFolder;
         try {
-            codeModelFolder = Files.createTempDirectory("code-model" + UUID.randomUUID());
+            codeModelFolder = FileUtils.createTempDirectory("code-model" + UUID.randomUUID());
             logger.info("Created temp directory for code model: {}", codeModelFolder);
         } catch (IOException ex) {
             logger.error("Failed to create temp directory for code model.", ex);


### PR DESCRIPTION
Adds an environment configuration `codegen.java.temp.directory` which allows for configuring the directory used when creating temporary folders. This allows for a few things:

- Clearer location and management of temporary files generated by Autorest Java. Allows to use a non-standard temporary directory that can more clearly show working files of Autorest Java.
- Potential optimizations of the temporary directory, such as using Windows Dev Drive.