### PR TITLE
tsp, multipart file field can have no filename; update filename encoding

### DIFF
--- a/javagen/src/main/resources/MultipartFormDataHelper.java
+++ b/javagen/src/main/resources/MultipartFormDataHelper.java
@@ -10,7 +10,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
-import java.util.regex.Pattern;
 
 // DO NOT modify this helper class
 
@@ -209,8 +208,6 @@ public final class MultipartFormDataHelper {
         requestLength += bytes.length;
         requestDataStream = new SequenceInputStream(requestDataStream, new ByteArrayInputStream(bytes));
     }
-
-    private static final Pattern REDACT_FILENAME = Pattern.compile("[^\\x20-\\x7E]|\"");
 
     private static String escapeName(String name) {
         return name.replace("\n", "%0A").replace("\r", "%0D").replace("\"", "%22");

--- a/javagen/src/main/resources/MultipartFormDataHelper.java
+++ b/javagen/src/main/resources/MultipartFormDataHelper.java
@@ -3,7 +3,6 @@ import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.util.BinaryData;
 import com.azure.core.util.CoreUtils;
 
-import java.text.Normalizer;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.SequenceInputStream;
@@ -85,8 +84,8 @@ public final class MultipartFormDataHelper {
     public MultipartFormDataHelper serializeTextField(String fieldName, String value) {
         if (value != null) {
             String serialized = partSeparator
-                    + CRLF + "Content-Disposition: form-data; name=\""
-                    + fieldName + "\"" + CRLF + CRLF
+                    + CRLF + "Content-Disposition: form-data; name=\"" + escapeName(fieldName) + "\""
+                    + CRLF + CRLF
                     + value
                     + CRLF;
             byte[] data = serialized.getBytes(encoderCharset);
@@ -105,7 +104,8 @@ public final class MultipartFormDataHelper {
      */
     public MultipartFormDataHelper serializeJsonField(String fieldName, Object jsonObject) {
         if (jsonObject != null) {
-            String serialized = partSeparator + CRLF + "Content-Disposition: form-data; name=\"" + fieldName + "\""
+            String serialized = partSeparator + CRLF
+                    + "Content-Disposition: form-data; name=\"" + escapeName(fieldName) + "\""
                     + CRLF + "Content-Type: application/json"
                     + CRLF + CRLF + BinaryData.fromObject(jsonObject) + CRLF;
             byte[] data = serialized.getBytes(encoderCharset);
@@ -132,11 +132,6 @@ public final class MultipartFormDataHelper {
             if (CoreUtils.isNullOrEmpty(contentType)) {
                 contentType = APPLICATION_OCTET_STREAM;
             }
-            if (CoreUtils.isNullOrEmpty(filename)) {
-                filename = fieldName;
-            }
-            filename = normalizeAscii(filename);
-
             writeFileField(fieldName, file, contentType, filename);
         }
         return this;
@@ -164,11 +159,6 @@ public final class MultipartFormDataHelper {
                     contentType = APPLICATION_OCTET_STREAM;
                 }
                 String filename = filenames.get(i);
-                if (CoreUtils.isNullOrEmpty(filename)) {
-                    filename = fieldName + String.valueOf(i + 1);
-                }
-                filename = normalizeAscii(filename);
-
                 writeFileField(fieldName, file, contentType, filename);
             }
         }
@@ -194,10 +184,14 @@ public final class MultipartFormDataHelper {
     }
 
     private void writeFileField(String fieldName, BinaryData file, String contentType, String filename) {
+        String contentDispositionFilename = "";
+        if (!CoreUtils.isNullOrEmpty(filename)) {
+            contentDispositionFilename = "; filename=\"" + escapeName(filename) + "\"";
+        }
+
         // Multipart preamble
         String fileFieldPreamble = partSeparator
-                + CRLF + "Content-Disposition: form-data; name=\"" + fieldName
-                + "\"; filename=\"" + filename + "\""
+                + CRLF + "Content-Disposition: form-data; name=\"" + escapeName(fieldName) + "\"" + contentDispositionFilename
                 + CRLF + "Content-Type: " + contentType + CRLF + CRLF;
         byte[] data = fileFieldPreamble.getBytes(encoderCharset);
         appendBytes(data);
@@ -218,7 +212,7 @@ public final class MultipartFormDataHelper {
 
     private static final Pattern REDACT_FILENAME = Pattern.compile("[^\\x20-\\x7E]|\"");
 
-    private static String normalizeAscii(String text) {
-        return REDACT_FILENAME.matcher(Normalizer.normalize(text, Normalizer.Form.NFD)).replaceAll("");
+    private static String escapeName(String name) {
+        return name.replace("\n", "%0A").replace("\r", "%0D").replace("\"", "%22");
     }
 }

--- a/typespec-extension/changelog.md
+++ b/typespec-extension/changelog.md
@@ -1,6 +1,10 @@
 # Release History
 
-## 0.13.3 (2024-02-07)
+## 0.13.5 (2024-02-09)
+
+Compatible with compiler 0.53.
+
+## 0.13.4 (2024-02-07)
 
 Compatible with compiler 0.53.
 

--- a/typespec-extension/changelog.md
+++ b/typespec-extension/changelog.md
@@ -4,6 +4,8 @@
 
 Compatible with compiler 0.53.
 
+- Behavior changed on "multipart/form-data" request. If `filename` is not provided, implementation will no longer provide a default filename to `Content-Disposition` line.
+
 ## 0.13.4 (2024-02-07)
 
 Compatible with compiler 0.53.

--- a/typespec-extension/package-lock.json
+++ b/typespec-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/typespec-java",
-      "version": "0.13.4",
+      "version": "0.13.5",
       "license": "MIT",
       "dependencies": {
         "@autorest/codemodel": "~4.20.0",

--- a/typespec-extension/package.json
+++ b/typespec-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "TypeSpec library for emitting Java client from the TypeSpec REST protocol binding",
   "keywords": [
     "TypeSpec"

--- a/typespec-tests/package.json
+++ b/typespec-tests/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@azure-tools/cadl-ranch-specs": "0.29.0",
-    "@azure-tools/typespec-java": "file:/../typespec-extension/azure-tools-typespec-java-0.13.4.tgz"
+    "@azure-tools/typespec-java": "file:/../typespec-extension/azure-tools-typespec-java-0.13.5.tgz"
   },
   "devDependencies": {
     "@typespec/prettier-plugin-typespec": "~0.53.0",

--- a/typespec-tests/src/main/java/com/cadl/multipart/implementation/MultipartFormDataHelper.java
+++ b/typespec-tests/src/main/java/com/cadl/multipart/implementation/MultipartFormDataHelper.java
@@ -13,7 +13,6 @@ import java.io.InputStream;
 import java.io.SequenceInputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.text.Normalizer;
 import java.util.List;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -89,8 +88,8 @@ public final class MultipartFormDataHelper {
      */
     public MultipartFormDataHelper serializeTextField(String fieldName, String value) {
         if (value != null) {
-            String serialized = partSeparator + CRLF + "Content-Disposition: form-data; name=\"" + fieldName + "\""
-                + CRLF + CRLF + value + CRLF;
+            String serialized = partSeparator + CRLF + "Content-Disposition: form-data; name=\"" + escapeName(fieldName)
+                + "\"" + CRLF + CRLF + value + CRLF;
             byte[] data = serialized.getBytes(encoderCharset);
             appendBytes(data);
         }
@@ -107,8 +106,9 @@ public final class MultipartFormDataHelper {
      */
     public MultipartFormDataHelper serializeJsonField(String fieldName, Object jsonObject) {
         if (jsonObject != null) {
-            String serialized = partSeparator + CRLF + "Content-Disposition: form-data; name=\"" + fieldName + "\""
-                + CRLF + "Content-Type: application/json" + CRLF + CRLF + BinaryData.fromObject(jsonObject) + CRLF;
+            String serialized
+                = partSeparator + CRLF + "Content-Disposition: form-data; name=\"" + escapeName(fieldName) + "\"" + CRLF
+                    + "Content-Type: application/json" + CRLF + CRLF + BinaryData.fromObject(jsonObject) + CRLF;
             byte[] data = serialized.getBytes(encoderCharset);
             appendBytes(data);
         }
@@ -130,11 +130,6 @@ public final class MultipartFormDataHelper {
             if (CoreUtils.isNullOrEmpty(contentType)) {
                 contentType = APPLICATION_OCTET_STREAM;
             }
-            if (CoreUtils.isNullOrEmpty(filename)) {
-                filename = fieldName;
-            }
-            filename = normalizeAscii(filename);
-
             writeFileField(fieldName, file, contentType, filename);
         }
         return this;
@@ -159,11 +154,6 @@ public final class MultipartFormDataHelper {
                     contentType = APPLICATION_OCTET_STREAM;
                 }
                 String filename = filenames.get(i);
-                if (CoreUtils.isNullOrEmpty(filename)) {
-                    filename = fieldName + String.valueOf(i + 1);
-                }
-                filename = normalizeAscii(filename);
-
                 writeFileField(fieldName, file, contentType, filename);
             }
         }
@@ -188,9 +178,15 @@ public final class MultipartFormDataHelper {
     }
 
     private void writeFileField(String fieldName, BinaryData file, String contentType, String filename) {
+        String contentDispositionFilename = "";
+        if (!CoreUtils.isNullOrEmpty(filename)) {
+            contentDispositionFilename = "; filename=\"" + escapeName(filename) + "\"";
+        }
+
         // Multipart preamble
-        String fileFieldPreamble = partSeparator + CRLF + "Content-Disposition: form-data; name=\"" + fieldName
-            + "\"; filename=\"" + filename + "\"" + CRLF + "Content-Type: " + contentType + CRLF + CRLF;
+        String fileFieldPreamble
+            = partSeparator + CRLF + "Content-Disposition: form-data; name=\"" + escapeName(fieldName) + "\""
+                + contentDispositionFilename + CRLF + "Content-Type: " + contentType + CRLF + CRLF;
         byte[] data = fileFieldPreamble.getBytes(encoderCharset);
         appendBytes(data);
 
@@ -210,7 +206,7 @@ public final class MultipartFormDataHelper {
 
     private static final Pattern REDACT_FILENAME = Pattern.compile("[^\\x20-\\x7E]|\"");
 
-    private static String normalizeAscii(String text) {
-        return REDACT_FILENAME.matcher(Normalizer.normalize(text, Normalizer.Form.NFD)).replaceAll("");
+    private static String escapeName(String name) {
+        return name.replace("\n", "%0A").replace("\r", "%0D").replace("\"", "%22");
     }
 }

--- a/typespec-tests/src/main/java/com/cadl/multipart/implementation/MultipartFormDataHelper.java
+++ b/typespec-tests/src/main/java/com/cadl/multipart/implementation/MultipartFormDataHelper.java
@@ -15,7 +15,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
-import java.util.regex.Pattern;
 
 // DO NOT modify this helper class
 
@@ -203,8 +202,6 @@ public final class MultipartFormDataHelper {
         requestLength += bytes.length;
         requestDataStream = new SequenceInputStream(requestDataStream, new ByteArrayInputStream(bytes));
     }
-
-    private static final Pattern REDACT_FILENAME = Pattern.compile("[^\\x20-\\x7E]|\"");
 
     private static String escapeName(String name) {
         return name.replace("\n", "%0A").replace("\r", "%0D").replace("\"", "%22");

--- a/typespec-tests/src/main/java/com/payload/multipart/implementation/MultipartFormDataHelper.java
+++ b/typespec-tests/src/main/java/com/payload/multipart/implementation/MultipartFormDataHelper.java
@@ -13,7 +13,6 @@ import java.io.InputStream;
 import java.io.SequenceInputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.text.Normalizer;
 import java.util.List;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -89,8 +88,8 @@ public final class MultipartFormDataHelper {
      */
     public MultipartFormDataHelper serializeTextField(String fieldName, String value) {
         if (value != null) {
-            String serialized = partSeparator + CRLF + "Content-Disposition: form-data; name=\"" + fieldName + "\""
-                + CRLF + CRLF + value + CRLF;
+            String serialized = partSeparator + CRLF + "Content-Disposition: form-data; name=\"" + escapeName(fieldName)
+                + "\"" + CRLF + CRLF + value + CRLF;
             byte[] data = serialized.getBytes(encoderCharset);
             appendBytes(data);
         }
@@ -107,8 +106,9 @@ public final class MultipartFormDataHelper {
      */
     public MultipartFormDataHelper serializeJsonField(String fieldName, Object jsonObject) {
         if (jsonObject != null) {
-            String serialized = partSeparator + CRLF + "Content-Disposition: form-data; name=\"" + fieldName + "\""
-                + CRLF + "Content-Type: application/json" + CRLF + CRLF + BinaryData.fromObject(jsonObject) + CRLF;
+            String serialized
+                = partSeparator + CRLF + "Content-Disposition: form-data; name=\"" + escapeName(fieldName) + "\"" + CRLF
+                    + "Content-Type: application/json" + CRLF + CRLF + BinaryData.fromObject(jsonObject) + CRLF;
             byte[] data = serialized.getBytes(encoderCharset);
             appendBytes(data);
         }
@@ -130,11 +130,6 @@ public final class MultipartFormDataHelper {
             if (CoreUtils.isNullOrEmpty(contentType)) {
                 contentType = APPLICATION_OCTET_STREAM;
             }
-            if (CoreUtils.isNullOrEmpty(filename)) {
-                filename = fieldName;
-            }
-            filename = normalizeAscii(filename);
-
             writeFileField(fieldName, file, contentType, filename);
         }
         return this;
@@ -159,11 +154,6 @@ public final class MultipartFormDataHelper {
                     contentType = APPLICATION_OCTET_STREAM;
                 }
                 String filename = filenames.get(i);
-                if (CoreUtils.isNullOrEmpty(filename)) {
-                    filename = fieldName + String.valueOf(i + 1);
-                }
-                filename = normalizeAscii(filename);
-
                 writeFileField(fieldName, file, contentType, filename);
             }
         }
@@ -188,9 +178,15 @@ public final class MultipartFormDataHelper {
     }
 
     private void writeFileField(String fieldName, BinaryData file, String contentType, String filename) {
+        String contentDispositionFilename = "";
+        if (!CoreUtils.isNullOrEmpty(filename)) {
+            contentDispositionFilename = "; filename=\"" + escapeName(filename) + "\"";
+        }
+
         // Multipart preamble
-        String fileFieldPreamble = partSeparator + CRLF + "Content-Disposition: form-data; name=\"" + fieldName
-            + "\"; filename=\"" + filename + "\"" + CRLF + "Content-Type: " + contentType + CRLF + CRLF;
+        String fileFieldPreamble
+            = partSeparator + CRLF + "Content-Disposition: form-data; name=\"" + escapeName(fieldName) + "\""
+                + contentDispositionFilename + CRLF + "Content-Type: " + contentType + CRLF + CRLF;
         byte[] data = fileFieldPreamble.getBytes(encoderCharset);
         appendBytes(data);
 
@@ -210,7 +206,7 @@ public final class MultipartFormDataHelper {
 
     private static final Pattern REDACT_FILENAME = Pattern.compile("[^\\x20-\\x7E]|\"");
 
-    private static String normalizeAscii(String text) {
-        return REDACT_FILENAME.matcher(Normalizer.normalize(text, Normalizer.Form.NFD)).replaceAll("");
+    private static String escapeName(String name) {
+        return name.replace("\n", "%0A").replace("\r", "%0D").replace("\"", "%22");
     }
 }

--- a/typespec-tests/src/main/java/com/payload/multipart/implementation/MultipartFormDataHelper.java
+++ b/typespec-tests/src/main/java/com/payload/multipart/implementation/MultipartFormDataHelper.java
@@ -15,7 +15,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
-import java.util.regex.Pattern;
 
 // DO NOT modify this helper class
 
@@ -203,8 +202,6 @@ public final class MultipartFormDataHelper {
         requestLength += bytes.length;
         requestDataStream = new SequenceInputStream(requestDataStream, new ByteArrayInputStream(bytes));
     }
-
-    private static final Pattern REDACT_FILENAME = Pattern.compile("[^\\x20-\\x7E]|\"");
 
     private static String escapeName(String name) {
         return name.replace("\n", "%0A").replace("\r", "%0D").replace("\"", "%22");

--- a/typespec-tests/src/test/java/com/payload/multipart/MultipartTests.java
+++ b/typespec-tests/src/test/java/com/payload/multipart/MultipartTests.java
@@ -204,10 +204,10 @@ public class MultipartTests {
                 "123",
                 Arrays.asList(
                         new PicturesFileDetails(BinaryData.fromFile(PNG_FILE)).setFilename("voilà.png"),
-                        new PicturesFileDetails(BinaryData.fromFile(PNG_FILE)).setFilename("ima\"\nge2.png")
+                        new PicturesFileDetails(BinaryData.fromFile(PNG_FILE)).setFilename("ima\"\n\rge2.png")
                 ))).block();
 
-        validationPolicy.validateFilenames("voila.png", "image2.png");
+        validationPolicy.validateFilenames("voilà.png", "ima%22%0A%0Dge2.png");
     }
 
     @Test


### PR DESCRIPTION
# 1. Allow no filename in request

At present, "no filename" case cannot be tested on cadl-ranch

---

### OpenAI
```
--c55a1781-e592-48
Content-Disposition: form-data; name="file"
Content-Type: application/octet-stream

RIFF��7
```

However OpenAI seems requires a filename.
```
com.azure.core.exception.HttpResponseException: Status code 400, "{
  "error": {
    "message": "1 validation error for Request\nbody -> file\n  Expected UploadFile, received: <class 'str'> (type=value_error)",
    "type": "invalid_request_error",
    "param": null,
    "code": null
  }
}"
```
(same result if set `Content-Type: audio/wav`)
(It will pass if I set the `filename` in `Content-Disposition`)

### OpenAI Assistants

```
Exception in thread "main" com.azure.core.exception.HttpResponseException: Status code 400, "{
  "error": {
    "message": "The browser (or proxy) sent a request that this server could not understand.",
    "type": "server_error",
    "param": null,
    "code": null
  }
}
"
```

same result via python (when no `filename`)

```python
response = requests.post('https://###.openai.azure.com/openai/files?api-version=2024-02-15-preview',
                         headers={'api-key': '###'},
                         files={'file': (None, '''The word 'apple' uses the code 442345, while the word 'banana' uses the code 673457.''')},
                         data={'purpose': 'assistants'})
response.raise_for_status()
```

So, I take the implementation is good.

### httpbin

https://httpbin.org/post also not able to recognize it be `files`, when no filename.
