### PR TITLE
Finalize Javadoc work in extension-base

### DIFF
--- a/extension-base/pom.xml
+++ b/extension-base/pom.xml
@@ -21,6 +21,10 @@
   <description>This module contains the base classes an utilities needed for writing an AutoRest extension in Java.</description>
   <url>https://github.com/Azure/autorest.java</url>
 
+  <properties>
+    <maven.javadoc.failOnWarnings>true</maven.javadoc.failOnWarnings>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.yaml</groupId>

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/jsonrpc/Connection.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/jsonrpc/Connection.java
@@ -16,7 +16,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -30,8 +29,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
+/**
+ * Represents a connection.
+ */
 public class Connection {
     private static final ObjectMapper MAPPER = new ObjectMapper()
         .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
@@ -43,8 +44,14 @@ public class Connection {
     private final Map<Integer, CallerResponse<?>> tasks = new ConcurrentHashMap<>();
     private final ExecutorService executorService = Executors.newCachedThreadPool();
     private final CompletableFuture<Void> loop;
-    private final Map<String, Function<JsonNode, String>> dispatch = new HashMap<>();
+    private final Map<String, Function<JsonNode, String>> dispatch = new ConcurrentHashMap<>();
 
+    /**
+     * Create a new Connection.
+     *
+     * @param writer The output stream to write to.
+     * @param input The input stream to read from.
+     */
     public Connection(OutputStream writer, InputStream input) {
         this.writer = writer;
         this.reader = new PeekingBinaryReader(input);
@@ -54,6 +61,9 @@ public class Connection {
 
     private boolean isAlive = true;
 
+    /**
+     * Stops the connection.
+     */
     public void stop() {
         isAlive = false;
         loop.cancel(true);
@@ -79,6 +89,13 @@ public class Connection {
         }
     }
 
+    /**
+     * Dispatches a message.
+     *
+     * @param <T> The type of the result.
+     * @param path The path.
+     * @param method The method that gets the result.
+     */
     public <T> void dispatch(String path, Supplier<T> method) {
         dispatch.put(path, input -> {
             T result = method.get();
@@ -103,23 +120,20 @@ public class Connection {
             ret.add(input);
         }
 
-        if (expectedArgs == 0) {
-            if (ret.size() == 0) {
-                // expected zero, received zero
-                return new ArrayList<>();
-            }
-
-            throw new RuntimeException("Invalid number of arguments");
-        }
-
         if (ret.size() == expectedArgs) {
-            // passed as an array
-            return ret;
+            // Return passed array if size is larger than 0, otherwise return a new ArrayList
+            return (expectedArgs == 0) ? new ArrayList<>() : ret;
         }
 
         throw new RuntimeException("Invalid number of arguments");
     }
 
+    /**
+     * Dispatches a notification.
+     *
+     * @param path The path.
+     * @param method The method.
+     */
     public void dispatchNotification(String path, Runnable method) {
         dispatch.put(path, input -> {
             method.run();
@@ -127,10 +141,19 @@ public class Connection {
         });
     }
 
-    public <P1, T> void dispatch(String path, Function<P1, T> method) {
-    }
-
-    public <P1, P2, T> void dispatch(String path, BiFunction<P1, P2, T> method, Class<? extends P1> p1Class, Class<? extends P2> p2Class) {
+    /**
+     * Dispatches a message.
+     *
+     * @param <T> The type of the result.
+     * @param <P1> The type of the parameter.
+     * @param <P2> The type of the parameter.
+     * @param path The path.
+     * @param method The method that gets the result.
+     * @param p1Class The class of the parameter.
+     * @param p2Class The class of the parameter.
+     */
+    public <P1, P2, T> void dispatch(String path, BiFunction<P1, P2, T> method, Class<? extends P1> p1Class,
+        Class<? extends P2> p2Class) {
         dispatch.put(path, input -> {
             List<JsonNode> args = readArguments(input, 2);
             try {
@@ -157,8 +180,6 @@ public class Connection {
         }
     }
 
-//    private void Log(String text) => OnDebug?.Invoke(text);
-
     private boolean listen() {
         while (isAlive) {
             try {
@@ -180,12 +201,10 @@ public class Connection {
                 // We're looking at headers
                 Map<String, String> headers = new HashMap<>();
                 String line = reader.readAsciiLine();
-//                System.err.println("Incoming line: " + line);
                 while (line != null && !line.isEmpty()) {
                     String[] bits = line.split(":", 2);
                     headers.put(bits[0].trim(), bits[1].trim());
                     line = reader.readAsciiLine();
-//                    System.err.println("Incoming line: " + line);
                 }
 
                 ch = reader.peekByte();
@@ -205,14 +224,10 @@ public class Connection {
                     continue;
                 }
 
-//                throw new RuntimeException("SHOULD NEVER GET HERE!");
                 return false;
 
             } catch (Exception e) {
-                if (isAlive) {
-//                    throw new RuntimeException("Error during Listen");
-                    continue;
-                } else {
+                if (!isAlive) {
                     throw new RuntimeException(e);
                 }
             }
@@ -220,12 +235,15 @@ public class Connection {
         return false;
     }
 
+    /**
+     * Processes a message.
+     *
+     * @param content The content.
+     */
     public void process(JsonNode content) {
-//        System.err.println("JSON RPC receive: " + content.toString());
         if (content instanceof ObjectNode) {
             executorService.submit(() -> {
                 ObjectNode jobject = (ObjectNode) content;
-//                System.err.println("receive: " + jobject.toPrettyString());
                 try {
                     Iterator<Map.Entry<String, JsonNode>> fieldIterator = jobject.fields();
                     while (fieldIterator.hasNext()) {
@@ -255,9 +273,13 @@ public class Connection {
                                 CallerResponse<?> f = tasks.remove(id);
 
                                 try {
-                                    if (f.getType().getRawClass().equals(Boolean.class) && (jobject.get("result") != null) && jobject.get("result").toString().equals("{}")) {
+                                    if (f.getType().getRawClass().equals(Boolean.class)
+                                        && (jobject.get("result") != null)
+                                        && jobject.get("result").toString().equals("{}")) {
                                         f.complete(Boolean.TRUE);
-                                    } else if (f.getType().getRawClass().equals(String.class) && (jobject.get("result") != null) && jobject.get("result").toString().equals("{}")) {
+                                    } else if (f.getType().getRawClass().equals(String.class)
+                                        && (jobject.get("result") != null)
+                                        && jobject.get("result").toString().equals("{}")) {
                                         f.complete("");
                                     } else {
                                         f.complete(MAPPER.convertValue(jobject.get("result"), f.getType()));
@@ -295,6 +317,11 @@ public class Connection {
         }
     }
 
+    /**
+     * Closes the connection.
+     *
+     * @throws IOException If an I/O error occurs.
+     */
     protected void close() throws IOException {
         // ensure that we are in a cancelled state.
         isAlive = false;
@@ -326,6 +353,13 @@ public class Connection {
         }
     }
 
+    /**
+     * Sends an error.
+     *
+     * @param id The id.
+     * @param code The code.
+     * @param message The message.
+     */
     public void sendError(int id, int code, String message) {
         JsonNode node = new ObjectNode(MAPPER.getNodeFactory())
             .put("jsonrpc", "2.0")
@@ -335,6 +369,12 @@ public class Connection {
         send(node.toString());
     }
 
+    /**
+     * Sends a response.
+     *
+     * @param id The id.
+     * @param value The value.
+     */
     public void respond(int id, String value) {
         JsonNode node;
         try {
@@ -348,29 +388,48 @@ public class Connection {
         send(node.toString());
     }
 
+    /**
+     * Sends a notification.
+     *
+     * @param methodName The method name.
+     * @param values The values.
+     */
     public void notify(String methodName, Object... values) {
-//        System.err.println("JSON-RPC call: " + methodName);
-        JsonNode node = new ObjectNode(MAPPER.getNodeFactory())
+        ObjectNode node = new ObjectNode(MAPPER.getNodeFactory())
             .put("jsonrpc", "2.0")
             .put("method", methodName);
         if (values != null && values.length > 0) {
-            node = ((ObjectNode) node).set("params", new ArrayNode(MAPPER.getNodeFactory(),
-                Arrays.stream(values).map(o -> MAPPER.convertValue(o, JsonNode.class)).collect(Collectors.toList())));
+            ArrayNode params = new ArrayNode(MAPPER.getNodeFactory());
+            for (Object value : values) {
+                params.add(MAPPER.convertValue(value, JsonNode.class));
+            }
+            node.set("params", params);
         }
         send(node.toString());
     }
 
+    /**
+     * Sends a notification.
+     *
+     * @param methodName The method name.
+     * @param parameter The parameter.
+     */
     public void notifyWithObject(String methodName, Object parameter) {
-//        System.err.println("JSON-RPC call: " + methodName);
-        JsonNode node = new ObjectNode(MAPPER.getNodeFactory())
+        ObjectNode node = new ObjectNode(MAPPER.getNodeFactory())
             .put("jsonrpc", "2.0")
             .put("method", methodName);
         if (parameter != null) {
-            node = ((ObjectNode) node).set("params", MAPPER.convertValue(parameter, JsonNode.class));
+            node = node.set("params", MAPPER.convertValue(parameter, JsonNode.class));
         }
         send(node.toString());
     }
 
+    /**
+     * Sends a notification.
+     *
+     * @param methodName The method name.
+     * @param serializedObject The serialized object.
+     */
     public void notifyWithSerializedObject(String methodName, String serializedObject) {
         String json = (serializedObject == null)
             ? "{\"jsonrpc\":\"2.0\",\"method\":\"" + methodName + "\"}"
@@ -379,17 +438,29 @@ public class Connection {
         send(json);
     }
 
+    /**
+     * Sends a request.
+     *
+     * @param <T> The type of the result.
+     * @param type The type.
+     * @param methodName The method name.
+     * @param values The values.
+     * @return The result.
+     */
     public <T> T request(JavaType type, String methodName, Object... values) {
         int id = requestId.getAndIncrement();
         CallerResponse<T> response = new CallerResponse<T>(id, type);
         tasks.put(id, response);
-        JsonNode node = new ObjectNode(MAPPER.getNodeFactory())
+        ObjectNode node = new ObjectNode(MAPPER.getNodeFactory())
             .put("jsonrpc", "2.0")
             .put("method", methodName)
             .put("id", id);
         if (values != null && values.length > 0) {
-            node = ((ObjectNode) node).set("params", new ArrayNode(MAPPER.getNodeFactory(),
-                Arrays.stream(values).map(o -> MAPPER.convertValue(o, JsonNode.class)).collect(Collectors.toList())));
+            ArrayNode params = new ArrayNode(MAPPER.getNodeFactory());
+            for (Object value : values) {
+                params.add(MAPPER.convertValue(value, JsonNode.class));
+            }
+            node.set("params", params);
         }
         send(node.toString());
         try {
@@ -399,16 +470,25 @@ public class Connection {
         }
     }
 
+    /**
+     * Sends a request.
+     *
+     * @param <T> The type of the result.
+     * @param type The type.
+     * @param methodName The method name.
+     * @param parameter The parameter.
+     * @return The result.
+     */
     public <T> T requestWithObject(JavaType type, String methodName, Object parameter) {
         int id = requestId.getAndIncrement();
         CallerResponse<T> response = new CallerResponse<T>(id, type);
         tasks.put(id, response);
-        JsonNode node = new ObjectNode(MAPPER.getNodeFactory())
+        ObjectNode node = new ObjectNode(MAPPER.getNodeFactory())
             .put("jsonrpc", "2.0")
             .put("method", methodName)
             .put("id", id);
         if (parameter != null) {
-            node = ((ObjectNode) node).set("params", MAPPER.convertValue(parameter, JsonNode.class));
+            node = node.set("params", MAPPER.convertValue(parameter, JsonNode.class));
         }
         send(node.toString());
         try {
@@ -418,6 +498,15 @@ public class Connection {
         }
     }
 
+    /**
+     * Sends a request.
+     *
+     * @param <T> The type of the result.
+     * @param type The type.
+     * @param method The method name.
+     * @param serializedObject The serialized object.
+     * @return The result.
+     */
     public <T> T requestWithSerializedObject(JavaType type, String method, String serializedObject) {
         int id = requestId.getAndIncrement();
         CallerResponse<T> response = new CallerResponse<>(id, type);
@@ -435,16 +524,9 @@ public class Connection {
         }
     }
 
-    public void batch(List<String> calls) {
-        send(new ArrayNode(MAPPER.getNodeFactory(), calls.stream().map(s -> {
-            try {
-                return MAPPER.readTree(s);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }).collect(Collectors.toList())).toString());
-    }
-
+    /**
+     * Waits for all requests to complete.
+     */
     public void waitForAll() {
         try {
             loop.get();

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/Message.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/Message.java
@@ -11,16 +11,42 @@ import java.util.List;
  * Represents a message.
  */
 public class Message {
+
+    /**
+     * Represents a message channel.
+     */
     @JsonProperty("Channel")
     public MessageChannel channel;
+
+    /**
+     * Represents details.
+     */
     @JsonProperty("Details")
     public Object details;
+
+    /**
+     * Represents text.
+     */
     @JsonProperty("Text")
     public String text;
+
+    /**
+     * Represents a key.
+     */
     @JsonProperty("Key")
     public List<String> key;
+
+    /**
+     * Represents a source location.
+     */
     @JsonProperty("Source")
     public List<SourceLocation> source;
+
+    /**
+     * Creates a new instance of the Message class.
+     */
+    public Message() {
+    }
 
     /**
      * Gets the source location of the message.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/MessageChannel.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/MessageChannel.java
@@ -9,14 +9,49 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * Represents a message channel.
  */
 public enum MessageChannel {
+    /**
+     * Represents an information message.
+     */
     INFORMATION("information"),
+
+    /**
+     * Represents a hint message.
+     */
     HINT("hint"),
+
+    /**
+     * Represents a warning message.
+     */
     WARNING("warning"),
+
+    /**
+     * Represents a debug message.
+     */
     DEBUG("debug"),
+
+    /**
+     * Represents a verbose message.
+     */
     VERBOSE("verbose"),
+
+    /**
+     * Represents an error message.
+     */
     ERROR("error"),
+
+    /**
+     * Represents a fatal message.
+     */
     FATAL("fatal"),
+
+    /**
+     * Represents a file message.
+     */
     FILE("file"),
+
+    /**
+     * Represents a configuration message.
+     */
     CONFIGURATION("configuration");
 
     private final String value;

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/SmartLocation.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/SmartLocation.java
@@ -12,6 +12,12 @@ public class SmartLocation {
     private List<Object> path;
 
     /**
+     * Creates a new instance of the SmartLocation class.
+     */
+    public SmartLocation() {
+    }
+
+    /**
      * Gets the path of the location.
      *
      * @return The path of the location.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/SourceLocation.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/SourceLocation.java
@@ -11,6 +11,12 @@ public class SourceLocation {
     private SmartLocation position;
 
     /**
+     * Creates a new instance of the SourceLocation class.
+     */
+    public SourceLocation() {
+    }
+
+    /**
      * Gets the position of the location.
      *
      * @return The position of the location.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/AndSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/AndSchema.java
@@ -15,6 +15,13 @@ public class AndSchema extends ComplexSchema {
     private String discriminatorValue;
 
     /**
+     * Creates a new instance of the AndSchema class.
+     */
+    public AndSchema() {
+        super();
+    }
+
+    /**
      * Gets the schemas that this schema composes. (Required)
      *
      * @return The schemas that this schema composes.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/AnnotatedPropertyUtils.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/AnnotatedPropertyUtils.java
@@ -18,6 +18,13 @@ import java.util.Map;
 public class AnnotatedPropertyUtils extends PropertyUtils {
     private final Map<Class<?>, Map<String, Property>> cachedPropertyMap = new HashMap<>();
 
+    /**
+     * Creates a new instance of AnnotatedPropertyUtils class.
+     */
+    public AnnotatedPropertyUtils() {
+        super();
+    }
+
     @Override
     protected Map<String, Property> getPropertiesMap(Class<?> type, BeanAccess bAccess) {
         if (cachedPropertyMap.get(type) != null) {

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/AnySchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/AnySchema.java
@@ -7,4 +7,10 @@ package com.azure.autorest.extension.base.model.codemodel;
  * A schema that is non-object, non-complex.
  */
 public class AnySchema extends Schema {
+    /**
+     * Creates a new instance of the AnySchema class.
+     */
+    public AnySchema() {
+        super();
+    }
 }

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ApiVersion.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ApiVersion.java
@@ -23,6 +23,12 @@ public class ApiVersion {
     private ApiVersion.Range range;
 
     /**
+     * Creates a new instance of the ApiVersion class.
+     */
+    public ApiVersion() {
+    }
+
+    /**
      * Gets the API version string used in the API. (Required)
      *
      * @return The API version string used in the API.
@@ -87,7 +93,14 @@ public class ApiVersion {
      * Represents the range of the API version.
      */
     public enum Range {
+        /**
+         * Represents a range that is empty.
+         */
         __EMPTY__("+"),
+
+        /**
+         * Represents a range that is empty.
+         */
         __EMPTY___("-");
         private final String value;
 

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ArmIdSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ArmIdSchema.java
@@ -7,4 +7,10 @@ package com.azure.autorest.extension.base.model.codemodel;
  * Represents an ARM ID schema.
  */
 public class ArmIdSchema extends PrimitiveSchema {
+    /**
+     * Creates a new instance of the ArmIdSchema class.
+     */
+    public ArmIdSchema() {
+        super();
+    }
 }

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ArraySchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ArraySchema.java
@@ -15,6 +15,13 @@ public class ArraySchema extends ValueSchema {
     private boolean uniqueItems;
 
     /**
+     * Creates a new instance of the ArraySchema class.
+     */
+    public ArraySchema() {
+        super();
+    }
+
+    /**
      * Gets the type of elements in the array. (Required)
      *
      * @return The type of elements in the array.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/BinarySchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/BinarySchema.java
@@ -7,4 +7,10 @@ package com.azure.autorest.extension.base.model.codemodel;
  * Represent a binary schema.
  */
 public class BinarySchema extends Schema {
+    /**
+     * Create a new instance of the BinarySchema class.
+     */
+    public BinarySchema() {
+        super();
+    }
 }

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/BooleanSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/BooleanSchema.java
@@ -8,6 +8,13 @@ package com.azure.autorest.extension.base.model.codemodel;
  */
 public class BooleanSchema extends PrimitiveSchema {
 
+    /**
+     * Creates a new instance of the BooleanSchema class.
+     */
+    public BooleanSchema() {
+        super();
+    }
+
     @Override
     public String toString() {
         return BooleanSchema.class.getName() + "@" + Integer.toHexString(System.identityHashCode(this)) + "[]";

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ByteArraySchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ByteArraySchema.java
@@ -14,6 +14,13 @@ public class ByteArraySchema extends PrimitiveSchema {
     private ByteArraySchema.Format format;
 
     /**
+     * Creates a new instance of the ByteArraySchema class.
+     */
+    public ByteArraySchema() {
+        super();
+    }
+
+    /**
      * Gets the byte array format. (Required)
      *
      * @return The byte array format.
@@ -60,7 +67,14 @@ public class ByteArraySchema extends PrimitiveSchema {
      * Represents the format of the byte array.
      */
     public enum Format {
+        /**
+         * The byte array is encoded as a base64url string.
+         */
         BASE_64_URL("base64url"),
+
+        /**
+         * The byte array is encoded as a byte string.
+         */
         BYTE("byte");
 
         private final String value;

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/CSharpLanguage.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/CSharpLanguage.java
@@ -8,6 +8,12 @@ package com.azure.autorest.extension.base.model.codemodel;
  */
 public class CSharpLanguage {
 
+    /**
+     * Creates a new instance of the CSharpLanguage class.
+     */
+    public CSharpLanguage() {
+    }
+
     @Override
     public String toString() {
         return CSharpLanguage.class.getName() + "@" + Integer.toHexString(System.identityHashCode(this)) + "[]";

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/CharSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/CharSchema.java
@@ -7,6 +7,14 @@ package com.azure.autorest.extension.base.model.codemodel;
  * Represents a char schema.
  */
 public class CharSchema extends PrimitiveSchema {
+
+    /**
+     * Creates a new instance of the CharSchema class.
+     */
+    public CharSchema() {
+        super();
+    }
+
     @Override
     public String toString() {
         return CharSchema.class.getName() + "@" + Integer.toHexString(System.identityHashCode(this)) + "[]";

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ChoiceSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ChoiceSchema.java
@@ -17,6 +17,13 @@ public class ChoiceSchema extends ValueSchema {
     private String crossLanguageDefinitionId;
 
     /**
+     * Creates a new instance of the ChoiceSchema class.
+     */
+    public ChoiceSchema() {
+        super();
+    }
+
+    /**
      * Gets the type of the choice. (Required)
      *
      * @return The type of the choice.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ChoiceValue.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ChoiceValue.java
@@ -14,6 +14,12 @@ public class ChoiceValue {
     private DictionaryAny extensions;
 
     /**
+     * Creates a new instance of the ChoiceValue class.
+     */
+    public ChoiceValue() {
+    }
+
+    /**
      * Gets the language for the choice value. (Required)
      *
      * @return The language for the choice value.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Client.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Client.java
@@ -19,6 +19,13 @@ public class Client extends Metadata {
     private String crossLanguageDefinitionId;
 
     /**
+     * Creates a new instance of the Client class.
+     */
+    public Client() {
+        super();
+    }
+
+    /**
      * Gets the summary of the client.
      *
      * @return The summary of the client.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/CodeModel.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/CodeModel.java
@@ -18,6 +18,13 @@ public class CodeModel extends Client {
     private TestModel testModel;
 
     /**
+     * Creates a new instance of the CodeModel class.
+     */
+    public CodeModel() {
+        super();
+    }
+
+    /**
      * Gets the code model information. (Required)
      *
      * @return The code model information.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/CodeModelCustomConstructor.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/CodeModelCustomConstructor.java
@@ -22,6 +22,11 @@ import java.util.Map;
  * Custom constructor for a CodeModel.
  */
 public class CodeModelCustomConstructor extends Constructor {
+    /**
+     * Creates a new instance of the CodeModelCustomConstructor class.
+     *
+     * @param loaderOptions The options for the loader.
+     */
     public CodeModelCustomConstructor(LoaderOptions loaderOptions) {
         super(loaderOptions);
         yamlClassConstructors.put(NodeId.scalar, new TypeEnumConstruct());

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ComplexSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ComplexSchema.java
@@ -7,4 +7,10 @@ package com.azure.autorest.extension.base.model.codemodel;
  * Represents a complex schema (types that can be an object).
  */
 public class ComplexSchema extends Schema {
+    /**
+     * Creates a new instance of the ComplexSchema class.
+     */
+    public ComplexSchema() {
+        super();
+    }
 }

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ConstantSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ConstantSchema.java
@@ -11,6 +11,13 @@ public class ConstantSchema extends Schema {
     private ConstantValue value;
 
     /**
+     * Creates a new instance of the ConstantSchema class.
+     */
+    public ConstantSchema() {
+        super();
+    }
+
+    /**
      * Gets the value type. (Required)
      *
      * @return The value type.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ConstantValue.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ConstantValue.java
@@ -14,6 +14,12 @@ public class ConstantValue {
     private DictionaryAny extensions;
 
     /**
+     * Creates a new instance of the ConstantValue class.
+     */
+    public ConstantValue() {
+    }
+
+    /**
      * Gets the language of the value. (Required)
      *
      * @return The language of the value.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Contact.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Contact.java
@@ -15,6 +15,12 @@ public class Contact {
     private DictionaryAny extensions;
 
     /**
+     * Creates a new instance of the Contact class.
+     */
+    public Contact() {
+    }
+
+    /**
      * Gets the name of the contact.
      *
      * @return The name of the contact.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ConvenienceApi.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ConvenienceApi.java
@@ -12,6 +12,13 @@ public class ConvenienceApi extends Metadata {
     private List<Request> requests;
 
     /**
+     * Creates a new instance of the ConvenienceApi class.
+     */
+    public ConvenienceApi() {
+        super();
+    }
+
+    /**
      * Gets the requests of the convenience API.
      *
      * @return The requests of the convenience API.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/CredentialSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/CredentialSchema.java
@@ -14,6 +14,13 @@ public class CredentialSchema extends PrimitiveSchema {
     private String pattern;
 
     /**
+     * Creates a new instance of the CredentialSchema class.
+     */
+    public CredentialSchema() {
+        super();
+    }
+
+    /**
      * Get the maximum length of the string.
      *
      * @return The maximum length of the string.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/DateSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/DateSchema.java
@@ -8,6 +8,13 @@ package com.azure.autorest.extension.base.model.codemodel;
  */
 public class DateSchema extends PrimitiveSchema {
 
+    /**
+     * Creates a new instance of the DateSchema class.
+     */
+    public DateSchema() {
+        super();
+    }
+
     @Override
     public String toString() {
         return DateSchema.class.getName() + "@" + Integer.toHexString(System.identityHashCode(this)) + "[]";

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/DateTimeSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/DateTimeSchema.java
@@ -12,6 +12,13 @@ public class DateTimeSchema extends PrimitiveSchema {
     private DateTimeSchema.Format format;
 
     /**
+     * Creates a new instance of the DateTimeSchema class.
+     */
+    public DateTimeSchema() {
+        super();
+    }
+
+    /**
      * Gets the date-time format. (Required)
      *
      * @return The date-time format.
@@ -58,7 +65,14 @@ public class DateTimeSchema extends PrimitiveSchema {
      * The format of the date-time.
      */
     public enum Format {
+        /**
+         * The date-time format.
+         */
         DATE_TIME("date-time"),
+
+        /**
+         * The RFC 1123 date-time format.
+         */
         DATE_TIME_RFC_1123("date-time-rfc1123");
         private final String value;
 

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Deprecation.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Deprecation.java
@@ -15,6 +15,12 @@ public class Deprecation {
     private List<ApiVersion> apiVersions = new ArrayList<>();
 
     /**
+     * Creates a new instance of the Deprecation class.
+     */
+    public Deprecation() {
+    }
+
+    /**
      * Gets the deprecated message. (Required)
      *
      * @return The deprecated message.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/DictionaryAny.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/DictionaryAny.java
@@ -8,6 +8,12 @@ package com.azure.autorest.extension.base.model.codemodel;
  */
 public class DictionaryAny {
 
+    /**
+     * Creates a new instance of the DictionaryAny class.
+     */
+    public DictionaryAny() {
+    }
+
     @Override
     public String toString() {
         return DictionaryAny.class.getName() + "@" + Integer.toHexString(System.identityHashCode(this)) + "[]";

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/DictionaryAnyProperty.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/DictionaryAnyProperty.java
@@ -22,6 +22,12 @@ public class DictionaryAnyProperty {
     private Map<String, Object> additionalProperties = new HashMap<>();
 
     /**
+     * Creates a new instance of the DictionaryAnyProperty class.
+     */
+    public DictionaryAnyProperty() {
+    }
+
+    /**
      * Gets the additional properties of the dictionary property.
      *
      * @return The additional properties of the dictionary property.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/DictionaryApiVersion.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/DictionaryApiVersion.java
@@ -8,6 +8,12 @@ package com.azure.autorest.extension.base.model.codemodel;
  */
 public class DictionaryApiVersion {
 
+    /**
+     * Creates a new instance of the DictionaryApiVersion class.
+     */
+    public DictionaryApiVersion() {
+    }
+
     @Override
     public String toString() {
         return DictionaryApiVersion.class.getName() + "@" + Integer.toHexString(System.identityHashCode(this)) + "[]";

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/DictionarySchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/DictionarySchema.java
@@ -13,6 +13,13 @@ public class DictionarySchema extends ComplexSchema {
     private Boolean nullableItems;
 
     /**
+     * Creates a new instance of the DictionarySchema class.
+     */
+    public DictionarySchema() {
+        super();
+    }
+
+    /**
      * Gets the type of the elements in the dictionary. (Required)
      *
      * @return The type of the elements in the dictionary.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Discriminator.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Discriminator.java
@@ -14,6 +14,12 @@ public class Discriminator {
     private Map<String, ComplexSchema> all;
 
     /**
+     * Creates a new instance of the Discriminator class.
+     */
+    public Discriminator() {
+    }
+
+    /**
      * Gets the property that is used to discriminate between the polymorphic types.
      *
      * @return The property that is used to discriminate between the polymorphic types.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/DurationSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/DurationSchema.java
@@ -12,6 +12,13 @@ public class DurationSchema extends PrimitiveSchema {
     private Format format;
 
     /**
+     * Creates a new instance of the DurationSchema class.
+     */
+    public DurationSchema() {
+        super();
+    }
+
+    /**
      * Gets the duration format.
      *
      * @return The duration format.
@@ -58,8 +65,19 @@ public class DurationSchema extends PrimitiveSchema {
      * The format of the duration.
      */
     public enum Format {
+        /**
+         * The duration is in RFC3339 format.
+         */
         DURATION("duration-rfc3339"),
+
+        /**
+         * The duration is in seconds as an integer.
+         */
         SECONDS_INTEGER("seconds-integer"),
+
+        /**
+         * The duration is in seconds as a number.
+         */
         SECONDS_NUMBER("seconds-number");
 
         private final String value;

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ExternalDocumentation.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ExternalDocumentation.java
@@ -15,6 +15,12 @@ public class ExternalDocumentation {
     private DictionaryAny extensions;
 
     /**
+     * Creates a new instance of the ExternalDocumentation class.
+     */
+    public ExternalDocumentation() {
+    }
+
+    /**
      * Gets the description of the external documentation.
      *
      * @return The description of the external documentation.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/FlagSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/FlagSchema.java
@@ -11,7 +11,14 @@ import java.util.Objects;
  * Represents a flag schema.
  */
 public class FlagSchema extends ValueSchema {
-    private List<FlagValue> choices = new ArrayList<FlagValue>();
+    private List<FlagValue> choices = new ArrayList<>();
+
+    /**
+     * Creates a new instance of the FlagSchema class.
+     */
+    public FlagSchema() {
+        super();
+    }
 
     /**
      * Get the possible choices in the set. (Required)

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/FlagValue.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/FlagValue.java
@@ -14,6 +14,12 @@ public class FlagValue {
     private DictionaryAny extensions;
 
     /**
+     * Creates a new instance of the FlagValue class.
+     */
+    public FlagValue() {
+    }
+
+    /**
      * Gets the language of the flag value. (Required)
      *
      * @return The language of the flag value.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Header.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Header.java
@@ -14,6 +14,12 @@ public class Header {
     private XmsExtensions extensions;
 
     /**
+     * Creates a new instance of the Header class.
+     */
+    public Header() {
+    }
+
+    /**
      * Gets the name of the header.
      *
      * @return The name of the header.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Info.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Info.java
@@ -18,6 +18,12 @@ public class Info {
     private DictionaryAny extensions;
 
     /**
+     * Creates a new instance of the Info class.
+     */
+    public Info() {
+    }
+
+    /**
      * Gets the title of the service. (Required)
      *
      * @return The title of the service.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/KnownMediaType.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/KnownMediaType.java
@@ -10,12 +10,39 @@ import java.util.Map;
  * Known media types.
  */
 public enum KnownMediaType {
+    /**
+     * The media type is binary.
+     */
     BINARY("binary"),
+
+    /**
+     * The media type is a form.
+     */
     FORM("form"),
+
+    /**
+     * The media type is JSON.
+     */
     JSON("json"),
+
+    /**
+     * The media type is multipart.
+     */
     MULTIPART("multipart"),
+
+    /**
+     * The media type is text.
+     */
     TEXT("text"),
+
+    /**
+     * The media type is unknown.
+     */
     UNKNOWN("unknown"),
+
+    /**
+     * The media type is XML.
+     */
     XML("xml");
 
     private final String value;

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Language.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Language.java
@@ -15,6 +15,12 @@ public class Language {
     private String comment;
 
     /**
+     * Creates a new instance of the Language class.
+     */
+    public Language() {
+    }
+
+    /**
      * Gets the name used in actual implementation. (Required)
      *
      * @return The name used in actual implementation.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/LanguageProperty.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/LanguageProperty.java
@@ -19,7 +19,13 @@ import java.util.Map;
 @JsonPropertyOrder
 public class LanguageProperty {
     @JsonIgnore
-    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+    private Map<String, Object> additionalProperties = new HashMap<>();
+
+    /**
+     * Creates a new instance of the LanguageProperty class.
+     */
+    public LanguageProperty() {
+    }
 
     /**
      * Gets the additional properties of the language property.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Languages.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Languages.java
@@ -24,6 +24,12 @@ public class Languages {
     private Language objectivec;
 
     /**
+     * Creates a new instance of the Languages class.
+     */
+    public Languages() {
+    }
+
+    /**
      * Gets the default language. (Required)
      *
      * @return The default language.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/License.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/License.java
@@ -14,6 +14,12 @@ public class License {
     private DictionaryAny extensions;
 
     /**
+     * Creates a new instance of the License class.
+     */
+    public License() {
+    }
+
+    /**
      * The name of the license. (Required)
      *
      * @return The name of the license.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/LongRunningMetadata.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/LongRunningMetadata.java
@@ -12,6 +12,12 @@ public class LongRunningMetadata {
     private Metadata pollingStrategy;
 
     /**
+     * Creates a new instance of the LongRunningMetadata class.
+     */
+    public LongRunningMetadata() {
+    }
+
+    /**
      * Gets the poll result type.
      *
      * @return The poll result type.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Metadata.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Metadata.java
@@ -9,14 +9,15 @@ import com.azure.autorest.extension.base.model.extensionmodel.XmsExtensions;
  * Represents metadata.
  */
 public class Metadata {
-
-    /**
-     * custom extensible metadata for individual language generators
-     * (Required)
-     */
     private Languages language;
     private Protocols protocol;
     private XmsExtensions extensions;
+
+    /**
+     * Creates a new instance of the Metadata class.
+     */
+    public Metadata() {
+    }
 
     /**
      * Gets the language of the metadata. (Required)

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/NotSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/NotSchema.java
@@ -10,6 +10,12 @@ public class NotSchema extends Schema {
     private Schema not;
 
     /**
+     * Creates a new instance of the NotSchema class.
+     */
+    public NotSchema() {
+    }
+
+    /**
      * Gets the schema that this may not be. (Required)
      *
      * @return The schema that this may not be.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/NumberSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/NumberSchema.java
@@ -15,6 +15,12 @@ public class NumberSchema extends PrimitiveSchema {
     private boolean exclusiveMinimum;
 
     /**
+     * Creates a new instance of the NumberSchema class.
+     */
+    public NumberSchema() {
+    }
+
+    /**
      * The precision of the number. (Required)
      *
      * @return The precision of the number.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ODataQuerySchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ODataQuerySchema.java
@@ -8,6 +8,12 @@ package com.azure.autorest.extension.base.model.codemodel;
  */
 public class ODataQuerySchema extends Schema {
 
+    /**
+     * Creates a new instance of the ODataQuerySchema class.
+     */
+    public ODataQuerySchema() {
+    }
+
     @Override
     public String toString() {
         return ODataQuerySchema.class.getName() + "@" + Integer.toHexString(System.identityHashCode(this)) + "[]";

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ObjectSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ObjectSchema.java
@@ -24,6 +24,12 @@ public class ObjectSchema extends ComplexSchema {
     private String crossLanguageDefinitionId;
 
     /**
+     * Creates a new instance of the ObjectSchema class.
+     */
+    public ObjectSchema() {
+    }
+
+    /**
      * Gets the discriminator for this object.
      *
      * @return The discriminator for this object.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Operation.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Operation.java
@@ -35,6 +35,12 @@ public class Operation extends Metadata {
     private OperationGroup operationGroup;
 
     /**
+     * Creates a new instance of the Operation class.
+     */
+    public Operation() {
+    }
+
+    /**
      * Gets the operation ID.
      *
      * @return The operation ID.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/OperationGroup.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/OperationGroup.java
@@ -15,6 +15,12 @@ public class OperationGroup extends Metadata {
     private Client codeModel;
 
     /**
+     * Creates a new instance of the OperationGroup class.
+     */
+    public OperationGroup() {
+    }
+
+    /**
      * Gets the key of the operation group. (Required)
      *
      * @return The key of the operation group.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/OrSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/OrSchema.java
@@ -14,6 +14,12 @@ public class OrSchema extends ComplexSchema {
     private List<ObjectSchema> anyOf = new ArrayList<>();
 
     /**
+     * Creates a new instance of the OrSchema class.
+     */
+    public OrSchema() {
+    }
+
+    /**
      * Gets the set of schemas that this schema is composed of. Every schema is optional. (Required)
      *
      * @return The set of schemas that this schema is composed of. Every schema is optional.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Parameter.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Parameter.java
@@ -21,6 +21,12 @@ public class Parameter extends Value {
     private String summary;
 
     /**
+     * Creates a new instance of the Parameter class.
+     */
+    public Parameter() {
+    }
+
+    /**
      * Gets the default value for the parameter in the client.
      *
      * @return The default value for the parameter in the client.
@@ -178,8 +184,19 @@ public class Parameter extends Value {
      * The location of the parameter's implementation.
      */
     public enum ImplementationLocation {
+        /**
+         * The parameter is implemented in the client.
+         */
         CLIENT("Client"),
+
+        /**
+         * The parameter is implemented in the context.
+         */
         CONTEXT("Context"),
+
+        /**
+         * The parameter is implemented in the method.
+         */
         METHOD("Method");
         private final String value;
 

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ParameterGroupSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ParameterGroupSchema.java
@@ -14,6 +14,12 @@ public class ParameterGroupSchema extends ComplexSchema {
     private List<Parameter> parameters = new ArrayList<>();
 
     /**
+     * Creates a new instance of the ParameterGroupSchema class.
+     */
+    public ParameterGroupSchema() {
+    }
+
+    /**
      * Gets the collection of properties that are in this object. (Required)
      *
      * @return The collection of properties that are in this object.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/PrimitiveSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/PrimitiveSchema.java
@@ -7,4 +7,10 @@ package com.azure.autorest.extension.base.model.codemodel;
  * Schema types that are primitive language values
  */
 public class PrimitiveSchema extends ValueSchema {
+    /**
+     * Creates a new instance of the PrimitiveSchema class.
+     */
+    public PrimitiveSchema() {
+        super();
+    }
 }

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Property.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Property.java
@@ -20,6 +20,12 @@ public class Property extends Value {
     private ObjectSchema parentSchema;
 
     /**
+     * Creates a new instance of the Property class.
+     */
+    public Property() {
+    }
+
+    /**
      * Gets whether the property is read-only.
      *
      * @return Whether the property is read-only.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Protocol.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Protocol.java
@@ -22,6 +22,12 @@ public class Protocol {
     private List<Header> headers;
 
     /**
+     * Creates a new instance of the Protocol class.
+     */
+    public Protocol() {
+    }
+
+    /**
      * Gets the location of the parameter.
      *
      * @return The location of the parameter.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Protocols.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Protocols.java
@@ -15,6 +15,12 @@ public class Protocols {
     private Protocol jsonrpc;
 
     /**
+     * Creates a new instance of the Protocols class.
+     */
+    public Protocols() {
+    }
+
+    /**
      * Gets the HTTP protocol.
      *
      * @return The HTTP protocol.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Relations.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Relations.java
@@ -13,6 +13,12 @@ public class Relations {
     private List<Schema> immediate;
 
     /**
+     * Creates a new instance of the Relations class.
+     */
+    public Relations() {
+    }
+
+    /**
      * Gets all schemas.
      *
      * @return The all schemas.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Request.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Request.java
@@ -14,6 +14,12 @@ public class Request extends Metadata {
     private List<Parameter> signatureParameters = new ArrayList<>();
 
     /**
+     * Creates a new instance of the Request class.
+     */
+    public Request() {
+    }
+
+    /**
      * Gets the parameter inputs to the operation.
      *
      * @return The parameter inputs to the operation.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/RequestParameterLocation.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/RequestParameterLocation.java
@@ -10,12 +10,39 @@ import java.util.Map;
  * The location of a parameter within an HTTP request.
  */
 public enum RequestParameterLocation {
+    /**
+     * The parameter is in the request body.
+     */
     BODY("body"),
+
+    /**
+     * The parameter is in a cookie.
+     */
     COOKIE("cookie"),
+
+    /**
+     * The parameter is in the request URI.
+     */
     URI("uri"),
+
+    /**
+     * The parameter is in the request path.
+     */
     PATH("path"),
+
+    /**
+     * The parameter is in the request header.
+     */
     HEADER("header"),
+
+    /**
+     * The parameter is not in the request.
+     */
     NONE("none"),
+
+    /**
+     * The parameter is in the request query.
+     */
     QUERY("query");
 
     private final String value;

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Response.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Response.java
@@ -11,6 +11,12 @@ public class Response extends Metadata {
     private Boolean binary;
 
     /**
+     * Creates a new instance of the Response class.
+     */
+    public Response() {
+    }
+
+    /**
      * Gets the schema of the response.
      *
      * @return The schema of the response.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ScenarioStep.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ScenarioStep.java
@@ -17,6 +17,12 @@ public class ScenarioStep {
     private String description;
 
     /**
+     * Creates a new instance of the ScenarioStep class.
+     */
+    public ScenarioStep() {
+    }
+
+    /**
      * Gets the description of the step.
      *
      * @return The description of the step.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ScenarioTest.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ScenarioTest.java
@@ -22,6 +22,12 @@ public class ScenarioTest {
     private Boolean useArmTemplate;
 
     /**
+     * Creates a new instance of the ScenarioTest class.
+     */
+    public ScenarioTest() {
+    }
+
+    /**
      * Gets the file path of the scenario test.
      *
      * @return The file path of the scenario test.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Schema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Schema.java
@@ -28,6 +28,12 @@ public class Schema extends Metadata {
     private ExternalDocumentation externalDocs;
 
     /**
+     * Creates a new instance of the Schema class.
+     */
+    public Schema() {
+    }
+
+    /**
      * Gets the all schema types. (Required)
      *
      * @return The all schema types.
@@ -265,37 +271,164 @@ public class Schema extends Metadata {
      * Represents all schema types.
      */
     public enum AllSchemaTypes {
+        /**
+         * Represents any type.
+         */
         ANY("any"),
+
+        /**
+         * Represents any object.
+         */
         ANY_OBJECT("any-object"),
+
+        /**
+         * Represents AND logic.
+         */
         AND("and"),
+
+        /**
+         * Represents arm-id.
+         */
         ARM_ID("arm-id"),
+
+        /**
+         * Represents array.
+         */
         ARRAY("array"),
+
+        /**
+         * Represents binary.
+         */
         BINARY("binary"),
+
+        /**
+         * Represents boolean.
+         */
         BOOLEAN("boolean"),
+
+        /**
+         * Represents byte array.
+         */
         BYTE_ARRAY("byte-array"),
+
+        /**
+         * Represents char.
+         */
         CHAR("char"),
+
+        /**
+         * Represents choice.
+         */
         CHOICE("choice"),
+
+        /**
+         * Represents constant.
+         */
         CONSTANT("constant"),
+
+        /**
+         * Represents credential.
+         */
         CREDENTIAL("credential"),
+
+        /**
+         * Represents date.
+         */
         DATE("date"),
+
+        /**
+         * Represents date-time.
+         */
         DATE_TIME("date-time"),
+
+        /**
+         * Represents dictionary.
+         */
         DICTIONARY("dictionary"),
+
+        /**
+         * Represents duration.
+         */
         DURATION("duration"),
+
+        /**
+         * Represents flag.
+         */
         FLAG("flag"),
+
+        /**
+         * Represents float.
+         */
         GROUP("group"),
+
+        /**
+         * Represents integer.
+         */
         INTEGER("integer"),
+
+        /**
+         * Represents NOT logic.
+         */
         NOT("not"),
+
+        /**
+         * Represents number.
+         */
         NUMBER("number"),
+
+        /**
+         * Represents object.
+         */
         OBJECT("object"),
+
+        /**
+         * Represents odata-query.
+         */
         ODATA_QUERY("odata-query"),
+
+        /**
+         * Represents OR logic.
+         */
         OR("or"),
+
+        /**
+         * Represents parameter-group.
+         */
         PARAMETER_GROUP("parameter-group"),
+
+        /**
+         * Represents sealed-choice.
+         */
         SEALED_CHOICE("sealed-choice"),
+
+        /**
+         * Represents string.
+         */
         STRING("string"),
+
+        /**
+         * Represents time.
+         */
         TIME("time"),
+
+        /**
+         * Represents unixtime.
+         */
         UNIXTIME("unixtime"),
+
+        /**
+         * Represents uri.
+         */
         URI("uri"),
+
+        /**
+         * Represents uuid.
+         */
         UUID("uuid"),
+
+        /**
+         * Represents XOR logic.
+         */
         XOR("xor");
         private final String value;
         private final static Map<String, Schema.AllSchemaTypes> CONSTANTS = new HashMap<>();

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/SchemaContext.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/SchemaContext.java
@@ -6,14 +6,48 @@ package com.azure.autorest.extension.base.model.codemodel;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * The context in which a schema is used.
+ */
 public enum SchemaContext {
+    /**
+     * The schema is used as an input.
+     */
     INPUT("input"),
+
+    /**
+     * The schema is used as an output.
+     */
     OUTPUT("output"),
+
+    /**
+     * The schema is used as an exception.
+     */
     EXCEPTION("exception"),
+
+    /**
+     * The schema is used publicly.
+     */
     PUBLIC("public"),
+
+    /**
+     * The schema is used as a paged result.
+     */
     PAGED("paged"),
+
+    /**
+     * The schema is used as an anonymous type.
+     */
     ANONYMOUS("anonymous"),
+
+    /**
+     * The schema is used internally.
+     */
     INTERNAL("internal"),
+
+    /**
+     * The schema is used as a JSON merge patch.
+     */
     JSON_MERGE_PATCH("json-merge-patch");
 
     private final String value;

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/SchemaResponse.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/SchemaResponse.java
@@ -10,6 +10,12 @@ public class SchemaResponse extends Response {
     private Schema schema;
 
     /**
+     * Creates a new instance of the SchemaResponse class.
+     */
+    public SchemaResponse() {
+    }
+
+    /**
      * Gets the schema of the response.
      *
      * @return The schema of the response.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Schemas.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Schemas.java
@@ -40,6 +40,12 @@ public class Schemas {
     private List<ParameterGroupSchema> parameterGroups = new ArrayList<>();
 
     /**
+     * Creates a new instance of the Schemas class.
+     */
+    public Schemas() {
+    }
+
+    /**
      * Gets the list of array schemas.
      *
      * @return The list of array schemas.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Scheme.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Scheme.java
@@ -19,6 +19,12 @@ public class Scheme {
     private String prefix;
 
     /**
+     * Creates a new instance of the Scheme class.
+     */
+    public Scheme() {
+    }
+
+    /**
      * Gets the type of the security scheme.
      *
      * @return The type of the security scheme.
@@ -112,7 +118,14 @@ public class Scheme {
      * The type of the security scheme.
      */
     public enum SecuritySchemeType {
+        /**
+         * OAuth2 security scheme.
+         */
         OAUTH2("OAuth2"),
+
+        /**
+         * Key security scheme.
+         */
         KEY("Key");
 
         private final String value;

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/SealedChoiceSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/SealedChoiceSchema.java
@@ -8,6 +8,14 @@ package com.azure.autorest.extension.base.model.codemodel;
  * Represents a choice of several values (ie, an 'enum').
  */
 public class SealedChoiceSchema extends ChoiceSchema {
+
+    /**
+     * Creates a new instance of the SealedChoiceSchema class.
+     */
+    public SealedChoiceSchema() {
+        super();
+    }
+
     @Override
     public String toString() {
         return sharedToString(this, SealedChoiceSchema.class.getName());

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Security.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Security.java
@@ -14,6 +14,12 @@ public class Security {
     private List<Scheme> schemes = new ArrayList<>();
 
     /**
+     * Creates a new instance of the Security class.
+     */
+    public Security() {
+    }
+
+    /**
      * Gets whether authentication is required.
      *
      * @return Whether authentication is required.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/SerializationFormat.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/SerializationFormat.java
@@ -12,6 +12,12 @@ public class SerializationFormat {
     private DictionaryAny extensions;
 
     /**
+     * Creates a new instance of the SerializationFormat class.
+     */
+    public SerializationFormat() {
+    }
+
+    /**
      * Gets the extensions.
      *
      * @return The extensions.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/SerializationFormats.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/SerializationFormats.java
@@ -14,6 +14,12 @@ public class SerializationFormats {
     private SerializationFormat protobuf;
 
     /**
+     * Creates a new instance of the SerializationFormats class.
+     */
+    public SerializationFormats() {
+    }
+
+    /**
      * Gets the JSON serialization format.
      *
      * @return The JSON serialization format.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/SerializationStyle.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/SerializationStyle.java
@@ -10,16 +10,59 @@ import java.util.Map;
  * Represents individual serialization styles.
  */
 public enum SerializationStyle {
+    /**
+     * The serialization style is binary.
+     */
     BINARY("binary"),
+
+    /**
+     * The serialization style is deep object.
+     */
     DEEP_OBJECT("deepObject"),
+
+    /**
+     * The serialization style is form.
+     */
     FORM("form"),
+
+    /**
+     * The serialization style is JSON.
+     */
     JSON("json"),
+
+    /**
+     * The serialization style is label.
+     */
     LABEL("label"),
+
+    /**
+     * The serialization style is matrix.
+     */
     MATRIX("matrix"),
+
+    /**
+     * The serialization style is pipe delimited.
+     */
     PIPE_DELIMITED("pipeDelimited"),
+
+    /**
+     * The serialization style is simple.
+     */
     SIMPLE("simple"),
+
+    /**
+     * The serialization style is space delimited.
+     */
     SPACE_DELIMITED("spaceDelimited"),
+
+    /**
+     * The serialization style is tab delimited.
+     */
     TAB_DELIMITED("tabDelimited"),
+
+    /**
+     * The serialization style is XML.
+     */
     XML("xml");
 
     private final String value;

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Server.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Server.java
@@ -14,6 +14,12 @@ public class Server {
     private List<Value> variables;
 
     /**
+     * Creates a new instance of the Server class.
+     */
+    public Server() {
+    }
+
+    /**
      * Gets the URL of the server.
      *
      * @return The URL of the server.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ServiceVersion.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ServiceVersion.java
@@ -7,4 +7,10 @@ package com.azure.autorest.extension.base.model.codemodel;
  * Represents a service version.
  */
 public class ServiceVersion extends Metadata {
+    /**
+     * Creates a new instance of the ServiceVersion class.
+     */
+    public ServiceVersion() {
+        super();
+    }
 }

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/StreamResponse.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/StreamResponse.java
@@ -8,6 +8,13 @@ package com.azure.autorest.extension.base.model.codemodel;
  */
 public class StreamResponse extends Response {
     /**
+     * Creates a new instance of the StreamResponse class.
+     */
+    public StreamResponse() {
+        super();
+    }
+
+    /**
      * Whether the response is a stream.
      *
      * @return Whether the response is a stream.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/StringSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/StringSchema.java
@@ -14,6 +14,13 @@ public class StringSchema extends PrimitiveSchema {
     private String pattern;
 
     /**
+     * Creates a new instance of the StringSchema class.
+     */
+    public StringSchema() {
+        super();
+    }
+
+    /**
      * Gets the maximum length of the string.
      *
      * @return The maximum length of the string.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/TestModel.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/TestModel.java
@@ -12,6 +12,12 @@ public class TestModel {
     private List<ScenarioTest> scenarioTests;
 
     /**
+     * Creates a new instance of the TestModel class.
+     */
+    public TestModel() {
+    }
+
+    /**
      * Gets the API scenario definitions.
      *
      * @return The API scenario definitions.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/TestScenario.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/TestScenario.java
@@ -18,6 +18,12 @@ public class TestScenario {
     private List<ScenarioStep> resolvedSteps;
 
     /**
+     * Creates a new instance of the TestScenario class.
+     */
+    public TestScenario() {
+    }
+
+    /**
      * Gets the description of the scenario.
      *
      * @return The description of the scenario.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/TimeSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/TimeSchema.java
@@ -7,4 +7,10 @@ package com.azure.autorest.extension.base.model.codemodel;
  * Represents a time schema.
  */
 public class TimeSchema extends PrimitiveSchema {
+    /**
+     * Creates a new instance of the TimeSchema class.
+     */
+    public TimeSchema() {
+        super();
+    }
 }

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/UnixTimeSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/UnixTimeSchema.java
@@ -8,6 +8,13 @@ package com.azure.autorest.extension.base.model.codemodel;
  */
 public class UnixTimeSchema extends PrimitiveSchema {
 
+    /**
+     * Creates a new instance of the UnixTimeSchema class.
+     */
+    public UnixTimeSchema() {
+        super();
+    }
+
     @Override
     public String toString() {
         return UnixTimeSchema.class.getName() + "@" + Integer.toHexString(System.identityHashCode(this)) + "[]";

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/UriSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/UriSchema.java
@@ -14,6 +14,13 @@ public class UriSchema extends PrimitiveSchema {
     private String pattern;
 
     /**
+     * Creates a new instance of the UriSchema class.
+     */
+    public UriSchema() {
+        super();
+    }
+
+    /**
      * Get the maximum length of the URI.
      *
      * @return The maximum length of the URI.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/UuidSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/UuidSchema.java
@@ -8,6 +8,13 @@ package com.azure.autorest.extension.base.model.codemodel;
  */
 public class UuidSchema extends PrimitiveSchema {
 
+    /**
+     * Creates a new instance of the UuidSchema class.
+     */
+    public UuidSchema() {
+        super();
+    }
+
     @Override
     public String toString() {
         return UuidSchema.class.getName() + '@' + Integer.toHexString(System.identityHashCode(this)) + "[]";

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Value.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Value.java
@@ -10,49 +10,22 @@ import java.util.List;
  * Represents a value.
  */
 public class Value extends Metadata {
-
-    /**
-     * custom extensible metadata for individual language generators
-     * (Required)
-     */
     private Schema schema;
-    /**
-     * all schema types
-     * (Required)
-     */
     private boolean required;
-
     private boolean nullable;
-    /**
-     * common name of the aspect -- in OAI3 this was typically the key in the parent dictionary
-     * (Required)
-     */
     private String $key;
-    /**
-     * description of the aspect.
-     * (Required)
-     */
     private String description;
-    /**
-     * (Required)
-     */
     private String uid;
-    /**
-     * a short description
-     */
     private String summary;
-    /**
-     * API versions that this applies to. Undefined means all versions
-     */
-    private List<ApiVersion> apiVersions = new ArrayList<ApiVersion>();
-    /**
-     * represents  deprecation information for a given aspect
-     */
+    private List<ApiVersion> apiVersions = new ArrayList<>();
     private Deprecation deprecated;
-    /**
-     * a reference to external documentation
-     */
     private ExternalDocumentation externalDocs;
+
+    /**
+     * Creates a new instance of the Value class.
+     */
+    public Value() {
+    }
 
     /**
      * Gets the summary of the value.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ValueSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ValueSchema.java
@@ -7,4 +7,10 @@ package com.azure.autorest.extension.base.model.codemodel;
  * Schema types that are non-object or complex types.
  */
 public class ValueSchema extends Schema {
+    /**
+     * Creates a new instance of the ValueSchema class.
+     */
+    public ValueSchema() {
+        super();
+    }
 }

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/XmlSerializationFormat.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/XmlSerializationFormat.java
@@ -12,16 +12,15 @@ public class XmlSerializationFormat extends SerializationFormat {
     private String name;
     private String namespace;
     private String prefix;
-    /**
-     * (Required)
-     */
     private boolean attribute;
-    /**
-     * (Required)
-     */
     private boolean wrapped;
-
     private boolean text;
+
+    /**
+     * Creates a new instance of the XmlSerializationFormat class.
+     */
+    public XmlSerializationFormat() {
+    }
 
     /**
      * Gets the name of the XML element.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/XorSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/XorSchema.java
@@ -14,6 +14,13 @@ public class XorSchema extends ComplexSchema {
     private List<Schema> oneOf = new ArrayList<>();
 
     /**
+     * Creates a new instance of the XorSchema class.
+     */
+    public XorSchema() {
+        super();
+    }
+
+    /**
      * Gets the set of schemas that this must be one and only one of. (Required)
      *
      * @return The set of schemas that this must be one and only one of.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/extensionmodel/AllowedResource.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/extensionmodel/AllowedResource.java
@@ -13,6 +13,12 @@ public class AllowedResource {
     private String type;
 
     /**
+     * Creates a new instance of the AllowedResource class.
+     */
+    public AllowedResource() {
+    }
+
+    /**
      * Gets the scopes that are allowed to access the resource.
      *
      * @return The scopes that are allowed to access the resource.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/extensionmodel/XmsArmIdDetails.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/extensionmodel/XmsArmIdDetails.java
@@ -12,6 +12,12 @@ public class XmsArmIdDetails {
     private List<AllowedResource> allowedResources;
 
     /**
+     * Creates a new instance of the XmsArmIdDetails class.
+     */
+    public XmsArmIdDetails() {
+    }
+
+    /**
      * Gets the resources that are allowed to be accessed.
      *
      * @return The resources that are allowed to be accessed.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/extensionmodel/XmsEnum.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/extensionmodel/XmsEnum.java
@@ -14,6 +14,12 @@ public class XmsEnum {
     private List<Value> values;
 
     /**
+     * Creates a new instance of the XmsEnum class.
+     */
+    public XmsEnum() {
+    }
+
+    /**
      * Gets the name of the enum.
      *
      * @return The name of the enum.
@@ -74,6 +80,12 @@ public class XmsEnum {
         private String value;
         private String description;
         private String name;
+
+        /**
+         * Creates a new instance of the Value class.
+         */
+        public Value() {
+        }
 
         /**
          * Gets the value of the enum.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/extensionmodel/XmsExamples.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/extensionmodel/XmsExamples.java
@@ -12,6 +12,12 @@ public class XmsExamples {
     private Map<String, Object> examples;
 
     /**
+     * Creates a new instance of the XmsExamples class.
+     */
+    public XmsExamples() {
+    }
+
+    /**
      * Gets the examples of the model.
      *
      * @return The examples of the model.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/extensionmodel/XmsExtensions.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/extensionmodel/XmsExtensions.java
@@ -27,6 +27,12 @@ public class XmsExtensions {
     private List<String> xmsVersioningAdded;
 
     /**
+     * Creates a new instance of the XmsExtensions class.
+     */
+    public XmsExtensions() {
+    }
+
+    /**
      * Gets the enum of the model.
      *
      * @return The enum of the model.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/extensionmodel/XmsInternalAutorestAnonymousSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/extensionmodel/XmsInternalAutorestAnonymousSchema.java
@@ -10,6 +10,12 @@ public class XmsInternalAutorestAnonymousSchema {
     private boolean anonymous = true;
 
     /**
+     * Creates a new instance of the XmsInternalAutorestAnonymousSchema class.
+     */
+    public XmsInternalAutorestAnonymousSchema() {
+    }
+
+    /**
      * Gets whether the schema is anonymous.
      *
      * @return Whether the schema is anonymous.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/extensionmodel/XmsLongRunningOperationOptions.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/extensionmodel/XmsLongRunningOperationOptions.java
@@ -13,6 +13,12 @@ public class XmsLongRunningOperationOptions {
     private String finalStateVia;
 
     /**
+     * Creates a new instance of the XmsLongRunningOperationOptions class.
+     */
+    public XmsLongRunningOperationOptions() {
+    }
+
+    /**
      * Gets the final state via.
      *
      * @return The final state via.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/extensionmodel/XmsPageable.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/extensionmodel/XmsPageable.java
@@ -15,6 +15,12 @@ public class XmsPageable {
     private Operation nextOperation;
 
     /**
+     * Creates a new instance of the XmsPageable class.
+     */
+    public XmsPageable() {
+    }
+
+    /**
      * Gets the name of the item in the pageable response.
      *
      * @return The name of the item in the pageable response.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/AutorestSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/AutorestSettings.java
@@ -23,6 +23,12 @@ public class AutorestSettings {
     private final List<String> require = new ArrayList<>();
 
     /**
+     * Creates a new instance of the AutorestSettings class.
+     */
+    public AutorestSettings() {
+    }
+
+    /**
      * Gets the title of what Autorest is generation.
      *
      * @return The title of what Autorest is generating.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -4,9 +4,10 @@
 package com.azure.autorest.extension.base.plugin;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import org.slf4j.Logger;
 
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -22,6 +23,7 @@ import java.util.stream.Collectors;
  * Settings that are used by the Java AutoRest Generator.
  */
 public class JavaSettings {
+    private static final TypeFactory TYPE_FACTORY = TypeFactory.defaultInstance();
     private static final String VERSION = "4.0.0";
     private static JavaSettings instance;
     private static NewPlugin host;
@@ -90,14 +92,15 @@ public class JavaSettings {
             loadStringSetting("output-folder", autorestSettings::setOutputFolder);
             loadStringSetting("java-sdks-folder", autorestSettings::setJavaSdksFolder);
             // input-file
-            List<Object> inputFiles = host.getValue(List.class, "input-file");
+            Type listObjectType = TYPE_FACTORY.constructCollectionType(List.class, Object.class);
+            List<Object> inputFiles = host.getValue(listObjectType, "input-file");
             if (inputFiles != null) {
                 autorestSettings.getInputFiles().addAll(
                     inputFiles.stream().map(Object::toString).collect(Collectors.toList()));
                 logger.debug("List of input files : {}", autorestSettings.getInputFiles());
             }
             // require (readme.md etc.)
-            List<Object> require = host.getValue(List.class, "require");
+            List<Object> require = host.getValue(listObjectType, "require");
             if (require != null) {
                 autorestSettings.getRequire().addAll(
                     require.stream().map(Object::toString).collect(Collectors.toList()));
@@ -107,8 +110,7 @@ public class JavaSettings {
             setHeader(getStringValue(host, "license-header"));
             instance = new JavaSettings(
                 autorestSettings,
-                host.getValue(new TypeReference<Map<String, Object>>() {
-                }.getType(), "modelerfour"),
+                host.getValue(TYPE_FACTORY.constructMapType(Map.class, String.class, Object.class), "modelerfour"),
                 getBooleanValue(host, "azure-arm", false),
                 getBooleanValue(host, "sdk-integration", false),
                 getStringValue(host, "fluent"),
@@ -141,14 +143,13 @@ public class JavaSettings {
                 getBooleanValue(host, "optional-constant-as-enum", false),
                 getBooleanValue(host, "data-plane", false),
                 getBooleanValue(host, "use-iterable", false),
-                host.getValue(List.class, "service-versions"),
+                host.getValue(TYPE_FACTORY.constructCollectionLikeType(List.class, String.class), "service-versions"),
                 getBooleanValue(host, "require-x-ms-flattened-to-flatten", false),
                 getStringValue(host, "client-flattened-annotation-target", ""),
                 getStringValue(host, "key-credential-header-name", ""),
                 getBooleanValue(host, "disable-client-builder", false),
                 getBooleanValue(host, "skip-formatting", false),
-                host.getValue(new TypeReference<Map<String, PollingDetails>>() {
-                }.getType(), "polling"),
+                host.getValue(TYPE_FACTORY.constructMapType(Map.class, String.class, PollingDetails.class), "polling"),
                 getBooleanValue(host, "generate-samples", false),
                 getBooleanValue(host, "generate-tests", false),
                 false, //getBooleanValue(host, "generate-send-request-method", false),
@@ -156,7 +157,7 @@ public class JavaSettings {
                 getBooleanValue(host, "annotate-getters-and-setters-for-serialization", false),
                 getStringValue(host, "default-http-exception-type"),
                 getBooleanValue(host, "use-default-http-status-code-to-exception-type-mapping", false),
-                host.getValue(new TypeReference<Map<Integer, String>>() {}.getType(),
+                host.getValue(TYPE_FACTORY.constructMapType(Map.class, Integer.class, String.class),
                     "http-status-code-to-exception-type-mapping"),
                 getBooleanValue(host, "partial-update", false),
                 getBooleanValue(host, "generic-response-type", false),
@@ -241,10 +242,10 @@ public class JavaSettings {
      * continue being annotated to ensure that there are no backwards compatibility breaks.
      * @param defaultHttpExceptionType The fully-qualified class that should be used as the default exception type. This
      * class must extend from HttpResponseException.
-     * @param useDefaultHttpStatusCodeToExceptionTypeMapping Determines whether a well-known HTTP status code to exception type mapping
-     * should be used if an HTTP status code-exception mapping isn't provided.
-     * @param httpStatusCodeToExceptionTypeMapping A mapping of HTTP response status code to the exception type that should be
-     * thrown if that status code is seen. All exception types must be fully-qualified and extend from
+     * @param useDefaultHttpStatusCodeToExceptionTypeMapping Determines whether a well-known HTTP status code to
+     * exception type mapping should be used if an HTTP status code-exception mapping isn't provided.
+     * @param httpStatusCodeToExceptionTypeMapping A mapping of HTTP response status code to the exception type that
+     * should be thrown if that status code is seen. All exception types must be fully-qualified and extend from
      * HttpResponseException.
      * @param handlePartialUpdate If set to true, the generated model will handle partial updates.
      * @param genericResponseTypes If set to true, responses will only use Response, ResponseBase, PagedResponse, and
@@ -1009,9 +1010,24 @@ public class JavaSettings {
      * Represents sync methods generation.
      */
     public enum SyncMethodsGeneration {
+        /**
+         * Generate all methods.
+         */
         ALL,
+
+        /**
+         * Generate only essential methods.
+         */
         ESSENTIAL,
+
+        /**
+         * Generate only sync methods.
+         */
         SYNC_ONLY,  // SYNC_ONLY requires "enable-sync-stack"
+
+        /**
+         * Generate no methods.
+         */
         NONE;
 
         /**
@@ -1072,8 +1088,19 @@ public class JavaSettings {
      * Represents the type of credential.
      */
     public enum CredentialType {
+        /**
+         * Token credential.
+         */
         TOKEN_CREDENTIAL,
+
+        /**
+         * Azure key credential.
+         */
         AZURE_KEY_CREDENTIAL,
+
+        /**
+         * No credential.
+         */
         NONE;
 
         /**
@@ -1317,6 +1344,12 @@ public class JavaSettings {
         private String finalType;
         @JsonProperty("poll-interval")
         private String pollInterval;
+
+        /**
+         * Creates a new PollingDetails object.
+         */
+        public PollingDetails() {
+        }
 
         /**
          * The default polling strategy format.

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/NewPlugin.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/NewPlugin.java
@@ -10,6 +10,7 @@ import com.azure.autorest.extension.base.model.codemodel.AnnotatedPropertyUtils;
 import com.azure.autorest.extension.base.model.codemodel.CodeModelCustomConstructor;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.type.TypeFactory;
@@ -37,6 +38,8 @@ import java.util.Objects;
 public abstract class NewPlugin {
     private static final Type MAP_STRING_STRING_TYPE = TypeFactory.defaultInstance()
         .constructMapType(Map.class, String.class, String.class);
+    private static final JavaType LIST_STRING = TypeFactory.defaultInstance()
+        .constructCollectionLikeType(List.class, String.class);
 
     /**
      * The ObjectMapper used to serialize and deserialize JSON.
@@ -85,10 +88,28 @@ public abstract class NewPlugin {
         return connection.request(jsonMapper.constructType(type), "GetValue", sessionId, key);
     }
 
+//    /**
+//     * Gets the Map value of a key.
+//     *
+//     * @param <K> The type of the key.
+//     * @param <V> The type of the value.
+//     * @param keyType The type of the key.
+//     * @param valueType The type of the value.
+//     * @param key The key.
+//     * @return The value of the key.
+//     */
 //    public <K, V> Map<K, V> getMapValue(Class<K> keyType, Class<V> valueType, String key) {
 //        return getValue(jsonMapper.getTypeFactory().constructMapType(Map.class, keyType, valueType), key);
 //    }
 //
+//    /**
+//     * Gets the List value of a key.
+//     *
+//     * @param <T> The type of the value.
+//     * @param valueType The type of the value.
+//     * @param key The key.
+//     * @return The value of the key.
+//     */
 //    public <T> List<T> getListValue(Class<T> valueType, String key) {
 //        return getValue(jsonMapper.getTypeFactory().constructCollectionType(List.class, valueType), key);
 //    }
@@ -112,11 +133,7 @@ public abstract class NewPlugin {
      */
     public String getStringValue(String key, String defaultValue) {
         String ret = getStringValue(key);
-        if (ret == null) {
-            return defaultValue;
-        } else {
-            return ret;
-        }
+        return  (ret == null) ? defaultValue : ret;
     }
 
     /**
@@ -138,11 +155,7 @@ public abstract class NewPlugin {
      */
     public boolean getBooleanValue(String key, boolean defaultValue) {
         Boolean ret = getBooleanValue(key);
-        if (ret == null) {
-            return defaultValue;
-        } else {
-            return ret;
-        }
+        return (ret == null) ? defaultValue : ret;
     }
 
     /**
@@ -151,8 +164,7 @@ public abstract class NewPlugin {
      * @return The input files.
      */
     public List<String> listInputs() {
-        return connection.request(jsonMapper.getTypeFactory().constructCollectionLikeType(List.class, String.class),
-            "ListInputs", sessionId, null);
+        return listInputs(null);
     }
 
     /**
@@ -162,8 +174,7 @@ public abstract class NewPlugin {
      * @return The input files of the specific type.
      */
     public List<String> listInputs(String artifactType) {
-        return connection.request(jsonMapper.getTypeFactory().constructCollectionLikeType(List.class, String.class),
-            "ListInputs", sessionId, artifactType);
+        return connection.request(LIST_STRING, "ListInputs", sessionId, artifactType);
     }
 
     /**

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/PluginLogger.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/PluginLogger.java
@@ -17,9 +17,24 @@ import java.util.stream.Stream;
  * A logger for AutoRest plugins.
  */
 public final class PluginLogger extends MarkerIgnoringBase {
+    /**
+     * The AutoRest plugin.
+     */
     private final NewPlugin plugin;
+
+    /**
+     * The keys for logging.
+     */
     private final List<String> keys;
+
+    /**
+     * Whether tracing is enabled.
+     */
     private final boolean isTracingEnabled;
+
+    /**
+     * Whether debugging is enabled.
+     */
     private final boolean isDebugEnabled;
 
     /**

--- a/fluentnamer/src/main/java/com/azure/autorest/fluent/util/FluentJavaSettings.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluent/util/FluentJavaSettings.java
@@ -7,7 +7,7 @@ import com.azure.autorest.extension.base.plugin.NewPlugin;
 import com.azure.autorest.extension.base.plugin.PluginLogger;
 import com.azure.autorest.fluent.model.ResourceCollectionAssociation;
 import com.azure.core.util.CoreUtils;
-import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
@@ -237,7 +237,9 @@ public class FluentJavaSettings {
 
         loadBooleanSetting("sdk-integration", b -> sdkIntegration = b);
 
-        Map<String, String> namingOverride = host.getValue(new TypeReference<Map<String, String>>() {}.getType(), "pipeline.fluentgen.naming.override");
+        Map<String, String> namingOverride = host.getValue(
+            TypeFactory.defaultInstance().constructMapType(Map.class, String.class, String.class),
+            "pipeline.fluentgen.naming.override");
         if (namingOverride != null) {
             this.namingOverride.putAll(namingOverride);
         }
@@ -270,7 +272,9 @@ public class FluentJavaSettings {
 
     private void loadResourceCollectionAssociationSetting(Consumer<List<ResourceCollectionAssociation>> action) {
         String settingName = "resource-collection-associations";
-        List<ResourceCollectionAssociation> settingValue = host.getValue(new TypeReference<List<ResourceCollectionAssociation>>() {}.getType(), settingName);
+        List<ResourceCollectionAssociation> settingValue = host.getValue(
+            TypeFactory.defaultInstance().constructCollectionLikeType(List.class, ResourceCollectionAssociation.class),
+            settingName);
         if (settingValue != null) {
             logger.debug("Option, array, {} : {}", settingName, settingValue);
             action.accept(settingValue);

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,8 @@
 
     <!-- This property configures whether PLAYBACK tests are ran in parallel. Default is true. -->
     <parallelizeTests>true</parallelizeTests>
+
+    <maven.javadoc.failOnWarnings>false</maven.javadoc.failOnWarnings>
   </properties>
 
   <dependencyManagement>
@@ -151,6 +153,7 @@
             <source>1.8</source>
             <detectJavaApiLink>false</detectJavaApiLink>
             <quiet>true</quiet>
+            <failOnWarnings>${maven.javadoc.failOnWarnings}</failOnWarnings>
           </configuration>
         </plugin>
 

--- a/postprocessor/src/main/java/com/azure/autorest/postprocessor/Postprocessor.java
+++ b/postprocessor/src/main/java/com/azure/autorest/postprocessor/Postprocessor.java
@@ -11,6 +11,7 @@ import com.azure.autorest.extension.base.plugin.PluginLogger;
 import com.azure.autorest.extension.base.util.FileUtils;
 import com.azure.autorest.partialupdate.util.PartialUpdateHandler;
 import com.azure.autorest.postprocessor.implementation.CodeFormatterUtil;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import org.slf4j.Logger;
 
 import java.io.File;
@@ -129,7 +130,8 @@ public class Postprocessor {
     }
 
     private static String getReadme(NewPlugin plugin) {
-        List<String> configurationFiles = plugin.getValue(List.class, "configurationFiles");
+        List<String> configurationFiles = plugin.getValue(
+            TypeFactory.defaultInstance().constructCollectionLikeType(List.class, String.class), "configurationFiles");
         return configurationFiles == null || configurationFiles.isEmpty()
             ? JavaSettings.getInstance().getAutorestSettings().getOutputFolder()
             : configurationFiles.stream().filter(key -> !key.contains(".autorest")).findFirst().orElse(null);

--- a/preprocessor/src/main/java/com/azure/autorest/preprocessor/Preprocessor.java
+++ b/preprocessor/src/main/java/com/azure/autorest/preprocessor/Preprocessor.java
@@ -225,6 +225,16 @@ public class Preprocessor extends NewPlugin {
         return wrappedPlugin.getValue(type, key);
     }
 
+//    @Override
+//    public <K, V> Map<K, V> getMapValue(Class<K> keyType, Class<V> valueType, String key) {
+//        return wrappedPlugin.getMapValue(keyType, valueType, key);
+//    }
+//
+//    @Override
+//    public <T> List<T> getListValue(Class<T> valueType, String key) {
+//        return wrappedPlugin.getListValue(valueType, key);
+//    }
+
     @Override
     public String getStringValue(String key) {
         return wrappedPlugin.getStringValue(key);


### PR DESCRIPTION
Finalizes fixes for Javadoc in `extension-base` and adds a configuration into the parent POM to allow child libraries to enable failing Javadocs on warnings to ensure `extension-base`'s Javadocs are kept up-to-date.