### PR TITLE
tsp, escape tab in javadoc

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/model/javamodel/JavaJavadocComment.java
+++ b/javagen/src/main/java/com/azure/autorest/model/javamodel/JavaJavadocComment.java
@@ -31,6 +31,8 @@ public class JavaJavadocComment {
         if (text != null) {
             // escape the "@"
             text = ESCAPE_AT.matcher(text).replaceAll("&#064;");
+            // escape tab
+            text = text.replace("\t", " ");
         }
         return CodeNamer.escapeComment(text);
     }

--- a/typespec-extension/changelog.md
+++ b/typespec-extension/changelog.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 0.15.5 (2024-03-27)
+
+Compatible with compiler 0.54.
+
 ## 0.15.4 (2024-03-26)
 
 Compatible with compiler 0.54.

--- a/typespec-extension/package-lock.json
+++ b/typespec-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/typespec-java",
-      "version": "0.15.4",
+      "version": "0.15.5",
       "license": "MIT",
       "dependencies": {
         "@autorest/codemodel": "~4.20.0",

--- a/typespec-extension/package.json
+++ b/typespec-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "description": "TypeSpec library for emitting Java client from the TypeSpec REST protocol binding",
   "keywords": [
     "TypeSpec"

--- a/typespec-tests/package.json
+++ b/typespec-tests/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@azure-tools/cadl-ranch-specs": "0.31.5",
-    "@azure-tools/typespec-java": "file:/../typespec-extension/azure-tools-typespec-java-0.15.4.tgz"
+    "@azure-tools/typespec-java": "file:/../typespec-extension/azure-tools-typespec-java-0.15.5.tgz"
   },
   "devDependencies": {
     "@typespec/prettier-plugin-typespec": "~0.54.0",

--- a/typespec-tests/src/main/java/com/cadl/naming/models/DataResponse.java
+++ b/typespec-tests/src/main/java/com/cadl/naming/models/DataResponse.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 /**
  * summary of Response
  * 
- * description of Response.
+ * description of Response. Include tab ' ' in doc.
  */
 @Immutable
 public final class DataResponse implements JsonSerializable<DataResponse> {

--- a/typespec-tests/tsp/naming.tsp
+++ b/typespec-tests/tsp/naming.tsp
@@ -15,7 +15,7 @@ using Azure.ClientGenerator.Core;
 namespace Cadl.Naming;
 
 @summary("summary of Response")
-@doc("description	of	Response")
+@doc("description of Response. Include tab '	' in doc.")
 @friendlyName("DataResponse")
 model Response {
   @summary("summary of name property")

--- a/typespec-tests/tsp/naming.tsp
+++ b/typespec-tests/tsp/naming.tsp
@@ -15,7 +15,7 @@ using Azure.ClientGenerator.Core;
 namespace Cadl.Naming;
 
 @summary("summary of Response")
-@doc("description of Response")
+@doc("description	of	Response")
 @friendlyName("DataResponse")
 model Response {
   @summary("summary of name property")


### PR DESCRIPTION
Previously this seems done by formatting.