### PR TITLE
eng, typespec now handles mgmt, so we cannot exclude fluent*

### DIFF
--- a/eng/pipelines/ci-typespec-java.yaml
+++ b/eng/pipelines/ci-typespec-java.yaml
@@ -16,8 +16,11 @@ pr:
     include:
       - '*'
     exclude:
-      - 'fluent*'
-      - 'postprocessor'
+      - 'androidgen'
+      - 'azure-dataplane-tests'
+      - 'azure-tests'
+      - 'fluent-tests'
+      - 'partial-update-tests'
       - 'vanilla-tests'
       - 'protocol*'
 

--- a/typespec-tests/src/main/java/com/cadl/armresourceprovider/implementation/ChildResourceImpl.java
+++ b/typespec-tests/src/main/java/com/cadl/armresourceprovider/implementation/ChildResourceImpl.java
@@ -127,9 +127,10 @@ public final class ChildResourceImpl implements ChildResource, ChildResource.Def
         com.cadl.armresourceprovider.ArmResourceProviderManager serviceManager) {
         this.innerObject = innerObject;
         this.serviceManager = serviceManager;
-        this.resourceGroupName = Utils.getValueFromIdByName(innerObject.id(), "resourceGroups");
-        this.topLevelArmResourceName = Utils.getValueFromIdByName(innerObject.id(), "topLevelArmResources");
-        this.childResourceName = Utils.getValueFromIdByName(innerObject.id(), "childResources");
+        this.resourceGroupName = ResourceManagerUtils.getValueFromIdByName(innerObject.id(), "resourceGroups");
+        this.topLevelArmResourceName
+            = ResourceManagerUtils.getValueFromIdByName(innerObject.id(), "topLevelArmResources");
+        this.childResourceName = ResourceManagerUtils.getValueFromIdByName(innerObject.id(), "childResources");
     }
 
     public ChildResource refresh() {

--- a/typespec-tests/src/main/java/com/cadl/armresourceprovider/implementation/ChildResourcesInterfacesImpl.java
+++ b/typespec-tests/src/main/java/com/cadl/armresourceprovider/implementation/ChildResourcesInterfacesImpl.java
@@ -62,28 +62,28 @@ public final class ChildResourcesInterfacesImpl implements ChildResourcesInterfa
         String topLevelArmResourceName) {
         PagedIterable<ChildResourceInner> inner
             = this.serviceClient().listByTopLevelArmResource(resourceGroupName, topLevelArmResourceName);
-        return Utils.mapPage(inner, inner1 -> new ChildResourceImpl(inner1, this.manager()));
+        return ResourceManagerUtils.mapPage(inner, inner1 -> new ChildResourceImpl(inner1, this.manager()));
     }
 
     public PagedIterable<ChildResource> listByTopLevelArmResource(String resourceGroupName,
         String topLevelArmResourceName, Context context) {
         PagedIterable<ChildResourceInner> inner
             = this.serviceClient().listByTopLevelArmResource(resourceGroupName, topLevelArmResourceName, context);
-        return Utils.mapPage(inner, inner1 -> new ChildResourceImpl(inner1, this.manager()));
+        return ResourceManagerUtils.mapPage(inner, inner1 -> new ChildResourceImpl(inner1, this.manager()));
     }
 
     public ChildResource getById(String id) {
-        String resourceGroupName = Utils.getValueFromIdByName(id, "resourceGroups");
+        String resourceGroupName = ResourceManagerUtils.getValueFromIdByName(id, "resourceGroups");
         if (resourceGroupName == null) {
             throw LOGGER.logExceptionAsError(new IllegalArgumentException(
                 String.format("The resource ID '%s' is not valid. Missing path segment 'resourceGroups'.", id)));
         }
-        String topLevelArmResourceName = Utils.getValueFromIdByName(id, "topLevelArmResources");
+        String topLevelArmResourceName = ResourceManagerUtils.getValueFromIdByName(id, "topLevelArmResources");
         if (topLevelArmResourceName == null) {
             throw LOGGER.logExceptionAsError(new IllegalArgumentException(
                 String.format("The resource ID '%s' is not valid. Missing path segment 'topLevelArmResources'.", id)));
         }
-        String childResourceName = Utils.getValueFromIdByName(id, "childResources");
+        String childResourceName = ResourceManagerUtils.getValueFromIdByName(id, "childResources");
         if (childResourceName == null) {
             throw LOGGER.logExceptionAsError(new IllegalArgumentException(
                 String.format("The resource ID '%s' is not valid. Missing path segment 'childResources'.", id)));
@@ -93,17 +93,17 @@ public final class ChildResourcesInterfacesImpl implements ChildResourcesInterfa
     }
 
     public Response<ChildResource> getByIdWithResponse(String id, Context context) {
-        String resourceGroupName = Utils.getValueFromIdByName(id, "resourceGroups");
+        String resourceGroupName = ResourceManagerUtils.getValueFromIdByName(id, "resourceGroups");
         if (resourceGroupName == null) {
             throw LOGGER.logExceptionAsError(new IllegalArgumentException(
                 String.format("The resource ID '%s' is not valid. Missing path segment 'resourceGroups'.", id)));
         }
-        String topLevelArmResourceName = Utils.getValueFromIdByName(id, "topLevelArmResources");
+        String topLevelArmResourceName = ResourceManagerUtils.getValueFromIdByName(id, "topLevelArmResources");
         if (topLevelArmResourceName == null) {
             throw LOGGER.logExceptionAsError(new IllegalArgumentException(
                 String.format("The resource ID '%s' is not valid. Missing path segment 'topLevelArmResources'.", id)));
         }
-        String childResourceName = Utils.getValueFromIdByName(id, "childResources");
+        String childResourceName = ResourceManagerUtils.getValueFromIdByName(id, "childResources");
         if (childResourceName == null) {
             throw LOGGER.logExceptionAsError(new IllegalArgumentException(
                 String.format("The resource ID '%s' is not valid. Missing path segment 'childResources'.", id)));
@@ -112,17 +112,17 @@ public final class ChildResourcesInterfacesImpl implements ChildResourcesInterfa
     }
 
     public void deleteById(String id) {
-        String resourceGroupName = Utils.getValueFromIdByName(id, "resourceGroups");
+        String resourceGroupName = ResourceManagerUtils.getValueFromIdByName(id, "resourceGroups");
         if (resourceGroupName == null) {
             throw LOGGER.logExceptionAsError(new IllegalArgumentException(
                 String.format("The resource ID '%s' is not valid. Missing path segment 'resourceGroups'.", id)));
         }
-        String topLevelArmResourceName = Utils.getValueFromIdByName(id, "topLevelArmResources");
+        String topLevelArmResourceName = ResourceManagerUtils.getValueFromIdByName(id, "topLevelArmResources");
         if (topLevelArmResourceName == null) {
             throw LOGGER.logExceptionAsError(new IllegalArgumentException(
                 String.format("The resource ID '%s' is not valid. Missing path segment 'topLevelArmResources'.", id)));
         }
-        String childResourceName = Utils.getValueFromIdByName(id, "childResources");
+        String childResourceName = ResourceManagerUtils.getValueFromIdByName(id, "childResources");
         if (childResourceName == null) {
             throw LOGGER.logExceptionAsError(new IllegalArgumentException(
                 String.format("The resource ID '%s' is not valid. Missing path segment 'childResources'.", id)));
@@ -131,17 +131,17 @@ public final class ChildResourcesInterfacesImpl implements ChildResourcesInterfa
     }
 
     public void deleteByIdWithResponse(String id, Context context) {
-        String resourceGroupName = Utils.getValueFromIdByName(id, "resourceGroups");
+        String resourceGroupName = ResourceManagerUtils.getValueFromIdByName(id, "resourceGroups");
         if (resourceGroupName == null) {
             throw LOGGER.logExceptionAsError(new IllegalArgumentException(
                 String.format("The resource ID '%s' is not valid. Missing path segment 'resourceGroups'.", id)));
         }
-        String topLevelArmResourceName = Utils.getValueFromIdByName(id, "topLevelArmResources");
+        String topLevelArmResourceName = ResourceManagerUtils.getValueFromIdByName(id, "topLevelArmResources");
         if (topLevelArmResourceName == null) {
             throw LOGGER.logExceptionAsError(new IllegalArgumentException(
                 String.format("The resource ID '%s' is not valid. Missing path segment 'topLevelArmResources'.", id)));
         }
-        String childResourceName = Utils.getValueFromIdByName(id, "childResources");
+        String childResourceName = ResourceManagerUtils.getValueFromIdByName(id, "childResources");
         if (childResourceName == null) {
             throw LOGGER.logExceptionAsError(new IllegalArgumentException(
                 String.format("The resource ID '%s' is not valid. Missing path segment 'childResources'.", id)));

--- a/typespec-tests/src/main/java/com/cadl/armresourceprovider/implementation/OperationsImpl.java
+++ b/typespec-tests/src/main/java/com/cadl/armresourceprovider/implementation/OperationsImpl.java
@@ -27,12 +27,12 @@ public final class OperationsImpl implements Operations {
 
     public PagedIterable<Operation> list() {
         PagedIterable<OperationInner> inner = this.serviceClient().list();
-        return Utils.mapPage(inner, inner1 -> new OperationImpl(inner1, this.manager()));
+        return ResourceManagerUtils.mapPage(inner, inner1 -> new OperationImpl(inner1, this.manager()));
     }
 
     public PagedIterable<Operation> list(Context context) {
         PagedIterable<OperationInner> inner = this.serviceClient().list(context);
-        return Utils.mapPage(inner, inner1 -> new OperationImpl(inner1, this.manager()));
+        return ResourceManagerUtils.mapPage(inner, inner1 -> new OperationImpl(inner1, this.manager()));
     }
 
     private OperationsClient serviceClient() {

--- a/typespec-tests/src/main/java/com/cadl/armresourceprovider/implementation/ResourceManagerUtils.java
+++ b/typespec-tests/src/main/java/com/cadl/armresourceprovider/implementation/ResourceManagerUtils.java
@@ -19,8 +19,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import reactor.core.publisher.Flux;
 
-final class Utils {
-    private Utils() {
+final class ResourceManagerUtils {
+    private ResourceManagerUtils() {
     }
 
     static String getValueFromIdByName(String id, String name) {

--- a/typespec-tests/src/main/java/com/cadl/armresourceprovider/implementation/TopLevelArmResourceImpl.java
+++ b/typespec-tests/src/main/java/com/cadl/armresourceprovider/implementation/TopLevelArmResourceImpl.java
@@ -123,8 +123,9 @@ public final class TopLevelArmResourceImpl
         com.cadl.armresourceprovider.ArmResourceProviderManager serviceManager) {
         this.innerObject = innerObject;
         this.serviceManager = serviceManager;
-        this.resourceGroupName = Utils.getValueFromIdByName(innerObject.id(), "resourceGroups");
-        this.topLevelArmResourceName = Utils.getValueFromIdByName(innerObject.id(), "topLevelArmResources");
+        this.resourceGroupName = ResourceManagerUtils.getValueFromIdByName(innerObject.id(), "resourceGroups");
+        this.topLevelArmResourceName
+            = ResourceManagerUtils.getValueFromIdByName(innerObject.id(), "topLevelArmResources");
     }
 
     public TopLevelArmResource refresh() {

--- a/typespec-tests/src/main/java/com/cadl/armresourceprovider/implementation/TopLevelArmResourceInterfacesImpl.java
+++ b/typespec-tests/src/main/java/com/cadl/armresourceprovider/implementation/TopLevelArmResourceInterfacesImpl.java
@@ -59,32 +59,32 @@ public final class TopLevelArmResourceInterfacesImpl implements TopLevelArmResou
 
     public PagedIterable<TopLevelArmResource> listByResourceGroup(String resourceGroupName) {
         PagedIterable<TopLevelArmResourceInner> inner = this.serviceClient().listByResourceGroup(resourceGroupName);
-        return Utils.mapPage(inner, inner1 -> new TopLevelArmResourceImpl(inner1, this.manager()));
+        return ResourceManagerUtils.mapPage(inner, inner1 -> new TopLevelArmResourceImpl(inner1, this.manager()));
     }
 
     public PagedIterable<TopLevelArmResource> listByResourceGroup(String resourceGroupName, Context context) {
         PagedIterable<TopLevelArmResourceInner> inner
             = this.serviceClient().listByResourceGroup(resourceGroupName, context);
-        return Utils.mapPage(inner, inner1 -> new TopLevelArmResourceImpl(inner1, this.manager()));
+        return ResourceManagerUtils.mapPage(inner, inner1 -> new TopLevelArmResourceImpl(inner1, this.manager()));
     }
 
     public PagedIterable<TopLevelArmResource> list() {
         PagedIterable<TopLevelArmResourceInner> inner = this.serviceClient().list();
-        return Utils.mapPage(inner, inner1 -> new TopLevelArmResourceImpl(inner1, this.manager()));
+        return ResourceManagerUtils.mapPage(inner, inner1 -> new TopLevelArmResourceImpl(inner1, this.manager()));
     }
 
     public PagedIterable<TopLevelArmResource> list(Context context) {
         PagedIterable<TopLevelArmResourceInner> inner = this.serviceClient().list(context);
-        return Utils.mapPage(inner, inner1 -> new TopLevelArmResourceImpl(inner1, this.manager()));
+        return ResourceManagerUtils.mapPage(inner, inner1 -> new TopLevelArmResourceImpl(inner1, this.manager()));
     }
 
     public TopLevelArmResource getById(String id) {
-        String resourceGroupName = Utils.getValueFromIdByName(id, "resourceGroups");
+        String resourceGroupName = ResourceManagerUtils.getValueFromIdByName(id, "resourceGroups");
         if (resourceGroupName == null) {
             throw LOGGER.logExceptionAsError(new IllegalArgumentException(
                 String.format("The resource ID '%s' is not valid. Missing path segment 'resourceGroups'.", id)));
         }
-        String topLevelArmResourceName = Utils.getValueFromIdByName(id, "topLevelArmResources");
+        String topLevelArmResourceName = ResourceManagerUtils.getValueFromIdByName(id, "topLevelArmResources");
         if (topLevelArmResourceName == null) {
             throw LOGGER.logExceptionAsError(new IllegalArgumentException(
                 String.format("The resource ID '%s' is not valid. Missing path segment 'topLevelArmResources'.", id)));
@@ -93,12 +93,12 @@ public final class TopLevelArmResourceInterfacesImpl implements TopLevelArmResou
     }
 
     public Response<TopLevelArmResource> getByIdWithResponse(String id, Context context) {
-        String resourceGroupName = Utils.getValueFromIdByName(id, "resourceGroups");
+        String resourceGroupName = ResourceManagerUtils.getValueFromIdByName(id, "resourceGroups");
         if (resourceGroupName == null) {
             throw LOGGER.logExceptionAsError(new IllegalArgumentException(
                 String.format("The resource ID '%s' is not valid. Missing path segment 'resourceGroups'.", id)));
         }
-        String topLevelArmResourceName = Utils.getValueFromIdByName(id, "topLevelArmResources");
+        String topLevelArmResourceName = ResourceManagerUtils.getValueFromIdByName(id, "topLevelArmResources");
         if (topLevelArmResourceName == null) {
             throw LOGGER.logExceptionAsError(new IllegalArgumentException(
                 String.format("The resource ID '%s' is not valid. Missing path segment 'topLevelArmResources'.", id)));
@@ -107,12 +107,12 @@ public final class TopLevelArmResourceInterfacesImpl implements TopLevelArmResou
     }
 
     public void deleteById(String id) {
-        String resourceGroupName = Utils.getValueFromIdByName(id, "resourceGroups");
+        String resourceGroupName = ResourceManagerUtils.getValueFromIdByName(id, "resourceGroups");
         if (resourceGroupName == null) {
             throw LOGGER.logExceptionAsError(new IllegalArgumentException(
                 String.format("The resource ID '%s' is not valid. Missing path segment 'resourceGroups'.", id)));
         }
-        String topLevelArmResourceName = Utils.getValueFromIdByName(id, "topLevelArmResources");
+        String topLevelArmResourceName = ResourceManagerUtils.getValueFromIdByName(id, "topLevelArmResources");
         if (topLevelArmResourceName == null) {
             throw LOGGER.logExceptionAsError(new IllegalArgumentException(
                 String.format("The resource ID '%s' is not valid. Missing path segment 'topLevelArmResources'.", id)));
@@ -121,12 +121,12 @@ public final class TopLevelArmResourceInterfacesImpl implements TopLevelArmResou
     }
 
     public void deleteByIdWithResponse(String id, Context context) {
-        String resourceGroupName = Utils.getValueFromIdByName(id, "resourceGroups");
+        String resourceGroupName = ResourceManagerUtils.getValueFromIdByName(id, "resourceGroups");
         if (resourceGroupName == null) {
             throw LOGGER.logExceptionAsError(new IllegalArgumentException(
                 String.format("The resource ID '%s' is not valid. Missing path segment 'resourceGroups'.", id)));
         }
-        String topLevelArmResourceName = Utils.getValueFromIdByName(id, "topLevelArmResources");
+        String topLevelArmResourceName = ResourceManagerUtils.getValueFromIdByName(id, "topLevelArmResources");
         if (topLevelArmResourceName == null) {
             throw LOGGER.logExceptionAsError(new IllegalArgumentException(
                 String.format("The resource ID '%s' is not valid. Missing path segment 'topLevelArmResources'.", id)));


### PR DESCRIPTION
typespec now depends on fluentgen/fluentnamer, so typespec CI cannot exclude fluentgen/fluentnamer folder

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3411946&view=logs&j=ca395085-040a-526b-2ce8-bdc85f692774&t=c310a698-906e-53a5-78f7-614142e7c740