### PR TITLE
client, add shadow variable for discriminator property

### DIFF
--- a/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/DocumentModelBuildOperationDetails.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/DocumentModelBuildOperationDetails.java
@@ -19,6 +19,11 @@ import java.util.Map;
 @Fluent
 public final class DocumentModelBuildOperationDetails extends OperationDetails {
     /*
+     * Type of operation.
+     */
+    private String kind = "documentModelBuild";
+
+    /*
      * Operation result upon success.
      */
     private DocumentModelDetails result;
@@ -27,7 +32,16 @@ public final class DocumentModelBuildOperationDetails extends OperationDetails {
      * Creates an instance of DocumentModelBuildOperationDetails class.
      */
     public DocumentModelBuildOperationDetails() {
-        setKind("documentModelBuild");
+    }
+
+    /**
+     * Get the kind property: Type of operation.
+     * 
+     * @return the kind value.
+     */
+    @Override
+    public String getKind() {
+        return this.kind;
     }
 
     /**
@@ -146,11 +160,11 @@ public final class DocumentModelBuildOperationDetails extends OperationDetails {
                 ? null
                 : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(getLastUpdatedDateTime()));
         jsonWriter.writeStringField("resourceLocation", getResourceLocation());
-        jsonWriter.writeStringField("kind", getKind());
         jsonWriter.writeNumberField("percentCompleted", getPercentCompleted());
         jsonWriter.writeStringField("apiVersion", getApiVersion());
         jsonWriter.writeMapField("tags", getTags(), (writer, element) -> writer.writeString(element));
         jsonWriter.writeJsonField("error", getError());
+        jsonWriter.writeStringField("kind", this.kind);
         jsonWriter.writeJsonField("result", this.result);
         return jsonWriter.writeEndObject();
     }
@@ -184,8 +198,6 @@ public final class DocumentModelBuildOperationDetails extends OperationDetails {
                         reader.getNullable(nonNullReader -> OffsetDateTime.parse(nonNullReader.getString())));
                 } else if ("resourceLocation".equals(fieldName)) {
                     deserializedDocumentModelBuildOperationDetails.setResourceLocation(reader.getString());
-                } else if ("kind".equals(fieldName)) {
-                    deserializedDocumentModelBuildOperationDetails.setKind(reader.getString());
                 } else if ("percentCompleted".equals(fieldName)) {
                     deserializedDocumentModelBuildOperationDetails
                         .setPercentCompleted(reader.getNullable(JsonReader::getInt));
@@ -196,6 +208,8 @@ public final class DocumentModelBuildOperationDetails extends OperationDetails {
                     deserializedDocumentModelBuildOperationDetails.setTags(tags);
                 } else if ("error".equals(fieldName)) {
                     deserializedDocumentModelBuildOperationDetails.setError(Error.fromJson(reader));
+                } else if ("kind".equals(fieldName)) {
+                    deserializedDocumentModelBuildOperationDetails.kind = reader.getString();
                 } else if ("result".equals(fieldName)) {
                     deserializedDocumentModelBuildOperationDetails.result = DocumentModelDetails.fromJson(reader);
                 } else {

--- a/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/DocumentModelComposeOperationDetails.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/DocumentModelComposeOperationDetails.java
@@ -19,6 +19,11 @@ import java.util.Map;
 @Fluent
 public final class DocumentModelComposeOperationDetails extends OperationDetails {
     /*
+     * Type of operation.
+     */
+    private String kind = "documentModelCompose";
+
+    /*
      * Operation result upon success.
      */
     private DocumentModelDetails result;
@@ -27,7 +32,16 @@ public final class DocumentModelComposeOperationDetails extends OperationDetails
      * Creates an instance of DocumentModelComposeOperationDetails class.
      */
     public DocumentModelComposeOperationDetails() {
-        setKind("documentModelCompose");
+    }
+
+    /**
+     * Get the kind property: Type of operation.
+     * 
+     * @return the kind value.
+     */
+    @Override
+    public String getKind() {
+        return this.kind;
     }
 
     /**
@@ -146,11 +160,11 @@ public final class DocumentModelComposeOperationDetails extends OperationDetails
                 ? null
                 : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(getLastUpdatedDateTime()));
         jsonWriter.writeStringField("resourceLocation", getResourceLocation());
-        jsonWriter.writeStringField("kind", getKind());
         jsonWriter.writeNumberField("percentCompleted", getPercentCompleted());
         jsonWriter.writeStringField("apiVersion", getApiVersion());
         jsonWriter.writeMapField("tags", getTags(), (writer, element) -> writer.writeString(element));
         jsonWriter.writeJsonField("error", getError());
+        jsonWriter.writeStringField("kind", this.kind);
         jsonWriter.writeJsonField("result", this.result);
         return jsonWriter.writeEndObject();
     }
@@ -184,8 +198,6 @@ public final class DocumentModelComposeOperationDetails extends OperationDetails
                         reader.getNullable(nonNullReader -> OffsetDateTime.parse(nonNullReader.getString())));
                 } else if ("resourceLocation".equals(fieldName)) {
                     deserializedDocumentModelComposeOperationDetails.setResourceLocation(reader.getString());
-                } else if ("kind".equals(fieldName)) {
-                    deserializedDocumentModelComposeOperationDetails.setKind(reader.getString());
                 } else if ("percentCompleted".equals(fieldName)) {
                     deserializedDocumentModelComposeOperationDetails
                         .setPercentCompleted(reader.getNullable(JsonReader::getInt));
@@ -196,6 +208,8 @@ public final class DocumentModelComposeOperationDetails extends OperationDetails
                     deserializedDocumentModelComposeOperationDetails.setTags(tags);
                 } else if ("error".equals(fieldName)) {
                     deserializedDocumentModelComposeOperationDetails.setError(Error.fromJson(reader));
+                } else if ("kind".equals(fieldName)) {
+                    deserializedDocumentModelComposeOperationDetails.kind = reader.getString();
                 } else if ("result".equals(fieldName)) {
                     deserializedDocumentModelComposeOperationDetails.result = DocumentModelDetails.fromJson(reader);
                 } else {

--- a/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/DocumentModelCopyToOperationDetails.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/DocumentModelCopyToOperationDetails.java
@@ -19,6 +19,11 @@ import java.util.Map;
 @Fluent
 public final class DocumentModelCopyToOperationDetails extends OperationDetails {
     /*
+     * Type of operation.
+     */
+    private String kind = "documentModelCopyTo";
+
+    /*
      * Operation result upon success.
      */
     private DocumentModelDetails result;
@@ -27,7 +32,16 @@ public final class DocumentModelCopyToOperationDetails extends OperationDetails 
      * Creates an instance of DocumentModelCopyToOperationDetails class.
      */
     public DocumentModelCopyToOperationDetails() {
-        setKind("documentModelCopyTo");
+    }
+
+    /**
+     * Get the kind property: Type of operation.
+     * 
+     * @return the kind value.
+     */
+    @Override
+    public String getKind() {
+        return this.kind;
     }
 
     /**
@@ -146,11 +160,11 @@ public final class DocumentModelCopyToOperationDetails extends OperationDetails 
                 ? null
                 : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(getLastUpdatedDateTime()));
         jsonWriter.writeStringField("resourceLocation", getResourceLocation());
-        jsonWriter.writeStringField("kind", getKind());
         jsonWriter.writeNumberField("percentCompleted", getPercentCompleted());
         jsonWriter.writeStringField("apiVersion", getApiVersion());
         jsonWriter.writeMapField("tags", getTags(), (writer, element) -> writer.writeString(element));
         jsonWriter.writeJsonField("error", getError());
+        jsonWriter.writeStringField("kind", this.kind);
         jsonWriter.writeJsonField("result", this.result);
         return jsonWriter.writeEndObject();
     }
@@ -184,8 +198,6 @@ public final class DocumentModelCopyToOperationDetails extends OperationDetails 
                         reader.getNullable(nonNullReader -> OffsetDateTime.parse(nonNullReader.getString())));
                 } else if ("resourceLocation".equals(fieldName)) {
                     deserializedDocumentModelCopyToOperationDetails.setResourceLocation(reader.getString());
-                } else if ("kind".equals(fieldName)) {
-                    deserializedDocumentModelCopyToOperationDetails.setKind(reader.getString());
                 } else if ("percentCompleted".equals(fieldName)) {
                     deserializedDocumentModelCopyToOperationDetails
                         .setPercentCompleted(reader.getNullable(JsonReader::getInt));
@@ -196,6 +208,8 @@ public final class DocumentModelCopyToOperationDetails extends OperationDetails 
                     deserializedDocumentModelCopyToOperationDetails.setTags(tags);
                 } else if ("error".equals(fieldName)) {
                     deserializedDocumentModelCopyToOperationDetails.setError(Error.fromJson(reader));
+                } else if ("kind".equals(fieldName)) {
+                    deserializedDocumentModelCopyToOperationDetails.kind = reader.getString();
                 } else if ("result".equals(fieldName)) {
                     deserializedDocumentModelCopyToOperationDetails.result = DocumentModelDetails.fromJson(reader);
                 } else {

--- a/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/OperationDetails.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/OperationDetails.java
@@ -86,17 +86,6 @@ public class OperationDetails implements JsonSerializable<OperationDetails> {
     }
 
     /**
-     * Set the kind property: Type of operation.
-     * 
-     * @param kind the kind value to set.
-     * @return the OperationDetails object itself.
-     */
-    protected OperationDetails setKind(String kind) {
-        this.kind = kind;
-        return this;
-    }
-
-    /**
      * Get the operationId property: Operation ID.
      * 
      * @return the operationId value.

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Cookiecuttershark.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Cookiecuttershark.java
@@ -18,11 +18,25 @@ import java.util.List;
  */
 @Fluent
 public final class Cookiecuttershark extends Shark {
+    /*
+     * The fishtype property.
+     */
+    private String fishtype = "cookiecuttershark";
+
     /**
      * Creates an instance of Cookiecuttershark class.
      */
     public Cookiecuttershark() {
-        setFishtype("cookiecuttershark");
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -79,10 +93,10 @@ public final class Cookiecuttershark extends Shark {
         jsonWriter.writeFloatField("length", getLength());
         jsonWriter.writeStringField("birthday",
             getBirthday() == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(getBirthday()));
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeNumberField("age", getAge());
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         return jsonWriter.writeEndObject();
     }
 
@@ -106,8 +120,6 @@ public final class Cookiecuttershark extends Shark {
                 } else if ("birthday".equals(fieldName)) {
                     deserializedCookiecuttershark.setBirthday(
                         reader.getNullable(nonNullReader -> OffsetDateTime.parse(nonNullReader.getString())));
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedCookiecuttershark.setFishtype(reader.getString());
                 } else if ("species".equals(fieldName)) {
                     deserializedCookiecuttershark.setSpecies(reader.getString());
                 } else if ("siblings".equals(fieldName)) {
@@ -115,6 +127,8 @@ public final class Cookiecuttershark extends Shark {
                     deserializedCookiecuttershark.setSiblings(siblings);
                 } else if ("age".equals(fieldName)) {
                     deserializedCookiecuttershark.setAge(reader.getNullable(JsonReader::getInt));
+                } else if ("fishtype".equals(fieldName)) {
+                    deserializedCookiecuttershark.fishtype = reader.getString();
                 } else {
                     reader.skipChildren();
                 }

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/DotFish.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/DotFish.java
@@ -43,17 +43,6 @@ public class DotFish implements JsonSerializable<DotFish> {
     }
 
     /**
-     * Set the fishType property: The fish.type property.
-     * 
-     * @param fishType the fishType value to set.
-     * @return the DotFish object itself.
-     */
-    protected DotFish setFishType(String fishType) {
-        this.fishType = fishType;
-        return this;
-    }
-
-    /**
      * Get the species property: The species property.
      * 
      * @return the species value.

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/DotSalmon.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/DotSalmon.java
@@ -18,6 +18,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @Fluent
 public final class DotSalmon extends DotFish {
     /*
+     * The fish.type property.
+     */
+    private String fishType = "DotSalmon";
+
+    /*
      * The location property.
      */
     private String location;
@@ -32,7 +37,16 @@ public final class DotSalmon extends DotFish {
      * Creates an instance of DotSalmon class.
      */
     public DotSalmon() {
-        setFishType("DotSalmon");
+    }
+
+    /**
+     * Get the fishType property: The fish.type property.
+     * 
+     * @return the fishType value.
+     */
+    @Override
+    public String getFishType() {
+        return this.fishType;
     }
 
     /**
@@ -89,8 +103,8 @@ public final class DotSalmon extends DotFish {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("fish.type", getFishType());
         jsonWriter.writeStringField("species", getSpecies());
+        jsonWriter.writeStringField("fish.type", this.fishType);
         jsonWriter.writeStringField("location", this.location);
         jsonWriter.writeBooleanField("iswild", this.isWild);
         return jsonWriter.writeEndObject();
@@ -110,10 +124,10 @@ public final class DotSalmon extends DotFish {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("fish.type".equals(fieldName)) {
-                    deserializedDotSalmon.setFishType(reader.getString());
-                } else if ("species".equals(fieldName)) {
+                if ("species".equals(fieldName)) {
                     deserializedDotSalmon.setSpecies(reader.getString());
+                } else if ("fish.type".equals(fieldName)) {
+                    deserializedDotSalmon.fishType = reader.getString();
                 } else if ("location".equals(fieldName)) {
                     deserializedDotSalmon.location = reader.getString();
                 } else if ("iswild".equals(fieldName)) {

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Fish.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Fish.java
@@ -54,17 +54,6 @@ public class Fish implements JsonSerializable<Fish> {
     }
 
     /**
-     * Set the fishtype property: The fishtype property.
-     * 
-     * @param fishtype the fishtype value to set.
-     * @return the Fish object itself.
-     */
-    protected Fish setFishtype(String fishtype) {
-        this.fishtype = fishtype;
-        return this;
-    }
-
-    /**
      * Get the species property: The species property.
      * 
      * @return the species value.

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/GoblinShark.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/GoblinShark.java
@@ -19,6 +19,11 @@ import java.util.List;
 @Fluent
 public final class GoblinShark extends Shark {
     /*
+     * The fishtype property.
+     */
+    private String fishtype = "goblin";
+
+    /*
      * The jawsize property.
      */
     private Integer jawsize;
@@ -32,7 +37,16 @@ public final class GoblinShark extends Shark {
      * Creates an instance of Goblinshark class.
      */
     public GoblinShark() {
-        setFishtype("goblin");
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -129,10 +143,10 @@ public final class GoblinShark extends Shark {
         jsonWriter.writeFloatField("length", getLength());
         jsonWriter.writeStringField("birthday",
             getBirthday() == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(getBirthday()));
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeNumberField("age", getAge());
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         jsonWriter.writeNumberField("jawsize", this.jawsize);
         jsonWriter.writeStringField("color", this.color == null ? null : this.color.toString());
         return jsonWriter.writeEndObject();
@@ -158,8 +172,6 @@ public final class GoblinShark extends Shark {
                 } else if ("birthday".equals(fieldName)) {
                     deserializedGoblinshark.setBirthday(
                         reader.getNullable(nonNullReader -> OffsetDateTime.parse(nonNullReader.getString())));
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedGoblinshark.setFishtype(reader.getString());
                 } else if ("species".equals(fieldName)) {
                     deserializedGoblinshark.setSpecies(reader.getString());
                 } else if ("siblings".equals(fieldName)) {
@@ -167,6 +179,8 @@ public final class GoblinShark extends Shark {
                     deserializedGoblinshark.setSiblings(siblings);
                 } else if ("age".equals(fieldName)) {
                     deserializedGoblinshark.setAge(reader.getNullable(JsonReader::getInt));
+                } else if ("fishtype".equals(fieldName)) {
+                    deserializedGoblinshark.fishtype = reader.getString();
                 } else if ("jawsize".equals(fieldName)) {
                     deserializedGoblinshark.jawsize = reader.getNullable(JsonReader::getInt);
                 } else if ("color".equals(fieldName)) {

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/MyBaseType.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/MyBaseType.java
@@ -48,17 +48,6 @@ public class MyBaseType implements JsonSerializable<MyBaseType> {
     }
 
     /**
-     * Set the kind property: The kind property.
-     * 
-     * @param kind the kind value to set.
-     * @return the MyBaseType object itself.
-     */
-    protected MyBaseType setKind(MyKind kind) {
-        this.kind = kind;
-        return this;
-    }
-
-    /**
      * Get the propB1 property: The propB1 property.
      * 
      * @return the propB1 value.

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/MyDerivedType.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/MyDerivedType.java
@@ -16,6 +16,11 @@ import java.io.IOException;
 @Fluent
 public final class MyDerivedType extends MyBaseType {
     /*
+     * The kind property.
+     */
+    private MyKind kind = MyKind.KIND1;
+
+    /*
      * The propD1 property.
      */
     private String propD1;
@@ -24,7 +29,16 @@ public final class MyDerivedType extends MyBaseType {
      * Creates an instance of MyDerivedType class.
      */
     public MyDerivedType() {
-        setKind(MyKind.KIND1);
+    }
+
+    /**
+     * Get the kind property: The kind property.
+     * 
+     * @return the kind value.
+     */
+    @Override
+    public MyKind getKind() {
+        return this.kind;
     }
 
     /**
@@ -71,8 +85,8 @@ public final class MyDerivedType extends MyBaseType {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("kind", getKind() == null ? null : getKind().toString());
         jsonWriter.writeStringField("propB1", getPropB1());
+        jsonWriter.writeStringField("kind", this.kind == null ? null : this.kind.toString());
         jsonWriter.writeStringField("propD1", this.propD1);
         if (getPropBH1() != null) {
             jsonWriter.writeStartObject("helper");
@@ -96,10 +110,10 @@ public final class MyDerivedType extends MyBaseType {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("kind".equals(fieldName)) {
-                    deserializedMyDerivedType.setKind(MyKind.fromString(reader.getString()));
-                } else if ("propB1".equals(fieldName)) {
+                if ("propB1".equals(fieldName)) {
                     deserializedMyDerivedType.setPropB1(reader.getString());
+                } else if ("kind".equals(fieldName)) {
+                    deserializedMyDerivedType.kind = MyKind.fromString(reader.getString());
                 } else if ("propD1".equals(fieldName)) {
                     deserializedMyDerivedType.propD1 = reader.getString();
                 } else if ("helper".equals(fieldName) && reader.currentToken() == JsonToken.START_OBJECT) {

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Salmon.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Salmon.java
@@ -17,6 +17,11 @@ import java.util.List;
 @Fluent
 public class Salmon extends Fish {
     /*
+     * The fishtype property.
+     */
+    private String fishtype = "salmon";
+
+    /*
      * The location property.
      */
     private String location;
@@ -30,7 +35,16 @@ public class Salmon extends Fish {
      * Creates an instance of Salmon class.
      */
     public Salmon() {
-        setFishtype("salmon");
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -107,9 +121,9 @@ public class Salmon extends Fish {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeFloatField("length", getLength());
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         jsonWriter.writeStringField("location", this.location);
         jsonWriter.writeBooleanField("iswild", this.iswild);
         return jsonWriter.writeEndObject();
@@ -157,13 +171,13 @@ public class Salmon extends Fish {
 
                 if ("length".equals(fieldName)) {
                     deserializedSalmon.setLength(reader.getFloat());
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedSalmon.setFishtype(reader.getString());
                 } else if ("species".equals(fieldName)) {
                     deserializedSalmon.setSpecies(reader.getString());
                 } else if ("siblings".equals(fieldName)) {
                     List<Fish> siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
                     deserializedSalmon.setSiblings(siblings);
+                } else if ("fishtype".equals(fieldName)) {
+                    deserializedSalmon.fishtype = reader.getString();
                 } else if ("location".equals(fieldName)) {
                     deserializedSalmon.location = reader.getString();
                 } else if ("iswild".equals(fieldName)) {

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Sawshark.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Sawshark.java
@@ -20,6 +20,11 @@ import java.util.List;
 @Fluent
 public final class Sawshark extends Shark {
     /*
+     * The fishtype property.
+     */
+    private String fishtype = "sawshark";
+
+    /*
      * The picture property.
      */
     private byte[] picture;
@@ -28,7 +33,16 @@ public final class Sawshark extends Shark {
      * Creates an instance of Sawshark class.
      */
     public Sawshark() {
-        setFishtype("sawshark");
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -105,10 +119,10 @@ public final class Sawshark extends Shark {
         jsonWriter.writeFloatField("length", getLength());
         jsonWriter.writeStringField("birthday",
             getBirthday() == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(getBirthday()));
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeNumberField("age", getAge());
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         jsonWriter.writeBinaryField("picture", this.picture);
         return jsonWriter.writeEndObject();
     }
@@ -133,8 +147,6 @@ public final class Sawshark extends Shark {
                 } else if ("birthday".equals(fieldName)) {
                     deserializedSawshark.setBirthday(
                         reader.getNullable(nonNullReader -> OffsetDateTime.parse(nonNullReader.getString())));
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedSawshark.setFishtype(reader.getString());
                 } else if ("species".equals(fieldName)) {
                     deserializedSawshark.setSpecies(reader.getString());
                 } else if ("siblings".equals(fieldName)) {
@@ -142,6 +154,8 @@ public final class Sawshark extends Shark {
                     deserializedSawshark.setSiblings(siblings);
                 } else if ("age".equals(fieldName)) {
                     deserializedSawshark.setAge(reader.getNullable(JsonReader::getInt));
+                } else if ("fishtype".equals(fieldName)) {
+                    deserializedSawshark.fishtype = reader.getString();
                 } else if ("picture".equals(fieldName)) {
                     deserializedSawshark.picture = reader.getBinary();
                 } else {

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Shark.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Shark.java
@@ -19,6 +19,11 @@ import java.util.List;
 @Fluent
 public class Shark extends Fish {
     /*
+     * The fishtype property.
+     */
+    private String fishtype = "shark";
+
+    /*
      * The age property.
      */
     private Integer age;
@@ -32,7 +37,16 @@ public class Shark extends Fish {
      * Creates an instance of Shark class.
      */
     public Shark() {
-        setFishtype("shark");
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -109,11 +123,11 @@ public class Shark extends Fish {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeFloatField("length", getLength());
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeStringField("birthday",
             this.birthday == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.birthday));
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         jsonWriter.writeNumberField("age", this.age);
         return jsonWriter.writeEndObject();
     }
@@ -164,8 +178,6 @@ public class Shark extends Fish {
 
                 if ("length".equals(fieldName)) {
                     deserializedShark.setLength(reader.getFloat());
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedShark.setFishtype(reader.getString());
                 } else if ("species".equals(fieldName)) {
                     deserializedShark.setSpecies(reader.getString());
                 } else if ("siblings".equals(fieldName)) {
@@ -174,6 +186,8 @@ public class Shark extends Fish {
                 } else if ("birthday".equals(fieldName)) {
                     deserializedShark.birthday
                         = reader.getNullable(nonNullReader -> OffsetDateTime.parse(nonNullReader.getString()));
+                } else if ("fishtype".equals(fieldName)) {
+                    deserializedShark.fishtype = reader.getString();
                 } else if ("age".equals(fieldName)) {
                     deserializedShark.age = reader.getNullable(JsonReader::getInt);
                 } else {

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/SmartSalmon.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/SmartSalmon.java
@@ -19,6 +19,11 @@ import java.util.Map;
 @Fluent
 public final class SmartSalmon extends Salmon {
     /*
+     * The fishtype property.
+     */
+    private String fishtype = "smart_salmon";
+
+    /*
      * The college_degree property.
      */
     private String collegeDegree;
@@ -32,7 +37,16 @@ public final class SmartSalmon extends Salmon {
      * Creates an instance of SmartSalmon class.
      */
     public SmartSalmon() {
-        setFishtype("smart_salmon");
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -127,11 +141,11 @@ public final class SmartSalmon extends Salmon {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeFloatField("length", getLength());
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeStringField("location", getLocation());
         jsonWriter.writeBooleanField("iswild", iswild());
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         jsonWriter.writeStringField("college_degree", this.collegeDegree);
         if (additionalProperties != null) {
             for (Map.Entry<String, Object> additionalProperty : additionalProperties.entrySet()) {
@@ -159,8 +173,6 @@ public final class SmartSalmon extends Salmon {
 
                 if ("length".equals(fieldName)) {
                     deserializedSmartSalmon.setLength(reader.getFloat());
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedSmartSalmon.setFishtype(reader.getString());
                 } else if ("species".equals(fieldName)) {
                     deserializedSmartSalmon.setSpecies(reader.getString());
                 } else if ("siblings".equals(fieldName)) {
@@ -170,6 +182,8 @@ public final class SmartSalmon extends Salmon {
                     deserializedSmartSalmon.setLocation(reader.getString());
                 } else if ("iswild".equals(fieldName)) {
                     deserializedSmartSalmon.setIswild(reader.getNullable(JsonReader::getBoolean));
+                } else if ("fishtype".equals(fieldName)) {
+                    deserializedSmartSalmon.fishtype = reader.getString();
                 } else if ("college_degree".equals(fieldName)) {
                     deserializedSmartSalmon.collegeDegree = reader.getString();
                 } else {

--- a/javagen/src/main/java/com/azure/autorest/implementation/ClientModelPropertiesManager.java
+++ b/javagen/src/main/java/com/azure/autorest/implementation/ClientModelPropertiesManager.java
@@ -136,9 +136,11 @@ public final class ClientModelPropertiesManager {
                 discriminatorProperty = new ClientModelPropertyWithMetadata(model, property, true);
             }
 
-            superPropertyConsumer(property, superRequiredProperties, superConstructorProperties,
-                superReadOnlyProperties, superSetterProperties, settings);
-            hasRequiredProperties |= property.isRequired();
+            if (!property.isPolymorphicDiscriminator()) {
+                superPropertyConsumer(property, superRequiredProperties, superConstructorProperties,
+                    superReadOnlyProperties, superSetterProperties, settings);
+                hasRequiredProperties |= property.isRequired();
+            }
 
             if (property.getNeedsFlatten()) {
                 flattenedProperties.put(property.getName(), new ClientModelPropertyWithMetadata(model, property, true));
@@ -170,14 +172,7 @@ public final class ClientModelPropertiesManager {
         readOnlyProperties = new LinkedHashMap<>();
         ClientModelProperty additionalProperties = null;
         for (ClientModelProperty property : model.getProperties()) {
-            if (property.isPolymorphicDiscriminator() && discriminatorProperty != null
-                && Objects.equals(discriminatorProperty.getProperty().getSerializedName(), property.getSerializedName())) {
-                // The super type has defined the discriminator property, don't include it in the models properties
-                // but override the property it's pointing to in the super properties. Overriding is needed to ensure
-                // the correct default value is used.
-                superPropertyConsumer(property, superRequiredProperties, superConstructorProperties,
-                    superReadOnlyProperties, superSetterProperties, settings);
-            } else if (property.isRequired()) {
+            if (property.isRequired()) {
                 hasRequiredProperties = true;
                 requiredProperties.put(property.getSerializedName(), property);
 

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -27,7 +27,6 @@ import com.azure.autorest.model.javamodel.JavaModifier;
 import com.azure.autorest.model.javamodel.JavaVisibility;
 import com.azure.autorest.template.util.ModelTemplateHeaderHelper;
 import com.azure.autorest.util.ClientModelUtil;
-import com.azure.autorest.util.CodeNamer;
 import com.azure.autorest.util.TemplateUtil;
 import com.azure.core.http.HttpHeader;
 import com.azure.core.util.CoreUtils;
@@ -587,11 +586,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                     // required, in which case the default value will be set in the constructor.
                     if (property.getDefaultValue() != null
                         && (!ClientModelUtil.includePropertyInConstructor(property, settings) || property.isConstant())) {
-                        if (property.isPolymorphicDiscriminator() && !settings.isStreamStyleSerialization()) {
-                            fieldSignature = propertyType + " " + CodeNamer.getEnumMemberName(propertyName) + " = " + property.getDefaultValue();
-                        } else {
-                            fieldSignature = propertyType + " " + propertyName + " = " + property.getDefaultValue();
-                        }
+                        fieldSignature = propertyType + " " + propertyName + " = " + property.getDefaultValue();
                     } else {
                         fieldSignature = propertyType + " " + propertyName;
                     }

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -214,10 +214,8 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                         settings);
                     boolean definedByModel = modelDefinesProperty(model, property);
                     if (hasDerivedTypes && notIncludedInConstructor && definedByModel
-                        && (settings.isStreamStyleSerialization() || property.isPolymorphicDiscriminator())) {
-                        // Super class and child classes may be in different packages.
-                        // Since we call polymorphic setter in child classes' constructor, we need the setter to be visibility of protected.
-                        methodVisibility = property.isPolymorphicDiscriminator() ? JavaVisibility.Protected : JavaVisibility.PackagePrivate;
+                        && (streamStyle || property.isPolymorphicDiscriminator())) {
+                        methodVisibility = /*property.isPolymorphicDiscriminator() ? JavaVisibility.Protected : */JavaVisibility.PackagePrivate;
                         generateSetterJavadoc(classBlock, model, property);
                         addGeneratedAnnotation(classBlock);
                         classBlock.method(methodVisibility, null,
@@ -829,9 +827,10 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
 
                 if (modelDefinesProperty(model, polymorphicProperty)) {
                     constructor.line("this." + polymorphicProperty.getName() + " = " + discriminatorValue + ";");
-                } else {
-                    constructor.line(polymorphicProperty.getSetterName() + "(" + discriminatorValue + ");");
                 }
+//                else {
+//                    constructor.line(polymorphicProperty.getSetterName() + "(" + discriminatorValue + ");");
+//                }
             }
 
             // constant properties should already be initialized in class variable definition

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -571,11 +571,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                     // required, in which case the default value will be set in the constructor.
                     if (property.getDefaultValue() != null
                         && (!ClientModelUtil.includePropertyInConstructor(property, settings) || property.isConstant())) {
-                        if (property.isPolymorphicDiscriminator() && !settings.isStreamStyleSerialization()) {
-                            fieldSignature = propertyType + " " + CodeNamer.getEnumMemberName(propertyName) + " = " + property.getDefaultValue();
-                        } else {
-                            fieldSignature = propertyType + " " + propertyName + " = " + property.getDefaultValue();
-                        }
+                        fieldSignature = propertyType + " " + propertyName + " = " + property.getDefaultValue();
                     } else {
                         fieldSignature = propertyType + " " + propertyName;
                     }

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -179,10 +179,13 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
 
                 // getter method of discriminator property in subclass is handled differently
                 final boolean polymorphicDiscriminatorInSubclass = property.isPolymorphicDiscriminator() && !modelDefinesProperty(model, property);
-                if (polymorphicDiscriminatorInSubclass && !settings.isStreamStyleSerialization()) {
-                    // add JsonTypeId and JsonProperty annotations to the getter method
-                    // so that this getter method in subclass would override Jackson's handling of the discriminator property in superclass
-                    addFieldAnnotations(model, property, classBlock, settings);
+                if (polymorphicDiscriminatorInSubclass) {
+                    classBlock.annotation("Override");
+                    if (!settings.isStreamStyleSerialization()) {
+                        // add JsonTypeId and JsonProperty annotations to the getter method
+                        // so that this getter method in subclass would override Jackson's handling of the discriminator property in superclass
+                        addFieldAnnotations(model, property, classBlock, settings);
+                    }
                 }
                 classBlock.method(methodVisibility, null,
                     propertyClientType + " " + getGetterName(model, property) + "()",

--- a/typespec-tests/Generate.ps1
+++ b/typespec-tests/Generate.ps1
@@ -58,7 +58,7 @@ $generateScript = {
     $tspOptions += " --option ""@azure-tools/typespec-java.customization-class=../../customization/src/main/java/CustomizationEncodeBytes.java"""
   } elseif ($tspFile -match "type[\\/]model[\\/]inheritance[\\/]nested-discriminator[\\/]main.tsp") {
     # nested discriminator is not supported
-    $tspOptions += " --option ""@azure-tools/typespec-java.customization-class=../../customization/src/main/java/CustomizationGoblinShark.java"""
+    $tspOptions += " --option ""@azure-tools/typespec-java.customization-class=../../customization/src/main/java/CustomizationNestedDiscriminator.java"""
   }
 
   $tspTrace = "--trace import-resolution --trace projection --trace typespec-java"

--- a/typespec-tests/Generate.ps1
+++ b/typespec-tests/Generate.ps1
@@ -56,6 +56,9 @@ $generateScript = {
     $tspOptions += " --option ""@azure-tools/typespec-java.customization-class=../../customization/src/main/java/CustomizationTest.java"""
   } elseif ($tspFile -match "encode[\\/]bytes[\\/]main.tsp") {
     $tspOptions += " --option ""@azure-tools/typespec-java.customization-class=../../customization/src/main/java/CustomizationEncodeBytes.java"""
+  } elseif ($tspFile -match "type[\\/]model[\\/]inheritance[\\/]nested-discriminator[\\/]main.tsp") {
+    # nested discriminator is not supported
+    $tspOptions += " --option ""@azure-tools/typespec-java.customization-class=../../customization/src/main/java/CustomizationGoblinShark.java"""
   }
 
   $tspTrace = "--trace import-resolution --trace projection --trace typespec-java"

--- a/typespec-tests/customization/src/main/java/CustomizationEncodeBytes.java
+++ b/typespec-tests/customization/src/main/java/CustomizationEncodeBytes.java
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import com.azure.autorest.customization.ClassCustomization;
-import com.azure.autorest.customization.ConstructorCustomization;
 import com.azure.autorest.customization.Customization;
 import com.azure.autorest.customization.LibraryCustomization;
 import com.azure.autorest.customization.PackageCustomization;

--- a/typespec-tests/customization/src/main/java/CustomizationGoblinShark.java
+++ b/typespec-tests/customization/src/main/java/CustomizationGoblinShark.java
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import com.azure.autorest.customization.ClassCustomization;
+import com.azure.autorest.customization.ConstructorCustomization;
+import com.azure.autorest.customization.Customization;
+import com.azure.autorest.customization.LibraryCustomization;
+import com.azure.autorest.customization.PackageCustomization;
+import org.slf4j.Logger;
+
+/**
+ * This class contains the customization code to customize the AutoRest generated code for App Configuration.
+ */
+public class CustomizationGoblinShark extends Customization {
+
+    @Override
+    public void customize(LibraryCustomization customization, Logger logger) {
+        logger.info("Customizing the Base64urlArrayBytesProperty");
+
+        PackageCustomization packageCustomization = customization.getPackage("com.type.model.inheritance.nesteddiscriminator.models");
+        ClassCustomization classCustomization = packageCustomization.getClass("GoblinShark");
+
+        ConstructorCustomization constructorCustomization = classCustomization.getConstructor("GoblinShark");
+        constructorCustomization.replaceBody("super(age, sharktype); this.sharktype = \"goblin\";");
+    }
+}

--- a/typespec-tests/customization/src/main/java/CustomizationNestedDiscriminator.java
+++ b/typespec-tests/customization/src/main/java/CustomizationNestedDiscriminator.java
@@ -11,7 +11,7 @@ import org.slf4j.Logger;
 /**
  * This class contains the customization code to customize the AutoRest generated code for App Configuration.
  */
-public class CustomizationGoblinShark extends Customization {
+public class CustomizationNestedDiscriminator extends Customization {
 
     @Override
     public void customize(LibraryCustomization customization, Logger logger) {
@@ -22,5 +22,10 @@ public class CustomizationGoblinShark extends Customization {
 
         ConstructorCustomization constructorCustomization = classCustomization.getConstructor("GoblinShark");
         constructorCustomization.replaceBody("super(age, sharktype); this.sharktype = \"goblin\";");
+
+        classCustomization = packageCustomization.getClass("SawShark");
+
+        constructorCustomization = classCustomization.getConstructor("SawShark");
+        constructorCustomization.replaceBody("super(age, sharktype); this.sharktype = \"saw\";");
     }
 }

--- a/typespec-tests/customization/src/main/java/CustomizationTest.java
+++ b/typespec-tests/customization/src/main/java/CustomizationTest.java
@@ -2,11 +2,6 @@ import com.azure.autorest.customization.ClassCustomization;
 import com.azure.autorest.customization.Customization;
 import com.azure.autorest.customization.LibraryCustomization;
 import com.azure.autorest.customization.PackageCustomization;
-import com.github.javaparser.StaticJavaParser;
-import com.github.javaparser.ast.Modifier;
-import com.github.javaparser.ast.NodeList;
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import com.github.javaparser.ast.stmt.BlockStmt;
 import org.slf4j.Logger;
 
 import java.util.Arrays;

--- a/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/access/implementation/models/AbstractModel.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/access/implementation/models/AbstractModel.java
@@ -51,18 +51,6 @@ public class AbstractModel implements JsonSerializable<AbstractModel> {
     }
 
     /**
-     * Set the kind property: The kind property.
-     * 
-     * @param kind the kind value to set.
-     * @return the AbstractModel object itself.
-     */
-    @Generated
-    protected AbstractModel setKind(String kind) {
-        this.kind = kind;
-        return this;
-    }
-
-    /**
      * Get the name property: The name property.
      * 
      * @return the name value.

--- a/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/access/implementation/models/RealModel.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/access/implementation/models/RealModel.java
@@ -16,6 +16,12 @@ import java.io.IOException;
  */
 @Immutable
 public final class RealModel extends AbstractModel {
+    /*
+     * The kind property.
+     */
+    @Generated
+    private String kind = "real";
+
     /**
      * Creates an instance of RealModel class.
      * 
@@ -24,7 +30,17 @@ public final class RealModel extends AbstractModel {
     @Generated
     private RealModel(String name) {
         super(name);
-        setKind("real");
+    }
+
+    /**
+     * Get the kind property: The kind property.
+     * 
+     * @return the kind value.
+     */
+    @Generated
+    @Override
+    public String getKind() {
+        return this.kind;
     }
 
     /**
@@ -35,7 +51,7 @@ public final class RealModel extends AbstractModel {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeStringField("name", getName());
-        jsonWriter.writeStringField("kind", getKind());
+        jsonWriter.writeStringField("kind", this.kind);
         return jsonWriter.writeEndObject();
     }
 
@@ -65,7 +81,7 @@ public final class RealModel extends AbstractModel {
                 }
             }
             RealModel deserializedRealModel = new RealModel(name);
-            deserializedRealModel.setKind(kind);
+            deserializedRealModel.kind = kind;
 
             return deserializedRealModel;
         });

--- a/typespec-tests/src/main/java/com/cadl/naming/models/BytesData.java
+++ b/typespec-tests/src/main/java/com/cadl/naming/models/BytesData.java
@@ -18,6 +18,12 @@ import java.io.IOException;
 @Immutable
 public final class BytesData extends Data {
     /*
+     * The @data.kind property.
+     */
+    @Generated
+    private String type = "bytes";
+
+    /*
      * Data as {@code byte[]}
      */
     @Generated
@@ -30,8 +36,18 @@ public final class BytesData extends Data {
      */
     @Generated
     private BytesData(byte[] dataAsBytes) {
-        setType("bytes");
         this.dataAsBytes = dataAsBytes;
+    }
+
+    /**
+     * Get the type property: The &#064;data.kind property.
+     * 
+     * @return the type value.
+     */
+    @Generated
+    @Override
+    public String getType() {
+        return this.type;
     }
 
     /**
@@ -51,8 +67,8 @@ public final class BytesData extends Data {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("@data.kind", getType());
         jsonWriter.writeBinaryField("data_bytes", this.dataAsBytes);
+        jsonWriter.writeStringField("@data.kind", this.type);
         return jsonWriter.writeEndObject();
     }
 
@@ -67,22 +83,22 @@ public final class BytesData extends Data {
     @Generated
     public static BytesData fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
-            String type = "bytes";
             byte[] dataAsBytes = null;
+            String type = "bytes";
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("@data.kind".equals(fieldName)) {
-                    type = reader.getString();
-                } else if ("data_bytes".equals(fieldName)) {
+                if ("data_bytes".equals(fieldName)) {
                     dataAsBytes = reader.getBinary();
+                } else if ("@data.kind".equals(fieldName)) {
+                    type = reader.getString();
                 } else {
                     reader.skipChildren();
                 }
             }
             BytesData deserializedBytesData = new BytesData(dataAsBytes);
-            deserializedBytesData.setType(type);
+            deserializedBytesData.type = type;
 
             return deserializedBytesData;
         });

--- a/typespec-tests/src/main/java/com/cadl/naming/models/Data.java
+++ b/typespec-tests/src/main/java/com/cadl/naming/models/Data.java
@@ -42,18 +42,6 @@ public class Data implements JsonSerializable<Data> {
     }
 
     /**
-     * Set the type property: The &#064;data.kind property.
-     * 
-     * @param type the type value to set.
-     * @return the Data object itself.
-     */
-    @Generated
-    protected Data setType(String type) {
-        this.type = type;
-        return this;
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Generated

--- a/typespec-tests/src/main/java/com/cadl/patch/models/Fish.java
+++ b/typespec-tests/src/main/java/com/cadl/patch/models/Fish.java
@@ -90,19 +90,6 @@ public class Fish implements JsonSerializable<Fish> {
     }
 
     /**
-     * Set the kind property: The kind property.
-     * 
-     * @param kind the kind value to set.
-     * @return the Fish object itself.
-     */
-    @Generated
-    protected Fish setKind(String kind) {
-        this.kind = kind;
-        this.updatedProperties.add("kind");
-        return this;
-    }
-
-    /**
      * Get the id property: The id property.
      * 
      * @return the id value.

--- a/typespec-tests/src/main/java/com/cadl/patch/models/Salmon.java
+++ b/typespec-tests/src/main/java/com/cadl/patch/models/Salmon.java
@@ -22,6 +22,12 @@ import java.util.Set;
 @Fluent
 public final class Salmon extends Fish {
     /*
+     * The kind property.
+     */
+    @Generated
+    private String kind = "salmon";
+
+    /*
      * The friends property.
      */
     @Generated
@@ -65,7 +71,17 @@ public final class Salmon extends Fish {
      */
     @Generated
     public Salmon() {
-        setKind("salmon");
+    }
+
+    /**
+     * Get the kind property: The kind property.
+     * 
+     * @return the kind value.
+     */
+    @Generated
+    @Override
+    public String getKind() {
+        return this.kind;
     }
 
     /**
@@ -169,9 +185,9 @@ public final class Salmon extends Fish {
             return toJsonMergePatch(jsonWriter);
         } else {
             jsonWriter.writeStartObject();
-            jsonWriter.writeStringField("kind", getKind());
             jsonWriter.writeIntField("age", getAge());
             jsonWriter.writeStringField("color", getColor());
+            jsonWriter.writeStringField("kind", this.kind);
             jsonWriter.writeArrayField("friends", this.friends, (writer, element) -> writer.writeJson(element));
             jsonWriter.writeMapField("hate", this.hate, (writer, element) -> writer.writeJson(element));
             jsonWriter.writeJsonField("partner", this.partner);
@@ -182,19 +198,19 @@ public final class Salmon extends Fish {
     @Generated
     private JsonWriter toJsonMergePatch(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        if (updatedProperties.contains("kind")) {
-            if (getKind() == null) {
-                jsonWriter.writeNullField("kind");
-            } else {
-                jsonWriter.writeStringField("kind", getKind());
-            }
-        }
         jsonWriter.writeIntField("age", getAge());
         if (updatedProperties.contains("color")) {
             if (getColor() == null) {
                 jsonWriter.writeNullField("color");
             } else {
                 jsonWriter.writeStringField("color", getColor());
+            }
+        }
+        if (updatedProperties.contains("kind")) {
+            if (this.kind == null) {
+                jsonWriter.writeNullField("kind");
+            } else {
+                jsonWriter.writeStringField("kind", this.kind);
             }
         }
         if (updatedProperties.contains("friends")) {
@@ -244,9 +260,9 @@ public final class Salmon extends Fish {
         return jsonReader.readObject(reader -> {
             String id = null;
             String name = null;
-            String kind = "salmon";
             int age = 0;
             String color = null;
+            String kind = "salmon";
             List<Fish> friends = null;
             Map<String, Fish> hate = null;
             Fish partner = null;
@@ -258,12 +274,12 @@ public final class Salmon extends Fish {
                     id = reader.getString();
                 } else if ("name".equals(fieldName)) {
                     name = reader.getString();
-                } else if ("kind".equals(fieldName)) {
-                    kind = reader.getString();
                 } else if ("age".equals(fieldName)) {
                     age = reader.getInt();
                 } else if ("color".equals(fieldName)) {
                     color = reader.getString();
+                } else if ("kind".equals(fieldName)) {
+                    kind = reader.getString();
                 } else if ("friends".equals(fieldName)) {
                     friends = reader.readArray(reader1 -> Fish.fromJson(reader1));
                 } else if ("hate".equals(fieldName)) {
@@ -277,9 +293,9 @@ public final class Salmon extends Fish {
             Salmon deserializedSalmon = new Salmon();
             deserializedSalmon.setId(id);
             deserializedSalmon.setName(name);
-            deserializedSalmon.setKind(kind);
             deserializedSalmon.setAge(age);
             deserializedSalmon.setColor(color);
+            deserializedSalmon.kind = kind;
             deserializedSalmon.friends = friends;
             deserializedSalmon.hate = hate;
             deserializedSalmon.partner = partner;

--- a/typespec-tests/src/main/java/com/cadl/patch/models/Shark.java
+++ b/typespec-tests/src/main/java/com/cadl/patch/models/Shark.java
@@ -19,6 +19,12 @@ import java.util.Set;
  */
 @Fluent
 public final class Shark extends Fish {
+    /*
+     * The kind property.
+     */
+    @Generated
+    private String kind = "shark";
+
     @Generated
     private boolean jsonMergePatch;
 
@@ -45,7 +51,17 @@ public final class Shark extends Fish {
      */
     @Generated
     public Shark() {
-        setKind("shark");
+    }
+
+    /**
+     * Get the kind property: The kind property.
+     * 
+     * @return the kind value.
+     */
+    @Generated
+    @Override
+    public String getKind() {
+        return this.kind;
     }
 
     /**
@@ -80,9 +96,9 @@ public final class Shark extends Fish {
             return toJsonMergePatch(jsonWriter);
         } else {
             jsonWriter.writeStartObject();
-            jsonWriter.writeStringField("kind", getKind());
             jsonWriter.writeIntField("age", getAge());
             jsonWriter.writeStringField("color", getColor());
+            jsonWriter.writeStringField("kind", this.kind);
             return jsonWriter.writeEndObject();
         }
     }
@@ -90,19 +106,19 @@ public final class Shark extends Fish {
     @Generated
     private JsonWriter toJsonMergePatch(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        if (updatedProperties.contains("kind")) {
-            if (getKind() == null) {
-                jsonWriter.writeNullField("kind");
-            } else {
-                jsonWriter.writeStringField("kind", getKind());
-            }
-        }
         jsonWriter.writeIntField("age", getAge());
         if (updatedProperties.contains("color")) {
             if (getColor() == null) {
                 jsonWriter.writeNullField("color");
             } else {
                 jsonWriter.writeStringField("color", getColor());
+            }
+        }
+        if (updatedProperties.contains("kind")) {
+            if (this.kind == null) {
+                jsonWriter.writeNullField("kind");
+            } else {
+                jsonWriter.writeStringField("kind", this.kind);
             }
         }
         return jsonWriter.writeEndObject();
@@ -121,9 +137,9 @@ public final class Shark extends Fish {
         return jsonReader.readObject(reader -> {
             String id = null;
             String name = null;
-            String kind = "shark";
             int age = 0;
             String color = null;
+            String kind = "shark";
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
@@ -132,12 +148,12 @@ public final class Shark extends Fish {
                     id = reader.getString();
                 } else if ("name".equals(fieldName)) {
                     name = reader.getString();
-                } else if ("kind".equals(fieldName)) {
-                    kind = reader.getString();
                 } else if ("age".equals(fieldName)) {
                     age = reader.getInt();
                 } else if ("color".equals(fieldName)) {
                     color = reader.getString();
+                } else if ("kind".equals(fieldName)) {
+                    kind = reader.getString();
                 } else {
                     reader.skipChildren();
                 }
@@ -145,9 +161,9 @@ public final class Shark extends Fish {
             Shark deserializedShark = new Shark();
             deserializedShark.setId(id);
             deserializedShark.setName(name);
-            deserializedShark.setKind(kind);
             deserializedShark.setAge(age);
             deserializedShark.setColor(color);
+            deserializedShark.kind = kind;
 
             return deserializedShark;
         });

--- a/typespec-tests/src/main/java/com/type/model/inheritance/enumdiscriminator/models/Cobra.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/enumdiscriminator/models/Cobra.java
@@ -16,6 +16,12 @@ import java.io.IOException;
  */
 @Immutable
 public final class Cobra extends Snake {
+    /*
+     * discriminator property
+     */
+    @Generated
+    private SnakeKind kind = SnakeKind.COBRA;
+
     /**
      * Creates an instance of Cobra class.
      * 
@@ -24,7 +30,17 @@ public final class Cobra extends Snake {
     @Generated
     public Cobra(int length) {
         super(length);
-        setKind(SnakeKind.COBRA);
+    }
+
+    /**
+     * Get the kind property: discriminator property.
+     * 
+     * @return the kind value.
+     */
+    @Generated
+    @Override
+    public SnakeKind getKind() {
+        return this.kind;
     }
 
     /**
@@ -35,7 +51,7 @@ public final class Cobra extends Snake {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeIntField("length", getLength());
-        jsonWriter.writeStringField("kind", getKind() == null ? null : getKind().toString());
+        jsonWriter.writeStringField("kind", this.kind == null ? null : this.kind.toString());
         return jsonWriter.writeEndObject();
     }
 
@@ -65,7 +81,7 @@ public final class Cobra extends Snake {
                 }
             }
             Cobra deserializedCobra = new Cobra(length);
-            deserializedCobra.setKind(kind);
+            deserializedCobra.kind = kind;
 
             return deserializedCobra;
         });

--- a/typespec-tests/src/main/java/com/type/model/inheritance/enumdiscriminator/models/Dog.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/enumdiscriminator/models/Dog.java
@@ -51,18 +51,6 @@ public class Dog implements JsonSerializable<Dog> {
     }
 
     /**
-     * Set the kind property: discriminator property.
-     * 
-     * @param kind the kind value to set.
-     * @return the Dog object itself.
-     */
-    @Generated
-    protected Dog setKind(DogKind kind) {
-        this.kind = kind;
-        return this;
-    }
-
-    /**
      * Get the weight property: Weight of the dog.
      * 
      * @return the weight value.

--- a/typespec-tests/src/main/java/com/type/model/inheritance/enumdiscriminator/models/Golden.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/enumdiscriminator/models/Golden.java
@@ -16,6 +16,12 @@ import java.io.IOException;
  */
 @Immutable
 public final class Golden extends Dog {
+    /*
+     * discriminator property
+     */
+    @Generated
+    private DogKind kind = DogKind.GOLDEN;
+
     /**
      * Creates an instance of Golden class.
      * 
@@ -24,7 +30,17 @@ public final class Golden extends Dog {
     @Generated
     public Golden(int weight) {
         super(weight);
-        setKind(DogKind.GOLDEN);
+    }
+
+    /**
+     * Get the kind property: discriminator property.
+     * 
+     * @return the kind value.
+     */
+    @Generated
+    @Override
+    public DogKind getKind() {
+        return this.kind;
     }
 
     /**
@@ -35,7 +51,7 @@ public final class Golden extends Dog {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeIntField("weight", getWeight());
-        jsonWriter.writeStringField("kind", getKind() == null ? null : getKind().toString());
+        jsonWriter.writeStringField("kind", this.kind == null ? null : this.kind.toString());
         return jsonWriter.writeEndObject();
     }
 
@@ -65,7 +81,7 @@ public final class Golden extends Dog {
                 }
             }
             Golden deserializedGolden = new Golden(weight);
-            deserializedGolden.setKind(kind);
+            deserializedGolden.kind = kind;
 
             return deserializedGolden;
         });

--- a/typespec-tests/src/main/java/com/type/model/inheritance/enumdiscriminator/models/Snake.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/enumdiscriminator/models/Snake.java
@@ -51,18 +51,6 @@ public class Snake implements JsonSerializable<Snake> {
     }
 
     /**
-     * Set the kind property: discriminator property.
-     * 
-     * @param kind the kind value to set.
-     * @return the Snake object itself.
-     */
-    @Generated
-    protected Snake setKind(SnakeKind kind) {
-        this.kind = kind;
-        return this;
-    }
-
-    /**
      * Get the length property: Length of the snake.
      * 
      * @return the length value.

--- a/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/Fish.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/Fish.java
@@ -51,18 +51,6 @@ public class Fish implements JsonSerializable<Fish> {
     }
 
     /**
-     * Set the kind property: The kind property.
-     * 
-     * @param kind the kind value to set.
-     * @return the Fish object itself.
-     */
-    @Generated
-    protected Fish setKind(String kind) {
-        this.kind = kind;
-        return this;
-    }
-
-    /**
      * Get the age property: The age property.
      * 
      * @return the age value.

--- a/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/GoblinShark.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/GoblinShark.java
@@ -16,6 +16,12 @@ import java.io.IOException;
  */
 @Immutable
 public final class GoblinShark extends Shark {
+    /*
+     * The sharktype property.
+     */
+    @Generated
+    private final String sharktype;
+
     /**
      * Creates an instance of GoblinShark class.
      * 
@@ -28,6 +34,17 @@ public final class GoblinShark extends Shark {
     }
 
     /**
+     * Get the sharktype property: The sharktype property.
+     * 
+     * @return the sharktype value.
+     */
+    @Generated
+    @Override
+    public String getSharktype() {
+        return this.sharktype;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Generated
@@ -35,8 +52,7 @@ public final class GoblinShark extends Shark {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeIntField("age", getAge());
-        jsonWriter.writeStringField("sharktype", getSharktype());
-        jsonWriter.writeStringField("kind", getKind());
+        jsonWriter.writeStringField("sharktype", this.sharktype);
         return jsonWriter.writeEndObject();
     }
 
@@ -53,7 +69,6 @@ public final class GoblinShark extends Shark {
         return jsonReader.readObject(reader -> {
             int age = 0;
             String sharktype = "goblin";
-            String kind = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
@@ -62,16 +77,11 @@ public final class GoblinShark extends Shark {
                     age = reader.getInt();
                 } else if ("sharktype".equals(fieldName)) {
                     sharktype = reader.getString();
-                } else if ("kind".equals(fieldName)) {
-                    kind = reader.getString();
                 } else {
                     reader.skipChildren();
                 }
             }
-            GoblinShark deserializedGoblinShark = new GoblinShark(age, sharktype);
-            deserializedGoblinShark.setKind(kind);
-
-            return deserializedGoblinShark;
+            return new GoblinShark(age, sharktype);
         });
     }
 }

--- a/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/GoblinShark.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/GoblinShark.java
@@ -31,6 +31,7 @@ public final class GoblinShark extends Shark {
     @Generated
     public GoblinShark(int age, String sharktype) {
         super(age, sharktype);
+        this.sharktype = "goblin";
     }
 
     /**

--- a/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/Salmon.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/Salmon.java
@@ -19,6 +19,12 @@ import java.util.Map;
 @Fluent
 public final class Salmon extends Fish {
     /*
+     * The kind property.
+     */
+    @Generated
+    private String kind = "salmon";
+
+    /*
      * The friends property.
      */
     @Generated
@@ -44,7 +50,17 @@ public final class Salmon extends Fish {
     @Generated
     public Salmon(int age) {
         super(age);
-        setKind("salmon");
+    }
+
+    /**
+     * Get the kind property: The kind property.
+     * 
+     * @return the kind value.
+     */
+    @Generated
+    @Override
+    public String getKind() {
+        return this.kind;
     }
 
     /**
@@ -121,7 +137,7 @@ public final class Salmon extends Fish {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeIntField("age", getAge());
-        jsonWriter.writeStringField("kind", getKind());
+        jsonWriter.writeStringField("kind", this.kind);
         jsonWriter.writeArrayField("friends", this.friends, (writer, element) -> writer.writeJson(element));
         jsonWriter.writeMapField("hate", this.hate, (writer, element) -> writer.writeJson(element));
         jsonWriter.writeJsonField("partner", this.partner);
@@ -163,7 +179,7 @@ public final class Salmon extends Fish {
                 }
             }
             Salmon deserializedSalmon = new Salmon(age);
-            deserializedSalmon.setKind(kind);
+            deserializedSalmon.kind = kind;
             deserializedSalmon.friends = friends;
             deserializedSalmon.hate = hate;
             deserializedSalmon.partner = partner;

--- a/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/SawShark.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/SawShark.java
@@ -31,6 +31,7 @@ public final class SawShark extends Shark {
     @Generated
     public SawShark(int age, String sharktype) {
         super(age, sharktype);
+        this.sharktype = "saw";
     }
 
     /**

--- a/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/SawShark.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/SawShark.java
@@ -16,6 +16,12 @@ import java.io.IOException;
  */
 @Immutable
 public final class SawShark extends Shark {
+    /*
+     * The sharktype property.
+     */
+    @Generated
+    private final String sharktype;
+
     /**
      * Creates an instance of SawShark class.
      * 
@@ -28,6 +34,17 @@ public final class SawShark extends Shark {
     }
 
     /**
+     * Get the sharktype property: The sharktype property.
+     * 
+     * @return the sharktype value.
+     */
+    @Generated
+    @Override
+    public String getSharktype() {
+        return this.sharktype;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Generated
@@ -35,8 +52,7 @@ public final class SawShark extends Shark {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeIntField("age", getAge());
-        jsonWriter.writeStringField("sharktype", getSharktype());
-        jsonWriter.writeStringField("kind", getKind());
+        jsonWriter.writeStringField("sharktype", this.sharktype);
         return jsonWriter.writeEndObject();
     }
 
@@ -53,7 +69,6 @@ public final class SawShark extends Shark {
         return jsonReader.readObject(reader -> {
             int age = 0;
             String sharktype = "saw";
-            String kind = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
@@ -62,16 +77,11 @@ public final class SawShark extends Shark {
                     age = reader.getInt();
                 } else if ("sharktype".equals(fieldName)) {
                     sharktype = reader.getString();
-                } else if ("kind".equals(fieldName)) {
-                    kind = reader.getString();
                 } else {
                     reader.skipChildren();
                 }
             }
-            SawShark deserializedSawShark = new SawShark(age, sharktype);
-            deserializedSawShark.setKind(kind);
-
-            return deserializedSawShark;
+            return new SawShark(age, sharktype);
         });
     }
 }

--- a/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/Shark.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/Shark.java
@@ -52,7 +52,6 @@ public class Shark extends Fish {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeIntField("age", getAge());
-        jsonWriter.writeStringField("kind", getKind());
         jsonWriter.writeStringField("sharktype", this.sharktype);
         return jsonWriter.writeEndObject();
     }
@@ -97,7 +96,6 @@ public class Shark extends Fish {
     static Shark fromJsonKnownDiscriminator(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
             int age = 0;
-            String kind = null;
             String sharktype = "shark";
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();
@@ -105,18 +103,13 @@ public class Shark extends Fish {
 
                 if ("age".equals(fieldName)) {
                     age = reader.getInt();
-                } else if ("kind".equals(fieldName)) {
-                    kind = reader.getString();
                 } else if ("sharktype".equals(fieldName)) {
                     sharktype = reader.getString();
                 } else {
                     reader.skipChildren();
                 }
             }
-            Shark deserializedShark = new Shark(age, sharktype);
-            deserializedShark.setKind(kind);
-
-            return deserializedShark;
+            return new Shark(age, sharktype);
         });
     }
 }

--- a/typespec-tests/src/main/java/com/type/model/inheritance/singlediscriminator/models/Bird.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/singlediscriminator/models/Bird.java
@@ -51,18 +51,6 @@ public class Bird implements JsonSerializable<Bird> {
     }
 
     /**
-     * Set the kind property: The kind property.
-     * 
-     * @param kind the kind value to set.
-     * @return the Bird object itself.
-     */
-    @Generated
-    protected Bird setKind(String kind) {
-        this.kind = kind;
-        return this;
-    }
-
-    /**
      * Get the wingspan property: The wingspan property.
      * 
      * @return the wingspan value.

--- a/typespec-tests/src/main/java/com/type/model/inheritance/singlediscriminator/models/Dinosaur.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/singlediscriminator/models/Dinosaur.java
@@ -51,18 +51,6 @@ public class Dinosaur implements JsonSerializable<Dinosaur> {
     }
 
     /**
-     * Set the kind property: The kind property.
-     * 
-     * @param kind the kind value to set.
-     * @return the Dinosaur object itself.
-     */
-    @Generated
-    protected Dinosaur setKind(String kind) {
-        this.kind = kind;
-        return this;
-    }
-
-    /**
      * Get the size property: The size property.
      * 
      * @return the size value.

--- a/typespec-tests/src/main/java/com/type/model/inheritance/singlediscriminator/models/Eagle.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/singlediscriminator/models/Eagle.java
@@ -19,6 +19,12 @@ import java.util.Map;
 @Fluent
 public final class Eagle extends Bird {
     /*
+     * The kind property.
+     */
+    @Generated
+    private String kind = "eagle";
+
+    /*
      * The friends property.
      */
     @Generated
@@ -44,7 +50,17 @@ public final class Eagle extends Bird {
     @Generated
     public Eagle(int wingspan) {
         super(wingspan);
-        setKind("eagle");
+    }
+
+    /**
+     * Get the kind property: The kind property.
+     * 
+     * @return the kind value.
+     */
+    @Generated
+    @Override
+    public String getKind() {
+        return this.kind;
     }
 
     /**
@@ -121,7 +137,7 @@ public final class Eagle extends Bird {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeIntField("wingspan", getWingspan());
-        jsonWriter.writeStringField("kind", getKind());
+        jsonWriter.writeStringField("kind", this.kind);
         jsonWriter.writeArrayField("friends", this.friends, (writer, element) -> writer.writeJson(element));
         jsonWriter.writeMapField("hate", this.hate, (writer, element) -> writer.writeJson(element));
         jsonWriter.writeJsonField("partner", this.partner);
@@ -163,7 +179,7 @@ public final class Eagle extends Bird {
                 }
             }
             Eagle deserializedEagle = new Eagle(wingspan);
-            deserializedEagle.setKind(kind);
+            deserializedEagle.kind = kind;
             deserializedEagle.friends = friends;
             deserializedEagle.hate = hate;
             deserializedEagle.partner = partner;

--- a/typespec-tests/src/main/java/com/type/model/inheritance/singlediscriminator/models/Goose.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/singlediscriminator/models/Goose.java
@@ -16,6 +16,12 @@ import java.io.IOException;
  */
 @Immutable
 public final class Goose extends Bird {
+    /*
+     * The kind property.
+     */
+    @Generated
+    private String kind = "goose";
+
     /**
      * Creates an instance of Goose class.
      * 
@@ -24,7 +30,17 @@ public final class Goose extends Bird {
     @Generated
     public Goose(int wingspan) {
         super(wingspan);
-        setKind("goose");
+    }
+
+    /**
+     * Get the kind property: The kind property.
+     * 
+     * @return the kind value.
+     */
+    @Generated
+    @Override
+    public String getKind() {
+        return this.kind;
     }
 
     /**
@@ -35,7 +51,7 @@ public final class Goose extends Bird {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeIntField("wingspan", getWingspan());
-        jsonWriter.writeStringField("kind", getKind());
+        jsonWriter.writeStringField("kind", this.kind);
         return jsonWriter.writeEndObject();
     }
 
@@ -65,7 +81,7 @@ public final class Goose extends Bird {
                 }
             }
             Goose deserializedGoose = new Goose(wingspan);
-            deserializedGoose.setKind(kind);
+            deserializedGoose.kind = kind;
 
             return deserializedGoose;
         });

--- a/typespec-tests/src/main/java/com/type/model/inheritance/singlediscriminator/models/SeaGull.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/singlediscriminator/models/SeaGull.java
@@ -16,6 +16,12 @@ import java.io.IOException;
  */
 @Immutable
 public final class SeaGull extends Bird {
+    /*
+     * The kind property.
+     */
+    @Generated
+    private String kind = "seagull";
+
     /**
      * Creates an instance of SeaGull class.
      * 
@@ -24,7 +30,17 @@ public final class SeaGull extends Bird {
     @Generated
     public SeaGull(int wingspan) {
         super(wingspan);
-        setKind("seagull");
+    }
+
+    /**
+     * Get the kind property: The kind property.
+     * 
+     * @return the kind value.
+     */
+    @Generated
+    @Override
+    public String getKind() {
+        return this.kind;
     }
 
     /**
@@ -35,7 +51,7 @@ public final class SeaGull extends Bird {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeIntField("wingspan", getWingspan());
-        jsonWriter.writeStringField("kind", getKind());
+        jsonWriter.writeStringField("kind", this.kind);
         return jsonWriter.writeEndObject();
     }
 
@@ -65,7 +81,7 @@ public final class SeaGull extends Bird {
                 }
             }
             SeaGull deserializedSeaGull = new SeaGull(wingspan);
-            deserializedSeaGull.setKind(kind);
+            deserializedSeaGull.kind = kind;
 
             return deserializedSeaGull;
         });

--- a/typespec-tests/src/main/java/com/type/model/inheritance/singlediscriminator/models/Sparrow.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/singlediscriminator/models/Sparrow.java
@@ -16,6 +16,12 @@ import java.io.IOException;
  */
 @Immutable
 public final class Sparrow extends Bird {
+    /*
+     * The kind property.
+     */
+    @Generated
+    private String kind = "sparrow";
+
     /**
      * Creates an instance of Sparrow class.
      * 
@@ -24,7 +30,17 @@ public final class Sparrow extends Bird {
     @Generated
     public Sparrow(int wingspan) {
         super(wingspan);
-        setKind("sparrow");
+    }
+
+    /**
+     * Get the kind property: The kind property.
+     * 
+     * @return the kind value.
+     */
+    @Generated
+    @Override
+    public String getKind() {
+        return this.kind;
     }
 
     /**
@@ -35,7 +51,7 @@ public final class Sparrow extends Bird {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeIntField("wingspan", getWingspan());
-        jsonWriter.writeStringField("kind", getKind());
+        jsonWriter.writeStringField("kind", this.kind);
         return jsonWriter.writeEndObject();
     }
 
@@ -65,7 +81,7 @@ public final class Sparrow extends Bird {
                 }
             }
             Sparrow deserializedSparrow = new Sparrow(wingspan);
-            deserializedSparrow.setKind(kind);
+            deserializedSparrow.kind = kind;
 
             return deserializedSparrow;
         });

--- a/typespec-tests/src/main/java/com/type/model/inheritance/singlediscriminator/models/TRex.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/singlediscriminator/models/TRex.java
@@ -16,6 +16,12 @@ import java.io.IOException;
  */
 @Immutable
 public final class TRex extends Dinosaur {
+    /*
+     * The kind property.
+     */
+    @Generated
+    private String kind = "t-rex";
+
     /**
      * Creates an instance of TRex class.
      * 
@@ -24,7 +30,17 @@ public final class TRex extends Dinosaur {
     @Generated
     private TRex(int size) {
         super(size);
-        setKind("t-rex");
+    }
+
+    /**
+     * Get the kind property: The kind property.
+     * 
+     * @return the kind value.
+     */
+    @Generated
+    @Override
+    public String getKind() {
+        return this.kind;
     }
 
     /**
@@ -35,7 +51,7 @@ public final class TRex extends Dinosaur {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeIntField("size", getSize());
-        jsonWriter.writeStringField("kind", getKind());
+        jsonWriter.writeStringField("kind", this.kind);
         return jsonWriter.writeEndObject();
     }
 
@@ -65,7 +81,7 @@ public final class TRex extends Dinosaur {
                 }
             }
             TRex deserializedTRex = new TRex(size);
-            deserializedTRex.setKind(kind);
+            deserializedTRex.kind = kind;
 
             return deserializedTRex;
         });

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/ExtendsUnknownAdditionalPropertiesDiscriminated.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/ExtendsUnknownAdditionalPropertiesDiscriminated.java
@@ -60,18 +60,6 @@ public class ExtendsUnknownAdditionalPropertiesDiscriminated
     }
 
     /**
-     * Set the kind property: The discriminator.
-     * 
-     * @param kind the kind value to set.
-     * @return the ExtendsUnknownAdditionalPropertiesDiscriminated object itself.
-     */
-    @Generated
-    protected ExtendsUnknownAdditionalPropertiesDiscriminated setKind(String kind) {
-        this.kind = kind;
-        return this;
-    }
-
-    /**
      * Get the name property: The name property.
      * 
      * @return the name value.

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/ExtendsUnknownAdditionalPropertiesDiscriminatedDerived.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/ExtendsUnknownAdditionalPropertiesDiscriminatedDerived.java
@@ -20,6 +20,12 @@ import java.util.Map;
 public final class ExtendsUnknownAdditionalPropertiesDiscriminatedDerived
     extends ExtendsUnknownAdditionalPropertiesDiscriminated {
     /*
+     * The discriminator
+     */
+    @Generated
+    private String kind = "derived";
+
+    /*
      * The index property
      */
     @Generated
@@ -40,8 +46,18 @@ public final class ExtendsUnknownAdditionalPropertiesDiscriminatedDerived
     @Generated
     public ExtendsUnknownAdditionalPropertiesDiscriminatedDerived(String name, int index) {
         super(name);
-        setKind("derived");
         this.index = index;
+    }
+
+    /**
+     * Get the kind property: The discriminator.
+     * 
+     * @return the kind value.
+     */
+    @Generated
+    @Override
+    public String getKind() {
+        return this.kind;
     }
 
     /**
@@ -84,8 +100,8 @@ public final class ExtendsUnknownAdditionalPropertiesDiscriminatedDerived
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeStringField("name", getName());
-        jsonWriter.writeStringField("kind", getKind());
         jsonWriter.writeIntField("index", this.index);
+        jsonWriter.writeStringField("kind", this.kind);
         jsonWriter.writeNumberField("age", this.age);
         if (getAdditionalProperties() != null) {
             for (Map.Entry<String, Object> additionalProperty : getAdditionalProperties().entrySet()) {
@@ -108,8 +124,8 @@ public final class ExtendsUnknownAdditionalPropertiesDiscriminatedDerived
         throws IOException {
         return jsonReader.readObject(reader -> {
             String name = null;
-            String kind = "derived";
             int index = 0;
+            String kind = "derived";
             Double age = null;
             Map<String, Object> additionalProperties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
@@ -118,10 +134,10 @@ public final class ExtendsUnknownAdditionalPropertiesDiscriminatedDerived
 
                 if ("name".equals(fieldName)) {
                     name = reader.getString();
-                } else if ("kind".equals(fieldName)) {
-                    kind = reader.getString();
                 } else if ("index".equals(fieldName)) {
                     index = reader.getInt();
+                } else if ("kind".equals(fieldName)) {
+                    kind = reader.getString();
                 } else if ("age".equals(fieldName)) {
                     age = reader.getNullable(JsonReader::getDouble);
                 } else {
@@ -134,7 +150,7 @@ public final class ExtendsUnknownAdditionalPropertiesDiscriminatedDerived
             }
             ExtendsUnknownAdditionalPropertiesDiscriminatedDerived deserializedExtendsUnknownAdditionalPropertiesDiscriminatedDerived
                 = new ExtendsUnknownAdditionalPropertiesDiscriminatedDerived(name, index);
-            deserializedExtendsUnknownAdditionalPropertiesDiscriminatedDerived.setKind(kind);
+            deserializedExtendsUnknownAdditionalPropertiesDiscriminatedDerived.kind = kind;
             deserializedExtendsUnknownAdditionalPropertiesDiscriminatedDerived.age = age;
             deserializedExtendsUnknownAdditionalPropertiesDiscriminatedDerived
                 .setAdditionalProperties(additionalProperties);

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/IsUnknownAdditionalPropertiesDiscriminated.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/IsUnknownAdditionalPropertiesDiscriminated.java
@@ -60,18 +60,6 @@ public class IsUnknownAdditionalPropertiesDiscriminated
     }
 
     /**
-     * Set the kind property: The discriminator.
-     * 
-     * @param kind the kind value to set.
-     * @return the IsUnknownAdditionalPropertiesDiscriminated object itself.
-     */
-    @Generated
-    protected IsUnknownAdditionalPropertiesDiscriminated setKind(String kind) {
-        this.kind = kind;
-        return this;
-    }
-
-    /**
      * Get the name property: The name property.
      * 
      * @return the name value.

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/IsUnknownAdditionalPropertiesDiscriminatedDerived.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/IsUnknownAdditionalPropertiesDiscriminatedDerived.java
@@ -20,6 +20,12 @@ import java.util.Map;
 public final class IsUnknownAdditionalPropertiesDiscriminatedDerived
     extends IsUnknownAdditionalPropertiesDiscriminated {
     /*
+     * The discriminator
+     */
+    @Generated
+    private String kind = "derived";
+
+    /*
      * The index property
      */
     @Generated
@@ -40,8 +46,18 @@ public final class IsUnknownAdditionalPropertiesDiscriminatedDerived
     @Generated
     public IsUnknownAdditionalPropertiesDiscriminatedDerived(String name, int index) {
         super(name);
-        setKind("derived");
         this.index = index;
+    }
+
+    /**
+     * Get the kind property: The discriminator.
+     * 
+     * @return the kind value.
+     */
+    @Generated
+    @Override
+    public String getKind() {
+        return this.kind;
     }
 
     /**
@@ -84,8 +100,8 @@ public final class IsUnknownAdditionalPropertiesDiscriminatedDerived
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeStringField("name", getName());
-        jsonWriter.writeStringField("kind", getKind());
         jsonWriter.writeIntField("index", this.index);
+        jsonWriter.writeStringField("kind", this.kind);
         jsonWriter.writeNumberField("age", this.age);
         if (getAdditionalProperties() != null) {
             for (Map.Entry<String, Object> additionalProperty : getAdditionalProperties().entrySet()) {
@@ -107,8 +123,8 @@ public final class IsUnknownAdditionalPropertiesDiscriminatedDerived
     public static IsUnknownAdditionalPropertiesDiscriminatedDerived fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
             String name = null;
-            String kind = "derived";
             int index = 0;
+            String kind = "derived";
             Double age = null;
             Map<String, Object> additionalProperties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
@@ -117,10 +133,10 @@ public final class IsUnknownAdditionalPropertiesDiscriminatedDerived
 
                 if ("name".equals(fieldName)) {
                     name = reader.getString();
-                } else if ("kind".equals(fieldName)) {
-                    kind = reader.getString();
                 } else if ("index".equals(fieldName)) {
                     index = reader.getInt();
+                } else if ("kind".equals(fieldName)) {
+                    kind = reader.getString();
                 } else if ("age".equals(fieldName)) {
                     age = reader.getNullable(JsonReader::getDouble);
                 } else {
@@ -133,7 +149,7 @@ public final class IsUnknownAdditionalPropertiesDiscriminatedDerived
             }
             IsUnknownAdditionalPropertiesDiscriminatedDerived deserializedIsUnknownAdditionalPropertiesDiscriminatedDerived
                 = new IsUnknownAdditionalPropertiesDiscriminatedDerived(name, index);
-            deserializedIsUnknownAdditionalPropertiesDiscriminatedDerived.setKind(kind);
+            deserializedIsUnknownAdditionalPropertiesDiscriminatedDerived.kind = kind;
             deserializedIsUnknownAdditionalPropertiesDiscriminatedDerived.age = age;
             deserializedIsUnknownAdditionalPropertiesDiscriminatedDerived.setAdditionalProperties(additionalProperties);
 

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Cookiecuttershark.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Cookiecuttershark.java
@@ -19,6 +19,11 @@ import java.util.List;
  */
 @Fluent
 public final class Cookiecuttershark extends Shark {
+    /*
+     * The fishtype property.
+     */
+    private String fishtype = "cookiecuttershark";
+
     /**
      * Creates an instance of Cookiecuttershark class.
      * 
@@ -27,7 +32,16 @@ public final class Cookiecuttershark extends Shark {
      */
     public Cookiecuttershark(float length, OffsetDateTime birthday) {
         super(length, birthday);
-        setFishtype("cookiecuttershark");
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -76,10 +90,10 @@ public final class Cookiecuttershark extends Shark {
         jsonWriter.writeFloatField("length", getLength());
         jsonWriter.writeStringField("birthday",
             getBirthday() == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(getBirthday()));
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeNumberField("age", getAge());
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         return jsonWriter.writeEndObject();
     }
 
@@ -97,10 +111,10 @@ public final class Cookiecuttershark extends Shark {
             float length = 0.0f;
             boolean birthdayFound = false;
             OffsetDateTime birthday = null;
-            String fishtype = "cookiecuttershark";
             String species = null;
             List<Fish> siblings = null;
             Integer age = null;
+            String fishtype = "cookiecuttershark";
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
@@ -111,24 +125,24 @@ public final class Cookiecuttershark extends Shark {
                 } else if ("birthday".equals(fieldName)) {
                     birthday = reader.getNullable(nonNullReader -> OffsetDateTime.parse(nonNullReader.getString()));
                     birthdayFound = true;
-                } else if ("fishtype".equals(fieldName)) {
-                    fishtype = reader.getString();
                 } else if ("species".equals(fieldName)) {
                     species = reader.getString();
                 } else if ("siblings".equals(fieldName)) {
                     siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
                 } else if ("age".equals(fieldName)) {
                     age = reader.getNullable(JsonReader::getInt);
+                } else if ("fishtype".equals(fieldName)) {
+                    fishtype = reader.getString();
                 } else {
                     reader.skipChildren();
                 }
             }
             if (lengthFound && birthdayFound) {
                 Cookiecuttershark deserializedCookiecuttershark = new Cookiecuttershark(length, birthday);
-                deserializedCookiecuttershark.setFishtype(fishtype);
                 deserializedCookiecuttershark.setSpecies(species);
                 deserializedCookiecuttershark.setSiblings(siblings);
                 deserializedCookiecuttershark.setAge(age);
+                deserializedCookiecuttershark.fishtype = fishtype;
 
                 return deserializedCookiecuttershark;
             }

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/DotFish.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/DotFish.java
@@ -43,17 +43,6 @@ public class DotFish implements JsonSerializable<DotFish> {
     }
 
     /**
-     * Set the fishType property: The fish.type property.
-     * 
-     * @param fishType the fishType value to set.
-     * @return the DotFish object itself.
-     */
-    protected DotFish setFishType(String fishType) {
-        this.fishType = fishType;
-        return this;
-    }
-
-    /**
      * Get the species property: The species property.
      * 
      * @return the species value.

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/DotSalmon.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/DotSalmon.java
@@ -16,6 +16,11 @@ import java.io.IOException;
 @Immutable
 public final class DotSalmon extends DotFish {
     /*
+     * The fish.type property.
+     */
+    private String fishType = "DotSalmon";
+
+    /*
      * The location property.
      */
     private String location;
@@ -29,7 +34,16 @@ public final class DotSalmon extends DotFish {
      * Creates an instance of DotSalmon class.
      */
     private DotSalmon() {
-        setFishType("DotSalmon");
+    }
+
+    /**
+     * Get the fishType property: The fish.type property.
+     * 
+     * @return the fishType value.
+     */
+    @Override
+    public String getFishType() {
+        return this.fishType;
     }
 
     /**
@@ -66,8 +80,8 @@ public final class DotSalmon extends DotFish {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("fish.type", getFishType());
         jsonWriter.writeStringField("species", getSpecies());
+        jsonWriter.writeStringField("fish.type", this.fishType);
         jsonWriter.writeStringField("location", this.location);
         jsonWriter.writeBooleanField("iswild", this.iswild);
         return jsonWriter.writeEndObject();
@@ -87,10 +101,10 @@ public final class DotSalmon extends DotFish {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("fish.type".equals(fieldName)) {
-                    deserializedDotSalmon.setFishType(reader.getString());
-                } else if ("species".equals(fieldName)) {
+                if ("species".equals(fieldName)) {
                     deserializedDotSalmon.setSpecies(reader.getString());
+                } else if ("fish.type".equals(fieldName)) {
+                    deserializedDotSalmon.fishType = reader.getString();
                 } else if ("location".equals(fieldName)) {
                     deserializedDotSalmon.location = reader.getString();
                 } else if ("iswild".equals(fieldName)) {

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Fish.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Fish.java
@@ -57,17 +57,6 @@ public class Fish implements JsonSerializable<Fish> {
     }
 
     /**
-     * Set the fishtype property: The fishtype property.
-     * 
-     * @param fishtype the fishtype value to set.
-     * @return the Fish object itself.
-     */
-    protected Fish setFishtype(String fishtype) {
-        this.fishtype = fishtype;
-        return this;
-    }
-
-    /**
      * Get the species property: The species property.
      * 
      * @return the species value.

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Goblinshark.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Goblinshark.java
@@ -20,6 +20,11 @@ import java.util.List;
 @Fluent
 public final class Goblinshark extends Shark {
     /*
+     * The fishtype property.
+     */
+    private String fishtype = "goblin";
+
+    /*
      * The jawsize property.
      */
     private Integer jawsize;
@@ -37,7 +42,16 @@ public final class Goblinshark extends Shark {
      */
     public Goblinshark(float length, OffsetDateTime birthday) {
         super(length, birthday);
-        setFishtype("goblin");
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -126,10 +140,10 @@ public final class Goblinshark extends Shark {
         jsonWriter.writeFloatField("length", getLength());
         jsonWriter.writeStringField("birthday",
             getBirthday() == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(getBirthday()));
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeNumberField("age", getAge());
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         jsonWriter.writeNumberField("jawsize", this.jawsize);
         jsonWriter.writeStringField("color", this.color == null ? null : this.color.toString());
         return jsonWriter.writeEndObject();
@@ -149,10 +163,10 @@ public final class Goblinshark extends Shark {
             float length = 0.0f;
             boolean birthdayFound = false;
             OffsetDateTime birthday = null;
-            String fishtype = "goblin";
             String species = null;
             List<Fish> siblings = null;
             Integer age = null;
+            String fishtype = "goblin";
             Integer jawsize = null;
             GoblinSharkColor color = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
@@ -165,14 +179,14 @@ public final class Goblinshark extends Shark {
                 } else if ("birthday".equals(fieldName)) {
                     birthday = reader.getNullable(nonNullReader -> OffsetDateTime.parse(nonNullReader.getString()));
                     birthdayFound = true;
-                } else if ("fishtype".equals(fieldName)) {
-                    fishtype = reader.getString();
                 } else if ("species".equals(fieldName)) {
                     species = reader.getString();
                 } else if ("siblings".equals(fieldName)) {
                     siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
                 } else if ("age".equals(fieldName)) {
                     age = reader.getNullable(JsonReader::getInt);
+                } else if ("fishtype".equals(fieldName)) {
+                    fishtype = reader.getString();
                 } else if ("jawsize".equals(fieldName)) {
                     jawsize = reader.getNullable(JsonReader::getInt);
                 } else if ("color".equals(fieldName)) {
@@ -183,10 +197,10 @@ public final class Goblinshark extends Shark {
             }
             if (lengthFound && birthdayFound) {
                 Goblinshark deserializedGoblinshark = new Goblinshark(length, birthday);
-                deserializedGoblinshark.setFishtype(fishtype);
                 deserializedGoblinshark.setSpecies(species);
                 deserializedGoblinshark.setSiblings(siblings);
                 deserializedGoblinshark.setAge(age);
+                deserializedGoblinshark.fishtype = fishtype;
                 deserializedGoblinshark.jawsize = jawsize;
                 deserializedGoblinshark.color = color;
 

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/MyBaseType.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/MyBaseType.java
@@ -48,17 +48,6 @@ public class MyBaseType implements JsonSerializable<MyBaseType> {
     }
 
     /**
-     * Set the kind property: The kind property.
-     * 
-     * @param kind the kind value to set.
-     * @return the MyBaseType object itself.
-     */
-    protected MyBaseType setKind(MyKind kind) {
-        this.kind = kind;
-        return this;
-    }
-
-    /**
      * Get the propB1 property: The propB1 property.
      * 
      * @return the propB1 value.

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/MyDerivedType.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/MyDerivedType.java
@@ -16,6 +16,11 @@ import java.io.IOException;
 @Immutable
 public final class MyDerivedType extends MyBaseType {
     /*
+     * The kind property.
+     */
+    private MyKind kind = MyKind.KIND1;
+
+    /*
      * The propD1 property.
      */
     private String propD1;
@@ -24,7 +29,16 @@ public final class MyDerivedType extends MyBaseType {
      * Creates an instance of MyDerivedType class.
      */
     private MyDerivedType() {
-        setKind(MyKind.KIND1);
+    }
+
+    /**
+     * Get the kind property: The kind property.
+     * 
+     * @return the kind value.
+     */
+    @Override
+    public MyKind getKind() {
+        return this.kind;
     }
 
     /**
@@ -52,8 +66,8 @@ public final class MyDerivedType extends MyBaseType {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("kind", getKind() == null ? null : getKind().toString());
         jsonWriter.writeStringField("propB1", getPropB1());
+        jsonWriter.writeStringField("kind", this.kind == null ? null : this.kind.toString());
         jsonWriter.writeStringField("propD1", this.propD1);
         if (getPropBH1() != null) {
             jsonWriter.writeStartObject("helper");
@@ -77,10 +91,10 @@ public final class MyDerivedType extends MyBaseType {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("kind".equals(fieldName)) {
-                    deserializedMyDerivedType.setKind(MyKind.fromString(reader.getString()));
-                } else if ("propB1".equals(fieldName)) {
+                if ("propB1".equals(fieldName)) {
                     deserializedMyDerivedType.setPropB1(reader.getString());
+                } else if ("kind".equals(fieldName)) {
+                    deserializedMyDerivedType.kind = MyKind.fromString(reader.getString());
                 } else if ("propD1".equals(fieldName)) {
                     deserializedMyDerivedType.propD1 = reader.getString();
                 } else if ("helper".equals(fieldName) && reader.currentToken() == JsonToken.START_OBJECT) {

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Salmon.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Salmon.java
@@ -17,6 +17,11 @@ import java.util.List;
 @Fluent
 public class Salmon extends Fish {
     /*
+     * The fishtype property.
+     */
+    private String fishtype = "salmon";
+
+    /*
      * The location property.
      */
     private String location;
@@ -33,7 +38,16 @@ public class Salmon extends Fish {
      */
     public Salmon(float length) {
         super(length);
-        setFishtype("salmon");
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -111,9 +125,9 @@ public class Salmon extends Fish {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeFloatField("length", getLength());
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         jsonWriter.writeStringField("location", this.location);
         jsonWriter.writeBooleanField("iswild", this.iswild);
         return jsonWriter.writeEndObject();
@@ -156,9 +170,9 @@ public class Salmon extends Fish {
         return jsonReader.readObject(reader -> {
             boolean lengthFound = false;
             float length = 0.0f;
-            String fishtype = "salmon";
             String species = null;
             List<Fish> siblings = null;
+            String fishtype = "salmon";
             String location = null;
             Boolean iswild = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
@@ -168,12 +182,12 @@ public class Salmon extends Fish {
                 if ("length".equals(fieldName)) {
                     length = reader.getFloat();
                     lengthFound = true;
-                } else if ("fishtype".equals(fieldName)) {
-                    fishtype = reader.getString();
                 } else if ("species".equals(fieldName)) {
                     species = reader.getString();
                 } else if ("siblings".equals(fieldName)) {
                     siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
+                } else if ("fishtype".equals(fieldName)) {
+                    fishtype = reader.getString();
                 } else if ("location".equals(fieldName)) {
                     location = reader.getString();
                 } else if ("iswild".equals(fieldName)) {
@@ -184,9 +198,9 @@ public class Salmon extends Fish {
             }
             if (lengthFound) {
                 Salmon deserializedSalmon = new Salmon(length);
-                deserializedSalmon.setFishtype(fishtype);
                 deserializedSalmon.setSpecies(species);
                 deserializedSalmon.setSiblings(siblings);
+                deserializedSalmon.fishtype = fishtype;
                 deserializedSalmon.location = location;
                 deserializedSalmon.iswild = iswild;
 

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Sawshark.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Sawshark.java
@@ -21,6 +21,11 @@ import java.util.List;
 @Fluent
 public final class Sawshark extends Shark {
     /*
+     * The fishtype property.
+     */
+    private String fishtype = "sawshark";
+
+    /*
      * The picture property.
      */
     private byte[] picture;
@@ -33,7 +38,16 @@ public final class Sawshark extends Shark {
      */
     public Sawshark(float length, OffsetDateTime birthday) {
         super(length, birthday);
-        setFishtype("sawshark");
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -102,10 +116,10 @@ public final class Sawshark extends Shark {
         jsonWriter.writeFloatField("length", getLength());
         jsonWriter.writeStringField("birthday",
             getBirthday() == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(getBirthday()));
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeNumberField("age", getAge());
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         jsonWriter.writeBinaryField("picture", this.picture);
         return jsonWriter.writeEndObject();
     }
@@ -124,10 +138,10 @@ public final class Sawshark extends Shark {
             float length = 0.0f;
             boolean birthdayFound = false;
             OffsetDateTime birthday = null;
-            String fishtype = "sawshark";
             String species = null;
             List<Fish> siblings = null;
             Integer age = null;
+            String fishtype = "sawshark";
             byte[] picture = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();
@@ -139,14 +153,14 @@ public final class Sawshark extends Shark {
                 } else if ("birthday".equals(fieldName)) {
                     birthday = reader.getNullable(nonNullReader -> OffsetDateTime.parse(nonNullReader.getString()));
                     birthdayFound = true;
-                } else if ("fishtype".equals(fieldName)) {
-                    fishtype = reader.getString();
                 } else if ("species".equals(fieldName)) {
                     species = reader.getString();
                 } else if ("siblings".equals(fieldName)) {
                     siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
                 } else if ("age".equals(fieldName)) {
                     age = reader.getNullable(JsonReader::getInt);
+                } else if ("fishtype".equals(fieldName)) {
+                    fishtype = reader.getString();
                 } else if ("picture".equals(fieldName)) {
                     picture = reader.getBinary();
                 } else {
@@ -155,10 +169,10 @@ public final class Sawshark extends Shark {
             }
             if (lengthFound && birthdayFound) {
                 Sawshark deserializedSawshark = new Sawshark(length, birthday);
-                deserializedSawshark.setFishtype(fishtype);
                 deserializedSawshark.setSpecies(species);
                 deserializedSawshark.setSiblings(siblings);
                 deserializedSawshark.setAge(age);
+                deserializedSawshark.fishtype = fishtype;
                 deserializedSawshark.picture = picture;
 
                 return deserializedSawshark;

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Shark.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Shark.java
@@ -21,6 +21,11 @@ import java.util.List;
 @Fluent
 public class Shark extends Fish {
     /*
+     * The fishtype property.
+     */
+    private String fishtype = "shark";
+
+    /*
      * The age property.
      */
     private Integer age;
@@ -38,8 +43,17 @@ public class Shark extends Fish {
      */
     public Shark(float length, OffsetDateTime birthday) {
         super(length);
-        setFishtype("shark");
         this.birthday = birthday;
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -112,11 +126,11 @@ public class Shark extends Fish {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeFloatField("length", getLength());
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeStringField("birthday",
             this.birthday == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.birthday));
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         jsonWriter.writeNumberField("age", this.age);
         return jsonWriter.writeEndObject();
     }
@@ -162,11 +176,11 @@ public class Shark extends Fish {
         return jsonReader.readObject(reader -> {
             boolean lengthFound = false;
             float length = 0.0f;
-            String fishtype = "shark";
             String species = null;
             List<Fish> siblings = null;
             boolean birthdayFound = false;
             OffsetDateTime birthday = null;
+            String fishtype = "shark";
             Integer age = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();
@@ -175,8 +189,6 @@ public class Shark extends Fish {
                 if ("length".equals(fieldName)) {
                     length = reader.getFloat();
                     lengthFound = true;
-                } else if ("fishtype".equals(fieldName)) {
-                    fishtype = reader.getString();
                 } else if ("species".equals(fieldName)) {
                     species = reader.getString();
                 } else if ("siblings".equals(fieldName)) {
@@ -184,6 +196,8 @@ public class Shark extends Fish {
                 } else if ("birthday".equals(fieldName)) {
                     birthday = reader.getNullable(nonNullReader -> OffsetDateTime.parse(nonNullReader.getString()));
                     birthdayFound = true;
+                } else if ("fishtype".equals(fieldName)) {
+                    fishtype = reader.getString();
                 } else if ("age".equals(fieldName)) {
                     age = reader.getNullable(JsonReader::getInt);
                 } else {
@@ -192,9 +206,9 @@ public class Shark extends Fish {
             }
             if (lengthFound && birthdayFound) {
                 Shark deserializedShark = new Shark(length, birthday);
-                deserializedShark.setFishtype(fishtype);
                 deserializedShark.setSpecies(species);
                 deserializedShark.setSiblings(siblings);
+                deserializedShark.fishtype = fishtype;
                 deserializedShark.age = age;
 
                 return deserializedShark;

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/SmartSalmon.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/SmartSalmon.java
@@ -19,6 +19,11 @@ import java.util.Map;
 @Fluent
 public final class SmartSalmon extends Salmon {
     /*
+     * The fishtype property.
+     */
+    private String fishtype = "smart_salmon";
+
+    /*
      * The college_degree property.
      */
     private String collegeDegree;
@@ -35,7 +40,16 @@ public final class SmartSalmon extends Salmon {
      */
     public SmartSalmon(float length) {
         super(length);
-        setFishtype("smart_salmon");
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -131,11 +145,11 @@ public final class SmartSalmon extends Salmon {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeFloatField("length", getLength());
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeStringField("location", getLocation());
         jsonWriter.writeBooleanField("iswild", iswild());
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         jsonWriter.writeStringField("college_degree", this.collegeDegree);
         if (additionalProperties != null) {
             for (Map.Entry<String, Object> additionalProperty : additionalProperties.entrySet()) {
@@ -157,11 +171,11 @@ public final class SmartSalmon extends Salmon {
         return jsonReader.readObject(reader -> {
             boolean lengthFound = false;
             float length = 0.0f;
-            String fishtype = "smart_salmon";
             String species = null;
             List<Fish> siblings = null;
             String location = null;
             Boolean iswild = null;
+            String fishtype = "smart_salmon";
             String collegeDegree = null;
             Map<String, Object> additionalProperties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
@@ -171,8 +185,6 @@ public final class SmartSalmon extends Salmon {
                 if ("length".equals(fieldName)) {
                     length = reader.getFloat();
                     lengthFound = true;
-                } else if ("fishtype".equals(fieldName)) {
-                    fishtype = reader.getString();
                 } else if ("species".equals(fieldName)) {
                     species = reader.getString();
                 } else if ("siblings".equals(fieldName)) {
@@ -181,6 +193,8 @@ public final class SmartSalmon extends Salmon {
                     location = reader.getString();
                 } else if ("iswild".equals(fieldName)) {
                     iswild = reader.getNullable(JsonReader::getBoolean);
+                } else if ("fishtype".equals(fieldName)) {
+                    fishtype = reader.getString();
                 } else if ("college_degree".equals(fieldName)) {
                     collegeDegree = reader.getString();
                 } else {
@@ -193,11 +207,11 @@ public final class SmartSalmon extends Salmon {
             }
             if (lengthFound) {
                 SmartSalmon deserializedSmartSalmon = new SmartSalmon(length);
-                deserializedSmartSalmon.setFishtype(fishtype);
                 deserializedSmartSalmon.setSpecies(species);
                 deserializedSmartSalmon.setSiblings(siblings);
                 deserializedSmartSalmon.setLocation(location);
                 deserializedSmartSalmon.setIswild(iswild);
+                deserializedSmartSalmon.fishtype = fishtype;
                 deserializedSmartSalmon.collegeDegree = collegeDegree;
                 deserializedSmartSalmon.additionalProperties = additionalProperties;
 

--- a/vanilla-tests/src/main/java/fixtures/discriminatorenum/models/Dog.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorenum/models/Dog.java
@@ -43,17 +43,6 @@ public class Dog implements JsonSerializable<Dog> {
     }
 
     /**
-     * Set the kind property: discriminator property.
-     * 
-     * @param kind the kind value to set.
-     * @return the Dog object itself.
-     */
-    protected Dog setKind(DogKind kind) {
-        this.kind = kind;
-        return this;
-    }
-
-    /**
      * Get the weight property: Weight of the dog.
      * 
      * @return the weight value.

--- a/vanilla-tests/src/main/java/fixtures/discriminatorenum/models/Golden.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorenum/models/Golden.java
@@ -15,11 +15,25 @@ import java.io.IOException;
  */
 @Fluent
 public final class Golden extends Dog {
+    /*
+     * discriminator property
+     */
+    private DogKind kind = DogKind.GOLDEN;
+
     /**
      * Creates an instance of Golden class.
      */
     public Golden() {
-        setKind(DogKind.GOLDEN);
+    }
+
+    /**
+     * Get the kind property: discriminator property.
+     * 
+     * @return the kind value.
+     */
+    @Override
+    public DogKind getKind() {
+        return this.kind;
     }
 
     /**
@@ -48,7 +62,7 @@ public final class Golden extends Dog {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeIntField("weight", getWeight());
-        jsonWriter.writeStringField("kind", getKind() == null ? null : getKind().toString());
+        jsonWriter.writeStringField("kind", this.kind == null ? null : this.kind.toString());
         return jsonWriter.writeEndObject();
     }
 
@@ -70,7 +84,7 @@ public final class Golden extends Dog {
                 if ("weight".equals(fieldName)) {
                     deserializedGolden.setWeight(reader.getInt());
                 } else if ("kind".equals(fieldName)) {
-                    deserializedGolden.setKind(DogKind.fromString(reader.getString()));
+                    deserializedGolden.kind = DogKind.fromString(reader.getString());
                 } else {
                     reader.skipChildren();
                 }

--- a/vanilla-tests/src/main/java/fixtures/discriminatorflattening/clientflatten/models/MetricAlertCriteria.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorflattening/clientflatten/models/MetricAlertCriteria.java
@@ -45,17 +45,6 @@ public class MetricAlertCriteria implements JsonSerializable<MetricAlertCriteria
     }
 
     /**
-     * Set the odataType property: specifies the type of the alert criteria.
-     * 
-     * @param odataType the odataType value to set.
-     * @return the MetricAlertCriteria object itself.
-     */
-    protected MetricAlertCriteria setOdataType(Odatatype odataType) {
-        this.odataType = odataType;
-        return this;
-    }
-
-    /**
      * Get the additionalProperties property: The rule criteria that defines the conditions of the alert rule.
      * 
      * @return the additionalProperties value.

--- a/vanilla-tests/src/main/java/fixtures/discriminatorflattening/clientflatten/models/MetricAlertSingleResourceMultipleMetricCriteria.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorflattening/clientflatten/models/MetricAlertSingleResourceMultipleMetricCriteria.java
@@ -19,6 +19,11 @@ import java.util.Map;
 @Fluent
 public final class MetricAlertSingleResourceMultipleMetricCriteria extends MetricAlertCriteria {
     /*
+     * specifies the type of the alert criteria.
+     */
+    private Odatatype odataType = Odatatype.MICROSOFT_AZURE_MONITOR_SINGLE_RESOURCE_MULTIPLE_METRIC_CRITERIA;
+
+    /*
      * The list of metric criteria for this 'all of' operation. 
      */
     private List<String> allOf;
@@ -27,7 +32,16 @@ public final class MetricAlertSingleResourceMultipleMetricCriteria extends Metri
      * Creates an instance of MetricAlertSingleResourceMultipleMetricCriteria class.
      */
     public MetricAlertSingleResourceMultipleMetricCriteria() {
-        setOdataType(Odatatype.MICROSOFT_AZURE_MONITOR_SINGLE_RESOURCE_MULTIPLE_METRIC_CRITERIA);
+    }
+
+    /**
+     * Get the odataType property: specifies the type of the alert criteria.
+     * 
+     * @return the odataType value.
+     */
+    @Override
+    public Odatatype getOdataType() {
+        return this.odataType;
     }
 
     /**
@@ -66,7 +80,7 @@ public final class MetricAlertSingleResourceMultipleMetricCriteria extends Metri
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("odata.type", getOdataType() == null ? null : getOdataType().toString());
+        jsonWriter.writeStringField("odata.type", this.odataType == null ? null : this.odataType.toString());
         jsonWriter.writeArrayField("allOf", this.allOf, (writer, element) -> writer.writeString(element));
         if (getAdditionalProperties() != null) {
             for (Map.Entry<String, Object> additionalProperty : getAdditionalProperties().entrySet()) {
@@ -93,8 +107,8 @@ public final class MetricAlertSingleResourceMultipleMetricCriteria extends Metri
                 reader.nextToken();
 
                 if ("odata.type".equals(fieldName)) {
-                    deserializedMetricAlertSingleResourceMultipleMetricCriteria
-                        .setOdataType(Odatatype.fromString(reader.getString()));
+                    deserializedMetricAlertSingleResourceMultipleMetricCriteria.odataType
+                        = Odatatype.fromString(reader.getString());
                 } else if ("allOf".equals(fieldName)) {
                     List<String> allOf = reader.readArray(reader1 -> reader1.getString());
                     deserializedMetricAlertSingleResourceMultipleMetricCriteria.allOf = allOf;

--- a/vanilla-tests/src/main/java/fixtures/discriminatorflattening/models/MetricAlertCriteria.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorflattening/models/MetricAlertCriteria.java
@@ -45,17 +45,6 @@ public class MetricAlertCriteria implements JsonSerializable<MetricAlertCriteria
     }
 
     /**
-     * Set the odataType property: specifies the type of the alert criteria.
-     * 
-     * @param odataType the odataType value to set.
-     * @return the MetricAlertCriteria object itself.
-     */
-    protected MetricAlertCriteria setOdataType(Odatatype odataType) {
-        this.odataType = odataType;
-        return this;
-    }
-
-    /**
      * Get the additionalProperties property: The rule criteria that defines the conditions of the alert rule.
      * 
      * @return the additionalProperties value.

--- a/vanilla-tests/src/main/java/fixtures/discriminatorflattening/models/MetricAlertSingleResourceMultipleMetricCriteria.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorflattening/models/MetricAlertSingleResourceMultipleMetricCriteria.java
@@ -19,6 +19,11 @@ import java.util.Map;
 @Fluent
 public final class MetricAlertSingleResourceMultipleMetricCriteria extends MetricAlertCriteria {
     /*
+     * specifies the type of the alert criteria.
+     */
+    private Odatatype odataType = Odatatype.MICROSOFT_AZURE_MONITOR_SINGLE_RESOURCE_MULTIPLE_METRIC_CRITERIA;
+
+    /*
      * The list of metric criteria for this 'all of' operation. 
      */
     private List<String> allOf;
@@ -27,7 +32,16 @@ public final class MetricAlertSingleResourceMultipleMetricCriteria extends Metri
      * Creates an instance of MetricAlertSingleResourceMultipleMetricCriteria class.
      */
     public MetricAlertSingleResourceMultipleMetricCriteria() {
-        setOdataType(Odatatype.MICROSOFT_AZURE_MONITOR_SINGLE_RESOURCE_MULTIPLE_METRIC_CRITERIA);
+    }
+
+    /**
+     * Get the odataType property: specifies the type of the alert criteria.
+     * 
+     * @return the odataType value.
+     */
+    @Override
+    public Odatatype getOdataType() {
+        return this.odataType;
     }
 
     /**
@@ -66,7 +80,7 @@ public final class MetricAlertSingleResourceMultipleMetricCriteria extends Metri
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("odata.type", getOdataType() == null ? null : getOdataType().toString());
+        jsonWriter.writeStringField("odata.type", this.odataType == null ? null : this.odataType.toString());
         jsonWriter.writeArrayField("allOf", this.allOf, (writer, element) -> writer.writeString(element));
         if (getAdditionalProperties() != null) {
             for (Map.Entry<String, Object> additionalProperty : getAdditionalProperties().entrySet()) {
@@ -93,8 +107,8 @@ public final class MetricAlertSingleResourceMultipleMetricCriteria extends Metri
                 reader.nextToken();
 
                 if ("odata.type".equals(fieldName)) {
-                    deserializedMetricAlertSingleResourceMultipleMetricCriteria
-                        .setOdataType(Odatatype.fromString(reader.getString()));
+                    deserializedMetricAlertSingleResourceMultipleMetricCriteria.odataType
+                        = Odatatype.fromString(reader.getString());
                 } else if ("allOf".equals(fieldName)) {
                     List<String> allOf = reader.readArray(reader1 -> reader1.getString());
                     deserializedMetricAlertSingleResourceMultipleMetricCriteria.allOf = allOf;

--- a/vanilla-tests/src/main/java/fixtures/discriminatorflattening/noflatten/models/MetricAlertCriteria.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorflattening/noflatten/models/MetricAlertCriteria.java
@@ -45,17 +45,6 @@ public class MetricAlertCriteria implements JsonSerializable<MetricAlertCriteria
     }
 
     /**
-     * Set the odataType property: specifies the type of the alert criteria.
-     * 
-     * @param odataType the odataType value to set.
-     * @return the MetricAlertCriteria object itself.
-     */
-    protected MetricAlertCriteria setOdataType(Odatatype odataType) {
-        this.odataType = odataType;
-        return this;
-    }
-
-    /**
      * Get the additionalProperties property: The rule criteria that defines the conditions of the alert rule.
      * 
      * @return the additionalProperties value.

--- a/vanilla-tests/src/main/java/fixtures/discriminatorflattening/noflatten/models/MetricAlertSingleResourceMultipleMetricCriteria.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorflattening/noflatten/models/MetricAlertSingleResourceMultipleMetricCriteria.java
@@ -19,6 +19,11 @@ import java.util.Map;
 @Fluent
 public final class MetricAlertSingleResourceMultipleMetricCriteria extends MetricAlertCriteria {
     /*
+     * specifies the type of the alert criteria.
+     */
+    private Odatatype odataType = Odatatype.MICROSOFT_AZURE_MONITOR_SINGLE_RESOURCE_MULTIPLE_METRIC_CRITERIA;
+
+    /*
      * The list of metric criteria for this 'all of' operation. 
      */
     private List<String> allOf;
@@ -27,7 +32,16 @@ public final class MetricAlertSingleResourceMultipleMetricCriteria extends Metri
      * Creates an instance of MetricAlertSingleResourceMultipleMetricCriteria class.
      */
     public MetricAlertSingleResourceMultipleMetricCriteria() {
-        setOdataType(Odatatype.MICROSOFT_AZURE_MONITOR_SINGLE_RESOURCE_MULTIPLE_METRIC_CRITERIA);
+    }
+
+    /**
+     * Get the odataType property: specifies the type of the alert criteria.
+     * 
+     * @return the odataType value.
+     */
+    @Override
+    public Odatatype getOdataType() {
+        return this.odataType;
     }
 
     /**
@@ -66,7 +80,7 @@ public final class MetricAlertSingleResourceMultipleMetricCriteria extends Metri
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("odata.type", getOdataType() == null ? null : getOdataType().toString());
+        jsonWriter.writeStringField("odata.type", this.odataType == null ? null : this.odataType.toString());
         jsonWriter.writeArrayField("allOf", this.allOf, (writer, element) -> writer.writeString(element));
         if (getAdditionalProperties() != null) {
             for (Map.Entry<String, Object> additionalProperty : getAdditionalProperties().entrySet()) {
@@ -93,8 +107,8 @@ public final class MetricAlertSingleResourceMultipleMetricCriteria extends Metri
                 reader.nextToken();
 
                 if ("odata.type".equals(fieldName)) {
-                    deserializedMetricAlertSingleResourceMultipleMetricCriteria
-                        .setOdataType(Odatatype.fromString(reader.getString()));
+                    deserializedMetricAlertSingleResourceMultipleMetricCriteria.odataType
+                        = Odatatype.fromString(reader.getString());
                 } else if ("allOf".equals(fieldName)) {
                     List<String> allOf = reader.readArray(reader1 -> reader1.getString());
                     deserializedMetricAlertSingleResourceMultipleMetricCriteria.allOf = allOf;

--- a/vanilla-tests/src/main/java/fixtures/discriminatorflattening/requirexmsflattened/models/MetricAlertCriteria.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorflattening/requirexmsflattened/models/MetricAlertCriteria.java
@@ -45,17 +45,6 @@ public class MetricAlertCriteria implements JsonSerializable<MetricAlertCriteria
     }
 
     /**
-     * Set the odataType property: specifies the type of the alert criteria.
-     * 
-     * @param odataType the odataType value to set.
-     * @return the MetricAlertCriteria object itself.
-     */
-    protected MetricAlertCriteria setOdataType(Odatatype odataType) {
-        this.odataType = odataType;
-        return this;
-    }
-
-    /**
      * Get the additionalProperties property: The rule criteria that defines the conditions of the alert rule.
      * 
      * @return the additionalProperties value.

--- a/vanilla-tests/src/main/java/fixtures/discriminatorflattening/requirexmsflattened/models/MetricAlertSingleResourceMultipleMetricCriteria.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorflattening/requirexmsflattened/models/MetricAlertSingleResourceMultipleMetricCriteria.java
@@ -19,6 +19,11 @@ import java.util.Map;
 @Fluent
 public final class MetricAlertSingleResourceMultipleMetricCriteria extends MetricAlertCriteria {
     /*
+     * specifies the type of the alert criteria.
+     */
+    private Odatatype odataType = Odatatype.MICROSOFT_AZURE_MONITOR_SINGLE_RESOURCE_MULTIPLE_METRIC_CRITERIA;
+
+    /*
      * The list of metric criteria for this 'all of' operation. 
      */
     private List<String> allOf;
@@ -27,7 +32,16 @@ public final class MetricAlertSingleResourceMultipleMetricCriteria extends Metri
      * Creates an instance of MetricAlertSingleResourceMultipleMetricCriteria class.
      */
     public MetricAlertSingleResourceMultipleMetricCriteria() {
-        setOdataType(Odatatype.MICROSOFT_AZURE_MONITOR_SINGLE_RESOURCE_MULTIPLE_METRIC_CRITERIA);
+    }
+
+    /**
+     * Get the odataType property: specifies the type of the alert criteria.
+     * 
+     * @return the odataType value.
+     */
+    @Override
+    public Odatatype getOdataType() {
+        return this.odataType;
     }
 
     /**
@@ -66,7 +80,7 @@ public final class MetricAlertSingleResourceMultipleMetricCriteria extends Metri
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("odata.type", getOdataType() == null ? null : getOdataType().toString());
+        jsonWriter.writeStringField("odata.type", this.odataType == null ? null : this.odataType.toString());
         jsonWriter.writeArrayField("allOf", this.allOf, (writer, element) -> writer.writeString(element));
         if (getAdditionalProperties() != null) {
             for (Map.Entry<String, Object> additionalProperty : getAdditionalProperties().entrySet()) {
@@ -93,8 +107,8 @@ public final class MetricAlertSingleResourceMultipleMetricCriteria extends Metri
                 reader.nextToken();
 
                 if ("odata.type".equals(fieldName)) {
-                    deserializedMetricAlertSingleResourceMultipleMetricCriteria
-                        .setOdataType(Odatatype.fromString(reader.getString()));
+                    deserializedMetricAlertSingleResourceMultipleMetricCriteria.odataType
+                        = Odatatype.fromString(reader.getString());
                 } else if ("allOf".equals(fieldName)) {
                     List<String> allOf = reader.readArray(reader1 -> reader1.getString());
                     deserializedMetricAlertSingleResourceMultipleMetricCriteria.allOf = allOf;

--- a/vanilla-tests/src/main/java/fixtures/discriminatorsetter/implementation/models/Dog.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorsetter/implementation/models/Dog.java
@@ -44,17 +44,6 @@ public class Dog implements JsonSerializable<Dog> {
     }
 
     /**
-     * Set the kind property: discriminator property.
-     * 
-     * @param kind the kind value to set.
-     * @return the Dog object itself.
-     */
-    protected Dog setKind(DogKind kind) {
-        this.kind = kind;
-        return this;
-    }
-
-    /**
      * Get the weight property: Weight of the dog.
      * 
      * @return the weight value.

--- a/vanilla-tests/src/main/java/fixtures/discriminatorsetter/models/Golden.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorsetter/models/Golden.java
@@ -17,11 +17,25 @@ import java.io.IOException;
  */
 @Fluent
 public final class Golden extends Dog {
+    /*
+     * discriminator property
+     */
+    private DogKind kind = DogKind.GOLDEN;
+
     /**
      * Creates an instance of Golden class.
      */
     public Golden() {
-        setKind(DogKind.GOLDEN);
+    }
+
+    /**
+     * Get the kind property: discriminator property.
+     * 
+     * @return the kind value.
+     */
+    @Override
+    public DogKind getKind() {
+        return this.kind;
     }
 
     /**
@@ -50,7 +64,7 @@ public final class Golden extends Dog {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeIntField("weight", getWeight());
-        jsonWriter.writeStringField("kind", getKind() == null ? null : getKind().toString());
+        jsonWriter.writeStringField("kind", this.kind == null ? null : this.kind.toString());
         return jsonWriter.writeEndObject();
     }
 
@@ -72,7 +86,7 @@ public final class Golden extends Dog {
                 if ("weight".equals(fieldName)) {
                     deserializedGolden.setWeight(reader.getInt());
                 } else if ("kind".equals(fieldName)) {
-                    deserializedGolden.setKind(DogKind.fromString(reader.getString()));
+                    deserializedGolden.kind = DogKind.fromString(reader.getString());
                 } else {
                     reader.skipChildren();
                 }

--- a/vanilla-tests/src/main/java/fixtures/inheritance/passdiscriminator/models/MetricAlertCriteria.java
+++ b/vanilla-tests/src/main/java/fixtures/inheritance/passdiscriminator/models/MetricAlertCriteria.java
@@ -61,17 +61,6 @@ public class MetricAlertCriteria {
     }
 
     /**
-     * Set the odataType property: specifies the type of the alert criteria.
-     * 
-     * @param odataType the odataType value to set.
-     * @return the MetricAlertCriteria object itself.
-     */
-    protected MetricAlertCriteria setOdataType(Odatatype odataType) {
-        this.odataType = odataType;
-        return this;
-    }
-
-    /**
      * Get the additionalProperties property: The rule criteria that defines the conditions of the alert rule.
      * 
      * @return the additionalProperties value.

--- a/vanilla-tests/src/main/java/fixtures/inheritance/passdiscriminator/models/MetricAlertSingleResourceMultipleMetricCriteria.java
+++ b/vanilla-tests/src/main/java/fixtures/inheritance/passdiscriminator/models/MetricAlertSingleResourceMultipleMetricCriteria.java
@@ -6,6 +6,7 @@ package fixtures.inheritance.passdiscriminator.models;
 
 import com.azure.core.annotation.Fluent;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeId;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.List;
@@ -22,6 +23,13 @@ import java.util.List;
 @Fluent
 public final class MetricAlertSingleResourceMultipleMetricCriteria extends MetricAlertCriteria {
     /*
+     * specifies the type of the alert criteria.
+     */
+    @JsonTypeId
+    @JsonProperty(value = "odata.type", required = true)
+    private Odatatype ODATA_TYPE = Odatatype.MICROSOFT_AZURE_MONITOR_SINGLE_RESOURCE_MULTIPLE_METRIC_CRITERIA;
+
+    /*
      * The list of metric criteria for this 'all of' operation. 
      */
     @JsonProperty(value = "allOf")
@@ -31,7 +39,16 @@ public final class MetricAlertSingleResourceMultipleMetricCriteria extends Metri
      * Creates an instance of MetricAlertSingleResourceMultipleMetricCriteria class.
      */
     public MetricAlertSingleResourceMultipleMetricCriteria() {
-        setOdataType(Odatatype.MICROSOFT_AZURE_MONITOR_SINGLE_RESOURCE_MULTIPLE_METRIC_CRITERIA);
+    }
+
+    /**
+     * Get the odataType property: specifies the type of the alert criteria.
+     * 
+     * @return the odataType value.
+     */
+    @Override
+    public Odatatype getOdataType() {
+        return this.odataType;
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/inheritance/passdiscriminator/models/MetricAlertSingleResourceMultipleMetricCriteria.java
+++ b/vanilla-tests/src/main/java/fixtures/inheritance/passdiscriminator/models/MetricAlertSingleResourceMultipleMetricCriteria.java
@@ -27,7 +27,7 @@ public final class MetricAlertSingleResourceMultipleMetricCriteria extends Metri
      */
     @JsonTypeId
     @JsonProperty(value = "odata.type", required = true)
-    private Odatatype ODATA_TYPE = Odatatype.MICROSOFT_AZURE_MONITOR_SINGLE_RESOURCE_MULTIPLE_METRIC_CRITERIA;
+    private Odatatype odataType = Odatatype.MICROSOFT_AZURE_MONITOR_SINGLE_RESOURCE_MULTIPLE_METRIC_CRITERIA;
 
     /*
      * The list of metric criteria for this 'all of' operation. 

--- a/vanilla-tests/src/main/java/fixtures/inheritance/passdiscriminator/models/MetricAlertSingleResourceMultipleMetricCriteria.java
+++ b/vanilla-tests/src/main/java/fixtures/inheritance/passdiscriminator/models/MetricAlertSingleResourceMultipleMetricCriteria.java
@@ -27,7 +27,7 @@ public final class MetricAlertSingleResourceMultipleMetricCriteria extends Metri
      */
     @JsonTypeId
     @JsonProperty(value = "odata.type", required = true)
-    private Odatatype odataType = Odatatype.MICROSOFT_AZURE_MONITOR_SINGLE_RESOURCE_MULTIPLE_METRIC_CRITERIA;
+    private Odatatype ODATA_TYPE = Odatatype.MICROSOFT_AZURE_MONITOR_SINGLE_RESOURCE_MULTIPLE_METRIC_CRITERIA;
 
     /*
      * The list of metric criteria for this 'all of' operation. 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Cookiecuttershark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Cookiecuttershark.java
@@ -18,11 +18,25 @@ import java.util.List;
  */
 @Fluent
 public final class Cookiecuttershark extends Shark {
+    /*
+     * The fishtype property.
+     */
+    private String fishtype = "cookiecuttershark";
+
     /**
      * Creates an instance of Cookiecuttershark class.
      */
     public Cookiecuttershark() {
-        setFishtype("cookiecuttershark");
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -89,10 +103,10 @@ public final class Cookiecuttershark extends Shark {
         jsonWriter.writeFloatField("length", getLength());
         jsonWriter.writeStringField("birthday",
             getBirthday() == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(getBirthday()));
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeNumberField("age", getAge());
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         return jsonWriter.writeEndObject();
     }
 
@@ -116,8 +130,6 @@ public final class Cookiecuttershark extends Shark {
                 } else if ("birthday".equals(fieldName)) {
                     deserializedCookiecuttershark.setBirthday(
                         reader.getNullable(nonNullReader -> OffsetDateTime.parse(nonNullReader.getString())));
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedCookiecuttershark.setFishtype(reader.getString());
                 } else if ("species".equals(fieldName)) {
                     deserializedCookiecuttershark.setSpecies(reader.getString());
                 } else if ("siblings".equals(fieldName)) {
@@ -125,6 +137,8 @@ public final class Cookiecuttershark extends Shark {
                     deserializedCookiecuttershark.setSiblings(siblings);
                 } else if ("age".equals(fieldName)) {
                     deserializedCookiecuttershark.setAge(reader.getNullable(JsonReader::getInt));
+                } else if ("fishtype".equals(fieldName)) {
+                    deserializedCookiecuttershark.fishtype = reader.getString();
                 } else {
                     reader.skipChildren();
                 }

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/DotFish.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/DotFish.java
@@ -43,17 +43,6 @@ public class DotFish implements JsonSerializable<DotFish> {
     }
 
     /**
-     * Set the fishType property: The fish.type property.
-     * 
-     * @param fishType the fishType value to set.
-     * @return the DotFish object itself.
-     */
-    protected DotFish setFishType(String fishType) {
-        this.fishType = fishType;
-        return this;
-    }
-
-    /**
      * Get the species property: The species property.
      * 
      * @return the species value.

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/DotSalmon.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/DotSalmon.java
@@ -16,6 +16,11 @@ import java.io.IOException;
 @Fluent
 public final class DotSalmon extends DotFish {
     /*
+     * The fish.type property.
+     */
+    private String fishType = "DotSalmon";
+
+    /*
      * The location property.
      */
     private String location;
@@ -29,7 +34,16 @@ public final class DotSalmon extends DotFish {
      * Creates an instance of DotSalmon class.
      */
     public DotSalmon() {
-        setFishType("DotSalmon");
+    }
+
+    /**
+     * Get the fishType property: The fish.type property.
+     * 
+     * @return the fishType value.
+     */
+    @Override
+    public String getFishType() {
+        return this.fishType;
     }
 
     /**
@@ -97,8 +111,8 @@ public final class DotSalmon extends DotFish {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("fish.type", getFishType());
         jsonWriter.writeStringField("species", getSpecies());
+        jsonWriter.writeStringField("fish.type", this.fishType);
         jsonWriter.writeStringField("location", this.location);
         jsonWriter.writeBooleanField("iswild", this.iswild);
         return jsonWriter.writeEndObject();
@@ -118,10 +132,10 @@ public final class DotSalmon extends DotFish {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("fish.type".equals(fieldName)) {
-                    deserializedDotSalmon.setFishType(reader.getString());
-                } else if ("species".equals(fieldName)) {
+                if ("species".equals(fieldName)) {
                     deserializedDotSalmon.setSpecies(reader.getString());
+                } else if ("fish.type".equals(fieldName)) {
+                    deserializedDotSalmon.fishType = reader.getString();
                 } else if ("location".equals(fieldName)) {
                     deserializedDotSalmon.location = reader.getString();
                 } else if ("iswild".equals(fieldName)) {

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Fish.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Fish.java
@@ -54,17 +54,6 @@ public class Fish implements JsonSerializable<Fish> {
     }
 
     /**
-     * Set the fishtype property: The fishtype property.
-     * 
-     * @param fishtype the fishtype value to set.
-     * @return the Fish object itself.
-     */
-    protected Fish setFishtype(String fishtype) {
-        this.fishtype = fishtype;
-        return this;
-    }
-
-    /**
      * Get the species property: The species property.
      * 
      * @return the species value.

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Goblinshark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Goblinshark.java
@@ -19,6 +19,11 @@ import java.util.List;
 @Fluent
 public final class Goblinshark extends Shark {
     /*
+     * The fishtype property.
+     */
+    private String fishtype = "goblin";
+
+    /*
      * The jawsize property.
      */
     private Integer jawsize;
@@ -32,7 +37,16 @@ public final class Goblinshark extends Shark {
      * Creates an instance of Goblinshark class.
      */
     public Goblinshark() {
-        setFishtype("goblin");
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -139,10 +153,10 @@ public final class Goblinshark extends Shark {
         jsonWriter.writeFloatField("length", getLength());
         jsonWriter.writeStringField("birthday",
             getBirthday() == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(getBirthday()));
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeNumberField("age", getAge());
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         jsonWriter.writeNumberField("jawsize", this.jawsize);
         jsonWriter.writeStringField("color", this.color == null ? null : this.color.toString());
         return jsonWriter.writeEndObject();
@@ -168,8 +182,6 @@ public final class Goblinshark extends Shark {
                 } else if ("birthday".equals(fieldName)) {
                     deserializedGoblinshark.setBirthday(
                         reader.getNullable(nonNullReader -> OffsetDateTime.parse(nonNullReader.getString())));
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedGoblinshark.setFishtype(reader.getString());
                 } else if ("species".equals(fieldName)) {
                     deserializedGoblinshark.setSpecies(reader.getString());
                 } else if ("siblings".equals(fieldName)) {
@@ -177,6 +189,8 @@ public final class Goblinshark extends Shark {
                     deserializedGoblinshark.setSiblings(siblings);
                 } else if ("age".equals(fieldName)) {
                     deserializedGoblinshark.setAge(reader.getNullable(JsonReader::getInt));
+                } else if ("fishtype".equals(fieldName)) {
+                    deserializedGoblinshark.fishtype = reader.getString();
                 } else if ("jawsize".equals(fieldName)) {
                     deserializedGoblinshark.jawsize = reader.getNullable(JsonReader::getInt);
                 } else if ("color".equals(fieldName)) {

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/MyBaseType.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/MyBaseType.java
@@ -48,17 +48,6 @@ public class MyBaseType implements JsonSerializable<MyBaseType> {
     }
 
     /**
-     * Set the kind property: The kind property.
-     * 
-     * @param kind the kind value to set.
-     * @return the MyBaseType object itself.
-     */
-    protected MyBaseType setKind(MyKind kind) {
-        this.kind = kind;
-        return this;
-    }
-
-    /**
      * Get the propB1 property: The propB1 property.
      * 
      * @return the propB1 value.

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/MyDerivedType.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/MyDerivedType.java
@@ -16,6 +16,11 @@ import java.io.IOException;
 @Fluent
 public final class MyDerivedType extends MyBaseType {
     /*
+     * The kind property.
+     */
+    private MyKind kind = MyKind.KIND1;
+
+    /*
      * The propD1 property.
      */
     private String propD1;
@@ -24,7 +29,16 @@ public final class MyDerivedType extends MyBaseType {
      * Creates an instance of MyDerivedType class.
      */
     public MyDerivedType() {
-        setKind(MyKind.KIND1);
+    }
+
+    /**
+     * Get the kind property: The kind property.
+     * 
+     * @return the kind value.
+     */
+    @Override
+    public MyKind getKind() {
+        return this.kind;
     }
 
     /**
@@ -81,8 +95,8 @@ public final class MyDerivedType extends MyBaseType {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("kind", getKind() == null ? null : getKind().toString());
         jsonWriter.writeStringField("propB1", getPropB1());
+        jsonWriter.writeStringField("kind", this.kind == null ? null : this.kind.toString());
         jsonWriter.writeStringField("propD1", this.propD1);
         if (getPropBH1() != null) {
             jsonWriter.writeStartObject("helper");
@@ -106,10 +120,10 @@ public final class MyDerivedType extends MyBaseType {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("kind".equals(fieldName)) {
-                    deserializedMyDerivedType.setKind(MyKind.fromString(reader.getString()));
-                } else if ("propB1".equals(fieldName)) {
+                if ("propB1".equals(fieldName)) {
                     deserializedMyDerivedType.setPropB1(reader.getString());
+                } else if ("kind".equals(fieldName)) {
+                    deserializedMyDerivedType.kind = MyKind.fromString(reader.getString());
                 } else if ("propD1".equals(fieldName)) {
                     deserializedMyDerivedType.propD1 = reader.getString();
                 } else if ("helper".equals(fieldName) && reader.currentToken() == JsonToken.START_OBJECT) {

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Salmon.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Salmon.java
@@ -17,6 +17,11 @@ import java.util.List;
 @Fluent
 public class Salmon extends Fish {
     /*
+     * The fishtype property.
+     */
+    private String fishtype = "salmon";
+
+    /*
      * The location property.
      */
     private String location;
@@ -30,7 +35,16 @@ public class Salmon extends Fish {
      * Creates an instance of Salmon class.
      */
     public Salmon() {
-        setFishtype("salmon");
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -117,9 +131,9 @@ public class Salmon extends Fish {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeFloatField("length", getLength());
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         jsonWriter.writeStringField("location", this.location);
         jsonWriter.writeBooleanField("iswild", this.iswild);
         return jsonWriter.writeEndObject();
@@ -167,13 +181,13 @@ public class Salmon extends Fish {
 
                 if ("length".equals(fieldName)) {
                     deserializedSalmon.setLength(reader.getFloat());
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedSalmon.setFishtype(reader.getString());
                 } else if ("species".equals(fieldName)) {
                     deserializedSalmon.setSpecies(reader.getString());
                 } else if ("siblings".equals(fieldName)) {
                     List<Fish> siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
                     deserializedSalmon.setSiblings(siblings);
+                } else if ("fishtype".equals(fieldName)) {
+                    deserializedSalmon.fishtype = reader.getString();
                 } else if ("location".equals(fieldName)) {
                     deserializedSalmon.location = reader.getString();
                 } else if ("iswild".equals(fieldName)) {

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Sawshark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Sawshark.java
@@ -20,6 +20,11 @@ import java.util.List;
 @Fluent
 public final class Sawshark extends Shark {
     /*
+     * The fishtype property.
+     */
+    private String fishtype = "sawshark";
+
+    /*
      * The picture property.
      */
     private byte[] picture;
@@ -28,7 +33,16 @@ public final class Sawshark extends Shark {
      * Creates an instance of Sawshark class.
      */
     public Sawshark() {
-        setFishtype("sawshark");
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -115,10 +129,10 @@ public final class Sawshark extends Shark {
         jsonWriter.writeFloatField("length", getLength());
         jsonWriter.writeStringField("birthday",
             getBirthday() == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(getBirthday()));
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeNumberField("age", getAge());
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         jsonWriter.writeBinaryField("picture", this.picture);
         return jsonWriter.writeEndObject();
     }
@@ -143,8 +157,6 @@ public final class Sawshark extends Shark {
                 } else if ("birthday".equals(fieldName)) {
                     deserializedSawshark.setBirthday(
                         reader.getNullable(nonNullReader -> OffsetDateTime.parse(nonNullReader.getString())));
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedSawshark.setFishtype(reader.getString());
                 } else if ("species".equals(fieldName)) {
                     deserializedSawshark.setSpecies(reader.getString());
                 } else if ("siblings".equals(fieldName)) {
@@ -152,6 +164,8 @@ public final class Sawshark extends Shark {
                     deserializedSawshark.setSiblings(siblings);
                 } else if ("age".equals(fieldName)) {
                     deserializedSawshark.setAge(reader.getNullable(JsonReader::getInt));
+                } else if ("fishtype".equals(fieldName)) {
+                    deserializedSawshark.fishtype = reader.getString();
                 } else if ("picture".equals(fieldName)) {
                     deserializedSawshark.picture = reader.getBinary();
                 } else {

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Shark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Shark.java
@@ -20,6 +20,11 @@ import java.util.List;
 @Fluent
 public class Shark extends Fish {
     /*
+     * The fishtype property.
+     */
+    private String fishtype = "shark";
+
+    /*
      * The age property.
      */
     private Integer age;
@@ -33,7 +38,16 @@ public class Shark extends Fish {
      * Creates an instance of Shark class.
      */
     public Shark() {
-        setFishtype("shark");
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -126,11 +140,11 @@ public class Shark extends Fish {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeFloatField("length", getLength());
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeStringField("birthday",
             this.birthday == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.birthday));
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         jsonWriter.writeNumberField("age", this.age);
         return jsonWriter.writeEndObject();
     }
@@ -181,8 +195,6 @@ public class Shark extends Fish {
 
                 if ("length".equals(fieldName)) {
                     deserializedShark.setLength(reader.getFloat());
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedShark.setFishtype(reader.getString());
                 } else if ("species".equals(fieldName)) {
                     deserializedShark.setSpecies(reader.getString());
                 } else if ("siblings".equals(fieldName)) {
@@ -191,6 +203,8 @@ public class Shark extends Fish {
                 } else if ("birthday".equals(fieldName)) {
                     deserializedShark.birthday
                         = reader.getNullable(nonNullReader -> OffsetDateTime.parse(nonNullReader.getString()));
+                } else if ("fishtype".equals(fieldName)) {
+                    deserializedShark.fishtype = reader.getString();
                 } else if ("age".equals(fieldName)) {
                     deserializedShark.age = reader.getNullable(JsonReader::getInt);
                 } else {

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/SmartSalmon.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/SmartSalmon.java
@@ -19,6 +19,11 @@ import java.util.Map;
 @Fluent
 public final class SmartSalmon extends Salmon {
     /*
+     * The fishtype property.
+     */
+    private String fishtype = "smart_salmon";
+
+    /*
      * The college_degree property.
      */
     private String collegeDegree;
@@ -32,7 +37,16 @@ public final class SmartSalmon extends Salmon {
      * Creates an instance of SmartSalmon class.
      */
     public SmartSalmon() {
-        setFishtype("smart_salmon");
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -137,11 +151,11 @@ public final class SmartSalmon extends Salmon {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeFloatField("length", getLength());
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeStringField("location", getLocation());
         jsonWriter.writeBooleanField("iswild", iswild());
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         jsonWriter.writeStringField("college_degree", this.collegeDegree);
         if (additionalProperties != null) {
             for (Map.Entry<String, Object> additionalProperty : additionalProperties.entrySet()) {
@@ -169,8 +183,6 @@ public final class SmartSalmon extends Salmon {
 
                 if ("length".equals(fieldName)) {
                     deserializedSmartSalmon.setLength(reader.getFloat());
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedSmartSalmon.setFishtype(reader.getString());
                 } else if ("species".equals(fieldName)) {
                     deserializedSmartSalmon.setSpecies(reader.getString());
                 } else if ("siblings".equals(fieldName)) {
@@ -180,6 +192,8 @@ public final class SmartSalmon extends Salmon {
                     deserializedSmartSalmon.setLocation(reader.getString());
                 } else if ("iswild".equals(fieldName)) {
                     deserializedSmartSalmon.setIswild(reader.getNullable(JsonReader::getBoolean));
+                } else if ("fishtype".equals(fieldName)) {
+                    deserializedSmartSalmon.fishtype = reader.getString();
                 } else if ("college_degree".equals(fieldName)) {
                     deserializedSmartSalmon.collegeDegree = reader.getString();
                 } else {

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Cookiecuttershark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Cookiecuttershark.java
@@ -19,6 +19,11 @@ import java.util.List;
  */
 @Fluent
 public final class Cookiecuttershark extends Shark {
+    /*
+     * The fishtype property.
+     */
+    private String fishtype = "cookiecuttershark";
+
     /**
      * Creates an instance of Cookiecuttershark class.
      * 
@@ -27,7 +32,16 @@ public final class Cookiecuttershark extends Shark {
      */
     public Cookiecuttershark(float length, OffsetDateTime birthday) {
         super(length, birthday);
-        setFishtype("cookiecuttershark");
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -76,10 +90,10 @@ public final class Cookiecuttershark extends Shark {
         jsonWriter.writeFloatField("length", getLength());
         jsonWriter.writeStringField("birthday",
             getBirthday() == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(getBirthday()));
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeNumberField("age", getAge());
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         return jsonWriter.writeEndObject();
     }
 
@@ -97,10 +111,10 @@ public final class Cookiecuttershark extends Shark {
             float length = 0.0f;
             boolean birthdayFound = false;
             OffsetDateTime birthday = null;
-            String fishtype = "cookiecuttershark";
             String species = null;
             List<Fish> siblings = null;
             Integer age = null;
+            String fishtype = "cookiecuttershark";
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
@@ -111,24 +125,24 @@ public final class Cookiecuttershark extends Shark {
                 } else if ("birthday".equals(fieldName)) {
                     birthday = reader.getNullable(nonNullReader -> OffsetDateTime.parse(nonNullReader.getString()));
                     birthdayFound = true;
-                } else if ("fishtype".equals(fieldName)) {
-                    fishtype = reader.getString();
                 } else if ("species".equals(fieldName)) {
                     species = reader.getString();
                 } else if ("siblings".equals(fieldName)) {
                     siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
                 } else if ("age".equals(fieldName)) {
                     age = reader.getNullable(JsonReader::getInt);
+                } else if ("fishtype".equals(fieldName)) {
+                    fishtype = reader.getString();
                 } else {
                     reader.skipChildren();
                 }
             }
             if (lengthFound && birthdayFound) {
                 Cookiecuttershark deserializedCookiecuttershark = new Cookiecuttershark(length, birthday);
-                deserializedCookiecuttershark.setFishtype(fishtype);
                 deserializedCookiecuttershark.setSpecies(species);
                 deserializedCookiecuttershark.setSiblings(siblings);
                 deserializedCookiecuttershark.setAge(age);
+                deserializedCookiecuttershark.fishtype = fishtype;
 
                 return deserializedCookiecuttershark;
             }

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/DotFish.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/DotFish.java
@@ -43,17 +43,6 @@ public class DotFish implements JsonSerializable<DotFish> {
     }
 
     /**
-     * Set the fishType property: The fish.type property.
-     * 
-     * @param fishType the fishType value to set.
-     * @return the DotFish object itself.
-     */
-    protected DotFish setFishType(String fishType) {
-        this.fishType = fishType;
-        return this;
-    }
-
-    /**
      * Get the species property: The species property.
      * 
      * @return the species value.

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/DotSalmon.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/DotSalmon.java
@@ -16,6 +16,11 @@ import java.io.IOException;
 @Fluent
 public final class DotSalmon extends DotFish {
     /*
+     * The fish.type property.
+     */
+    private String fishType = "DotSalmon";
+
+    /*
      * The location property.
      */
     private String location;
@@ -29,7 +34,16 @@ public final class DotSalmon extends DotFish {
      * Creates an instance of DotSalmon class.
      */
     public DotSalmon() {
-        setFishType("DotSalmon");
+    }
+
+    /**
+     * Get the fishType property: The fish.type property.
+     * 
+     * @return the fishType value.
+     */
+    @Override
+    public String getFishType() {
+        return this.fishType;
     }
 
     /**
@@ -97,8 +111,8 @@ public final class DotSalmon extends DotFish {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("fish.type", getFishType());
         jsonWriter.writeStringField("species", getSpecies());
+        jsonWriter.writeStringField("fish.type", this.fishType);
         jsonWriter.writeStringField("location", this.location);
         jsonWriter.writeBooleanField("iswild", this.iswild);
         return jsonWriter.writeEndObject();
@@ -118,10 +132,10 @@ public final class DotSalmon extends DotFish {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("fish.type".equals(fieldName)) {
-                    deserializedDotSalmon.setFishType(reader.getString());
-                } else if ("species".equals(fieldName)) {
+                if ("species".equals(fieldName)) {
                     deserializedDotSalmon.setSpecies(reader.getString());
+                } else if ("fish.type".equals(fieldName)) {
+                    deserializedDotSalmon.fishType = reader.getString();
                 } else if ("location".equals(fieldName)) {
                     deserializedDotSalmon.location = reader.getString();
                 } else if ("iswild".equals(fieldName)) {

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Fish.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Fish.java
@@ -57,17 +57,6 @@ public class Fish implements JsonSerializable<Fish> {
     }
 
     /**
-     * Set the fishtype property: The fishtype property.
-     * 
-     * @param fishtype the fishtype value to set.
-     * @return the Fish object itself.
-     */
-    protected Fish setFishtype(String fishtype) {
-        this.fishtype = fishtype;
-        return this;
-    }
-
-    /**
      * Get the species property: The species property.
      * 
      * @return the species value.

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Goblinshark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Goblinshark.java
@@ -20,6 +20,11 @@ import java.util.List;
 @Fluent
 public final class Goblinshark extends Shark {
     /*
+     * The fishtype property.
+     */
+    private String fishtype = "goblin";
+
+    /*
      * The jawsize property.
      */
     private Integer jawsize;
@@ -37,7 +42,16 @@ public final class Goblinshark extends Shark {
      */
     public Goblinshark(float length, OffsetDateTime birthday) {
         super(length, birthday);
-        setFishtype("goblin");
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -126,10 +140,10 @@ public final class Goblinshark extends Shark {
         jsonWriter.writeFloatField("length", getLength());
         jsonWriter.writeStringField("birthday",
             getBirthday() == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(getBirthday()));
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeNumberField("age", getAge());
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         jsonWriter.writeNumberField("jawsize", this.jawsize);
         jsonWriter.writeStringField("color", this.color == null ? null : this.color.toString());
         return jsonWriter.writeEndObject();
@@ -149,10 +163,10 @@ public final class Goblinshark extends Shark {
             float length = 0.0f;
             boolean birthdayFound = false;
             OffsetDateTime birthday = null;
-            String fishtype = "goblin";
             String species = null;
             List<Fish> siblings = null;
             Integer age = null;
+            String fishtype = "goblin";
             Integer jawsize = null;
             GoblinSharkColor color = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
@@ -165,14 +179,14 @@ public final class Goblinshark extends Shark {
                 } else if ("birthday".equals(fieldName)) {
                     birthday = reader.getNullable(nonNullReader -> OffsetDateTime.parse(nonNullReader.getString()));
                     birthdayFound = true;
-                } else if ("fishtype".equals(fieldName)) {
-                    fishtype = reader.getString();
                 } else if ("species".equals(fieldName)) {
                     species = reader.getString();
                 } else if ("siblings".equals(fieldName)) {
                     siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
                 } else if ("age".equals(fieldName)) {
                     age = reader.getNullable(JsonReader::getInt);
+                } else if ("fishtype".equals(fieldName)) {
+                    fishtype = reader.getString();
                 } else if ("jawsize".equals(fieldName)) {
                     jawsize = reader.getNullable(JsonReader::getInt);
                 } else if ("color".equals(fieldName)) {
@@ -183,10 +197,10 @@ public final class Goblinshark extends Shark {
             }
             if (lengthFound && birthdayFound) {
                 Goblinshark deserializedGoblinshark = new Goblinshark(length, birthday);
-                deserializedGoblinshark.setFishtype(fishtype);
                 deserializedGoblinshark.setSpecies(species);
                 deserializedGoblinshark.setSiblings(siblings);
                 deserializedGoblinshark.setAge(age);
+                deserializedGoblinshark.fishtype = fishtype;
                 deserializedGoblinshark.jawsize = jawsize;
                 deserializedGoblinshark.color = color;
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/MyBaseType.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/MyBaseType.java
@@ -48,17 +48,6 @@ public class MyBaseType implements JsonSerializable<MyBaseType> {
     }
 
     /**
-     * Set the kind property: The kind property.
-     * 
-     * @param kind the kind value to set.
-     * @return the MyBaseType object itself.
-     */
-    protected MyBaseType setKind(MyKind kind) {
-        this.kind = kind;
-        return this;
-    }
-
-    /**
      * Get the propB1 property: The propB1 property.
      * 
      * @return the propB1 value.

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/MyDerivedType.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/MyDerivedType.java
@@ -16,6 +16,11 @@ import java.io.IOException;
 @Fluent
 public final class MyDerivedType extends MyBaseType {
     /*
+     * The kind property.
+     */
+    private MyKind kind = MyKind.KIND1;
+
+    /*
      * The propD1 property.
      */
     private String propD1;
@@ -24,7 +29,16 @@ public final class MyDerivedType extends MyBaseType {
      * Creates an instance of MyDerivedType class.
      */
     public MyDerivedType() {
-        setKind(MyKind.KIND1);
+    }
+
+    /**
+     * Get the kind property: The kind property.
+     * 
+     * @return the kind value.
+     */
+    @Override
+    public MyKind getKind() {
+        return this.kind;
     }
 
     /**
@@ -81,8 +95,8 @@ public final class MyDerivedType extends MyBaseType {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("kind", getKind() == null ? null : getKind().toString());
         jsonWriter.writeStringField("propB1", getPropB1());
+        jsonWriter.writeStringField("kind", this.kind == null ? null : this.kind.toString());
         jsonWriter.writeStringField("propD1", this.propD1);
         if (getPropBH1() != null) {
             jsonWriter.writeStartObject("helper");
@@ -106,10 +120,10 @@ public final class MyDerivedType extends MyBaseType {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("kind".equals(fieldName)) {
-                    deserializedMyDerivedType.setKind(MyKind.fromString(reader.getString()));
-                } else if ("propB1".equals(fieldName)) {
+                if ("propB1".equals(fieldName)) {
                     deserializedMyDerivedType.setPropB1(reader.getString());
+                } else if ("kind".equals(fieldName)) {
+                    deserializedMyDerivedType.kind = MyKind.fromString(reader.getString());
                 } else if ("propD1".equals(fieldName)) {
                     deserializedMyDerivedType.propD1 = reader.getString();
                 } else if ("helper".equals(fieldName) && reader.currentToken() == JsonToken.START_OBJECT) {

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Salmon.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Salmon.java
@@ -17,6 +17,11 @@ import java.util.List;
 @Fluent
 public class Salmon extends Fish {
     /*
+     * The fishtype property.
+     */
+    private String fishtype = "salmon";
+
+    /*
      * The location property.
      */
     private String location;
@@ -33,7 +38,16 @@ public class Salmon extends Fish {
      */
     public Salmon(float length) {
         super(length);
-        setFishtype("salmon");
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -111,9 +125,9 @@ public class Salmon extends Fish {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeFloatField("length", getLength());
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         jsonWriter.writeStringField("location", this.location);
         jsonWriter.writeBooleanField("iswild", this.iswild);
         return jsonWriter.writeEndObject();
@@ -156,9 +170,9 @@ public class Salmon extends Fish {
         return jsonReader.readObject(reader -> {
             boolean lengthFound = false;
             float length = 0.0f;
-            String fishtype = "salmon";
             String species = null;
             List<Fish> siblings = null;
+            String fishtype = "salmon";
             String location = null;
             Boolean iswild = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
@@ -168,12 +182,12 @@ public class Salmon extends Fish {
                 if ("length".equals(fieldName)) {
                     length = reader.getFloat();
                     lengthFound = true;
-                } else if ("fishtype".equals(fieldName)) {
-                    fishtype = reader.getString();
                 } else if ("species".equals(fieldName)) {
                     species = reader.getString();
                 } else if ("siblings".equals(fieldName)) {
                     siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
+                } else if ("fishtype".equals(fieldName)) {
+                    fishtype = reader.getString();
                 } else if ("location".equals(fieldName)) {
                     location = reader.getString();
                 } else if ("iswild".equals(fieldName)) {
@@ -184,9 +198,9 @@ public class Salmon extends Fish {
             }
             if (lengthFound) {
                 Salmon deserializedSalmon = new Salmon(length);
-                deserializedSalmon.setFishtype(fishtype);
                 deserializedSalmon.setSpecies(species);
                 deserializedSalmon.setSiblings(siblings);
+                deserializedSalmon.fishtype = fishtype;
                 deserializedSalmon.location = location;
                 deserializedSalmon.iswild = iswild;
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Sawshark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Sawshark.java
@@ -21,6 +21,11 @@ import java.util.List;
 @Fluent
 public final class Sawshark extends Shark {
     /*
+     * The fishtype property.
+     */
+    private String fishtype = "sawshark";
+
+    /*
      * The picture property.
      */
     private byte[] picture;
@@ -33,7 +38,16 @@ public final class Sawshark extends Shark {
      */
     public Sawshark(float length, OffsetDateTime birthday) {
         super(length, birthday);
-        setFishtype("sawshark");
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -102,10 +116,10 @@ public final class Sawshark extends Shark {
         jsonWriter.writeFloatField("length", getLength());
         jsonWriter.writeStringField("birthday",
             getBirthday() == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(getBirthday()));
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeNumberField("age", getAge());
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         jsonWriter.writeBinaryField("picture", this.picture);
         return jsonWriter.writeEndObject();
     }
@@ -124,10 +138,10 @@ public final class Sawshark extends Shark {
             float length = 0.0f;
             boolean birthdayFound = false;
             OffsetDateTime birthday = null;
-            String fishtype = "sawshark";
             String species = null;
             List<Fish> siblings = null;
             Integer age = null;
+            String fishtype = "sawshark";
             byte[] picture = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();
@@ -139,14 +153,14 @@ public final class Sawshark extends Shark {
                 } else if ("birthday".equals(fieldName)) {
                     birthday = reader.getNullable(nonNullReader -> OffsetDateTime.parse(nonNullReader.getString()));
                     birthdayFound = true;
-                } else if ("fishtype".equals(fieldName)) {
-                    fishtype = reader.getString();
                 } else if ("species".equals(fieldName)) {
                     species = reader.getString();
                 } else if ("siblings".equals(fieldName)) {
                     siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
                 } else if ("age".equals(fieldName)) {
                     age = reader.getNullable(JsonReader::getInt);
+                } else if ("fishtype".equals(fieldName)) {
+                    fishtype = reader.getString();
                 } else if ("picture".equals(fieldName)) {
                     picture = reader.getBinary();
                 } else {
@@ -155,10 +169,10 @@ public final class Sawshark extends Shark {
             }
             if (lengthFound && birthdayFound) {
                 Sawshark deserializedSawshark = new Sawshark(length, birthday);
-                deserializedSawshark.setFishtype(fishtype);
                 deserializedSawshark.setSpecies(species);
                 deserializedSawshark.setSiblings(siblings);
                 deserializedSawshark.setAge(age);
+                deserializedSawshark.fishtype = fishtype;
                 deserializedSawshark.picture = picture;
 
                 return deserializedSawshark;

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Shark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Shark.java
@@ -21,6 +21,11 @@ import java.util.List;
 @Fluent
 public class Shark extends Fish {
     /*
+     * The fishtype property.
+     */
+    private String fishtype = "shark";
+
+    /*
      * The age property.
      */
     private Integer age;
@@ -38,8 +43,17 @@ public class Shark extends Fish {
      */
     public Shark(float length, OffsetDateTime birthday) {
         super(length);
-        setFishtype("shark");
         this.birthday = birthday;
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -112,11 +126,11 @@ public class Shark extends Fish {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeFloatField("length", getLength());
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeStringField("birthday",
             this.birthday == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.birthday));
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         jsonWriter.writeNumberField("age", this.age);
         return jsonWriter.writeEndObject();
     }
@@ -162,11 +176,11 @@ public class Shark extends Fish {
         return jsonReader.readObject(reader -> {
             boolean lengthFound = false;
             float length = 0.0f;
-            String fishtype = "shark";
             String species = null;
             List<Fish> siblings = null;
             boolean birthdayFound = false;
             OffsetDateTime birthday = null;
+            String fishtype = "shark";
             Integer age = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();
@@ -175,8 +189,6 @@ public class Shark extends Fish {
                 if ("length".equals(fieldName)) {
                     length = reader.getFloat();
                     lengthFound = true;
-                } else if ("fishtype".equals(fieldName)) {
-                    fishtype = reader.getString();
                 } else if ("species".equals(fieldName)) {
                     species = reader.getString();
                 } else if ("siblings".equals(fieldName)) {
@@ -184,6 +196,8 @@ public class Shark extends Fish {
                 } else if ("birthday".equals(fieldName)) {
                     birthday = reader.getNullable(nonNullReader -> OffsetDateTime.parse(nonNullReader.getString()));
                     birthdayFound = true;
+                } else if ("fishtype".equals(fieldName)) {
+                    fishtype = reader.getString();
                 } else if ("age".equals(fieldName)) {
                     age = reader.getNullable(JsonReader::getInt);
                 } else {
@@ -192,9 +206,9 @@ public class Shark extends Fish {
             }
             if (lengthFound && birthdayFound) {
                 Shark deserializedShark = new Shark(length, birthday);
-                deserializedShark.setFishtype(fishtype);
                 deserializedShark.setSpecies(species);
                 deserializedShark.setSiblings(siblings);
+                deserializedShark.fishtype = fishtype;
                 deserializedShark.age = age;
 
                 return deserializedShark;

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/SmartSalmon.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/SmartSalmon.java
@@ -19,6 +19,11 @@ import java.util.Map;
 @Fluent
 public final class SmartSalmon extends Salmon {
     /*
+     * The fishtype property.
+     */
+    private String fishtype = "smart_salmon";
+
+    /*
      * The college_degree property.
      */
     private String collegeDegree;
@@ -35,7 +40,16 @@ public final class SmartSalmon extends Salmon {
      */
     public SmartSalmon(float length) {
         super(length);
-        setFishtype("smart_salmon");
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -131,11 +145,11 @@ public final class SmartSalmon extends Salmon {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeFloatField("length", getLength());
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeStringField("location", getLocation());
         jsonWriter.writeBooleanField("iswild", iswild());
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         jsonWriter.writeStringField("college_degree", this.collegeDegree);
         if (additionalProperties != null) {
             for (Map.Entry<String, Object> additionalProperty : additionalProperties.entrySet()) {
@@ -157,11 +171,11 @@ public final class SmartSalmon extends Salmon {
         return jsonReader.readObject(reader -> {
             boolean lengthFound = false;
             float length = 0.0f;
-            String fishtype = "smart_salmon";
             String species = null;
             List<Fish> siblings = null;
             String location = null;
             Boolean iswild = null;
+            String fishtype = "smart_salmon";
             String collegeDegree = null;
             Map<String, Object> additionalProperties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
@@ -171,8 +185,6 @@ public final class SmartSalmon extends Salmon {
                 if ("length".equals(fieldName)) {
                     length = reader.getFloat();
                     lengthFound = true;
-                } else if ("fishtype".equals(fieldName)) {
-                    fishtype = reader.getString();
                 } else if ("species".equals(fieldName)) {
                     species = reader.getString();
                 } else if ("siblings".equals(fieldName)) {
@@ -181,6 +193,8 @@ public final class SmartSalmon extends Salmon {
                     location = reader.getString();
                 } else if ("iswild".equals(fieldName)) {
                     iswild = reader.getNullable(JsonReader::getBoolean);
+                } else if ("fishtype".equals(fieldName)) {
+                    fishtype = reader.getString();
                 } else if ("college_degree".equals(fieldName)) {
                     collegeDegree = reader.getString();
                 } else {
@@ -193,11 +207,11 @@ public final class SmartSalmon extends Salmon {
             }
             if (lengthFound) {
                 SmartSalmon deserializedSmartSalmon = new SmartSalmon(length);
-                deserializedSmartSalmon.setFishtype(fishtype);
                 deserializedSmartSalmon.setSpecies(species);
                 deserializedSmartSalmon.setSiblings(siblings);
                 deserializedSmartSalmon.setLocation(location);
                 deserializedSmartSalmon.setIswild(iswild);
+                deserializedSmartSalmon.fishtype = fishtype;
                 deserializedSmartSalmon.collegeDegree = collegeDegree;
                 deserializedSmartSalmon.additionalProperties = additionalProperties;
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Cookiecuttershark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Cookiecuttershark.java
@@ -18,11 +18,25 @@ import java.util.List;
  */
 @Fluent
 public final class Cookiecuttershark extends Shark {
+    /*
+     * The fishtype property.
+     */
+    private String fishtype = "cookiecuttershark";
+
     /**
      * Creates an instance of Cookiecuttershark class.
      */
     public Cookiecuttershark() {
-        setFishtype("cookiecuttershark");
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -89,10 +103,10 @@ public final class Cookiecuttershark extends Shark {
         jsonWriter.writeFloatField("length", getLength());
         jsonWriter.writeStringField("birthday",
             getBirthday() == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(getBirthday()));
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeNumberField("age", getAge());
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         return jsonWriter.writeEndObject();
     }
 
@@ -116,8 +130,6 @@ public final class Cookiecuttershark extends Shark {
                 } else if ("birthday".equals(fieldName)) {
                     deserializedCookiecuttershark.setBirthday(
                         reader.getNullable(nonNullReader -> OffsetDateTime.parse(nonNullReader.getString())));
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedCookiecuttershark.setFishtype(reader.getString());
                 } else if ("species".equals(fieldName)) {
                     deserializedCookiecuttershark.setSpecies(reader.getString());
                 } else if ("siblings".equals(fieldName)) {
@@ -125,6 +137,8 @@ public final class Cookiecuttershark extends Shark {
                     deserializedCookiecuttershark.setSiblings(siblings);
                 } else if ("age".equals(fieldName)) {
                     deserializedCookiecuttershark.setAge(reader.getNullable(JsonReader::getInt));
+                } else if ("fishtype".equals(fieldName)) {
+                    deserializedCookiecuttershark.fishtype = reader.getString();
                 } else {
                     reader.skipChildren();
                 }

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/DotFish.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/DotFish.java
@@ -43,17 +43,6 @@ public class DotFish implements JsonSerializable<DotFish> {
     }
 
     /**
-     * Set the fishType property: The fish.type property.
-     * 
-     * @param fishType the fishType value to set.
-     * @return the DotFish object itself.
-     */
-    protected DotFish setFishType(String fishType) {
-        this.fishType = fishType;
-        return this;
-    }
-
-    /**
      * Get the species property: The species property.
      * 
      * @return the species value.

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/DotSalmon.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/DotSalmon.java
@@ -16,6 +16,11 @@ import java.io.IOException;
 @Immutable
 public final class DotSalmon extends DotFish {
     /*
+     * The fish.type property.
+     */
+    private String fishType = "DotSalmon";
+
+    /*
      * The location property.
      */
     private String location;
@@ -29,7 +34,16 @@ public final class DotSalmon extends DotFish {
      * Creates an instance of DotSalmon class.
      */
     private DotSalmon() {
-        setFishType("DotSalmon");
+    }
+
+    /**
+     * Get the fishType property: The fish.type property.
+     * 
+     * @return the fishType value.
+     */
+    @Override
+    public String getFishType() {
+        return this.fishType;
     }
 
     /**
@@ -66,8 +80,8 @@ public final class DotSalmon extends DotFish {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("fish.type", getFishType());
         jsonWriter.writeStringField("species", getSpecies());
+        jsonWriter.writeStringField("fish.type", this.fishType);
         jsonWriter.writeStringField("location", this.location);
         jsonWriter.writeBooleanField("iswild", this.iswild);
         return jsonWriter.writeEndObject();
@@ -87,10 +101,10 @@ public final class DotSalmon extends DotFish {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("fish.type".equals(fieldName)) {
-                    deserializedDotSalmon.setFishType(reader.getString());
-                } else if ("species".equals(fieldName)) {
+                if ("species".equals(fieldName)) {
                     deserializedDotSalmon.setSpecies(reader.getString());
+                } else if ("fish.type".equals(fieldName)) {
+                    deserializedDotSalmon.fishType = reader.getString();
                 } else if ("location".equals(fieldName)) {
                     deserializedDotSalmon.location = reader.getString();
                 } else if ("iswild".equals(fieldName)) {

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Fish.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Fish.java
@@ -54,17 +54,6 @@ public class Fish implements JsonSerializable<Fish> {
     }
 
     /**
-     * Set the fishtype property: The fishtype property.
-     * 
-     * @param fishtype the fishtype value to set.
-     * @return the Fish object itself.
-     */
-    protected Fish setFishtype(String fishtype) {
-        this.fishtype = fishtype;
-        return this;
-    }
-
-    /**
      * Get the species property: The species property.
      * 
      * @return the species value.

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Goblinshark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Goblinshark.java
@@ -19,6 +19,11 @@ import java.util.List;
 @Fluent
 public final class Goblinshark extends Shark {
     /*
+     * The fishtype property.
+     */
+    private String fishtype = "goblin";
+
+    /*
      * The jawsize property.
      */
     private Integer jawsize;
@@ -32,7 +37,16 @@ public final class Goblinshark extends Shark {
      * Creates an instance of Goblinshark class.
      */
     public Goblinshark() {
-        setFishtype("goblin");
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -139,10 +153,10 @@ public final class Goblinshark extends Shark {
         jsonWriter.writeFloatField("length", getLength());
         jsonWriter.writeStringField("birthday",
             getBirthday() == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(getBirthday()));
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeNumberField("age", getAge());
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         jsonWriter.writeNumberField("jawsize", this.jawsize);
         jsonWriter.writeStringField("color", this.color == null ? null : this.color.toString());
         return jsonWriter.writeEndObject();
@@ -168,8 +182,6 @@ public final class Goblinshark extends Shark {
                 } else if ("birthday".equals(fieldName)) {
                     deserializedGoblinshark.setBirthday(
                         reader.getNullable(nonNullReader -> OffsetDateTime.parse(nonNullReader.getString())));
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedGoblinshark.setFishtype(reader.getString());
                 } else if ("species".equals(fieldName)) {
                     deserializedGoblinshark.setSpecies(reader.getString());
                 } else if ("siblings".equals(fieldName)) {
@@ -177,6 +189,8 @@ public final class Goblinshark extends Shark {
                     deserializedGoblinshark.setSiblings(siblings);
                 } else if ("age".equals(fieldName)) {
                     deserializedGoblinshark.setAge(reader.getNullable(JsonReader::getInt));
+                } else if ("fishtype".equals(fieldName)) {
+                    deserializedGoblinshark.fishtype = reader.getString();
                 } else if ("jawsize".equals(fieldName)) {
                     deserializedGoblinshark.jawsize = reader.getNullable(JsonReader::getInt);
                 } else if ("color".equals(fieldName)) {

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/MyBaseType.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/MyBaseType.java
@@ -48,17 +48,6 @@ public class MyBaseType implements JsonSerializable<MyBaseType> {
     }
 
     /**
-     * Set the kind property: The kind property.
-     * 
-     * @param kind the kind value to set.
-     * @return the MyBaseType object itself.
-     */
-    protected MyBaseType setKind(MyKind kind) {
-        this.kind = kind;
-        return this;
-    }
-
-    /**
      * Get the propB1 property: The propB1 property.
      * 
      * @return the propB1 value.

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/MyDerivedType.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/MyDerivedType.java
@@ -16,6 +16,11 @@ import java.io.IOException;
 @Immutable
 public final class MyDerivedType extends MyBaseType {
     /*
+     * The kind property.
+     */
+    private MyKind kind = MyKind.KIND1;
+
+    /*
      * The propD1 property.
      */
     private String propD1;
@@ -24,7 +29,16 @@ public final class MyDerivedType extends MyBaseType {
      * Creates an instance of MyDerivedType class.
      */
     private MyDerivedType() {
-        setKind(MyKind.KIND1);
+    }
+
+    /**
+     * Get the kind property: The kind property.
+     * 
+     * @return the kind value.
+     */
+    @Override
+    public MyKind getKind() {
+        return this.kind;
     }
 
     /**
@@ -52,8 +66,8 @@ public final class MyDerivedType extends MyBaseType {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("kind", getKind() == null ? null : getKind().toString());
         jsonWriter.writeStringField("propB1", getPropB1());
+        jsonWriter.writeStringField("kind", this.kind == null ? null : this.kind.toString());
         jsonWriter.writeStringField("propD1", this.propD1);
         if (getPropBH1() != null) {
             jsonWriter.writeStartObject("helper");
@@ -77,10 +91,10 @@ public final class MyDerivedType extends MyBaseType {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("kind".equals(fieldName)) {
-                    deserializedMyDerivedType.setKind(MyKind.fromString(reader.getString()));
-                } else if ("propB1".equals(fieldName)) {
+                if ("propB1".equals(fieldName)) {
                     deserializedMyDerivedType.setPropB1(reader.getString());
+                } else if ("kind".equals(fieldName)) {
+                    deserializedMyDerivedType.kind = MyKind.fromString(reader.getString());
                 } else if ("propD1".equals(fieldName)) {
                     deserializedMyDerivedType.propD1 = reader.getString();
                 } else if ("helper".equals(fieldName) && reader.currentToken() == JsonToken.START_OBJECT) {

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Salmon.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Salmon.java
@@ -17,6 +17,11 @@ import java.util.List;
 @Fluent
 public class Salmon extends Fish {
     /*
+     * The fishtype property.
+     */
+    private String fishtype = "salmon";
+
+    /*
      * The location property.
      */
     private String location;
@@ -30,7 +35,16 @@ public class Salmon extends Fish {
      * Creates an instance of Salmon class.
      */
     public Salmon() {
-        setFishtype("salmon");
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -117,9 +131,9 @@ public class Salmon extends Fish {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeFloatField("length", getLength());
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         jsonWriter.writeStringField("location", this.location);
         jsonWriter.writeBooleanField("iswild", this.iswild);
         return jsonWriter.writeEndObject();
@@ -167,13 +181,13 @@ public class Salmon extends Fish {
 
                 if ("length".equals(fieldName)) {
                     deserializedSalmon.setLength(reader.getFloat());
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedSalmon.setFishtype(reader.getString());
                 } else if ("species".equals(fieldName)) {
                     deserializedSalmon.setSpecies(reader.getString());
                 } else if ("siblings".equals(fieldName)) {
                     List<Fish> siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
                     deserializedSalmon.setSiblings(siblings);
+                } else if ("fishtype".equals(fieldName)) {
+                    deserializedSalmon.fishtype = reader.getString();
                 } else if ("location".equals(fieldName)) {
                     deserializedSalmon.location = reader.getString();
                 } else if ("iswild".equals(fieldName)) {

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Sawshark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Sawshark.java
@@ -20,6 +20,11 @@ import java.util.List;
 @Fluent
 public final class Sawshark extends Shark {
     /*
+     * The fishtype property.
+     */
+    private String fishtype = "sawshark";
+
+    /*
      * The picture property.
      */
     private byte[] picture;
@@ -28,7 +33,16 @@ public final class Sawshark extends Shark {
      * Creates an instance of Sawshark class.
      */
     public Sawshark() {
-        setFishtype("sawshark");
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -115,10 +129,10 @@ public final class Sawshark extends Shark {
         jsonWriter.writeFloatField("length", getLength());
         jsonWriter.writeStringField("birthday",
             getBirthday() == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(getBirthday()));
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeNumberField("age", getAge());
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         jsonWriter.writeBinaryField("picture", this.picture);
         return jsonWriter.writeEndObject();
     }
@@ -143,8 +157,6 @@ public final class Sawshark extends Shark {
                 } else if ("birthday".equals(fieldName)) {
                     deserializedSawshark.setBirthday(
                         reader.getNullable(nonNullReader -> OffsetDateTime.parse(nonNullReader.getString())));
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedSawshark.setFishtype(reader.getString());
                 } else if ("species".equals(fieldName)) {
                     deserializedSawshark.setSpecies(reader.getString());
                 } else if ("siblings".equals(fieldName)) {
@@ -152,6 +164,8 @@ public final class Sawshark extends Shark {
                     deserializedSawshark.setSiblings(siblings);
                 } else if ("age".equals(fieldName)) {
                     deserializedSawshark.setAge(reader.getNullable(JsonReader::getInt));
+                } else if ("fishtype".equals(fieldName)) {
+                    deserializedSawshark.fishtype = reader.getString();
                 } else if ("picture".equals(fieldName)) {
                     deserializedSawshark.picture = reader.getBinary();
                 } else {

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Shark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Shark.java
@@ -20,6 +20,11 @@ import java.util.List;
 @Fluent
 public class Shark extends Fish {
     /*
+     * The fishtype property.
+     */
+    private String fishtype = "shark";
+
+    /*
      * The age property.
      */
     private Integer age;
@@ -33,7 +38,16 @@ public class Shark extends Fish {
      * Creates an instance of Shark class.
      */
     public Shark() {
-        setFishtype("shark");
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -126,11 +140,11 @@ public class Shark extends Fish {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeFloatField("length", getLength());
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeStringField("birthday",
             this.birthday == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.birthday));
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         jsonWriter.writeNumberField("age", this.age);
         return jsonWriter.writeEndObject();
     }
@@ -181,8 +195,6 @@ public class Shark extends Fish {
 
                 if ("length".equals(fieldName)) {
                     deserializedShark.setLength(reader.getFloat());
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedShark.setFishtype(reader.getString());
                 } else if ("species".equals(fieldName)) {
                     deserializedShark.setSpecies(reader.getString());
                 } else if ("siblings".equals(fieldName)) {
@@ -191,6 +203,8 @@ public class Shark extends Fish {
                 } else if ("birthday".equals(fieldName)) {
                     deserializedShark.birthday
                         = reader.getNullable(nonNullReader -> OffsetDateTime.parse(nonNullReader.getString()));
+                } else if ("fishtype".equals(fieldName)) {
+                    deserializedShark.fishtype = reader.getString();
                 } else if ("age".equals(fieldName)) {
                     deserializedShark.age = reader.getNullable(JsonReader::getInt);
                 } else {

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/SmartSalmon.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/SmartSalmon.java
@@ -19,6 +19,11 @@ import java.util.Map;
 @Fluent
 public final class SmartSalmon extends Salmon {
     /*
+     * The fishtype property.
+     */
+    private String fishtype = "smart_salmon";
+
+    /*
      * The college_degree property.
      */
     private String collegeDegree;
@@ -32,7 +37,16 @@ public final class SmartSalmon extends Salmon {
      * Creates an instance of SmartSalmon class.
      */
     public SmartSalmon() {
-        setFishtype("smart_salmon");
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -137,11 +151,11 @@ public final class SmartSalmon extends Salmon {
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeFloatField("length", getLength());
-        jsonWriter.writeStringField("fishtype", getFishtype());
         jsonWriter.writeStringField("species", getSpecies());
         jsonWriter.writeArrayField("siblings", getSiblings(), (writer, element) -> writer.writeJson(element));
         jsonWriter.writeStringField("location", getLocation());
         jsonWriter.writeBooleanField("iswild", iswild());
+        jsonWriter.writeStringField("fishtype", this.fishtype);
         jsonWriter.writeStringField("college_degree", this.collegeDegree);
         if (additionalProperties != null) {
             for (Map.Entry<String, Object> additionalProperty : additionalProperties.entrySet()) {
@@ -169,8 +183,6 @@ public final class SmartSalmon extends Salmon {
 
                 if ("length".equals(fieldName)) {
                     deserializedSmartSalmon.setLength(reader.getFloat());
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedSmartSalmon.setFishtype(reader.getString());
                 } else if ("species".equals(fieldName)) {
                     deserializedSmartSalmon.setSpecies(reader.getString());
                 } else if ("siblings".equals(fieldName)) {
@@ -180,6 +192,8 @@ public final class SmartSalmon extends Salmon {
                     deserializedSmartSalmon.setLocation(reader.getString());
                 } else if ("iswild".equals(fieldName)) {
                     deserializedSmartSalmon.setIswild(reader.getNullable(JsonReader::getBoolean));
+                } else if ("fishtype".equals(fieldName)) {
+                    deserializedSmartSalmon.fishtype = reader.getString();
                 } else if ("college_degree".equals(fieldName)) {
                     deserializedSmartSalmon.collegeDegree = reader.getString();
                 } else {

--- a/vanilla-tests/src/test/java/fixtures/inheritance/ValidateDiscriminatorIsPassedTests.java
+++ b/vanilla-tests/src/test/java/fixtures/inheritance/ValidateDiscriminatorIsPassedTests.java
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package fixtures.inheritance.passdiscriminator;
+package fixtures.inheritance;
 
 import com.azure.core.util.BinaryData;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -14,6 +14,7 @@ import fixtures.inheritance.passdiscriminator.models.MetricAlertCriteria;
 import fixtures.inheritance.passdiscriminator.models.MetricAlertSingleResourceMultipleMetricCriteria;
 import fixtures.inheritance.passdiscriminator.models.Odatatype;
 import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -33,8 +34,9 @@ public class ValidateDiscriminatorIsPassedTests {
         assertEquals(JsonTypeInfo.As.PROPERTY, jsonTypeInfo.include());
     }
 
+    @Disabled("design changed")
     @Test
-    public void subClassAcceptsDiscriminator() throws IllegalAccessException {
+    public void subClassAcceptsDiscriminator() {
         JsonTypeInfo jsonTypeInfo = MetricAlertSingleResourceMultipleMetricCriteria.class
             .getAnnotation(JsonTypeInfo.class);
         assertNotNull(jsonTypeInfo);

--- a/vanilla-tests/src/test/java/fixtures/inheritance/ValidateDiscriminatorIsPassedTests.java
+++ b/vanilla-tests/src/test/java/fixtures/inheritance/ValidateDiscriminatorIsPassedTests.java
@@ -14,7 +14,6 @@ import fixtures.inheritance.passdiscriminator.models.MetricAlertCriteria;
 import fixtures.inheritance.passdiscriminator.models.MetricAlertSingleResourceMultipleMetricCriteria;
 import fixtures.inheritance.passdiscriminator.models.Odatatype;
 import org.junit.Test;
-import org.junit.jupiter.api.Disabled;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -34,14 +33,13 @@ public class ValidateDiscriminatorIsPassedTests {
         assertEquals(JsonTypeInfo.As.PROPERTY, jsonTypeInfo.include());
     }
 
-    @Disabled("design changed")
     @Test
     public void subClassAcceptsDiscriminator() {
         JsonTypeInfo jsonTypeInfo = MetricAlertSingleResourceMultipleMetricCriteria.class
             .getAnnotation(JsonTypeInfo.class);
         assertNotNull(jsonTypeInfo);
         assertTrue(jsonTypeInfo.visible());
-        assertEquals(JsonTypeInfo.As.EXISTING_PROPERTY, jsonTypeInfo.include());
+        assertEquals(JsonTypeInfo.As.PROPERTY, jsonTypeInfo.include());
 
         String discriminatorValue = MetricAlertSingleResourceMultipleMetricCriteria.class
             .getAnnotation(JsonTypeName.class)

--- a/vanilla-tests/src/test/java/fixtures/inheritance/ValidateDiscriminatorTests.java
+++ b/vanilla-tests/src/test/java/fixtures/inheritance/ValidateDiscriminatorTests.java
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package fixtures.inheritance;
+
+import com.azure.core.util.BinaryData;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fixtures.discriminatorflattening.models.MetricAlertCriteria;
+import fixtures.discriminatorflattening.models.MetricAlertSingleResourceMultipleMetricCriteria;
+import fixtures.discriminatorflattening.models.Odatatype;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class ValidateDiscriminatorTests {
+
+    private final static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Test
+    public void testAzureJsonSerialization() throws IOException {
+        MetricAlertCriteria superclass = new MetricAlertCriteria();
+        String superclassJson = BinaryData.fromObject(superclass).toString();
+        JsonNode jsonNode = OBJECT_MAPPER.readTree(superclassJson);
+        assertEquals(1, jsonNode.size());
+        assertEquals("MetricAlertCriteria", jsonNode.get("odata.type").asText());
+
+        MetricAlertCriteria subclass = new MetricAlertSingleResourceMultipleMetricCriteria();
+        String subclassJson = BinaryData.fromObject(subclass).toString();
+        jsonNode = OBJECT_MAPPER.readTree(subclassJson);
+        assertEquals(1, jsonNode.size());
+        assertEquals(Odatatype.MICROSOFT_AZURE_MONITOR_SINGLE_RESOURCE_MULTIPLE_METRIC_CRITERIA.toString(), jsonNode.get("odata.type").asText());
+
+        // de-serialization of unknown type
+        String unknownJson = "{\"odata.type\": \"invalid\"}";
+        MetricAlertCriteria unknown = BinaryData.fromString(unknownJson).toObject(MetricAlertCriteria.class);
+        assertEquals("invalid", unknown.getOdataType().toString());
+        assertEquals(MetricAlertCriteria.class, unknown.getClass());
+        // serialization keeps the unknown type
+        unknownJson = BinaryData.fromObject(unknown).toString();
+        jsonNode = OBJECT_MAPPER.readTree(unknownJson);
+        assertEquals(1, jsonNode.size());
+        assertEquals("invalid", jsonNode.get("odata.type").asText());
+    }
+}

--- a/vanilla-tests/src/test/java/fixtures/inheritance/passdiscriminator/ValidateDiscriminatorIsPassedTests.java
+++ b/vanilla-tests/src/test/java/fixtures/inheritance/passdiscriminator/ValidateDiscriminatorIsPassedTests.java
@@ -83,8 +83,13 @@ public class ValidateDiscriminatorIsPassedTests {
 
         // de-serialization of unknown type
         String unknownJson = "{\"odata.type\": \"invalid\"}";
-        MetricAlertCriteria criteria = BinaryData.fromString(unknownJson).toObject(MetricAlertCriteria.class);
-        assertEquals("invalid", criteria.getOdataType().toString());
-        assertEquals(MetricAlertCriteria.class, criteria.getClass());
+        MetricAlertCriteria unknown = BinaryData.fromString(unknownJson).toObject(MetricAlertCriteria.class);
+        assertEquals("invalid", unknown.getOdataType().toString());
+        assertEquals(MetricAlertCriteria.class, unknown.getClass());
+        // serialization keeps the unknown type
+        unknownJson = BinaryData.fromObject(unknown).toString();
+        jsonNode = OBJECT_MAPPER.readTree(unknownJson);
+        assertEquals(1, jsonNode.size());
+        assertEquals("invalid", jsonNode.get("odata.type").asText());
     }
 }


### PR DESCRIPTION
another fix on https://github.com/Azure/autorest.java/issues/2574

Remove `setKind` method in superclass.
Shadow `kind` variable in subclass.
Override `getKind` method in subclass.

code change https://github.com/Azure/autorest.java/pull/2639/files/e9c1c0dbad94325dacb299fc8f29a1d6c892fd7b..db632bbb53ab4612517996b0298ea42f44824de1

test like this (for both azure-json and Jackson) https://github.com/Azure/autorest.java/pull/2639/commits/e9c1c0dbad94325dacb299fc8f29a1d6c892fd7b