### PR TITLE
tsp, fix examples loading

### DIFF
--- a/typespec-extension/src/code-model-builder.ts
+++ b/typespec-extension/src/code-model-builder.ts
@@ -671,7 +671,12 @@ export class CodeModelBuilder {
     const operationName = this.getName(operation);
     const opId = groupName ? `${groupName}_${operationName}` : `${operationName}`;
 
-    const operationExample = this.operationExamples.get(operation);
+    let operationExample = this.operationExamples.get(operation);
+    if (!operationExample && operation.sourceOperation) {
+      // if the operation is customized in client.tsp, the operation would be different from that of main.tsp
+      // try the operation.sourceOperation
+      operationExample = this.operationExamples.get(operation.sourceOperation);
+    }
 
     const codeModelOperation = new CodeModelOperation(operationName, this.getDoc(operation), {
       operationId: opId,

--- a/typespec-extension/src/operation-utils.ts
+++ b/typespec-extension/src/operation-utils.ts
@@ -70,6 +70,7 @@ export async function loadExamples(program: Program, options: EmitterOptions): P
       : resolvePath(operationExamplesDirectory);
     if (!(await isDirectoryExists(program, exampleDir))) {
       if (program.projectRoot) {
+        // try resolve "examples-directory" relative to program.projectRoot
         exampleDir = version
           ? resolvePath(program.projectRoot, operationExamplesDirectory, version)
           : resolvePath(program.projectRoot, operationExamplesDirectory);

--- a/typespec-extension/src/operation-utils.ts
+++ b/typespec-extension/src/operation-utils.ts
@@ -68,13 +68,13 @@ export async function loadExamples(program: Program, options: EmitterOptions): P
     let exampleDir = version
       ? resolvePath(operationExamplesDirectory, version)
       : resolvePath(operationExamplesDirectory);
-    if (!(await isDirectoryExists(program, exampleDir))) {
+    if (!(await directoryExists(program, exampleDir))) {
       if (program.projectRoot) {
         // try resolve "examples-directory" relative to program.projectRoot
         exampleDir = version
           ? resolvePath(program.projectRoot, operationExamplesDirectory, version)
           : resolvePath(program.projectRoot, operationExamplesDirectory);
-        if (!(await isDirectoryExists(program, exampleDir))) {
+        if (!(await directoryExists(program, exampleDir))) {
           logWarning(program, `Examples directory '${exampleDir}' does not exist.`);
           return operationExamplesMap;
         }
@@ -111,7 +111,7 @@ export async function loadExamples(program: Program, options: EmitterOptions): P
   return operationExamplesMap;
 }
 
-async function isDirectoryExists(program: Program, directory: string) {
+async function directoryExists(program: Program, directory: string) {
   try {
     if (!(await program.host.stat(directory)).isDirectory()) {
       return false;


### PR DESCRIPTION
fix https://github.com/Azure/autorest.java/issues/2635

2 fallback logic
- if example folder not found based on CWD, fallback to path relative to `program.projectRoot` https://github.com/Azure/autorest.java/pull/2637/commits/f7c3c321cfc9f8624d55bbb675fa23e7d57fddaf
- if example not found for an `operation`, fallback to check `operation.sourceOperation` https://github.com/Azure/autorest.java/pull/2637/commits/7c92381bc3583a44788feb20a5a2d11b15a244f0