### PR TITLE
eng, cadl-ranch, it requires generatorMode

### DIFF
--- a/eng/pipelines/ci-typespec-java.yaml
+++ b/eng/pipelines/ci-typespec-java.yaml
@@ -116,6 +116,6 @@ jobs:
           azureSubscription: "Cadl Ranch Storage"
           scriptType: "bash"
           scriptLocation: "inlineScript"
-          inlineScript: node $(Build.SourcesDirectory)/typespec-tests/node_modules/\@azure-tools/cadl-ranch/dist/cli/cli.js upload-coverage --coverageFile $(Build.SourcesDirectory)/typespec-tests/cadl-ranch-coverage-java.json --generatorName java --storageAccountName azuresdkcadlranch --generatorVersion $(node -p -e "require('./typespec-extension/package.json').version")
+          inlineScript: node $(Build.SourcesDirectory)/typespec-tests/node_modules/\@azure-tools/cadl-ranch/dist/cli/cli.js upload-coverage --coverageFile $(Build.SourcesDirectory)/typespec-tests/cadl-ranch-coverage-java.json --generatorName java --storageAccountName azuresdkcadlranch --generatorMode azure --generatorVersion $(node -p -e "require('./typespec-extension/package.json').version")
 
       - template: /eng/pipelines/steps/cleanup-maven-local-cache.yml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@autorest/java",
-  "version": "4.1.25",
+  "version": "4.1.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@autorest/java",
-      "version": "4.1.25",
+      "version": "4.1.26",
       "license": "MIT",
       "devDependencies": {
         "@microsoft.azure/autorest.testserver": "3.3.48",

--- a/typespec-tests/package.json
+++ b/typespec-tests/package.json
@@ -9,7 +9,7 @@
     "testserver-run": "npx cadl-ranch serve ./node_modules/@azure-tools/cadl-ranch-specs/http --coverageFile ./cadl-ranch-coverage-java.json"
   },
   "dependencies": {
-    "@azure-tools/cadl-ranch-specs": "0.28.6",
+    "@azure-tools/cadl-ranch-specs": "0.28.7",
     "@azure-tools/typespec-java": "file:/../typespec-extension/azure-tools-typespec-java-0.12.2.tgz"
   },
   "devDependencies": {


### PR DESCRIPTION
Don't know which version of cadl-ranch now require we set `generatorMode` option
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3419707&view=logs&j=ca395085-040a-526b-2ce8-bdc85f692774&t=697bc912-22e6-55aa-4251-5cc4b0487ace