### PR TITLE
client, no serialization on GroupSchema

### DIFF
--- a/azure-tests/src/main/java/fixtures/azureparametergrouping/models/FirstParameterGroup.java
+++ b/azure-tests/src/main/java/fixtures/azureparametergrouping/models/FirstParameterGroup.java
@@ -5,17 +5,12 @@
 package fixtures.azureparametergrouping.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonToken;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 
 /**
  * Parameter group.
  */
 @Fluent
-public final class FirstParameterGroup implements JsonSerializable<FirstParameterGroup> {
+public final class FirstParameterGroup {
     /*
      * The header-one property.
      */
@@ -78,44 +73,5 @@ public final class FirstParameterGroup implements JsonSerializable<FirstParamete
      * @throws IllegalArgumentException thrown if the instance is not valid.
      */
     public void validate() {
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("header-one", this.headerOne);
-        jsonWriter.writeNumberField("query-one", this.queryOne);
-        return jsonWriter.writeEndObject();
-    }
-
-    /**
-     * Reads an instance of FirstParameterGroup from the JsonReader.
-     * 
-     * @param jsonReader The JsonReader being read.
-     * @return An instance of FirstParameterGroup if the JsonReader was pointing to an instance of it, or null if it was
-     * pointing to JSON null.
-     * @throws IOException If an error occurs while reading the FirstParameterGroup.
-     */
-    public static FirstParameterGroup fromJson(JsonReader jsonReader) throws IOException {
-        return jsonReader.readObject(reader -> {
-            FirstParameterGroup deserializedFirstParameterGroup = new FirstParameterGroup();
-            while (reader.nextToken() != JsonToken.END_OBJECT) {
-                String fieldName = reader.getFieldName();
-                reader.nextToken();
-
-                if ("header-one".equals(fieldName)) {
-                    deserializedFirstParameterGroup.headerOne = reader.getString();
-                } else if ("query-one".equals(fieldName)) {
-                    deserializedFirstParameterGroup.queryOne = reader.getNullable(JsonReader::getInt);
-                } else {
-                    reader.skipChildren();
-                }
-            }
-
-            return deserializedFirstParameterGroup;
-        });
     }
 }

--- a/azure-tests/src/main/java/fixtures/azureparametergrouping/models/Grouper.java
+++ b/azure-tests/src/main/java/fixtures/azureparametergrouping/models/Grouper.java
@@ -5,17 +5,12 @@
 package fixtures.azureparametergrouping.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonToken;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 
 /**
  * Parameter group.
  */
 @Fluent
-public final class Grouper implements JsonSerializable<Grouper> {
+public final class Grouper {
     /*
      * A grouped parameter that is a constant.
      */
@@ -78,44 +73,5 @@ public final class Grouper implements JsonSerializable<Grouper> {
      * @throws IllegalArgumentException thrown if the instance is not valid.
      */
     public void validate() {
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("groupedConstant", this.groupedConstant);
-        jsonWriter.writeStringField("groupedParameter", this.groupedParameter);
-        return jsonWriter.writeEndObject();
-    }
-
-    /**
-     * Reads an instance of Grouper from the JsonReader.
-     * 
-     * @param jsonReader The JsonReader being read.
-     * @return An instance of Grouper if the JsonReader was pointing to an instance of it, or null if it was pointing to
-     * JSON null.
-     * @throws IOException If an error occurs while reading the Grouper.
-     */
-    public static Grouper fromJson(JsonReader jsonReader) throws IOException {
-        return jsonReader.readObject(reader -> {
-            Grouper deserializedGrouper = new Grouper();
-            while (reader.nextToken() != JsonToken.END_OBJECT) {
-                String fieldName = reader.getFieldName();
-                reader.nextToken();
-
-                if ("groupedConstant".equals(fieldName)) {
-                    deserializedGrouper.groupedConstant = reader.getString();
-                } else if ("groupedParameter".equals(fieldName)) {
-                    deserializedGrouper.groupedParameter = reader.getString();
-                } else {
-                    reader.skipChildren();
-                }
-            }
-
-            return deserializedGrouper;
-        });
     }
 }

--- a/azure-tests/src/main/java/fixtures/azureparametergrouping/models/ParameterGroupingPostMultiParamGroupsSecondParamGroup.java
+++ b/azure-tests/src/main/java/fixtures/azureparametergrouping/models/ParameterGroupingPostMultiParamGroupsSecondParamGroup.java
@@ -5,18 +5,12 @@
 package fixtures.azureparametergrouping.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonToken;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 
 /**
  * Parameter group.
  */
 @Fluent
-public final class ParameterGroupingPostMultiParamGroupsSecondParamGroup
-    implements JsonSerializable<ParameterGroupingPostMultiParamGroupsSecondParamGroup> {
+public final class ParameterGroupingPostMultiParamGroupsSecondParamGroup {
     /*
      * The header-two property.
      */
@@ -79,47 +73,5 @@ public final class ParameterGroupingPostMultiParamGroupsSecondParamGroup
      * @throws IllegalArgumentException thrown if the instance is not valid.
      */
     public void validate() {
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("header-two", this.headerTwo);
-        jsonWriter.writeNumberField("query-two", this.queryTwo);
-        return jsonWriter.writeEndObject();
-    }
-
-    /**
-     * Reads an instance of ParameterGroupingPostMultiParamGroupsSecondParamGroup from the JsonReader.
-     * 
-     * @param jsonReader The JsonReader being read.
-     * @return An instance of ParameterGroupingPostMultiParamGroupsSecondParamGroup if the JsonReader was pointing to an
-     * instance of it, or null if it was pointing to JSON null.
-     * @throws IOException If an error occurs while reading the ParameterGroupingPostMultiParamGroupsSecondParamGroup.
-     */
-    public static ParameterGroupingPostMultiParamGroupsSecondParamGroup fromJson(JsonReader jsonReader)
-        throws IOException {
-        return jsonReader.readObject(reader -> {
-            ParameterGroupingPostMultiParamGroupsSecondParamGroup deserializedParameterGroupingPostMultiParamGroupsSecondParamGroup
-                = new ParameterGroupingPostMultiParamGroupsSecondParamGroup();
-            while (reader.nextToken() != JsonToken.END_OBJECT) {
-                String fieldName = reader.getFieldName();
-                reader.nextToken();
-
-                if ("header-two".equals(fieldName)) {
-                    deserializedParameterGroupingPostMultiParamGroupsSecondParamGroup.headerTwo = reader.getString();
-                } else if ("query-two".equals(fieldName)) {
-                    deserializedParameterGroupingPostMultiParamGroupsSecondParamGroup.queryTwo
-                        = reader.getNullable(JsonReader::getInt);
-                } else {
-                    reader.skipChildren();
-                }
-            }
-
-            return deserializedParameterGroupingPostMultiParamGroupsSecondParamGroup;
-        });
     }
 }

--- a/azure-tests/src/main/java/fixtures/azureparametergrouping/models/ParameterGroupingPostOptionalParameters.java
+++ b/azure-tests/src/main/java/fixtures/azureparametergrouping/models/ParameterGroupingPostOptionalParameters.java
@@ -5,18 +5,12 @@
 package fixtures.azureparametergrouping.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonToken;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 
 /**
  * Parameter group.
  */
 @Fluent
-public final class ParameterGroupingPostOptionalParameters
-    implements JsonSerializable<ParameterGroupingPostOptionalParameters> {
+public final class ParameterGroupingPostOptionalParameters {
     /*
      * The customHeader property.
      */
@@ -79,45 +73,5 @@ public final class ParameterGroupingPostOptionalParameters
      * @throws IllegalArgumentException thrown if the instance is not valid.
      */
     public void validate() {
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("customHeader", this.customHeader);
-        jsonWriter.writeNumberField("query", this.query);
-        return jsonWriter.writeEndObject();
-    }
-
-    /**
-     * Reads an instance of ParameterGroupingPostOptionalParameters from the JsonReader.
-     * 
-     * @param jsonReader The JsonReader being read.
-     * @return An instance of ParameterGroupingPostOptionalParameters if the JsonReader was pointing to an instance of
-     * it, or null if it was pointing to JSON null.
-     * @throws IOException If an error occurs while reading the ParameterGroupingPostOptionalParameters.
-     */
-    public static ParameterGroupingPostOptionalParameters fromJson(JsonReader jsonReader) throws IOException {
-        return jsonReader.readObject(reader -> {
-            ParameterGroupingPostOptionalParameters deserializedParameterGroupingPostOptionalParameters
-                = new ParameterGroupingPostOptionalParameters();
-            while (reader.nextToken() != JsonToken.END_OBJECT) {
-                String fieldName = reader.getFieldName();
-                reader.nextToken();
-
-                if ("customHeader".equals(fieldName)) {
-                    deserializedParameterGroupingPostOptionalParameters.customHeader = reader.getString();
-                } else if ("query".equals(fieldName)) {
-                    deserializedParameterGroupingPostOptionalParameters.query = reader.getNullable(JsonReader::getInt);
-                } else {
-                    reader.skipChildren();
-                }
-            }
-
-            return deserializedParameterGroupingPostOptionalParameters;
-        });
     }
 }

--- a/azure-tests/src/main/java/fixtures/azureparametergrouping/models/ParameterGroupingPostRequiredParameters.java
+++ b/azure-tests/src/main/java/fixtures/azureparametergrouping/models/ParameterGroupingPostRequiredParameters.java
@@ -5,18 +5,12 @@
 package fixtures.azureparametergrouping.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonToken;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 
 /**
  * Parameter group.
  */
 @Fluent
-public final class ParameterGroupingPostRequiredParameters
-    implements JsonSerializable<ParameterGroupingPostRequiredParameters> {
+public final class ParameterGroupingPostRequiredParameters {
     /*
      * The customHeader property.
      */
@@ -133,52 +127,5 @@ public final class ParameterGroupingPostRequiredParameters
             throw new IllegalArgumentException(
                 "Missing required property path in model ParameterGroupingPostRequiredParameters");
         }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("path", this.path);
-        jsonWriter.writeIntField("body", this.body);
-        jsonWriter.writeStringField("customHeader", this.customHeader);
-        jsonWriter.writeNumberField("query", this.query);
-        return jsonWriter.writeEndObject();
-    }
-
-    /**
-     * Reads an instance of ParameterGroupingPostRequiredParameters from the JsonReader.
-     * 
-     * @param jsonReader The JsonReader being read.
-     * @return An instance of ParameterGroupingPostRequiredParameters if the JsonReader was pointing to an instance of
-     * it, or null if it was pointing to JSON null.
-     * @throws IllegalStateException If the deserialized JSON object was missing any required properties.
-     * @throws IOException If an error occurs while reading the ParameterGroupingPostRequiredParameters.
-     */
-    public static ParameterGroupingPostRequiredParameters fromJson(JsonReader jsonReader) throws IOException {
-        return jsonReader.readObject(reader -> {
-            ParameterGroupingPostRequiredParameters deserializedParameterGroupingPostRequiredParameters
-                = new ParameterGroupingPostRequiredParameters();
-            while (reader.nextToken() != JsonToken.END_OBJECT) {
-                String fieldName = reader.getFieldName();
-                reader.nextToken();
-
-                if ("path".equals(fieldName)) {
-                    deserializedParameterGroupingPostRequiredParameters.path = reader.getString();
-                } else if ("body".equals(fieldName)) {
-                    deserializedParameterGroupingPostRequiredParameters.body = reader.getInt();
-                } else if ("customHeader".equals(fieldName)) {
-                    deserializedParameterGroupingPostRequiredParameters.customHeader = reader.getString();
-                } else if ("query".equals(fieldName)) {
-                    deserializedParameterGroupingPostRequiredParameters.query = reader.getNullable(JsonReader::getInt);
-                } else {
-                    reader.skipChildren();
-                }
-            }
-
-            return deserializedParameterGroupingPostRequiredParameters;
-        });
     }
 }

--- a/azure-tests/src/main/java/fixtures/azureparametergrouping/models/ParameterGroupingPostReservedWordsParameters.java
+++ b/azure-tests/src/main/java/fixtures/azureparametergrouping/models/ParameterGroupingPostReservedWordsParameters.java
@@ -5,18 +5,12 @@
 package fixtures.azureparametergrouping.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonToken;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 
 /**
  * Parameter group.
  */
 @Fluent
-public final class ParameterGroupingPostReservedWordsParameters
-    implements JsonSerializable<ParameterGroupingPostReservedWordsParameters> {
+public final class ParameterGroupingPostReservedWordsParameters {
     /*
      * 'from' is a reserved word. Pass in 'bob' to pass.
      */
@@ -79,45 +73,5 @@ public final class ParameterGroupingPostReservedWordsParameters
      * @throws IllegalArgumentException thrown if the instance is not valid.
      */
     public void validate() {
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("from", this.from);
-        jsonWriter.writeStringField("accept", this.accept);
-        return jsonWriter.writeEndObject();
-    }
-
-    /**
-     * Reads an instance of ParameterGroupingPostReservedWordsParameters from the JsonReader.
-     * 
-     * @param jsonReader The JsonReader being read.
-     * @return An instance of ParameterGroupingPostReservedWordsParameters if the JsonReader was pointing to an instance
-     * of it, or null if it was pointing to JSON null.
-     * @throws IOException If an error occurs while reading the ParameterGroupingPostReservedWordsParameters.
-     */
-    public static ParameterGroupingPostReservedWordsParameters fromJson(JsonReader jsonReader) throws IOException {
-        return jsonReader.readObject(reader -> {
-            ParameterGroupingPostReservedWordsParameters deserializedParameterGroupingPostReservedWordsParameters
-                = new ParameterGroupingPostReservedWordsParameters();
-            while (reader.nextToken() != JsonToken.END_OBJECT) {
-                String fieldName = reader.getFieldName();
-                reader.nextToken();
-
-                if ("from".equals(fieldName)) {
-                    deserializedParameterGroupingPostReservedWordsParameters.from = reader.getString();
-                } else if ("accept".equals(fieldName)) {
-                    deserializedParameterGroupingPostReservedWordsParameters.accept = reader.getString();
-                } else {
-                    reader.skipChildren();
-                }
-            }
-
-            return deserializedParameterGroupingPostReservedWordsParameters;
-        });
     }
 }

--- a/azure-tests/src/main/java/fixtures/azurespecials/models/HeaderCustomNamedRequestIdParamGroupingParameters.java
+++ b/azure-tests/src/main/java/fixtures/azurespecials/models/HeaderCustomNamedRequestIdParamGroupingParameters.java
@@ -5,18 +5,12 @@
 package fixtures.azurespecials.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonToken;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 
 /**
  * Parameter group.
  */
 @Fluent
-public final class HeaderCustomNamedRequestIdParamGroupingParameters
-    implements JsonSerializable<HeaderCustomNamedRequestIdParamGroupingParameters> {
+public final class HeaderCustomNamedRequestIdParamGroupingParameters {
     /*
      * The fooRequestId
      */
@@ -58,44 +52,5 @@ public final class HeaderCustomNamedRequestIdParamGroupingParameters
             throw new IllegalArgumentException(
                 "Missing required property fooClientRequestId in model HeaderCustomNamedRequestIdParamGroupingParameters");
         }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("foo-client-request-id", this.fooClientRequestId);
-        return jsonWriter.writeEndObject();
-    }
-
-    /**
-     * Reads an instance of HeaderCustomNamedRequestIdParamGroupingParameters from the JsonReader.
-     * 
-     * @param jsonReader The JsonReader being read.
-     * @return An instance of HeaderCustomNamedRequestIdParamGroupingParameters if the JsonReader was pointing to an
-     * instance of it, or null if it was pointing to JSON null.
-     * @throws IllegalStateException If the deserialized JSON object was missing any required properties.
-     * @throws IOException If an error occurs while reading the HeaderCustomNamedRequestIdParamGroupingParameters.
-     */
-    public static HeaderCustomNamedRequestIdParamGroupingParameters fromJson(JsonReader jsonReader) throws IOException {
-        return jsonReader.readObject(reader -> {
-            HeaderCustomNamedRequestIdParamGroupingParameters deserializedHeaderCustomNamedRequestIdParamGroupingParameters
-                = new HeaderCustomNamedRequestIdParamGroupingParameters();
-            while (reader.nextToken() != JsonToken.END_OBJECT) {
-                String fieldName = reader.getFieldName();
-                reader.nextToken();
-
-                if ("foo-client-request-id".equals(fieldName)) {
-                    deserializedHeaderCustomNamedRequestIdParamGroupingParameters.fooClientRequestId
-                        = reader.getString();
-                } else {
-                    reader.skipChildren();
-                }
-            }
-
-            return deserializedHeaderCustomNamedRequestIdParamGroupingParameters;
-        });
     }
 }

--- a/azure-tests/src/main/java/fixtures/paging/models/CustomParameterGroup.java
+++ b/azure-tests/src/main/java/fixtures/paging/models/CustomParameterGroup.java
@@ -5,17 +5,12 @@
 package fixtures.paging.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonToken;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 
 /**
  * Parameter group.
  */
 @Fluent
-public final class CustomParameterGroup implements JsonSerializable<CustomParameterGroup> {
+public final class CustomParameterGroup {
     /*
      * Sets the api version to use.
      */
@@ -84,45 +79,5 @@ public final class CustomParameterGroup implements JsonSerializable<CustomParame
         if (getTenant() == null) {
             throw new IllegalArgumentException("Missing required property tenant in model CustomParameterGroup");
         }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("api_version", this.apiVersion);
-        jsonWriter.writeStringField("tenant", this.tenant);
-        return jsonWriter.writeEndObject();
-    }
-
-    /**
-     * Reads an instance of CustomParameterGroup from the JsonReader.
-     * 
-     * @param jsonReader The JsonReader being read.
-     * @return An instance of CustomParameterGroup if the JsonReader was pointing to an instance of it, or null if it
-     * was pointing to JSON null.
-     * @throws IllegalStateException If the deserialized JSON object was missing any required properties.
-     * @throws IOException If an error occurs while reading the CustomParameterGroup.
-     */
-    public static CustomParameterGroup fromJson(JsonReader jsonReader) throws IOException {
-        return jsonReader.readObject(reader -> {
-            CustomParameterGroup deserializedCustomParameterGroup = new CustomParameterGroup();
-            while (reader.nextToken() != JsonToken.END_OBJECT) {
-                String fieldName = reader.getFieldName();
-                reader.nextToken();
-
-                if ("api_version".equals(fieldName)) {
-                    deserializedCustomParameterGroup.apiVersion = reader.getString();
-                } else if ("tenant".equals(fieldName)) {
-                    deserializedCustomParameterGroup.tenant = reader.getString();
-                } else {
-                    reader.skipChildren();
-                }
-            }
-
-            return deserializedCustomParameterGroup;
-        });
     }
 }

--- a/azure-tests/src/main/java/fixtures/paging/models/PagingGetMultiplePagesLroOptions.java
+++ b/azure-tests/src/main/java/fixtures/paging/models/PagingGetMultiplePagesLroOptions.java
@@ -5,17 +5,12 @@
 package fixtures.paging.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonToken;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 
 /**
  * Parameter group.
  */
 @Fluent
-public final class PagingGetMultiplePagesLroOptions implements JsonSerializable<PagingGetMultiplePagesLroOptions> {
+public final class PagingGetMultiplePagesLroOptions {
     /*
      * Sets the maximum number of items to return in the response.
      */
@@ -80,45 +75,5 @@ public final class PagingGetMultiplePagesLroOptions implements JsonSerializable<
      * @throws IllegalArgumentException thrown if the instance is not valid.
      */
     public void validate() {
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        jsonWriter.writeStartObject();
-        jsonWriter.writeNumberField("maxresults", this.maxresults);
-        jsonWriter.writeNumberField("timeout", this.timeout);
-        return jsonWriter.writeEndObject();
-    }
-
-    /**
-     * Reads an instance of PagingGetMultiplePagesLroOptions from the JsonReader.
-     * 
-     * @param jsonReader The JsonReader being read.
-     * @return An instance of PagingGetMultiplePagesLroOptions if the JsonReader was pointing to an instance of it, or
-     * null if it was pointing to JSON null.
-     * @throws IOException If an error occurs while reading the PagingGetMultiplePagesLroOptions.
-     */
-    public static PagingGetMultiplePagesLroOptions fromJson(JsonReader jsonReader) throws IOException {
-        return jsonReader.readObject(reader -> {
-            PagingGetMultiplePagesLroOptions deserializedPagingGetMultiplePagesLroOptions
-                = new PagingGetMultiplePagesLroOptions();
-            while (reader.nextToken() != JsonToken.END_OBJECT) {
-                String fieldName = reader.getFieldName();
-                reader.nextToken();
-
-                if ("maxresults".equals(fieldName)) {
-                    deserializedPagingGetMultiplePagesLroOptions.maxresults = reader.getNullable(JsonReader::getInt);
-                } else if ("timeout".equals(fieldName)) {
-                    deserializedPagingGetMultiplePagesLroOptions.timeout = reader.getNullable(JsonReader::getInt);
-                } else {
-                    reader.skipChildren();
-                }
-            }
-
-            return deserializedPagingGetMultiplePagesLroOptions;
-        });
     }
 }

--- a/azure-tests/src/main/java/fixtures/paging/models/PagingGetMultiplePagesOptions.java
+++ b/azure-tests/src/main/java/fixtures/paging/models/PagingGetMultiplePagesOptions.java
@@ -5,17 +5,12 @@
 package fixtures.paging.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonToken;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 
 /**
  * Parameter group.
  */
 @Fluent
-public final class PagingGetMultiplePagesOptions implements JsonSerializable<PagingGetMultiplePagesOptions> {
+public final class PagingGetMultiplePagesOptions {
     /*
      * Sets the maximum number of items to return in the response.
      */
@@ -80,45 +75,5 @@ public final class PagingGetMultiplePagesOptions implements JsonSerializable<Pag
      * @throws IllegalArgumentException thrown if the instance is not valid.
      */
     public void validate() {
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        jsonWriter.writeStartObject();
-        jsonWriter.writeNumberField("maxresults", this.maxresults);
-        jsonWriter.writeNumberField("timeout", this.timeout);
-        return jsonWriter.writeEndObject();
-    }
-
-    /**
-     * Reads an instance of PagingGetMultiplePagesOptions from the JsonReader.
-     * 
-     * @param jsonReader The JsonReader being read.
-     * @return An instance of PagingGetMultiplePagesOptions if the JsonReader was pointing to an instance of it, or null
-     * if it was pointing to JSON null.
-     * @throws IOException If an error occurs while reading the PagingGetMultiplePagesOptions.
-     */
-    public static PagingGetMultiplePagesOptions fromJson(JsonReader jsonReader) throws IOException {
-        return jsonReader.readObject(reader -> {
-            PagingGetMultiplePagesOptions deserializedPagingGetMultiplePagesOptions
-                = new PagingGetMultiplePagesOptions();
-            while (reader.nextToken() != JsonToken.END_OBJECT) {
-                String fieldName = reader.getFieldName();
-                reader.nextToken();
-
-                if ("maxresults".equals(fieldName)) {
-                    deserializedPagingGetMultiplePagesOptions.maxresults = reader.getNullable(JsonReader::getInt);
-                } else if ("timeout".equals(fieldName)) {
-                    deserializedPagingGetMultiplePagesOptions.timeout = reader.getNullable(JsonReader::getInt);
-                } else {
-                    reader.skipChildren();
-                }
-            }
-
-            return deserializedPagingGetMultiplePagesOptions;
-        });
     }
 }

--- a/azure-tests/src/main/java/fixtures/paging/models/PagingGetMultiplePagesWithOffsetOptions.java
+++ b/azure-tests/src/main/java/fixtures/paging/models/PagingGetMultiplePagesWithOffsetOptions.java
@@ -5,18 +5,12 @@
 package fixtures.paging.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonToken;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 
 /**
  * Parameter group.
  */
 @Fluent
-public final class PagingGetMultiplePagesWithOffsetOptions
-    implements JsonSerializable<PagingGetMultiplePagesWithOffsetOptions> {
+public final class PagingGetMultiplePagesWithOffsetOptions {
     /*
      * Sets the maximum number of items to return in the response.
      */
@@ -106,51 +100,5 @@ public final class PagingGetMultiplePagesWithOffsetOptions
      * @throws IllegalArgumentException thrown if the instance is not valid.
      */
     public void validate() {
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        jsonWriter.writeStartObject();
-        jsonWriter.writeIntField("offset", this.offset);
-        jsonWriter.writeNumberField("maxresults", this.maxresults);
-        jsonWriter.writeNumberField("timeout", this.timeout);
-        return jsonWriter.writeEndObject();
-    }
-
-    /**
-     * Reads an instance of PagingGetMultiplePagesWithOffsetOptions from the JsonReader.
-     * 
-     * @param jsonReader The JsonReader being read.
-     * @return An instance of PagingGetMultiplePagesWithOffsetOptions if the JsonReader was pointing to an instance of
-     * it, or null if it was pointing to JSON null.
-     * @throws IllegalStateException If the deserialized JSON object was missing any required properties.
-     * @throws IOException If an error occurs while reading the PagingGetMultiplePagesWithOffsetOptions.
-     */
-    public static PagingGetMultiplePagesWithOffsetOptions fromJson(JsonReader jsonReader) throws IOException {
-        return jsonReader.readObject(reader -> {
-            PagingGetMultiplePagesWithOffsetOptions deserializedPagingGetMultiplePagesWithOffsetOptions
-                = new PagingGetMultiplePagesWithOffsetOptions();
-            while (reader.nextToken() != JsonToken.END_OBJECT) {
-                String fieldName = reader.getFieldName();
-                reader.nextToken();
-
-                if ("offset".equals(fieldName)) {
-                    deserializedPagingGetMultiplePagesWithOffsetOptions.offset = reader.getInt();
-                } else if ("maxresults".equals(fieldName)) {
-                    deserializedPagingGetMultiplePagesWithOffsetOptions.maxresults
-                        = reader.getNullable(JsonReader::getInt);
-                } else if ("timeout".equals(fieldName)) {
-                    deserializedPagingGetMultiplePagesWithOffsetOptions.timeout
-                        = reader.getNullable(JsonReader::getInt);
-                } else {
-                    reader.skipChildren();
-                }
-            }
-
-            return deserializedPagingGetMultiplePagesWithOffsetOptions;
-        });
     }
 }

--- a/azure-tests/src/main/java/fixtures/paging/models/PagingGetOdataMultiplePagesOptions.java
+++ b/azure-tests/src/main/java/fixtures/paging/models/PagingGetOdataMultiplePagesOptions.java
@@ -5,17 +5,12 @@
 package fixtures.paging.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonToken;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 
 /**
  * Parameter group.
  */
 @Fluent
-public final class PagingGetOdataMultiplePagesOptions implements JsonSerializable<PagingGetOdataMultiplePagesOptions> {
+public final class PagingGetOdataMultiplePagesOptions {
     /*
      * Sets the maximum number of items to return in the response.
      */
@@ -80,45 +75,5 @@ public final class PagingGetOdataMultiplePagesOptions implements JsonSerializabl
      * @throws IllegalArgumentException thrown if the instance is not valid.
      */
     public void validate() {
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        jsonWriter.writeStartObject();
-        jsonWriter.writeNumberField("maxresults", this.maxresults);
-        jsonWriter.writeNumberField("timeout", this.timeout);
-        return jsonWriter.writeEndObject();
-    }
-
-    /**
-     * Reads an instance of PagingGetOdataMultiplePagesOptions from the JsonReader.
-     * 
-     * @param jsonReader The JsonReader being read.
-     * @return An instance of PagingGetOdataMultiplePagesOptions if the JsonReader was pointing to an instance of it, or
-     * null if it was pointing to JSON null.
-     * @throws IOException If an error occurs while reading the PagingGetOdataMultiplePagesOptions.
-     */
-    public static PagingGetOdataMultiplePagesOptions fromJson(JsonReader jsonReader) throws IOException {
-        return jsonReader.readObject(reader -> {
-            PagingGetOdataMultiplePagesOptions deserializedPagingGetOdataMultiplePagesOptions
-                = new PagingGetOdataMultiplePagesOptions();
-            while (reader.nextToken() != JsonToken.END_OBJECT) {
-                String fieldName = reader.getFieldName();
-                reader.nextToken();
-
-                if ("maxresults".equals(fieldName)) {
-                    deserializedPagingGetOdataMultiplePagesOptions.maxresults = reader.getNullable(JsonReader::getInt);
-                } else if ("timeout".equals(fieldName)) {
-                    deserializedPagingGetOdataMultiplePagesOptions.timeout = reader.getNullable(JsonReader::getInt);
-                } else {
-                    reader.skipChildren();
-                }
-            }
-
-            return deserializedPagingGetOdataMultiplePagesOptions;
-        });
     }
 }

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/SchemaContext.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/SchemaContext.java
@@ -48,7 +48,12 @@ public enum SchemaContext {
     /**
      * The schema is used as a JSON merge patch.
      */
-    JSON_MERGE_PATCH("json-merge-patch");
+    JSON_MERGE_PATCH("json-merge-patch"),
+
+    /**
+     * The schema is used as options group.
+     */
+    OPTIONS_GROUP("options-group");
 
     private final String value;
     private final static Map<String, SchemaContext> CONSTANTS = new HashMap<>();

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ImplementationDetails.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ImplementationDetails.java
@@ -77,7 +77,14 @@ public class ImplementationDetails {
          * <p>
          * Codegen should handle serialization and deserialization specially for json-merge-patch model
          */
-        JSON_MERGE_PATCH("json-merge-patch");
+        JSON_MERGE_PATCH("json-merge-patch"),
+
+        /**
+         * Model used in options group
+         * <p>
+         * Serialization code will not be generated
+         */
+        OPTIONS_GROUP("options-group");
 
         private final static Map<String, Usage> CONSTANTS = new HashMap<>();
 
@@ -143,6 +150,8 @@ public class ImplementationDetails {
                     return INTERNAL;
                 case JSON_MERGE_PATCH:
                     return JSON_MERGE_PATCH;
+                case OPTIONS_GROUP:
+                    return OPTIONS_GROUP;
                 default:
                     throw new IllegalArgumentException(schemaContext.toString());
             }

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -13,6 +13,7 @@ import com.azure.autorest.model.clientmodel.ClientModelPropertyAccess;
 import com.azure.autorest.model.clientmodel.ClientModelPropertyReference;
 import com.azure.autorest.model.clientmodel.GenericType;
 import com.azure.autorest.model.clientmodel.IType;
+import com.azure.autorest.model.clientmodel.ImplementationDetails;
 import com.azure.autorest.model.clientmodel.IterableType;
 import com.azure.autorest.model.clientmodel.ListType;
 import com.azure.autorest.model.clientmodel.MapType;
@@ -1166,7 +1167,9 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
      */
     private static boolean modelRequireSerialization(ClientModel model) {
         // TODO (weidxu): any other case? "binary"?
-        return !ClientModelUtil.isMultipartModel(model);
+        return !ClientModelUtil.isMultipartModel(model)
+                // not GroupSchema
+                && !(model.getImplementationDetails() != null && model.getImplementationDetails().getUsages() != null && model.getImplementationDetails().getUsages().contains(ImplementationDetails.Usage.OPTIONS_GROUP));
     }
 
     /**

--- a/preprocessor/src/main/java/com/azure/autorest/preprocessor/tranformer/Transformer.java
+++ b/preprocessor/src/main/java/com/azure/autorest/preprocessor/tranformer/Transformer.java
@@ -24,6 +24,7 @@ import com.azure.autorest.extension.base.model.codemodel.Protocols;
 import com.azure.autorest.extension.base.model.codemodel.Request;
 import com.azure.autorest.extension.base.model.codemodel.RequestParameterLocation;
 import com.azure.autorest.extension.base.model.codemodel.Schema;
+import com.azure.autorest.extension.base.model.codemodel.SchemaContext;
 import com.azure.autorest.extension.base.model.codemodel.Schemas;
 import com.azure.autorest.extension.base.model.codemodel.SealedChoiceSchema;
 import com.azure.autorest.extension.base.model.codemodel.StringSchema;
@@ -53,7 +54,7 @@ public class Transformer {
       markFlattenedSchemas(codeModel);
     }
     transformOperationGroups(codeModel.getOperationGroups(), codeModel);
-    // multi-clients for Cadl
+    // multi-clients for TypeSpec
     if (codeModel.getClients() != null) {
       transformClients(codeModel.getClients(), codeModel);
     }
@@ -61,8 +62,18 @@ public class Transformer {
   }
 
   private void transformSchemas(Schemas schemas) {
+    // merge GroupSchema into ObjectSchema
+    if (schemas.getGroups() != null) {
+      schemas.getGroups().forEach(group -> {
+        if (group.getUsage() == null) {
+          group.setUsage(new HashSet<>());
+        }
+        group.getUsage().add(SchemaContext.OPTIONS_GROUP);
+      });
+    }
     schemas.getObjects().addAll(schemas.getGroups());
     schemas.setGroups(new ArrayList<>());
+
     for (ObjectSchema objectSchema : schemas.getObjects()) {
       renameType(objectSchema);
       for (Property property : objectSchema.getProperties()) {

--- a/typespec-tests/src/main/java/com/cadl/flatten/models/SendLongOptions.java
+++ b/typespec-tests/src/main/java/com/cadl/flatten/models/SendLongOptions.java
@@ -6,17 +6,12 @@ package com.cadl.flatten.models;
 
 import com.azure.core.annotation.Fluent;
 import com.azure.core.annotation.Generated;
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonToken;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 
 /**
  * Options for sendLong API.
  */
 @Fluent
-public final class SendLongOptions implements JsonSerializable<SendLongOptions> {
+public final class SendLongOptions {
     /*
      * The name property.
      */
@@ -309,96 +304,5 @@ public final class SendLongOptions implements JsonSerializable<SendLongOptions> 
     public SendLongOptions setDummy(String dummy) {
         this.dummy = dummy;
         return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Generated
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("name", this.name);
-        jsonWriter.writeStringField("input", this.input);
-        jsonWriter.writeIntField("dataInt", this.dataInt);
-        jsonWriter.writeStringField("title", this.title);
-        jsonWriter.writeStringField("status", this.status == null ? null : this.status.toString());
-        jsonWriter.writeStringField("filter", this.filter);
-        jsonWriter.writeJsonField("user", this.user);
-        jsonWriter.writeNumberField("dataIntOptional", this.dataIntOptional);
-        jsonWriter.writeNumberField("dataLong", this.dataLong);
-        jsonWriter.writeNumberField("data_float", this.dataFloat);
-        jsonWriter.writeStringField("description", this.description);
-        jsonWriter.writeStringField("_dummy", this.dummy);
-        return jsonWriter.writeEndObject();
-    }
-
-    /**
-     * Reads an instance of SendLongOptions from the JsonReader.
-     * 
-     * @param jsonReader The JsonReader being read.
-     * @return An instance of SendLongOptions if the JsonReader was pointing to an instance of it, or null if it was
-     * pointing to JSON null.
-     * @throws IllegalStateException If the deserialized JSON object was missing any required properties.
-     * @throws IOException If an error occurs while reading the SendLongOptions.
-     */
-    @Generated
-    public static SendLongOptions fromJson(JsonReader jsonReader) throws IOException {
-        return jsonReader.readObject(reader -> {
-            String name = null;
-            String input = null;
-            int dataInt = 0;
-            String title = null;
-            Status status = null;
-            String filter = null;
-            User user = null;
-            Integer dataIntOptional = null;
-            Long dataLong = null;
-            Double dataFloat = null;
-            String description = null;
-            String dummy = null;
-            while (reader.nextToken() != JsonToken.END_OBJECT) {
-                String fieldName = reader.getFieldName();
-                reader.nextToken();
-
-                if ("name".equals(fieldName)) {
-                    name = reader.getString();
-                } else if ("input".equals(fieldName)) {
-                    input = reader.getString();
-                } else if ("dataInt".equals(fieldName)) {
-                    dataInt = reader.getInt();
-                } else if ("title".equals(fieldName)) {
-                    title = reader.getString();
-                } else if ("status".equals(fieldName)) {
-                    status = Status.fromString(reader.getString());
-                } else if ("filter".equals(fieldName)) {
-                    filter = reader.getString();
-                } else if ("user".equals(fieldName)) {
-                    user = User.fromJson(reader);
-                } else if ("dataIntOptional".equals(fieldName)) {
-                    dataIntOptional = reader.getNullable(JsonReader::getInt);
-                } else if ("dataLong".equals(fieldName)) {
-                    dataLong = reader.getNullable(JsonReader::getLong);
-                } else if ("data_float".equals(fieldName)) {
-                    dataFloat = reader.getNullable(JsonReader::getDouble);
-                } else if ("description".equals(fieldName)) {
-                    description = reader.getString();
-                } else if ("_dummy".equals(fieldName)) {
-                    dummy = reader.getString();
-                } else {
-                    reader.skipChildren();
-                }
-            }
-            SendLongOptions deserializedSendLongOptions = new SendLongOptions(name, input, dataInt, title, status);
-            deserializedSendLongOptions.filter = filter;
-            deserializedSendLongOptions.user = user;
-            deserializedSendLongOptions.dataIntOptional = dataIntOptional;
-            deserializedSendLongOptions.dataLong = dataLong;
-            deserializedSendLongOptions.dataFloat = dataFloat;
-            deserializedSendLongOptions.description = description;
-            deserializedSendLongOptions.dummy = dummy;
-
-            return deserializedSendLongOptions;
-        });
     }
 }

--- a/typespec-tests/src/main/java/com/cadl/union/models/SendLongOptions.java
+++ b/typespec-tests/src/main/java/com/cadl/union/models/SendLongOptions.java
@@ -7,17 +7,12 @@ package com.cadl.union.models;
 import com.azure.core.annotation.Fluent;
 import com.azure.core.annotation.Generated;
 import com.azure.core.util.BinaryData;
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonToken;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 
 /**
  * Options for sendLong API.
  */
 @Fluent
-public final class SendLongOptions implements JsonSerializable<SendLongOptions> {
+public final class SendLongOptions {
     /*
      * The id property.
      */
@@ -218,80 +213,5 @@ public final class SendLongOptions implements JsonSerializable<SendLongOptions> 
     public SendLongOptions setDataFloat(Double dataFloat) {
         this.dataFloat = dataFloat;
         return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Generated
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("id", this.id);
-        jsonWriter.writeStringField("input", this.input);
-        jsonWriter.writeIntField("dataInt", this.dataInt);
-        jsonWriter.writeStringField("filter", this.filter);
-        jsonWriter.writeJsonField("user", this.user);
-        if (this.dataUnion != null) {
-            jsonWriter.writeUntypedField("dataUnion", this.dataUnion.toObject(Object.class));
-        }
-        jsonWriter.writeNumberField("dataLong", this.dataLong);
-        jsonWriter.writeNumberField("data_float", this.dataFloat);
-        return jsonWriter.writeEndObject();
-    }
-
-    /**
-     * Reads an instance of SendLongOptions from the JsonReader.
-     * 
-     * @param jsonReader The JsonReader being read.
-     * @return An instance of SendLongOptions if the JsonReader was pointing to an instance of it, or null if it was
-     * pointing to JSON null.
-     * @throws IllegalStateException If the deserialized JSON object was missing any required properties.
-     * @throws IOException If an error occurs while reading the SendLongOptions.
-     */
-    @Generated
-    public static SendLongOptions fromJson(JsonReader jsonReader) throws IOException {
-        return jsonReader.readObject(reader -> {
-            String id = null;
-            String input = null;
-            int dataInt = 0;
-            String filter = null;
-            User user = null;
-            BinaryData dataUnion = null;
-            Long dataLong = null;
-            Double dataFloat = null;
-            while (reader.nextToken() != JsonToken.END_OBJECT) {
-                String fieldName = reader.getFieldName();
-                reader.nextToken();
-
-                if ("id".equals(fieldName)) {
-                    id = reader.getString();
-                } else if ("input".equals(fieldName)) {
-                    input = reader.getString();
-                } else if ("dataInt".equals(fieldName)) {
-                    dataInt = reader.getInt();
-                } else if ("filter".equals(fieldName)) {
-                    filter = reader.getString();
-                } else if ("user".equals(fieldName)) {
-                    user = User.fromJson(reader);
-                } else if ("dataUnion".equals(fieldName)) {
-                    dataUnion = reader.getNullable(nonNullReader -> BinaryData.fromObject(nonNullReader.readUntyped()));
-                } else if ("dataLong".equals(fieldName)) {
-                    dataLong = reader.getNullable(JsonReader::getLong);
-                } else if ("data_float".equals(fieldName)) {
-                    dataFloat = reader.getNullable(JsonReader::getDouble);
-                } else {
-                    reader.skipChildren();
-                }
-            }
-            SendLongOptions deserializedSendLongOptions = new SendLongOptions(id, input, dataInt);
-            deserializedSendLongOptions.filter = filter;
-            deserializedSendLongOptions.user = user;
-            deserializedSendLongOptions.dataUnion = dataUnion;
-            deserializedSendLongOptions.dataLong = dataLong;
-            deserializedSendLongOptions.dataFloat = dataFloat;
-
-            return deserializedSendLongOptions;
-        });
     }
 }

--- a/typespec-tests/src/main/java/com/parameters/spread/models/SpreadWithMultipleParametersOptions.java
+++ b/typespec-tests/src/main/java/com/parameters/spread/models/SpreadWithMultipleParametersOptions.java
@@ -6,18 +6,12 @@ package com.parameters.spread.models;
 
 import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonToken;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 
 /**
  * Options for spreadWithMultipleParameters API.
  */
 @Immutable
-public final class SpreadWithMultipleParametersOptions
-    implements JsonSerializable<SpreadWithMultipleParametersOptions> {
+public final class SpreadWithMultipleParametersOptions {
     /*
      * The id property.
      */
@@ -169,71 +163,5 @@ public final class SpreadWithMultipleParametersOptions
     @Generated
     public String getProp6() {
         return this.prop6;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Generated
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("id", this.id);
-        jsonWriter.writeStringField("x-ms-test-header", this.xMsTestHeader);
-        jsonWriter.writeStringField("prop1", this.prop1);
-        jsonWriter.writeStringField("prop2", this.prop2);
-        jsonWriter.writeStringField("prop3", this.prop3);
-        jsonWriter.writeStringField("prop4", this.prop4);
-        jsonWriter.writeStringField("prop5", this.prop5);
-        jsonWriter.writeStringField("prop6", this.prop6);
-        return jsonWriter.writeEndObject();
-    }
-
-    /**
-     * Reads an instance of SpreadWithMultipleParametersOptions from the JsonReader.
-     * 
-     * @param jsonReader The JsonReader being read.
-     * @return An instance of SpreadWithMultipleParametersOptions if the JsonReader was pointing to an instance of it,
-     * or null if it was pointing to JSON null.
-     * @throws IllegalStateException If the deserialized JSON object was missing any required properties.
-     * @throws IOException If an error occurs while reading the SpreadWithMultipleParametersOptions.
-     */
-    @Generated
-    public static SpreadWithMultipleParametersOptions fromJson(JsonReader jsonReader) throws IOException {
-        return jsonReader.readObject(reader -> {
-            String id = null;
-            String xMsTestHeader = null;
-            String prop1 = null;
-            String prop2 = null;
-            String prop3 = null;
-            String prop4 = null;
-            String prop5 = null;
-            String prop6 = null;
-            while (reader.nextToken() != JsonToken.END_OBJECT) {
-                String fieldName = reader.getFieldName();
-                reader.nextToken();
-
-                if ("id".equals(fieldName)) {
-                    id = reader.getString();
-                } else if ("x-ms-test-header".equals(fieldName)) {
-                    xMsTestHeader = reader.getString();
-                } else if ("prop1".equals(fieldName)) {
-                    prop1 = reader.getString();
-                } else if ("prop2".equals(fieldName)) {
-                    prop2 = reader.getString();
-                } else if ("prop3".equals(fieldName)) {
-                    prop3 = reader.getString();
-                } else if ("prop4".equals(fieldName)) {
-                    prop4 = reader.getString();
-                } else if ("prop5".equals(fieldName)) {
-                    prop5 = reader.getString();
-                } else if ("prop6".equals(fieldName)) {
-                    prop6 = reader.getString();
-                } else {
-                    reader.skipChildren();
-                }
-            }
-            return new SpreadWithMultipleParametersOptions(id, xMsTestHeader, prop1, prop2, prop3, prop4, prop5, prop6);
-        });
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/modelflattening/models/FlattenParameterGroup.java
+++ b/vanilla-tests/src/main/java/fixtures/modelflattening/models/FlattenParameterGroup.java
@@ -5,17 +5,12 @@
 package fixtures.modelflattening.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonToken;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 
 /**
  * Parameter group.
  */
 @Fluent
-public final class FlattenParameterGroup implements JsonSerializable<FlattenParameterGroup> {
+public final class FlattenParameterGroup {
     /*
      * Product name with value 'groupproduct'
      */
@@ -239,64 +234,5 @@ public final class FlattenParameterGroup implements JsonSerializable<FlattenPara
         if (getProductId() == null) {
             throw new IllegalArgumentException("Missing required property productId in model FlattenParameterGroup");
         }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        jsonWriter.writeStartObject();
-        jsonWriter.writeStringField("name", this.name);
-        jsonWriter.writeStringField("productId", this.productId);
-        jsonWriter.writeJsonField("SimpleBodyProduct", this.simpleBodyProduct);
-        jsonWriter.writeStringField("description", this.description);
-        jsonWriter.writeStringField("max_product_display_name", this.maxProductDisplayName);
-        jsonWriter.writeStringField("capacity", this.capacity == null ? null : this.capacity.toString());
-        jsonWriter.writeStringField("generic_value", this.genericValue);
-        jsonWriter.writeStringField("@odata.value", this.odataValue);
-        return jsonWriter.writeEndObject();
-    }
-
-    /**
-     * Reads an instance of FlattenParameterGroup from the JsonReader.
-     * 
-     * @param jsonReader The JsonReader being read.
-     * @return An instance of FlattenParameterGroup if the JsonReader was pointing to an instance of it, or null if it
-     * was pointing to JSON null.
-     * @throws IllegalStateException If the deserialized JSON object was missing any required properties.
-     * @throws IOException If an error occurs while reading the FlattenParameterGroup.
-     */
-    public static FlattenParameterGroup fromJson(JsonReader jsonReader) throws IOException {
-        return jsonReader.readObject(reader -> {
-            FlattenParameterGroup deserializedFlattenParameterGroup = new FlattenParameterGroup();
-            while (reader.nextToken() != JsonToken.END_OBJECT) {
-                String fieldName = reader.getFieldName();
-                reader.nextToken();
-
-                if ("name".equals(fieldName)) {
-                    deserializedFlattenParameterGroup.name = reader.getString();
-                } else if ("productId".equals(fieldName)) {
-                    deserializedFlattenParameterGroup.productId = reader.getString();
-                } else if ("SimpleBodyProduct".equals(fieldName)) {
-                    deserializedFlattenParameterGroup.simpleBodyProduct = SimpleProduct.fromJson(reader);
-                } else if ("description".equals(fieldName)) {
-                    deserializedFlattenParameterGroup.description = reader.getString();
-                } else if ("max_product_display_name".equals(fieldName)) {
-                    deserializedFlattenParameterGroup.maxProductDisplayName = reader.getString();
-                } else if ("capacity".equals(fieldName)) {
-                    deserializedFlattenParameterGroup.capacity
-                        = SimpleProductPropertiesMaxProductCapacity.fromString(reader.getString());
-                } else if ("generic_value".equals(fieldName)) {
-                    deserializedFlattenParameterGroup.genericValue = reader.getString();
-                } else if ("@odata.value".equals(fieldName)) {
-                    deserializedFlattenParameterGroup.odataValue = reader.getString();
-                } else {
-                    reader.skipChildren();
-                }
-            }
-
-            return deserializedFlattenParameterGroup;
-        });
     }
 }


### PR DESCRIPTION
`GroupSchema` is used to group method parameters. It does not correspond to a wire JSON model, and hence should not implement `JsonSerializable`.

code https://github.com/Azure/autorest.java/pull/2682/commits/ada2f3322167e4334af73d60593fc54e44429a5b