### PR TITLE
tsp, unbranded, temporary remove generic-core as explicit dependency in POM

### DIFF
--- a/extension-base/src/main/java/com/azure/autorest/extension/base/util/HttpExceptionType.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/util/HttpExceptionType.java
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.autorest.extension.base.util;
+
+/**
+ * Represents exception types for HTTP requests and responses.
+ */
+public enum HttpExceptionType {
+    /**
+     * The exception thrown when failing to authenticate the HTTP request with status code of {@code 4XX}, typically
+     * {@code 401 Unauthorized}.
+     *
+     * <p>A runtime exception indicating request authorization failure caused by one of the following scenarios:</p>
+     * <ul>
+     *     <li>A client did not send the required authorization credentials to access the requested resource, i.e.
+     *     Authorization HTTP header is missing in the request</li>
+     *     <li>If the request contains the HTTP Authorization header, then the exception indicates that authorization
+     *     has been refused for the credentials contained in the request header.</li>
+     * </ul>
+     */
+    CLIENT_AUTHENTICATION,
+
+    /**
+     * The exception thrown when the HTTP request tried to create an already existing resource and received a status
+     * code {@code 4XX}, typically {@code 412 Conflict}.
+     */
+    RESOURCE_EXISTS,
+
+    /**
+     * The exception thrown for invalid resource modification with status code of {@code 4XX}, typically
+     * {@code 409 Conflict}.
+     */
+    RESOURCE_MODIFIED,
+
+    /**
+     * The exception thrown when receiving an error response with status code {@code 412 response} (for update) or
+     * {@code 404 Not Found} (for get/post).
+     */
+    RESOURCE_NOT_FOUND,
+
+    /**
+     * This exception thrown when an HTTP request has reached the maximum number of redirect attempts with a status code
+     * of {@code 3XX}.
+     */
+    TOO_MANY_REDIRECTS
+}

--- a/javagen/pom.xml
+++ b/javagen/pom.xml
@@ -17,12 +17,12 @@
   <artifactId>azure-autorest-javagen</artifactId>
   <version>1.0.0-beta.1</version>
 
-  <repositories>
-    <repository>
-      <id>clientcore</id>
-      <url>https://clientcore.blob.core.windows.net/artifacts</url>
-    </repository>
-  </repositories>
+<!--  <repositories>-->
+<!--    <repository>-->
+<!--      <id>clientcore</id>-->
+<!--      <url>https://clientcore.blob.core.windows.net/artifacts</url>-->
+<!--    </repository>-->
+<!--  </repositories>-->
 
   <dependencies>
     <dependency>
@@ -75,11 +75,11 @@
       <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.generic</groupId>
-      <artifactId>generic-core</artifactId>
-      <version>1.0.0-beta.1</version>
-    </dependency>
+<!--    <dependency>-->
+<!--      <groupId>com.generic</groupId>-->
+<!--      <artifactId>generic-core</artifactId>-->
+<!--      <version>1.0.0-beta.1</version>-->
+<!--    </dependency>-->
   </dependencies>
 
   <profiles>

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/Annotation.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/Annotation.java
@@ -69,18 +69,13 @@ public class Annotation {
             .knownClass(com.azure.core.annotation.HeaderCollection.class)
             .build();
 
-    public static final Annotation METADATA = new Annotation.Builder()
-            .knownClass(com.generic.core.annotation.Metadata.class)
-            .build();
-    public static final Annotation HTTP_REQUEST_INFORMATION = new Annotation.Builder()
-            .knownClass(com.generic.core.http.annotation.HttpRequestInformation.class)
-            .build();
-    public static final Annotation UNEXPECTED_RESPONSE_EXCEPTION_INFORMATION = new Annotation.Builder()
-            .knownClass(com.generic.core.http.annotation.UnexpectedResponseExceptionInformation.class)
-            .build();
-    public static final Annotation TYPE_CONDITIONS = new Annotation.Builder()
-            .knownClass(com.generic.core.annotation.TypeConditions.class)
-            .build();
+    // clientcore
+    public static final Annotation METADATA = new Annotation("com.generic.core.annotation", "Metadata");
+    public static final Annotation HTTP_REQUEST_INFORMATION
+            = new Annotation("com.generic.core.http.annotation", "HttpRequestInformation");
+    public static final Annotation UNEXPECTED_RESPONSE_EXCEPTION_INFORMATION
+            = new Annotation("com.generic.core.http.annotation", "UnexpectedResponseExceptionInformation");
+    public static final Annotation TYPE_CONDITIONS = new Annotation("com.generic.core.annotation", "TypeConditions");
 
     private final String fullName;
     private final String packageName;

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethod.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethod.java
@@ -4,11 +4,11 @@
 package com.azure.autorest.model.clientmodel;
 
 import com.azure.autorest.extension.base.plugin.JavaSettings;
+import com.azure.autorest.extension.base.util.HttpExceptionType;
 import com.azure.autorest.util.CodeNamer;
 import com.azure.autorest.util.MethodNamer;
 import com.azure.core.http.ContentType;
 import com.azure.core.http.HttpMethod;
-import com.generic.core.http.exception.HttpExceptionType;
 
 import java.util.HashMap;
 import java.util.List;

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodExample.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodExample.java
@@ -5,6 +5,7 @@ package com.azure.autorest.model.clientmodel;
 
 import com.azure.autorest.Javagen;
 import com.azure.autorest.extension.base.plugin.PluginLogger;
+import com.azure.core.http.HttpHeaderName;
 import com.azure.core.http.HttpHeaders;
 import com.azure.core.util.CoreUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -105,7 +106,7 @@ public class ProxyMethodExample {
                 if (responseMap.containsKey("headers") && responseMap.get("headers") instanceof Map) {
                     Map<String, Object> headersMap = (Map<String, Object>) responseMap.get("headers");
                     headersMap.forEach((header, value) -> {
-                        httpHeaders.add(header, value.toString());
+                        httpHeaders.add(HttpHeaderName.fromString(header), value.toString());
                     });
                 }
                 this.body = responseMap.getOrDefault("body", null);

--- a/javagen/src/main/java/com/azure/autorest/template/example/ProtocolExampleWriter.java
+++ b/javagen/src/main/java/com/azure/autorest/template/example/ProtocolExampleWriter.java
@@ -33,7 +33,7 @@ import com.azure.core.util.serializer.CollectionFormat;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -357,20 +357,20 @@ public class ProtocolExampleWriter {
             String value = (String) parameterValue;
             switch (collectionFormat) {
                 case CSV:
-                    elements = Arrays.asList(value.split(",", -1));
+                    elements = Collections.singletonList(value.split(",", -1));
                     break;
                 case SSV:
-                    elements = Arrays.asList(value.split(" ", -1));
+                    elements = Collections.singletonList(value.split(" ", -1));
                     break;
                 case PIPES:
-                    elements = Arrays.asList(value.split("\\|", -1));
+                    elements = Collections.singletonList(value.split("\\|", -1));
                     break;
                 case TSV:
-                    elements = Arrays.asList(value.split("\t", -1));
+                    elements = Collections.singletonList(value.split("\t", -1));
                     break;
                 default:
                     // TODO (weidxu): CollectionFormat.MULTI
-                    elements = Arrays.asList(value.split(",", -1));
+                    elements = Collections.singletonList(value.split(",", -1));
                     break;
             }
         } else if (parameterValue instanceof List) {

--- a/javagen/src/main/java/com/azure/autorest/template/example/ProtocolExampleWriter.java
+++ b/javagen/src/main/java/com/azure/autorest/template/example/ProtocolExampleWriter.java
@@ -33,7 +33,7 @@ import com.azure.core.util.serializer.CollectionFormat;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -357,20 +357,20 @@ public class ProtocolExampleWriter {
             String value = (String) parameterValue;
             switch (collectionFormat) {
                 case CSV:
-                    elements = Collections.singletonList(value.split(",", -1));
+                    elements = Arrays.stream(value.split(",", -1)).collect(Collectors.toList());
                     break;
                 case SSV:
-                    elements = Collections.singletonList(value.split(" ", -1));
+                    elements = Arrays.stream(value.split(" ", -1)).collect(Collectors.toList());
                     break;
                 case PIPES:
-                    elements = Collections.singletonList(value.split("\\|", -1));
+                    elements = Arrays.stream(value.split("\\|", -1)).collect(Collectors.toList());
                     break;
                 case TSV:
-                    elements = Collections.singletonList(value.split("\t", -1));
+                    elements = Arrays.stream(value.split("\t", -1)).collect(Collectors.toList());
                     break;
                 default:
                     // TODO (weidxu): CollectionFormat.MULTI
-                    elements = Collections.singletonList(value.split(",", -1));
+                    elements = Arrays.stream(value.split(",", -1)).collect(Collectors.toList());
                     break;
             }
         } else if (parameterValue instanceof List) {


### PR DESCRIPTION
It seems causing some build failure in preview build https://github.com/Azure/autorest.java/runs/23553740795

And we probably don't want to load jar from places not maven.

pick a few from https://github.com/Azure/autorest.java/pull/2626