### PR TITLE
json-merge-patch, add test case for map's key is `null`

### DIFF
--- a/typespec-tests/src/test/java/com/cadl/patch/PatchClientTest.java
+++ b/typespec-tests/src/test/java/com/cadl/patch/PatchClientTest.java
@@ -74,6 +74,21 @@ public class PatchClientTest {
     }
 
     @Test
+    public void testSerializationForMapNullKeyProperty() {
+        Exception exception = Assertions.assertThrows(NullPointerException.class, () -> {
+            Resource resource = new Resource(new HashMap<>());
+            JsonMergePatchHelper.getResourceAccessor().prepareModelForJsonMergePatch(resource, true);
+            resource.getMap().put(null, new InnerModel("value1"));
+            BinaryData.fromObject(resource).toString();
+        });
+
+        String expectedMessage = "'fieldName' cannot be null.";
+        String actualMessage = exception.getMessage();
+
+        Assertions.assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
     public void testSerializationForArrayProperty() throws JsonProcessingException {
         Resource resource = new Resource(new HashMap<>());
         resource.setArray(Arrays.asList(new InnerModel("value1"), new InnerModel("value2")));


### PR DESCRIPTION
When a map's key is `null`, it should throw error when doing serialization both in `toJson()` and `toJsonMergePatch()`.
We will throw `NullPointorException` when map's key value is `null`. This PR add a test case for this.

