### PR TITLE
mgmt, support flattenProperty

### DIFF
--- a/typespec-extension/changelog.md
+++ b/typespec-extension/changelog.md
@@ -5,6 +5,7 @@
 Compatible with compiler 0.52.
 
 - Supported `@clientName` from "@azure-tools/typespec-client-generator-core".
+- Supported `@flattenProperty` from "@azure-tools/typespec-client-generator-core".
 
 ## 0.12.3 (2024-01-22)
 

--- a/typespec-extension/src/code-model-builder.ts
+++ b/typespec-extension/src/code-model-builder.ts
@@ -72,6 +72,7 @@ import {
   SdkClient,
   getCrossLanguageDefinitionId,
   getClientNameOverride,
+  shouldFlattenProperty,
 } from "@azure-tools/typespec-client-generator-core";
 import { fail } from "assert";
 import {
@@ -2277,13 +2278,16 @@ export class CodeModelBuilder {
     const schema = this.processSchema(prop, prop.name);
     let nullable = isNullableType(prop.type);
 
-    let extensions = undefined;
+    let extensions: Record<string, any> | undefined = undefined;
     if (this.isSecret(prop)) {
-      extensions = {
-        "x-ms-secret": true,
-      };
+      extensions = extensions ?? {};
+      extensions["x-ms-secret"] = true;
       // if the property does not return in response, it had to be nullable
       nullable = true;
+    }
+    if (shouldFlattenProperty(this.sdkContext, prop)) {
+      extensions = extensions ?? {};
+      extensions["x-ms-client-flatten"] = true;
     }
 
     return new Property(this.getName(prop), this.getDoc(prop), schema, {


### PR DESCRIPTION
However, saw a critical problem when trying to write a test. The `properties` property is in lib, not in service tsp...
https://github.com/Azure/typespec-azure/blob/main/packages/typespec-azure-resource-manager/lib/models.tsp#L23

Locally, I've tested on other property. Not checked in. We should got a cadl-ranch case soon.