### PR TITLE
dpg, make `ServiceVersion` only contain api-versions no later than the pinned one

### DIFF
--- a/typespec-extension/changelog.md
+++ b/typespec-extension/changelog.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.15.14 (2024-04-27)
+
+Compatible with compiler 0.55.
+
+- Added `ServiceVersion` filter for pinned api-version.
+
 ## 0.15.13 (2024-04-26)
 
 Compatible with compiler 0.55.

--- a/typespec-extension/package-lock.json
+++ b/typespec-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.15.13",
+  "version": "0.15.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/typespec-java",
-      "version": "0.15.13",
+      "version": "0.15.14",
       "license": "MIT",
       "dependencies": {
         "@autorest/codemodel": "~4.20.0",

--- a/typespec-extension/package.json
+++ b/typespec-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.15.13",
+  "version": "0.15.14",
   "description": "TypeSpec library for emitting Java client from the TypeSpec REST protocol binding",
   "keywords": [
     "TypeSpec"

--- a/typespec-extension/src/code-model-builder.ts
+++ b/typespec-extension/src/code-model-builder.ts
@@ -164,7 +164,7 @@ import {
   modelIs,
   getNamePrefixForProperty,
   isAllValueInteger,
-  ComparableApiVersion,
+  isStable,
 } from "./type-utils.js";
 import {
   getServiceVersion,
@@ -678,16 +678,9 @@ export class CodeModelBuilder {
     if (!pinnedApiVersion) {
       return versions;
     }
-    const pinnedVersion: ComparableApiVersion = new ComparableApiVersion(pinnedApiVersion);
     return versions
-      .map((it: Version) => new ComparableApiVersion(it))
-      .filter((it: ComparableApiVersion) => {
-        if (pinnedVersion.isStable() && !it.isStable()) {
-          return false;
-        }
-        return it.noLaterThan(pinnedVersion);
-      })
-      .map((it: ComparableApiVersion) => it.version);
+      .slice(0, versions.indexOf(pinnedApiVersion) + 1)
+      .filter((version) => !isStable(pinnedApiVersion) || isStable(version));
   }
 
   /**

--- a/typespec-extension/src/code-model-builder.ts
+++ b/typespec-extension/src/code-model-builder.ts
@@ -164,6 +164,7 @@ import {
   modelIs,
   getNamePrefixForProperty,
   isAllValueInteger,
+  ComparableApiVersion,
 } from "./type-utils.js";
 import {
   getServiceVersion,
@@ -558,13 +559,6 @@ export class CodeModelBuilder {
       const versioning = getVersion(this.program, client.service);
       if (versioning && versioning.getVersions()) {
         // @versioned in versioning
-        codeModelClient.apiVersions = [];
-        for (const version of versioning.getVersions()) {
-          const apiVersion = new ApiVersion();
-          apiVersion.version = version.value;
-          codeModelClient.apiVersions.push(apiVersion);
-        }
-
         if (!this.sdkContext.apiVersion || ["all", "latest"].includes(this.sdkContext.apiVersion)) {
           this.apiVersion = getDefaultApiVersion(this.sdkContext, client.service);
         } else {
@@ -572,6 +566,13 @@ export class CodeModelBuilder {
           if (!this.apiVersion) {
             throw new Error("Unrecognized api-version: " + this.sdkContext.apiVersion);
           }
+        }
+
+        codeModelClient.apiVersions = [];
+        for (const version of this.getFilteredApiVersions(this.apiVersion, versioning.getVersions())) {
+          const apiVersion = new ApiVersion();
+          apiVersion.version = version.value;
+          codeModelClient.apiVersions.push(apiVersion);
         }
       }
 
@@ -665,6 +666,21 @@ export class CodeModelBuilder {
     return clients;
   }
 
+  private getFilteredApiVersions(pinnedApiVersion: Version | undefined, versions: Version[]): Version[] {
+    if (!pinnedApiVersion) {
+      return versions;
+    }
+    const pinnedVersion: ComparableApiVersion = new ComparableApiVersion(pinnedApiVersion);
+    return versions.map((it: Version) => new ComparableApiVersion(it))
+    .filter((it: ComparableApiVersion) => {
+      if (pinnedVersion.isStable() && !it.isStable()) {
+        return false;
+      }
+      return it.noLaterThan(pinnedVersion);
+    })
+    .map((it: ComparableApiVersion) => it.version);
+  }
+
   /**
    * `@armProviderNamespace` currently will add a default server if not defined globally:
    * https://github.com/Azure/typespec-azure/blob/8b8d7c05f168d9305a09691c4fedcb88f4a57652/packages/typespec-azure-resource-manager/src/namespace.ts#L121-L128
@@ -678,9 +694,6 @@ export class CodeModelBuilder {
   }
 
   private needToSkipProcessingOperation(operation: Operation, clientContext: ClientContext): boolean {
-    if (!this.existsAtCurrentVersion(operation)) {
-      return true;
-    }
     // don't generate protocol and convenience method for overloaded operations
     // issue link: https://github.com/Azure/autorest.java/issues/1958#issuecomment-1562558219 we will support generate overload methods for non-union type in future (TODO issue: https://github.com/Azure/autorest.java/issues/2160)
     if (getOverloadedOperation(this.program, operation)) {
@@ -688,20 +701,6 @@ export class CodeModelBuilder {
       return true;
     }
     return false;
-  }
-
-  private existsAtCurrentVersion(type: Type): boolean {
-    const availabilityMap = getAvailabilityMap(this.program, type);
-    // if unversioned then everything exists
-    if (
-      !availabilityMap ||
-      !this.apiVersion ||
-      this.supportsAdvancedVersioning() // if supports non-breaking versioning, then it always exists
-    ) {
-      return true;
-    }
-    const availability = availabilityMap.get(this.apiVersion?.name);
-    return availability === Availability.Added || availability === Availability.Available;
   }
 
   /**
@@ -801,7 +800,6 @@ export class CodeModelBuilder {
     clientContext.hostParameters.forEach((it) => codeModelOperation.addParameter(it));
     // parameters
     op.parameters.parameters
-      .filter((param) => this.existsAtCurrentVersion(param.param))
       .map((it) => this.processParameter(codeModelOperation, it, clientContext));
     // "accept" header
     this.addAcceptHeaderParameter(codeModelOperation, op.responses);
@@ -2294,8 +2292,7 @@ export class CodeModelBuilder {
       if (
         prop.name === discriminatorPropertyName || // skip the discriminator property
         isNeverType(prop.type) || // skip property of type "never"
-        !isPayloadProperty(this.program, prop) ||
-        !this.existsAtCurrentVersion(prop)
+        !isPayloadProperty(this.program, prop)
       ) {
         continue;
       }
@@ -2331,9 +2328,7 @@ export class CodeModelBuilder {
     const resource = this.dummyObjectSchema(type, resourceModelName, namespace);
     const declaredProperties = walkPropertiesInherited(type);
     for (const prop of declaredProperties) {
-      if (this.existsAtCurrentVersion(type)) {
-        resource.addProperty(this.processModelProperty(prop));
-      }
+      resource.addProperty(this.processModelProperty(prop));
     }
     return resource;
   }

--- a/typespec-extension/src/type-utils.ts
+++ b/typespec-extension/src/type-utils.ts
@@ -52,22 +52,8 @@ export class ProcessingCache<In, Out> {
   }
 }
 
-/**
- * Expose `isStable` and comparison capability of an Api Version.
- */
-export class ComparableApiVersion {
-  version: Version;
-  constructor(version: Version) {
-    this.version = version;
-  }
-
-  isStable(): boolean {
-    return !this.version.value.includes("preview");
-  }
-
-  noLaterThan(anotherVersion: ComparableApiVersion): boolean {
-    return this.version.value <= anotherVersion.version.value;
-  }
+export function isStable(version: Version): boolean {
+  return !version.value.toLowerCase().includes("preview");
 }
 
 /** adds only if the item is not in the collection already

--- a/typespec-extension/src/type-utils.ts
+++ b/typespec-extension/src/type-utils.ts
@@ -62,7 +62,7 @@ export class ComparableApiVersion {
   }
 
   isStable(): boolean {
-    return !this.version.value.includes('preview');
+    return !this.version.value.includes("preview");
   }
 
   noLaterThan(anotherVersion: ComparableApiVersion): boolean {

--- a/typespec-extension/src/type-utils.ts
+++ b/typespec-extension/src/type-utils.ts
@@ -25,6 +25,7 @@ import { SchemaContext } from "@autorest/codemodel";
 import { DurationSchema } from "./common/schemas/time.js";
 import { getNamespace, pascalCase } from "./utils.js";
 import { getUnionAsEnum } from "@azure-tools/typespec-azure-core";
+import { Version } from "@typespec/versioning";
 
 /** Acts as a cache for processing inputs.
  *
@@ -48,6 +49,24 @@ export class ProcessingCache<In, Out> {
       return result;
     }
     return undefined;
+  }
+}
+
+/**
+ * Expose `isStable` and comparison capability of an Api Version.
+ */
+export class ComparableApiVersion {
+  version: Version;
+  constructor(version: Version) {
+    this.version = version;
+  }
+
+  isStable(): boolean {
+    return !this.version.value.includes('preview');
+  }
+
+  noLaterThan(anotherVersion: ComparableApiVersion): boolean {
+    return this.version.value <= anotherVersion.version.value;
   }
 }
 

--- a/typespec-tests/package.json
+++ b/typespec-tests/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@azure-tools/cadl-ranch-specs": "0.32.0",
-    "@azure-tools/typespec-java": "file:/../typespec-extension/azure-tools-typespec-java-0.15.13.tgz"
+    "@azure-tools/typespec-java": "file:/../typespec-extension/azure-tools-typespec-java-0.15.14.tgz"
   },
   "devDependencies": {
     "@typespec/prettier-plugin-typespec": "~0.55.0",

--- a/typespec-tests/src/main/java/com/cadl/versioning/VersioningServiceVersion.java
+++ b/typespec-tests/src/main/java/com/cadl/versioning/VersioningServiceVersion.java
@@ -11,19 +11,9 @@ import com.azure.core.util.ServiceVersion;
  */
 public enum VersioningServiceVersion implements ServiceVersion {
     /**
-     * Enum value 2022-06-01-preview.
-     */
-    V2022_06_01_PREVIEW("2022-06-01-preview"),
-
-    /**
      * Enum value 2022-09-01.
      */
-    V2022_09_01("2022-09-01"),
-
-    /**
-     * Enum value 2022-12-01-preview.
-     */
-    V2022_12_01_PREVIEW("2022-12-01-preview");
+    V2022_09_01("2022-09-01");
 
     private final String version;
 
@@ -45,6 +35,6 @@ public enum VersioningServiceVersion implements ServiceVersion {
      * @return The latest {@link VersioningServiceVersion}.
      */
     public static VersioningServiceVersion getLatest() {
-        return V2022_12_01_PREVIEW;
+        return V2022_09_01;
     }
 }


### PR DESCRIPTION
fix https://github.com/Azure/autorest.java/issues/2723

1. Let `ServiceVersion` contain only versions no later than the pinned api-version.
2. If pinned api-version(or default latest api-version) is stable, make `ServiceVersion` contain only stable versions.
3. Removed previous emitter logic of filtering operations/parameters/model(Properties). TCGC would do it now.