### PR TITLE
tsp, mgmt, sdk integration

### DIFF
--- a/typespec-extension/src/main/java/com/azure/typespec/Main.java
+++ b/typespec-extension/src/main/java/com/azure/typespec/Main.java
@@ -73,14 +73,19 @@ public class Main {
         String outputDir = emitterOptions.getOutputDir();
         Path outputDirPath = Paths.get(outputDir);
         if (Files.exists(outputDirPath)) {
-            try (Stream<Path> filestream = Files.list(outputDirPath)) {
-                Set<String> filenames = filestream
-                    .map(p -> p.getFileName().toString())
-                    .map(name -> name.toLowerCase(Locale.ROOT))
-                    .collect(Collectors.toSet());
+            if (emitterOptions.getArm()) {
+                // check ../../parents/azure-client-sdk-parent
+                sdkIntegration = Files.exists(Paths.get(outputDir, "../../parents/azure-client-sdk-parent"));
+            } else {
+                try (Stream<Path> filestream = Files.list(outputDirPath)) {
+                    Set<String> filenames = filestream
+                            .map(p -> p.getFileName().toString())
+                            .map(name -> name.toLowerCase(Locale.ROOT))
+                            .collect(Collectors.toSet());
 
-                // if there is already pom and source, do not overwrite them (includes README.md, CHANGELOG.md etc.)
-                sdkIntegration = !filenames.containsAll(Arrays.asList("pom.xml", "src"));
+                    // if there is already pom and source, do not overwrite them (includes README.md, CHANGELOG.md etc.)
+                    sdkIntegration = !filenames.containsAll(Arrays.asList("pom.xml", "src"));
+                }
             }
         }
 


### PR DESCRIPTION
The meaning of `sdkIntegration` in ARM is a bit different from that of DPG.

Basically it should be always enabled, if target is the SDK repo.

---

One remaining problem is the tag in readme/changelog/pom.

Swagger readme have tag, but there is no such concept in typespec. Still not sure how we best handle this. Maybe we need an emitter option, e.g. `readme-tag`.

![image](https://github.com/Azure/autorest.java/assets/53292327/7906250b-eb20-40a1-ac71-9ae93551f946)
