### PR TITLE
tsp, remove serialization interface/code from multipart model

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -3,6 +3,7 @@
 
 package com.azure.autorest.template;
 
+import com.azure.autorest.extension.base.model.codemodel.KnownMediaType;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.model.clientmodel.Annotation;
 import com.azure.autorest.model.clientmodel.ArrayType;
@@ -1143,7 +1144,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
      */
     private static boolean modelRequireSerialization(ClientModel model) {
         // TODO (weidxu): any other case? "binary"?
-        return !model.getSerializationFormats().contains("multipart");
+        return !model.getSerializationFormats().contains(KnownMediaType.MULTIPART.value());
     }
 
     /**

--- a/typespec-tests/src/main/java/com/cadl/multipart/models/FormData.java
+++ b/typespec-tests/src/main/java/com/cadl/multipart/models/FormData.java
@@ -7,17 +7,12 @@ package com.cadl.multipart.models;
 import com.azure.core.annotation.Fluent;
 import com.azure.core.annotation.Generated;
 import com.azure.core.util.BinaryData;
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonToken;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 
 /**
  * The FormData model.
  */
 @Fluent
-public final class FormData implements JsonSerializable<FormData> {
+public final class FormData {
     /*
      * The name property.
      */
@@ -142,61 +137,5 @@ public final class FormData implements JsonSerializable<FormData> {
     public FormData setImageFilename(String imageFilename) {
         this.imageFilename = imageFilename;
         return this;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("name", this.name);
-        jsonWriter.writeIntField("resolution", this.resolution);
-        jsonWriter.writeStringField("type", this.type == null ? null : this.type.toString());
-        jsonWriter.writeJsonField("size", this.size);
-        jsonWriter.writeUntypedField("image", this.image.toObject(Object.class));
-        jsonWriter.writeStringField("image", this.imageFilename);
-        return jsonWriter.writeEndObject();
-    }
-
-    /**
-     * Reads an instance of FormData from the JsonReader.
-     * 
-     * @param jsonReader The JsonReader being read.
-     * @return An instance of FormData if the JsonReader was pointing to an instance of it, or null if it was pointing
-     * to JSON null.
-     * @throws IllegalStateException If the deserialized JSON object was missing any required properties.
-     * @throws IOException If an error occurs while reading the FormData.
-     */
-    public static FormData fromJson(JsonReader jsonReader) throws IOException {
-        return jsonReader.readObject(reader -> {
-            String name = null;
-            int resolution = 0;
-            ImageType type = null;
-            Size size = null;
-            BinaryData image = null;
-            String imageFilename = null;
-            while (reader.nextToken() != JsonToken.END_OBJECT) {
-                String fieldName = reader.getFieldName();
-                reader.nextToken();
-
-                if ("name".equals(fieldName)) {
-                    name = reader.getString();
-                } else if ("resolution".equals(fieldName)) {
-                    resolution = reader.getInt();
-                } else if ("type".equals(fieldName)) {
-                    type = ImageType.fromString(reader.getString());
-                } else if ("size".equals(fieldName)) {
-                    size = Size.fromJson(reader);
-                } else if ("image".equals(fieldName)) {
-                    image = reader.getNullable(nonNullReader -> BinaryData.fromObject(nonNullReader.readUntyped()));
-                } else if ("image".equals(fieldName)) {
-                    imageFilename = reader.getString();
-                } else {
-                    reader.skipChildren();
-                }
-            }
-            FormData deserializedFormData = new FormData(name, resolution, type, size, image);
-            deserializedFormData.imageFilename = imageFilename;
-
-            return deserializedFormData;
-        });
     }
 }

--- a/typespec-tests/src/main/java/com/payload/multipart/models/BinaryArrayPartsRequest.java
+++ b/typespec-tests/src/main/java/com/payload/multipart/models/BinaryArrayPartsRequest.java
@@ -6,18 +6,13 @@ package com.payload.multipart.models;
 
 import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonToken;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 import java.util.List;
 
 /**
  * The BinaryArrayPartsRequest model.
  */
 @Immutable
-public final class BinaryArrayPartsRequest implements JsonSerializable<BinaryArrayPartsRequest> {
+public final class BinaryArrayPartsRequest {
     /*
      * The id property.
      */
@@ -60,42 +55,5 @@ public final class BinaryArrayPartsRequest implements JsonSerializable<BinaryArr
     @Generated
     public List<byte[]> getPictures() {
         return this.pictures;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("id", this.id);
-        jsonWriter.writeArrayField("pictures", this.pictures, (writer, element) -> writer.writeBinary(element));
-        return jsonWriter.writeEndObject();
-    }
-
-    /**
-     * Reads an instance of BinaryArrayPartsRequest from the JsonReader.
-     * 
-     * @param jsonReader The JsonReader being read.
-     * @return An instance of BinaryArrayPartsRequest if the JsonReader was pointing to an instance of it, or null if it
-     * was pointing to JSON null.
-     * @throws IllegalStateException If the deserialized JSON object was missing any required properties.
-     * @throws IOException If an error occurs while reading the BinaryArrayPartsRequest.
-     */
-    public static BinaryArrayPartsRequest fromJson(JsonReader jsonReader) throws IOException {
-        return jsonReader.readObject(reader -> {
-            String id = null;
-            List<byte[]> pictures = null;
-            while (reader.nextToken() != JsonToken.END_OBJECT) {
-                String fieldName = reader.getFieldName();
-                reader.nextToken();
-
-                if ("id".equals(fieldName)) {
-                    id = reader.getString();
-                } else if ("pictures".equals(fieldName)) {
-                    pictures = reader.readArray(reader1 -> reader1.getBinary());
-                } else {
-                    reader.skipChildren();
-                }
-            }
-            return new BinaryArrayPartsRequest(id, pictures);
-        });
     }
 }

--- a/typespec-tests/src/main/java/com/payload/multipart/models/ComplexPartsRequest.java
+++ b/typespec-tests/src/main/java/com/payload/multipart/models/ComplexPartsRequest.java
@@ -7,18 +7,13 @@ package com.payload.multipart.models;
 import com.azure.core.annotation.Fluent;
 import com.azure.core.annotation.Generated;
 import com.azure.core.util.BinaryData;
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonToken;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 import java.util.List;
 
 /**
  * The ComplexPartsRequest model.
  */
 @Fluent
-public final class ComplexPartsRequest implements JsonSerializable<ComplexPartsRequest> {
+public final class ComplexPartsRequest {
     /*
      * The id property.
      */
@@ -144,64 +139,5 @@ public final class ComplexPartsRequest implements JsonSerializable<ComplexPartsR
     @Generated
     public List<byte[]> getPictures() {
         return this.pictures;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("id", this.id);
-        jsonWriter.writeJsonField("address", this.address);
-        jsonWriter.writeUntypedField("profileImage", this.profileImage.toObject(Object.class));
-        jsonWriter.writeArrayField("previousAddresses", this.previousAddresses,
-            (writer, element) -> writer.writeJson(element));
-        jsonWriter.writeArrayField("pictures", this.pictures, (writer, element) -> writer.writeBinary(element));
-        jsonWriter.writeStringField("profileImage", this.profileImageFilename);
-        return jsonWriter.writeEndObject();
-    }
-
-    /**
-     * Reads an instance of ComplexPartsRequest from the JsonReader.
-     * 
-     * @param jsonReader The JsonReader being read.
-     * @return An instance of ComplexPartsRequest if the JsonReader was pointing to an instance of it, or null if it was
-     * pointing to JSON null.
-     * @throws IllegalStateException If the deserialized JSON object was missing any required properties.
-     * @throws IOException If an error occurs while reading the ComplexPartsRequest.
-     */
-    public static ComplexPartsRequest fromJson(JsonReader jsonReader) throws IOException {
-        return jsonReader.readObject(reader -> {
-            String id = null;
-            Address address = null;
-            BinaryData profileImage = null;
-            List<Address> previousAddresses = null;
-            List<byte[]> pictures = null;
-            String profileImageFilename = null;
-            while (reader.nextToken() != JsonToken.END_OBJECT) {
-                String fieldName = reader.getFieldName();
-                reader.nextToken();
-
-                if ("id".equals(fieldName)) {
-                    id = reader.getString();
-                } else if ("address".equals(fieldName)) {
-                    address = Address.fromJson(reader);
-                } else if ("profileImage".equals(fieldName)) {
-                    profileImage
-                        = reader.getNullable(nonNullReader -> BinaryData.fromObject(nonNullReader.readUntyped()));
-                } else if ("previousAddresses".equals(fieldName)) {
-                    previousAddresses = reader.readArray(reader1 -> Address.fromJson(reader1));
-                } else if ("pictures".equals(fieldName)) {
-                    pictures = reader.readArray(reader1 -> reader1.getBinary());
-                } else if ("profileImage".equals(fieldName)) {
-                    profileImageFilename = reader.getString();
-                } else {
-                    reader.skipChildren();
-                }
-            }
-            ComplexPartsRequest deserializedComplexPartsRequest
-                = new ComplexPartsRequest(id, address, profileImage, previousAddresses, pictures);
-            deserializedComplexPartsRequest.profileImageFilename = profileImageFilename;
-
-            return deserializedComplexPartsRequest;
-        });
     }
 }

--- a/typespec-tests/src/main/java/com/payload/multipart/models/JsonArrayPartsRequest.java
+++ b/typespec-tests/src/main/java/com/payload/multipart/models/JsonArrayPartsRequest.java
@@ -7,18 +7,13 @@ package com.payload.multipart.models;
 import com.azure.core.annotation.Fluent;
 import com.azure.core.annotation.Generated;
 import com.azure.core.util.BinaryData;
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonToken;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 import java.util.List;
 
 /**
  * The JsonArrayPartsRequest model.
  */
 @Fluent
-public final class JsonArrayPartsRequest implements JsonSerializable<JsonArrayPartsRequest> {
+public final class JsonArrayPartsRequest {
     /*
      * The profileImage property.
      */
@@ -89,52 +84,5 @@ public final class JsonArrayPartsRequest implements JsonSerializable<JsonArrayPa
     @Generated
     public List<Address> getPreviousAddresses() {
         return this.previousAddresses;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        jsonWriter.writeStartObject();
-        jsonWriter.writeUntypedField("profileImage", this.profileImage.toObject(Object.class));
-        jsonWriter.writeArrayField("previousAddresses", this.previousAddresses,
-            (writer, element) -> writer.writeJson(element));
-        jsonWriter.writeStringField("profileImage", this.profileImageFilename);
-        return jsonWriter.writeEndObject();
-    }
-
-    /**
-     * Reads an instance of JsonArrayPartsRequest from the JsonReader.
-     * 
-     * @param jsonReader The JsonReader being read.
-     * @return An instance of JsonArrayPartsRequest if the JsonReader was pointing to an instance of it, or null if it
-     * was pointing to JSON null.
-     * @throws IllegalStateException If the deserialized JSON object was missing any required properties.
-     * @throws IOException If an error occurs while reading the JsonArrayPartsRequest.
-     */
-    public static JsonArrayPartsRequest fromJson(JsonReader jsonReader) throws IOException {
-        return jsonReader.readObject(reader -> {
-            BinaryData profileImage = null;
-            List<Address> previousAddresses = null;
-            String profileImageFilename = null;
-            while (reader.nextToken() != JsonToken.END_OBJECT) {
-                String fieldName = reader.getFieldName();
-                reader.nextToken();
-
-                if ("profileImage".equals(fieldName)) {
-                    profileImage
-                        = reader.getNullable(nonNullReader -> BinaryData.fromObject(nonNullReader.readUntyped()));
-                } else if ("previousAddresses".equals(fieldName)) {
-                    previousAddresses = reader.readArray(reader1 -> Address.fromJson(reader1));
-                } else if ("profileImage".equals(fieldName)) {
-                    profileImageFilename = reader.getString();
-                } else {
-                    reader.skipChildren();
-                }
-            }
-            JsonArrayPartsRequest deserializedJsonArrayPartsRequest
-                = new JsonArrayPartsRequest(profileImage, previousAddresses);
-            deserializedJsonArrayPartsRequest.profileImageFilename = profileImageFilename;
-
-            return deserializedJsonArrayPartsRequest;
-        });
     }
 }

--- a/typespec-tests/src/main/java/com/payload/multipart/models/JsonPartRequest.java
+++ b/typespec-tests/src/main/java/com/payload/multipart/models/JsonPartRequest.java
@@ -7,17 +7,12 @@ package com.payload.multipart.models;
 import com.azure.core.annotation.Fluent;
 import com.azure.core.annotation.Generated;
 import com.azure.core.util.BinaryData;
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonToken;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 
 /**
  * The JsonPartRequest model.
  */
 @Fluent
-public final class JsonPartRequest implements JsonSerializable<JsonPartRequest> {
+public final class JsonPartRequest {
     /*
      * The address property.
      */
@@ -88,50 +83,5 @@ public final class JsonPartRequest implements JsonSerializable<JsonPartRequest> 
     public JsonPartRequest setProfileImageFilename(String profileImageFilename) {
         this.profileImageFilename = profileImageFilename;
         return this;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        jsonWriter.writeStartObject();
-        jsonWriter.writeJsonField("address", this.address);
-        jsonWriter.writeUntypedField("profileImage", this.profileImage.toObject(Object.class));
-        jsonWriter.writeStringField("profileImage", this.profileImageFilename);
-        return jsonWriter.writeEndObject();
-    }
-
-    /**
-     * Reads an instance of JsonPartRequest from the JsonReader.
-     * 
-     * @param jsonReader The JsonReader being read.
-     * @return An instance of JsonPartRequest if the JsonReader was pointing to an instance of it, or null if it was
-     * pointing to JSON null.
-     * @throws IllegalStateException If the deserialized JSON object was missing any required properties.
-     * @throws IOException If an error occurs while reading the JsonPartRequest.
-     */
-    public static JsonPartRequest fromJson(JsonReader jsonReader) throws IOException {
-        return jsonReader.readObject(reader -> {
-            Address address = null;
-            BinaryData profileImage = null;
-            String profileImageFilename = null;
-            while (reader.nextToken() != JsonToken.END_OBJECT) {
-                String fieldName = reader.getFieldName();
-                reader.nextToken();
-
-                if ("address".equals(fieldName)) {
-                    address = Address.fromJson(reader);
-                } else if ("profileImage".equals(fieldName)) {
-                    profileImage
-                        = reader.getNullable(nonNullReader -> BinaryData.fromObject(nonNullReader.readUntyped()));
-                } else if ("profileImage".equals(fieldName)) {
-                    profileImageFilename = reader.getString();
-                } else {
-                    reader.skipChildren();
-                }
-            }
-            JsonPartRequest deserializedJsonPartRequest = new JsonPartRequest(address, profileImage);
-            deserializedJsonPartRequest.profileImageFilename = profileImageFilename;
-
-            return deserializedJsonPartRequest;
-        });
     }
 }

--- a/typespec-tests/src/main/java/com/payload/multipart/models/MultiBinaryPartsRequest.java
+++ b/typespec-tests/src/main/java/com/payload/multipart/models/MultiBinaryPartsRequest.java
@@ -7,17 +7,12 @@ package com.payload.multipart.models;
 import com.azure.core.annotation.Fluent;
 import com.azure.core.annotation.Generated;
 import com.azure.core.util.BinaryData;
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonToken;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 
 /**
  * The MultiBinaryPartsRequest model.
  */
 @Fluent
-public final class MultiBinaryPartsRequest implements JsonSerializable<MultiBinaryPartsRequest> {
+public final class MultiBinaryPartsRequest {
     /*
      * The profileImage property.
      */
@@ -126,58 +121,5 @@ public final class MultiBinaryPartsRequest implements JsonSerializable<MultiBina
     public MultiBinaryPartsRequest setPictureFilename(String pictureFilename) {
         this.pictureFilename = pictureFilename;
         return this;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        jsonWriter.writeStartObject();
-        jsonWriter.writeUntypedField("profileImage", this.profileImage.toObject(Object.class));
-        jsonWriter.writeStringField("profileImage", this.profileImageFilename);
-        if (this.picture != null) {
-            jsonWriter.writeUntypedField("picture", this.picture.toObject(Object.class));
-        }
-        jsonWriter.writeStringField("picture", this.pictureFilename);
-        return jsonWriter.writeEndObject();
-    }
-
-    /**
-     * Reads an instance of MultiBinaryPartsRequest from the JsonReader.
-     * 
-     * @param jsonReader The JsonReader being read.
-     * @return An instance of MultiBinaryPartsRequest if the JsonReader was pointing to an instance of it, or null if it
-     * was pointing to JSON null.
-     * @throws IllegalStateException If the deserialized JSON object was missing any required properties.
-     * @throws IOException If an error occurs while reading the MultiBinaryPartsRequest.
-     */
-    public static MultiBinaryPartsRequest fromJson(JsonReader jsonReader) throws IOException {
-        return jsonReader.readObject(reader -> {
-            BinaryData profileImage = null;
-            String profileImageFilename = null;
-            BinaryData picture = null;
-            String pictureFilename = null;
-            while (reader.nextToken() != JsonToken.END_OBJECT) {
-                String fieldName = reader.getFieldName();
-                reader.nextToken();
-
-                if ("profileImage".equals(fieldName)) {
-                    profileImage
-                        = reader.getNullable(nonNullReader -> BinaryData.fromObject(nonNullReader.readUntyped()));
-                } else if ("profileImage".equals(fieldName)) {
-                    profileImageFilename = reader.getString();
-                } else if ("picture".equals(fieldName)) {
-                    picture = reader.getNullable(nonNullReader -> BinaryData.fromObject(nonNullReader.readUntyped()));
-                } else if ("picture".equals(fieldName)) {
-                    pictureFilename = reader.getString();
-                } else {
-                    reader.skipChildren();
-                }
-            }
-            MultiBinaryPartsRequest deserializedMultiBinaryPartsRequest = new MultiBinaryPartsRequest(profileImage);
-            deserializedMultiBinaryPartsRequest.profileImageFilename = profileImageFilename;
-            deserializedMultiBinaryPartsRequest.picture = picture;
-            deserializedMultiBinaryPartsRequest.pictureFilename = pictureFilename;
-
-            return deserializedMultiBinaryPartsRequest;
-        });
     }
 }

--- a/typespec-tests/src/main/java/com/payload/multipart/models/MultiPartRequest.java
+++ b/typespec-tests/src/main/java/com/payload/multipart/models/MultiPartRequest.java
@@ -7,17 +7,12 @@ package com.payload.multipart.models;
 import com.azure.core.annotation.Fluent;
 import com.azure.core.annotation.Generated;
 import com.azure.core.util.BinaryData;
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonToken;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 
 /**
  * The MultiPartRequest model.
  */
 @Fluent
-public final class MultiPartRequest implements JsonSerializable<MultiPartRequest> {
+public final class MultiPartRequest {
     /*
      * The id property.
      */
@@ -88,50 +83,5 @@ public final class MultiPartRequest implements JsonSerializable<MultiPartRequest
     public MultiPartRequest setProfileImageFilename(String profileImageFilename) {
         this.profileImageFilename = profileImageFilename;
         return this;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("id", this.id);
-        jsonWriter.writeUntypedField("profileImage", this.profileImage.toObject(Object.class));
-        jsonWriter.writeStringField("profileImage", this.profileImageFilename);
-        return jsonWriter.writeEndObject();
-    }
-
-    /**
-     * Reads an instance of MultiPartRequest from the JsonReader.
-     * 
-     * @param jsonReader The JsonReader being read.
-     * @return An instance of MultiPartRequest if the JsonReader was pointing to an instance of it, or null if it was
-     * pointing to JSON null.
-     * @throws IllegalStateException If the deserialized JSON object was missing any required properties.
-     * @throws IOException If an error occurs while reading the MultiPartRequest.
-     */
-    public static MultiPartRequest fromJson(JsonReader jsonReader) throws IOException {
-        return jsonReader.readObject(reader -> {
-            String id = null;
-            BinaryData profileImage = null;
-            String profileImageFilename = null;
-            while (reader.nextToken() != JsonToken.END_OBJECT) {
-                String fieldName = reader.getFieldName();
-                reader.nextToken();
-
-                if ("id".equals(fieldName)) {
-                    id = reader.getString();
-                } else if ("profileImage".equals(fieldName)) {
-                    profileImage
-                        = reader.getNullable(nonNullReader -> BinaryData.fromObject(nonNullReader.readUntyped()));
-                } else if ("profileImage".equals(fieldName)) {
-                    profileImageFilename = reader.getString();
-                } else {
-                    reader.skipChildren();
-                }
-            }
-            MultiPartRequest deserializedMultiPartRequest = new MultiPartRequest(id, profileImage);
-            deserializedMultiPartRequest.profileImageFilename = profileImageFilename;
-
-            return deserializedMultiPartRequest;
-        });
     }
 }


### PR DESCRIPTION
fix https://github.com/Azure/autorest.java/issues/2473

Add this for case that the model does not need any serialization code.
```java
    private static boolean modelRequireSerialization(ClientModel model) {
        // TODO (weidxu): any other case? "binary"?
        return !model.getSerializationFormats().contains("multipart");
    }
```

`model.getSerializationFormats()` is due to https://github.com/Azure/autorest.java/pull/2494 (if any recommendation for this, I can improve here as well)