### PR TITLE
Remove JSON flatten setting

### DIFF
--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/DotFish.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/DotFish.java
@@ -79,7 +79,7 @@ public class DotFish implements JsonSerializable<DotFish> {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("fish\\.type", this.fishType);
+        jsonWriter.writeStringField("fish.type", this.fishType);
         jsonWriter.writeStringField("species", this.species);
         return jsonWriter.writeEndObject();
     }
@@ -99,7 +99,7 @@ public class DotFish implements JsonSerializable<DotFish> {
                 while (readerToUse.nextToken() != JsonToken.END_OBJECT) {
                     String fieldName = readerToUse.getFieldName();
                     readerToUse.nextToken();
-                    if ("fish\\.type".equals(fieldName)) {
+                    if ("fish.type".equals(fieldName)) {
                         discriminatorValue = readerToUse.getString();
                         break;
                     } else {
@@ -123,7 +123,7 @@ public class DotFish implements JsonSerializable<DotFish> {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("fish\\.type".equals(fieldName)) {
+                if ("fish.type".equals(fieldName)) {
                     deserializedDotFish.fishType = reader.getString();
                 } else if ("species".equals(fieldName)) {
                     deserializedDotFish.species = reader.getString();

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/DotSalmon.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/DotSalmon.java
@@ -16,7 +16,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * The DotSalmon model.
  */
 @Fluent
-public class DotSalmon extends DotFish {
+public final class DotSalmon extends DotFish {
     /*
      * The location property.
      */
@@ -89,7 +89,7 @@ public class DotSalmon extends DotFish {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("fish\\.type", getFishType());
+        jsonWriter.writeStringField("fish.type", getFishType());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeStringField("location", this.location);
         jsonWriter.writeBooleanField("iswild", this.isWild);
@@ -110,7 +110,7 @@ public class DotSalmon extends DotFish {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("fish\\.type".equals(fieldName)) {
+                if ("fish.type".equals(fieldName)) {
                     deserializedDotSalmon.setFishType(reader.getString());
                 } else if ("species".equals(fieldName)) {
                     deserializedDotSalmon.setSpecies(reader.getString());

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -143,7 +143,6 @@ public class JavaSettings {
                 getBooleanValue(host, "data-plane", false),
                 getBooleanValue(host, "use-iterable", false),
                 host.getValue(TYPE_FACTORY.constructCollectionLikeType(List.class, String.class), "service-versions"),
-                getBooleanValue(host, "require-x-ms-flattened-to-flatten", false),
                 getStringValue(host, "client-flattened-annotation-target", ""),
                 getStringValue(host, "key-credential-header-name", ""),
                 getBooleanValue(host, "disable-client-builder", false),
@@ -223,8 +222,6 @@ public class JavaSettings {
      * @param dataPlaneClient Whether to generate a data plane client.
      * @param useIterable Whether to use Iterable instead of List for collection types.
      * @param serviceVersions The versions of the service.
-     * @param requireXMsFlattenedToFlatten If set to true, a model must have x-ms-flattened to be annotated with
-     * JsonFlatten.
      * @param clientFlattenAnnotationTarget The target for the <code>@JsonFlatten</code> annotation for
      * x-ms-client-flatten.
      * @param keyCredentialHeaderName The header name for the key credential.
@@ -304,7 +301,6 @@ public class JavaSettings {
         boolean dataPlaneClient,
         boolean useIterable,
         List<String> serviceVersions,
-        boolean requireXMsFlattenedToFlatten,
         String clientFlattenAnnotationTarget,
         String keyCredentialHeaderName,
         boolean clientBuilderDisabled,
@@ -366,7 +362,6 @@ public class JavaSettings {
         this.dataPlaneClient = dataPlaneClient;
         this.useIterable = useIterable;
         this.serviceVersions = serviceVersions;
-        this.requireXMsFlattenedToFlatten = requireXMsFlattenedToFlatten;
         this.clientFlattenAnnotationTarget =
             (clientFlattenAnnotationTarget == null || clientFlattenAnnotationTarget.isEmpty())
                 ? ClientFlattenAnnotationTarget.TYPE
@@ -1198,17 +1193,6 @@ public class JavaSettings {
      */
     public List<String> getServiceVersions() {
         return serviceVersions;
-    }
-
-    private final boolean requireXMsFlattenedToFlatten;
-
-    /**
-     * Whether a model must have x-ms-flattened to be annotated with JsonFlatten.
-     *
-     * @return Whether a model must have x-ms-flattened to be annotated with JsonFlatten.
-     */
-    public boolean requireXMsFlattenedToFlatten() {
-        return requireXMsFlattenedToFlatten;
     }
 
     private final boolean generateSamples;

--- a/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
@@ -244,12 +244,6 @@ public class ModelMapper implements IMapper<ObjectSchema, ClientModel> {
             if (settings.getModelerSettings().isFlattenModel()  // enabled by modelerfour
                 && settings.getClientFlattenAnnotationTarget() == JavaSettings.ClientFlattenAnnotationTarget.TYPE) {
                 needsFlatten = hasFlattenedProperty(compositeType, parentsNeedFlatten);
-                if (isPolymorphic) {
-                    String discriminatorSerializedName = SchemaUtil.getDiscriminatorSerializedName(compositeType);
-                    // OR the need flattening based on the model containing 'x-ms-flattened' and if the discriminator
-                    // contains '.' and 'x-ms-flattened' isn't required for flattening.
-                    needsFlatten |= (discriminatorSerializedName.contains(".") && !settings.requireXMsFlattenedToFlatten());
-                }
             }
 
             String polymorphicDiscriminator = null;

--- a/readme.md
+++ b/readme.md
@@ -79,8 +79,7 @@ Settings can be provided on the command line through `--name:value` or in a READ
 |`--custom-types-subpackage=STRING`|The sub-package that the custom types should be generated in. The types that custom types reference, or inherit from will also be automatically moved to this sub-package. **Recommended usage**: You can set this value to `models` and set `--models-subpackage=implementation.models`to generate models to `implementation.models` by default and pick specific models to be public through `--custom-types=`.|
 |`--client-type-prefix=STRING`|The prefix that will be added to each generated client type.|
 |`--service-interface-as-public`|Indicates whether to generate service interfaces as public. This resolves `SecurityManager` issues to prevent reflectively access non-public APIs. Default is true.|
-|`--require-x-ms-flattened-to-flatten`|Indicates whether `x-ms-flattened` is required to annotated a class with `@JsonFlatten` if the discriminator has `.` in its name. Default is false.|
-|`--client-flattened-annotation-target=TYPE,FIELD,NONE,DISABLED`|Indicates the target of `@JsonFlatten` annotation for `x-ms-client-flatten`. Default is `TYPE`. If value is `FIELD`, it implies `require-x-ms-flattened-to-flatten=true`.|
+|`--client-flattened-annotation-target=TYPE,FIELD,NONE,DISABLED`|Indicates the target of `@JsonFlatten` annotation for `x-ms-client-flatten`. Default is `TYPE`.|
 |`--disable-client-builder`|Indicates whether to disable generating the `ClientBuilder` class. This is for SDK that already contains a hand-written `ClientBuilder` class. Default is false.|
 |`--skip-formatting`|Indicates whether to skip formatting Java file. Default is false.|
 |`--polling`|Configures how to generate long running operations. See [Polling Configuration](#polling-configuration) to see more details on how to use this flag.|
@@ -375,7 +374,7 @@ help-content:
         description: The prefix that will be added to each generated client type.
       - key: client-flattened-annotation-target
         type: string
-        description: \[TYPE,FIELD,NONE,DISABLED] Indicates the target of `@JsonFlatten` annotation for `x-ms-client-flatten`. Default is `TYPE`. If value is `FIELD`, it implies `require-x-ms-flattened-to-flatten=true`.
+        description: \[TYPE,FIELD,NONE,DISABLED] Indicates the target of `@JsonFlatten` annotation for `x-ms-client-flatten`. Default is `TYPE`.
       - key: disable-client-builder
         type: bool
         description: Indicates whether to disable generating the `ClientBuilder` class. This is for SDK that already contains a hand-written `ClientBuilder` class. Default is false.

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/DotFish.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/DotFish.java
@@ -87,7 +87,7 @@ public class DotFish implements JsonSerializable<DotFish> {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("fish\\.type", this.fishType);
+        jsonWriter.writeStringField("fish.type", this.fishType);
         jsonWriter.writeStringField("species", this.species);
         return jsonWriter.writeEndObject();
     }
@@ -107,7 +107,7 @@ public class DotFish implements JsonSerializable<DotFish> {
                 while (readerToUse.nextToken() != JsonToken.END_OBJECT) {
                     String fieldName = readerToUse.getFieldName();
                     readerToUse.nextToken();
-                    if ("fish\\.type".equals(fieldName)) {
+                    if ("fish.type".equals(fieldName)) {
                         discriminatorValue = readerToUse.getString();
                         break;
                     } else {
@@ -131,7 +131,7 @@ public class DotFish implements JsonSerializable<DotFish> {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("fish\\.type".equals(fieldName)) {
+                if ("fish.type".equals(fieldName)) {
                     deserializedDotFish.fishType = reader.getString();
                 } else if ("species".equals(fieldName)) {
                     deserializedDotFish.species = reader.getString();

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/DotSalmon.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/DotSalmon.java
@@ -14,7 +14,7 @@ import java.io.IOException;
  * The DotSalmon model.
  */
 @Immutable
-public class DotSalmon extends DotFish {
+public final class DotSalmon extends DotFish {
     /*
      * The location property.
      */
@@ -66,7 +66,7 @@ public class DotSalmon extends DotFish {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("fish\\.type", getFishType());
+        jsonWriter.writeStringField("fish.type", getFishType());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeStringField("location", this.location);
         jsonWriter.writeBooleanField("iswild", this.iswild);
@@ -87,7 +87,7 @@ public class DotSalmon extends DotFish {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("fish\\.type".equals(fieldName)) {
+                if ("fish.type".equals(fieldName)) {
                     deserializedDotSalmon.setFishType(reader.getString());
                 } else if ("species".equals(fieldName)) {
                     deserializedDotSalmon.setSpecies(reader.getString());

--- a/vanilla-tests/src/main/java/fixtures/inheritance/passdiscriminator/models/MetricAlertCriteria.java
+++ b/vanilla-tests/src/main/java/fixtures/inheritance/passdiscriminator/models/MetricAlertCriteria.java
@@ -5,7 +5,6 @@
 package fixtures.inheritance.passdiscriminator.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.JsonFlatten;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -16,14 +15,13 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 /**
  * The rule criteria that defines the conditions of the alert rule.
  */
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
-    property = "odata\\.type",
+    property = "odata.type",
     defaultImpl = MetricAlertCriteria.class,
     visible = true)
 @JsonTypeName("MetricAlertCriteria")
@@ -31,16 +29,13 @@ import java.util.regex.Pattern;
     @JsonSubTypes.Type(
         name = "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
         value = MetricAlertSingleResourceMultipleMetricCriteria.class) })
-@JsonFlatten
 @Fluent
 public class MetricAlertCriteria {
-    private static final Pattern KEY_ESCAPER = Pattern.compile("\\.");;
-
     /*
      * specifies the type of the alert criteria.
      */
     @JsonTypeId
-    @JsonProperty(value = "odata\\.type", required = true)
+    @JsonProperty(value = "odata.type", required = true)
     private Odatatype odataType;
 
     /*
@@ -102,7 +97,7 @@ public class MetricAlertCriteria {
         if (additionalProperties == null) {
             additionalProperties = new HashMap<>();
         }
-        additionalProperties.put(KEY_ESCAPER.matcher(key).replaceAll("."), value);
+        additionalProperties.put(key, value);
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/inheritance/passdiscriminator/models/MetricAlertSingleResourceMultipleMetricCriteria.java
+++ b/vanilla-tests/src/main/java/fixtures/inheritance/passdiscriminator/models/MetricAlertSingleResourceMultipleMetricCriteria.java
@@ -5,7 +5,6 @@
 package fixtures.inheritance.passdiscriminator.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.JsonFlatten;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -16,13 +15,12 @@ import java.util.List;
  */
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
-    property = "odata\\.type",
+    property = "odata.type",
     defaultImpl = MetricAlertSingleResourceMultipleMetricCriteria.class,
     visible = true)
 @JsonTypeName("Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria")
-@JsonFlatten
 @Fluent
-public class MetricAlertSingleResourceMultipleMetricCriteria extends MetricAlertCriteria {
+public final class MetricAlertSingleResourceMultipleMetricCriteria extends MetricAlertCriteria {
     /*
      * The list of metric criteria for this 'all of' operation. 
      */

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/DotFish.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/DotFish.java
@@ -87,7 +87,7 @@ public class DotFish implements JsonSerializable<DotFish> {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("fish\\.type", this.fishType);
+        jsonWriter.writeStringField("fish.type", this.fishType);
         jsonWriter.writeStringField("species", this.species);
         return jsonWriter.writeEndObject();
     }
@@ -107,7 +107,7 @@ public class DotFish implements JsonSerializable<DotFish> {
                 while (readerToUse.nextToken() != JsonToken.END_OBJECT) {
                     String fieldName = readerToUse.getFieldName();
                     readerToUse.nextToken();
-                    if ("fish\\.type".equals(fieldName)) {
+                    if ("fish.type".equals(fieldName)) {
                         discriminatorValue = readerToUse.getString();
                         break;
                     } else {
@@ -131,7 +131,7 @@ public class DotFish implements JsonSerializable<DotFish> {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("fish\\.type".equals(fieldName)) {
+                if ("fish.type".equals(fieldName)) {
                     deserializedDotFish.fishType = reader.getString();
                 } else if ("species".equals(fieldName)) {
                     deserializedDotFish.species = reader.getString();

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/DotSalmon.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/DotSalmon.java
@@ -14,7 +14,7 @@ import java.io.IOException;
  * The DotSalmon model.
  */
 @Fluent
-public class DotSalmon extends DotFish {
+public final class DotSalmon extends DotFish {
     /*
      * The location property.
      */
@@ -97,7 +97,7 @@ public class DotSalmon extends DotFish {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("fish\\.type", getFishType());
+        jsonWriter.writeStringField("fish.type", getFishType());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeStringField("location", this.location);
         jsonWriter.writeBooleanField("iswild", this.iswild);
@@ -118,7 +118,7 @@ public class DotSalmon extends DotFish {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("fish\\.type".equals(fieldName)) {
+                if ("fish.type".equals(fieldName)) {
                     deserializedDotSalmon.setFishType(reader.getString());
                 } else if ("species".equals(fieldName)) {
                     deserializedDotSalmon.setSpecies(reader.getString());

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/DotFish.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/DotFish.java
@@ -87,7 +87,7 @@ public class DotFish implements JsonSerializable<DotFish> {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("fish\\.type", this.fishType);
+        jsonWriter.writeStringField("fish.type", this.fishType);
         jsonWriter.writeStringField("species", this.species);
         return jsonWriter.writeEndObject();
     }
@@ -107,7 +107,7 @@ public class DotFish implements JsonSerializable<DotFish> {
                 while (readerToUse.nextToken() != JsonToken.END_OBJECT) {
                     String fieldName = readerToUse.getFieldName();
                     readerToUse.nextToken();
-                    if ("fish\\.type".equals(fieldName)) {
+                    if ("fish.type".equals(fieldName)) {
                         discriminatorValue = readerToUse.getString();
                         break;
                     } else {
@@ -131,7 +131,7 @@ public class DotFish implements JsonSerializable<DotFish> {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("fish\\.type".equals(fieldName)) {
+                if ("fish.type".equals(fieldName)) {
                     deserializedDotFish.fishType = reader.getString();
                 } else if ("species".equals(fieldName)) {
                     deserializedDotFish.species = reader.getString();

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/DotSalmon.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/DotSalmon.java
@@ -14,7 +14,7 @@ import java.io.IOException;
  * The DotSalmon model.
  */
 @Fluent
-public class DotSalmon extends DotFish {
+public final class DotSalmon extends DotFish {
     /*
      * The location property.
      */
@@ -97,7 +97,7 @@ public class DotSalmon extends DotFish {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("fish\\.type", getFishType());
+        jsonWriter.writeStringField("fish.type", getFishType());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeStringField("location", this.location);
         jsonWriter.writeBooleanField("iswild", this.iswild);
@@ -118,7 +118,7 @@ public class DotSalmon extends DotFish {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("fish\\.type".equals(fieldName)) {
+                if ("fish.type".equals(fieldName)) {
                     deserializedDotSalmon.setFishType(reader.getString());
                 } else if ("species".equals(fieldName)) {
                     deserializedDotSalmon.setSpecies(reader.getString());

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/DotFish.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/DotFish.java
@@ -87,7 +87,7 @@ public class DotFish implements JsonSerializable<DotFish> {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("fish\\.type", this.fishType);
+        jsonWriter.writeStringField("fish.type", this.fishType);
         jsonWriter.writeStringField("species", this.species);
         return jsonWriter.writeEndObject();
     }
@@ -107,7 +107,7 @@ public class DotFish implements JsonSerializable<DotFish> {
                 while (readerToUse.nextToken() != JsonToken.END_OBJECT) {
                     String fieldName = readerToUse.getFieldName();
                     readerToUse.nextToken();
-                    if ("fish\\.type".equals(fieldName)) {
+                    if ("fish.type".equals(fieldName)) {
                         discriminatorValue = readerToUse.getString();
                         break;
                     } else {
@@ -131,7 +131,7 @@ public class DotFish implements JsonSerializable<DotFish> {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("fish\\.type".equals(fieldName)) {
+                if ("fish.type".equals(fieldName)) {
                     deserializedDotFish.fishType = reader.getString();
                 } else if ("species".equals(fieldName)) {
                     deserializedDotFish.species = reader.getString();

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/DotSalmon.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/DotSalmon.java
@@ -14,7 +14,7 @@ import java.io.IOException;
  * The DotSalmon model.
  */
 @Immutable
-public class DotSalmon extends DotFish {
+public final class DotSalmon extends DotFish {
     /*
      * The location property.
      */
@@ -66,7 +66,7 @@ public class DotSalmon extends DotFish {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("fish\\.type", getFishType());
+        jsonWriter.writeStringField("fish.type", getFishType());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeStringField("location", this.location);
         jsonWriter.writeBooleanField("iswild", this.iswild);
@@ -87,7 +87,7 @@ public class DotSalmon extends DotFish {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("fish\\.type".equals(fieldName)) {
+                if ("fish.type".equals(fieldName)) {
                     deserializedDotSalmon.setFishType(reader.getString());
                 } else if ("species".equals(fieldName)) {
                     deserializedDotSalmon.setSpecies(reader.getString());


### PR DESCRIPTION
Removes the setting `require-x-ms-flattened-to-flatten` as flattening should always require `x-ms-flattened` to be enabled to produce flattened objects.