### PR TITLE
mgmt, fix bytebuddy version update tag

### DIFF
--- a/eng/versioning/sync_versions.py
+++ b/eng/versioning/sync_versions.py
@@ -35,15 +35,14 @@ def load_versions(content: str) -> Dict[Package, str]:
         if not line.startswith('#'):
             segments = line.split(';')
             package = segments[0]
-            if ('_' in package):
+            if (package.startswith('testdep_')):
                 # fix e.g. "testdep_net.bytebuddy:byte-buddy;1.14.8"
                 package = package.split('_')[1]
             version = None if len(segments) == 1 else segments[1]
             package_segments = package.split(':')
             if len(package_segments) == 2:
                 package_obj = Package(package_segments[0], package_segments[1])
-                if (not package_obj in packages):
-                    packages[package_obj] = version
+                packages[package_obj] = version
     return packages
 
 

--- a/fluent-tests/src/test/java/com/azure/mgmttest/RuntimeTests.java
+++ b/fluent-tests/src/test/java/com/azure/mgmttest/RuntimeTests.java
@@ -73,6 +73,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -140,6 +141,7 @@ public class RuntimeTests {
     public void testPom() throws ParserConfigurationException, IOException, SAXException {
         File pomFile = new File("pom_generated_resources.xml");
 
+        // verify pom basic
         Map<String, String> rootTags = new HashMap<>();
 
         DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
@@ -159,6 +161,15 @@ public class RuntimeTests {
 
         Assertions.assertTrue(rootTags.containsKey("name"));
         Assertions.assertTrue(rootTags.get("name").contains("Azure SDK"));
+
+        // verify x-version-update tag used in Azure Java repo
+        String content = new String(Files.readAllBytes(pomFile.toPath()));
+        Assertions.assertTrue(content.contains("<artifactId>mockito-core</artifactId>"));
+        Assertions.assertTrue(content.contains("<artifactId>byte-buddy</artifactId>"));
+        Assertions.assertTrue(content.contains("<artifactId>byte-buddy-agent</artifactId>"));
+        Assertions.assertTrue(content.contains("<!-- {x-version-update;org.mockito:mockito-core;external_dependency} -->"));
+        Assertions.assertTrue(content.contains("<!-- {x-version-update;testdep_net.bytebuddy:byte-buddy;external_dependency} -->"));
+        Assertions.assertTrue(content.contains("<!-- {x-version-update;testdep_net.bytebuddy:byte-buddy-agent;external_dependency} -->"));
     }
 
     @Test

--- a/fluent-tests/src/test/java/com/azure/mgmttest/RuntimeTests.java
+++ b/fluent-tests/src/test/java/com/azure/mgmttest/RuntimeTests.java
@@ -448,7 +448,7 @@ public class RuntimeTests {
         assertMethodNotExist(StorageAccountsClient.class, "getByResourceGroupWithResponseAsync", "String", "String", "StorageAccountExpand", "Context");
     }
 
-    private static void assertMethodNotExist(Class clazz, String methodName, String... parameterTypeSimpleNames) {
+    private static <T> void assertMethodNotExist(Class<T> clazz, String methodName, String... parameterTypeSimpleNames) {
         String parametersSignature = String.join(",", parameterTypeSimpleNames);
         Method[] methods = clazz.getDeclaredMethods();
         for(Method method : methods) {
@@ -462,7 +462,7 @@ public class RuntimeTests {
         }
     }
 
-    private static void assertMethodExist(Class clazz, String methodName, String... parameterTypeSimpleNames) {
+    private static <T> void assertMethodExist(Class<T> clazz, String methodName, String... parameterTypeSimpleNames) {
         boolean found = false;
         String parametersSignature = String.join(",", parameterTypeSimpleNames);
         Method[] methods = clazz.getDeclaredMethods();

--- a/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
+++ b/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
@@ -73,7 +73,7 @@ public class Project {
         JUNIT_JUPITER_API("org.junit.jupiter", "junit-jupiter-api", "5.9.3"),
         JUNIT_JUPITER_ENGINE("org.junit.jupiter", "junit-jupiter-engine", "5.9.3"),
         MOCKITO_CORE("org.mockito", "mockito-core", "4.11.0"),
-        BYTE_BUDDY("net.bytebuddy", "byte-buddy", "1.12.23"),
+        BYTE_BUDDY("net.bytebuddy", "byte-buddy", "1.14.8"),
         BYTE_BUDDY_AGENT("net.bytebuddy", "byte-buddy-agent", "1.14.8"),
         SLF4J_SIMPLE("org.slf4j", "slf4j-simple", "1.7.36");
 

--- a/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
+++ b/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
@@ -42,17 +42,6 @@ public class Project {
 
     public static final String AZURE_GROUP_ID = ExternalPackage.CORE.getGroupId();
 
-    public static final Map<String, String> VERSION_UPDATE_TAG = Map.of(
-            // see https://github.com/Azure/azure-sdk-for-java/blob/main/eng/versioning/external_dependencies.txt
-            "net.bytebuddy:byte-buddy", "testdep_net.bytebuddy:byte-buddy",
-            "net.bytebuddy:byte-buddy-agent", "testdep_net.bytebuddy:byte-buddy-agent"
-    );
-    public static String getVersionUpdateTag(String groupId, String artifactId) {
-        String tag = groupId + ":" + artifactId;
-        String ret = VERSION_UPDATE_TAG.get(tag);
-        return ret == null ? tag : ret;
-    }
-
     protected String serviceName;
     protected String serviceDescription;
     protected String namespace;
@@ -245,6 +234,25 @@ public class Project {
             }
         }
         return ret;
+    }
+
+    private static final Map<String, String> VERSION_UPDATE_TAG_MAP = Map.of(
+            // see https://github.com/Azure/azure-sdk-for-java/blob/main/eng/versioning/external_dependencies.txt
+            "net.bytebuddy:byte-buddy", "testdep_net.bytebuddy:byte-buddy",
+            "net.bytebuddy:byte-buddy-agent", "testdep_net.bytebuddy:byte-buddy-agent"
+    );
+
+    /**
+     * Gets the version update tag (x-version-update) for the groupId and artifactId.
+     *
+     * @param groupId the group ID.
+     * @param artifactId the artifact ID.
+     * @return the version update tag.
+     */
+    public static String getVersionUpdateTag(String groupId, String artifactId) {
+        String tag = groupId + ":" + artifactId;
+        String ret = VERSION_UPDATE_TAG_MAP.get(tag);
+        return ret == null ? tag : ret;
     }
 
     protected void findPackageVersions() {

--- a/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
+++ b/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
@@ -31,6 +31,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -40,6 +41,17 @@ public class Project {
     private static final Logger LOGGER = new PluginLogger(Javagen.getPluginInstance(), Project.class);
 
     public static final String AZURE_GROUP_ID = ExternalPackage.CORE.getGroupId();
+
+    public static final Map<String, String> VERSION_UPDATE_TAG = Map.of(
+            // see https://github.com/Azure/azure-sdk-for-java/blob/main/eng/versioning/external_dependencies.txt
+            "net.bytebuddy:byte-buddy", "testdep_net.bytebuddy:byte-buddy",
+            "net.bytebuddy:byte-buddy-agent", "testdep_net.bytebuddy:byte-buddy-agent"
+    );
+    public static String getVersionUpdateTag(String groupId, String artifactId) {
+        String tag = groupId + ":" + artifactId;
+        String ret = VERSION_UPDATE_TAG.get(tag);
+        return ret == null ? tag : ret;
+    }
 
     protected String serviceName;
     protected String serviceDescription;
@@ -266,7 +278,7 @@ public class Project {
         try (BufferedReader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
             reader.lines().forEach(line -> {
                 for (Dependency dependency : Dependency.values()) {
-                    String artifact = dependency.getGroupId() + ":" + dependency.getArtifactId();
+                    String artifact = getVersionUpdateTag(dependency.getGroupId(), dependency.getArtifactId());
                     checkArtifact(line, artifact).ifPresent(dependency::setVersion);
                 }
             });

--- a/javagen/src/main/java/com/azure/autorest/template/PomTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/PomTemplate.java
@@ -5,6 +5,7 @@ package com.azure.autorest.template;
 
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.model.clientmodel.Pom;
+import com.azure.autorest.model.projectmodel.Project;
 import com.azure.autorest.model.xmlmodel.XmlBlock;
 import com.azure.autorest.model.xmlmodel.XmlFile;
 import com.azure.core.util.CoreUtils;
@@ -137,9 +138,8 @@ public class PomTemplate implements IXmlTemplate<Pom, XmlFile> {
                             dependenciesBlock.tag("artifactId", artifactId);
                             if (version != null) {
                                 dependencyBlock.tagWithInlineComment("version", version,
-                                        String.format("{x-version-update;%1$s:%2$s;%3$s}",
-                                                groupId,
-                                                artifactId,
+                                        String.format("{x-version-update;%1$s;%2$s}",
+                                                Project.getVersionUpdateTag(groupId, artifactId),
                                                 externalDependency ? "external_dependency" : "dependency"));
                             }
                             if (scope != null) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/java",
-  "version": "4.1.25",
+  "version": "4.1.26",
   "description": "The Java extension for classic generators in AutoRest.",
   "scripts": {
     "autorest": "autorest",


### PR DESCRIPTION
```xml
    <dependency>
      <groupId>net.bytebuddy</groupId>
      <artifactId>byte-buddy</artifactId>
      <version>1.14.8</version> <!-- {x-version-update;testdep_net.bytebuddy:byte-buddy;external_dependency} -->
      <scope>test</scope>
    </dependency>
    <dependency>
      <groupId>net.bytebuddy</groupId>
      <artifactId>byte-buddy-agent</artifactId>
      <version>1.14.8</version> <!-- {x-version-update;testdep_net.bytebuddy:byte-buddy-agent;external_dependency} -->
      <scope>test</scope>
    </dependency>
```

The tag has prefix `testdep_`.