### PR TITLE
client, add test case for Jackson serialization

### DIFF
--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentServiceClientTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentServiceClientTemplate.java
@@ -145,7 +145,7 @@ public class FluentServiceClientTemplate extends ServiceClientTemplate {
                 });
 
                 block.publicMethod("String getHeaderValue(String s)", code -> {
-                    code.methodReturn("httpHeaders.getValue(s)");
+                    code.methodReturn("httpHeaders.getValue(HttpHeaderName.fromString(s))");
                 });
 
                 block.publicMethod("HttpHeaders getHeaders()", code -> {

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ServiceClient.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ServiceClient.java
@@ -223,6 +223,9 @@ public class ServiceClient {
         }
 
         if (includeImplementationImports) {
+            if (settings.isFluent()) {
+                ClassType.HTTP_HEADER_NAME.addImportsTo(imports, includeImplementationImports);
+            }
             if (settings.isFluentPremium()) {
                 imports.add("com.azure.resourcemanager.resources.fluentcore.AzureServiceClient");
             }

--- a/typespec-tests/src/main/java/com/cadl/armresourceprovider/implementation/ArmResourceProviderClientImpl.java
+++ b/typespec-tests/src/main/java/com/cadl/armresourceprovider/implementation/ArmResourceProviderClientImpl.java
@@ -307,7 +307,7 @@ public final class ArmResourceProviderClientImpl implements ArmResourceProviderC
         }
 
         public String getHeaderValue(String s) {
-            return httpHeaders.getValue(s);
+            return httpHeaders.getValue(HttpHeaderName.fromString(s));
         }
 
         public HttpHeaders getHeaders() {

--- a/typespec-tests/src/main/java/com/cadl/armresourceprovider/implementation/ArmResourceProviderClientImpl.java
+++ b/typespec-tests/src/main/java/com/cadl/armresourceprovider/implementation/ArmResourceProviderClientImpl.java
@@ -5,6 +5,7 @@
 package com.cadl.armresourceprovider.implementation;
 
 import com.azure.core.annotation.ServiceClient;
+import com.azure.core.http.HttpHeaderName;
 import com.azure.core.http.HttpHeaders;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpResponse;

--- a/vanilla-tests/src/test/java/fixtures/inheritance/passdiscriminator/ValidateDiscriminatorIsPassedTests.java
+++ b/vanilla-tests/src/test/java/fixtures/inheritance/passdiscriminator/ValidateDiscriminatorIsPassedTests.java
@@ -78,5 +78,10 @@ public class ValidateDiscriminatorIsPassedTests {
         String subclassJson = BinaryData.fromObject(subclass).toString();
         jsonNode = OBJECT_MAPPER.readTree(subclassJson);
         assertEquals(Odatatype.MICROSOFT_AZURE_MONITOR_SINGLE_RESOURCE_MULTIPLE_METRIC_CRITERIA.toString(), jsonNode.get("odata.type").asText());
+
+        String unknownJson = "{\"odata.type\": \"invalid\"}";
+        MetricAlertCriteria criteria = BinaryData.fromString(unknownJson).toObject(MetricAlertCriteria.class);
+        assertEquals("invalid", criteria.getOdataType().toString());
+        assertEquals(MetricAlertCriteria.class, criteria.getClass());
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/inheritance/passdiscriminator/ValidateDiscriminatorIsPassedTests.java
+++ b/vanilla-tests/src/test/java/fixtures/inheritance/passdiscriminator/ValidateDiscriminatorIsPassedTests.java
@@ -72,13 +72,16 @@ public class ValidateDiscriminatorIsPassedTests {
         MetricAlertCriteria superclass = new MetricAlertCriteria();
         String superclassJson = BinaryData.fromObject(superclass).toString();
         JsonNode jsonNode = OBJECT_MAPPER.readTree(superclassJson);
+        assertEquals(1, jsonNode.size());
         assertEquals("MetricAlertCriteria", jsonNode.get("odata.type").asText());
 
         MetricAlertCriteria subclass = new MetricAlertSingleResourceMultipleMetricCriteria();
         String subclassJson = BinaryData.fromObject(subclass).toString();
         jsonNode = OBJECT_MAPPER.readTree(subclassJson);
+        assertEquals(1, jsonNode.size());
         assertEquals(Odatatype.MICROSOFT_AZURE_MONITOR_SINGLE_RESOURCE_MULTIPLE_METRIC_CRITERIA.toString(), jsonNode.get("odata.type").asText());
 
+        // de-serialization of unknown type
         String unknownJson = "{\"odata.type\": \"invalid\"}";
         MetricAlertCriteria criteria = BinaryData.fromString(unknownJson).toObject(MetricAlertCriteria.class);
         assertEquals("invalid", criteria.getOdataType().toString());

--- a/vanilla-tests/src/test/java/fixtures/inheritance/passdiscriminator/ValidateDiscriminatorIsPassedTests.java
+++ b/vanilla-tests/src/test/java/fixtures/inheritance/passdiscriminator/ValidateDiscriminatorIsPassedTests.java
@@ -3,14 +3,19 @@
 
 package fixtures.inheritance.passdiscriminator;
 
+import com.azure.core.util.BinaryData;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeId;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import fixtures.inheritance.passdiscriminator.models.MetricAlertCriteria;
 import fixtures.inheritance.passdiscriminator.models.MetricAlertSingleResourceMultipleMetricCriteria;
+import fixtures.inheritance.passdiscriminator.models.Odatatype;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Objects;
 
@@ -58,5 +63,20 @@ public class ValidateDiscriminatorIsPassedTests {
         }
 
         fail("Generation didn't match expected pattern when passing discriminator property to child classes.");
+    }
+
+    private final static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Test
+    public void testJacksonSerialization() throws IOException {
+        MetricAlertCriteria superclass = new MetricAlertCriteria();
+        String superclassJson = BinaryData.fromObject(superclass).toString();
+        JsonNode jsonNode = OBJECT_MAPPER.readTree(superclassJson);
+        assertEquals("MetricAlertCriteria", jsonNode.get("odata.type").asText());
+
+        MetricAlertCriteria subclass = new MetricAlertSingleResourceMultipleMetricCriteria();
+        String subclassJson = BinaryData.fromObject(subclass).toString();
+        jsonNode = OBJECT_MAPPER.readTree(subclassJson);
+        assertEquals(Odatatype.MICROSOFT_AZURE_MONITOR_SINGLE_RESOURCE_MULTIPLE_METRIC_CRITERIA.toString(), jsonNode.get("odata.type").asText());
     }
 }


### PR DESCRIPTION
Make sure any change to `setKind` won't break Jackson scenario.

a minor code change to avoid mgmt generated code calling deprecated core API
https://github.com/Azure/autorest.java/pull/2622/commits/c9f8a71668d75cfb7610acbe081dbca3654968b7