### PR TITLE
tsp, add test for cadl-ranch Azure.Core.Scalar

### DIFF
--- a/typespec-tests/src/test/java/com/_specs_/azure/core/scalar/ScalarTests.java
+++ b/typespec-tests/src/test/java/com/_specs_/azure/core/scalar/ScalarTests.java
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com._specs_.azure.core.scalar;
+
+import com._specs_.azure.core.scalar.models.AzureLocationModel;
+import com.azure.core.http.policy.HttpLogDetailLevel;
+import com.azure.core.http.policy.HttpLogOptions;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ScalarTests {
+    private ScalarClient client = new ScalarClientBuilder()
+            .httpLogOptions(new HttpLogOptions().setLogLevel(HttpLogDetailLevel.BODY_AND_HEADERS))
+            .buildClient();
+
+    @Test
+    public void testGet() {
+        Assertions.assertEquals("eastus", client.get());
+    }
+
+    @Test
+    public void testHeader() {
+        client.headerMethod("eastus");
+    }
+
+    @Test
+    public void testPost() {
+        AzureLocationModel azureLocationModel = client.post(new AzureLocationModel("eastus"));
+        Assertions.assertEquals("eastus", azureLocationModel.getLocation());
+    }
+
+    @Test
+    public void testPut() {
+        client.put("eastus");
+    }
+
+    @Test
+    public void testQuery() {
+        client.query("eastus");
+    }
+}

--- a/typespec-tests/src/test/java/com/_specs_/azure/core/scalar/ScalarTests.java
+++ b/typespec-tests/src/test/java/com/_specs_/azure/core/scalar/ScalarTests.java
@@ -10,33 +10,35 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class ScalarTests {
-    private ScalarClient client = new ScalarClientBuilder()
-            .httpLogOptions(new HttpLogOptions().setLogLevel(HttpLogDetailLevel.BODY_AND_HEADERS))
+
+    private final static String LOCATION_REGION = "eastus";
+    private final ScalarClient client = new ScalarClientBuilder()
+            .httpLogOptions(new HttpLogOptions().setLogLevel(HttpLogDetailLevel.BASIC))
             .buildClient();
 
     @Test
     public void testGet() {
-        Assertions.assertEquals("eastus", client.get());
+        Assertions.assertEquals(LOCATION_REGION, client.get());
     }
 
     @Test
     public void testHeader() {
-        client.headerMethod("eastus");
+        client.headerMethod(LOCATION_REGION);
     }
 
     @Test
     public void testPost() {
-        AzureLocationModel azureLocationModel = client.post(new AzureLocationModel("eastus"));
-        Assertions.assertEquals("eastus", azureLocationModel.getLocation());
+        AzureLocationModel azureLocationModel = client.post(new AzureLocationModel(LOCATION_REGION));
+        Assertions.assertEquals(LOCATION_REGION, azureLocationModel.getLocation());
     }
 
     @Test
     public void testPut() {
-        client.put("eastus");
+        client.put(LOCATION_REGION);
     }
 
     @Test
     public void testQuery() {
-        client.query("eastus");
+        client.query(LOCATION_REGION);
     }
 }


### PR DESCRIPTION
Add test cases for for tsp, cadl-ranch Azure.Core.Scalar

`put/hearderMethod/query` has no return value, so it only invoke .