### PR TITLE
Add models-subpackage option for TypeSpec

### DIFF
--- a/typespec-extension/src/main/java/com/azure/autorest/TypeSpecPlugin.java
+++ b/typespec-extension/src/main/java/com/azure/autorest/TypeSpecPlugin.java
@@ -207,7 +207,6 @@ public class TypeSpecPlugin extends Javagen {
         SETTINGS_MAP.put("use-default-http-status-code-to-exception-type-mapping", true);
         SETTINGS_MAP.put("polling", new HashMap<String, Object>());
 
-        SETTINGS_MAP.put("models-subpackage", "models");
         SETTINGS_MAP.put("client-logger", true);
         SETTINGS_MAP.put("required-fields-as-ctor-args", true);
         SETTINGS_MAP.put("required-parameter-client-methods", true);
@@ -272,10 +271,16 @@ public class TypeSpecPlugin extends Javagen {
         if (options.getCustomTypeSubpackage() != null) {
             SETTINGS_MAP.put("custom-types-subpackage", options.getCustomTypeSubpackage());
         }
+
+        if (options.getModelsSubpackage() != null) {
+            SETTINGS_MAP.put("models-subpackage", options.getModelsSubpackage());
+        }
+
         if (options.getCustomizationClass() != null) {
             SETTINGS_MAP.put("customization-class",
                 Paths.get(options.getOutputDir()).resolve(options.getCustomizationClass()).toAbsolutePath().toString());
         }
+
         if (emitterOptions.getPolling() != null) {
             SETTINGS_MAP.put("polling", options.getPolling());
         }

--- a/typespec-extension/src/main/java/com/azure/typespec/model/EmitterOptions.java
+++ b/typespec-extension/src/main/java/com/azure/typespec/model/EmitterOptions.java
@@ -66,6 +66,9 @@ public class EmitterOptions {
     @JsonProperty(value = "arm")
     private Boolean arm = false;
 
+    @JsonProperty(value="models-subpackage")
+    private String modelsSubpackage;
+
     @JsonProperty(value="dev-options")
     private DevOptions devOptions;
 
@@ -149,6 +152,10 @@ public class EmitterOptions {
 
     public Boolean getArm() {
         return arm;
+    }
+
+    public String getModelsSubpackage() {
+        return modelsSubpackage;
     }
 
     public static class EmptyStringToNullDeserializer extends JsonDeserializer<String> {


### PR DESCRIPTION
There is a usecase in Event Grid where the `models` package is renamed to `systemevents`. So, enabling the `models-subpackage` option in TypeSpec. This is already supported by autorest.