### PR TITLE
client, test gen, exclude PolymorphicDiscriminator property from mock data

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/util/ModelTestCaseUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/ModelTestCaseUtil.java
@@ -66,7 +66,9 @@ public class ModelTestCaseUtil {
 
         // class
         for (ClientModelProperty property : model.getProperties()) {
-            addForProperty(depth, jsonObject, property, model.getNeedsFlatten());
+            if (!property.isPolymorphicDiscriminator()) {
+                addForProperty(depth, jsonObject, property, model.getNeedsFlatten());
+            }
         }
 
         // superclasses
@@ -75,7 +77,9 @@ public class ModelTestCaseUtil {
             ClientModel parentModel = ClientModelUtil.getClientModel(parentModelName);
             if (parentModel != null) {
                 for (ClientModelProperty property : parentModel.getProperties()) {
-                    addForProperty(depth, jsonObject, property, parentModel.getNeedsFlatten());
+                    if (!property.isPolymorphicDiscriminator()) {
+                        addForProperty(depth, jsonObject, property, parentModel.getNeedsFlatten());
+                    }
                 }
             }
             parentModelName = parentModel == null ? null : parentModel.getParentModelName();

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/CookiecuttersharkTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/CookiecuttersharkTests.java
@@ -15,64 +15,44 @@ public final class CookiecuttersharkTests {
     @org.junit.jupiter.api.Test
     public void testDeserialize() throws Exception {
         Cookiecuttershark model = BinaryData.fromString(
-            "{\"fishtype\":\"jzzvdud\",\"age\":1163750271,\"birthday\":\"2021-03-18T06:36:17Z\",\"species\":\"dslfhotwmcy\",\"length\":44.5553,\"siblings\":[{\"fishtype\":\"jnpg\",\"species\":\"ftadehxnltyfs\",\"length\":89.95281,\"siblings\":[{\"fishtype\":\"uesnzwdejbavo\",\"species\":\"zdmohctbqvu\",\"length\":90.22537,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":28.46756},{\"fishtype\":\"Fish\",\"length\":34.753197}]}]},{\"fishtype\":\"vo\",\"species\":\"ujjugwdkcglh\",\"length\":94.58838,\"siblings\":[{\"fishtype\":\"dyggdtjixhbku\",\"species\":\"qweykhmenev\",\"length\":34.070343,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":59.155167}]}]},{\"fishtype\":\"hybcibv\",\"species\":\"dcsi\",\"length\":33.80321,\"siblings\":[{\"fishtype\":\"amdecte\",\"species\":\"iqscjeypv\",\"length\":78.81726,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":71.00282},{\"fishtype\":\"Fish\",\"length\":64.86957},{\"fishtype\":\"Fish\",\"length\":4.124391}]},{\"fishtype\":\"c\",\"species\":\"efovgmk\",\"length\":12.696767,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":92.70471},{\"fishtype\":\"Fish\",\"length\":38.220562},{\"fishtype\":\"Fish\",\"length\":97.29868},{\"fishtype\":\"Fish\",\"length\":24.898804}]}]},{\"fishtype\":\"qjpkcattpngjcrc\",\"species\":\"sqpjhvmdajvn\",\"length\":78.49014,\"siblings\":[{\"fishtype\":\"q\",\"species\":\"a\",\"length\":89.8033,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":23.191893},{\"fishtype\":\"Fish\",\"length\":31.31023},{\"fishtype\":\"Fish\",\"length\":94.267494}]},{\"fishtype\":\"yhltrpmopjmcm\",\"species\":\"u\",\"length\":37.39239,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":12.270075},{\"fishtype\":\"Fish\",\"length\":98.63335},{\"fishtype\":\"Fish\",\"length\":26.569813}]},{\"fishtype\":\"aodsfcpkv\",\"species\":\"dpuozmyz\",\"length\":89.91945,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":34.15059}]}]}]}")
+            "{\"fishtype\":\"cookiecuttershark\",\"age\":1085002799,\"birthday\":\"2021-07-24T18:44:29Z\",\"species\":\"pbtoqcjmkl\",\"length\":5.423278,\"siblings\":[{\"fishtype\":\"Fish\",\"species\":\"idtqajzyu\",\"length\":17.32046,\"siblings\":[{\"fishtype\":\"Fish\",\"species\":\"jkrlkhbzhfepg\",\"length\":58.94148,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":53.090946}]}]},{\"fishtype\":\"Fish\",\"species\":\"locx\",\"length\":3.4862816,\"siblings\":[{\"fishtype\":\"Fish\",\"species\":\"erhhbcsglumm\",\"length\":91.597664,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":29.64415}]},{\"fishtype\":\"Fish\",\"species\":\"dxob\",\"length\":62.736557,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":1.4938772},{\"fishtype\":\"Fish\",\"length\":12.01387}]}]}]}")
             .toObject(Cookiecuttershark.class);
-        Assertions.assertEquals("dslfhotwmcy", model.getSpecies());
-        Assertions.assertEquals(44.5553f, model.getLength());
-        Assertions.assertEquals("ftadehxnltyfs", model.getSiblings().get(0).getSpecies());
-        Assertions.assertEquals(89.95281f, model.getSiblings().get(0).getLength());
-        Assertions.assertEquals("zdmohctbqvu", model.getSiblings().get(0).getSiblings().get(0).getSpecies());
-        Assertions.assertEquals(90.22537f, model.getSiblings().get(0).getSiblings().get(0).getLength());
-        Assertions.assertEquals(28.46756f,
+        Assertions.assertEquals("pbtoqcjmkl", model.getSpecies());
+        Assertions.assertEquals(5.423278f, model.getLength());
+        Assertions.assertEquals("idtqajzyu", model.getSiblings().get(0).getSpecies());
+        Assertions.assertEquals(17.32046f, model.getSiblings().get(0).getLength());
+        Assertions.assertEquals("jkrlkhbzhfepg", model.getSiblings().get(0).getSiblings().get(0).getSpecies());
+        Assertions.assertEquals(58.94148f, model.getSiblings().get(0).getSiblings().get(0).getLength());
+        Assertions.assertEquals(53.090946f,
             model.getSiblings().get(0).getSiblings().get(0).getSiblings().get(0).getLength());
-        Assertions.assertEquals(1163750271, model.getAge());
-        Assertions.assertEquals(OffsetDateTime.parse("2021-03-18T06:36:17Z"), model.getBirthday());
+        Assertions.assertEquals(1085002799, model.getAge());
+        Assertions.assertEquals(OffsetDateTime.parse("2021-07-24T18:44:29Z"), model.getBirthday());
     }
 
     @org.junit.jupiter.api.Test
     public void testSerialize() throws Exception {
-        Cookiecuttershark model
-            = new Cookiecuttershark(44.5553f, OffsetDateTime.parse("2021-03-18T06:36:17Z")).setSpecies("dslfhotwmcy")
-                .setSiblings(Arrays.asList(
-                    new Fish(89.95281f).setSpecies("ftadehxnltyfs")
-                        .setSiblings(Arrays.asList(new Fish(90.22537f).setSpecies("zdmohctbqvu")
-                            .setSiblings(Arrays.asList(new Fish(28.46756f), new Fish(34.753197f))))),
-                    new Fish(94.58838f).setSpecies("ujjugwdkcglh")
-                        .setSiblings(Arrays.asList(new Fish(34.070343f).setSpecies("qweykhmenev")
-                            .setSiblings(Arrays.asList(new Fish(59.155167f))))),
-                    new Fish(33.80321f).setSpecies("dcsi")
-                        .setSiblings(
-                            Arrays
-                                .asList(
-                                    new Fish(78.81726f).setSpecies("iqscjeypv")
-                                        .setSiblings(Arrays.asList(new Fish(71.00282f), new Fish(64.86957f),
-                                            new Fish(4.124391f))),
-                                    new Fish(12.696767f).setSpecies("efovgmk")
-                                        .setSiblings(Arrays.asList(new Fish(92.70471f), new Fish(38.220562f),
-                                            new Fish(97.29868f), new Fish(24.898804f))))),
-                    new Fish(78.49014f).setSpecies("sqpjhvmdajvn")
-                        .setSiblings(
-                            Arrays
-                                .asList(
-                                    new Fish(89.8033f).setSpecies("a")
-                                        .setSiblings(Arrays.asList(new Fish(23.191893f), new Fish(31.31023f),
-                                            new Fish(94.267494f))),
-                                    new Fish(37.39239f).setSpecies("u")
-                                        .setSiblings(Arrays.asList(new Fish(12.270075f), new Fish(98.63335f),
-                                            new Fish(26.569813f))),
-                                    new Fish(89.91945f).setSpecies("dpuozmyz")
-                                        .setSiblings(Arrays.asList(new Fish(34.15059f)))))))
-                .setAge(1163750271);
+        Cookiecuttershark model = new Cookiecuttershark(5.423278f, OffsetDateTime.parse("2021-07-24T18:44:29Z"))
+            .setSpecies("pbtoqcjmkl")
+            .setSiblings(Arrays.asList(
+                new Fish(17.32046f).setSpecies("idtqajzyu")
+                    .setSiblings(Arrays.asList(new Fish(58.94148f).setSpecies("jkrlkhbzhfepg")
+                        .setSiblings(Arrays.asList(new Fish(53.090946f))))),
+                new Fish(3.4862816f).setSpecies("locx")
+                    .setSiblings(Arrays.asList(
+                        new Fish(91.597664f).setSpecies("erhhbcsglumm").setSiblings(Arrays.asList(new Fish(29.64415f))),
+                        new Fish(62.736557f).setSpecies("dxob")
+                            .setSiblings(Arrays.asList(new Fish(1.4938772f), new Fish(12.01387f)))))))
+            .setAge(1085002799);
         model = BinaryData.fromObject(model).toObject(Cookiecuttershark.class);
-        Assertions.assertEquals("dslfhotwmcy", model.getSpecies());
-        Assertions.assertEquals(44.5553f, model.getLength());
-        Assertions.assertEquals("ftadehxnltyfs", model.getSiblings().get(0).getSpecies());
-        Assertions.assertEquals(89.95281f, model.getSiblings().get(0).getLength());
-        Assertions.assertEquals("zdmohctbqvu", model.getSiblings().get(0).getSiblings().get(0).getSpecies());
-        Assertions.assertEquals(90.22537f, model.getSiblings().get(0).getSiblings().get(0).getLength());
-        Assertions.assertEquals(28.46756f,
+        Assertions.assertEquals("pbtoqcjmkl", model.getSpecies());
+        Assertions.assertEquals(5.423278f, model.getLength());
+        Assertions.assertEquals("idtqajzyu", model.getSiblings().get(0).getSpecies());
+        Assertions.assertEquals(17.32046f, model.getSiblings().get(0).getLength());
+        Assertions.assertEquals("jkrlkhbzhfepg", model.getSiblings().get(0).getSiblings().get(0).getSpecies());
+        Assertions.assertEquals(58.94148f, model.getSiblings().get(0).getSiblings().get(0).getLength());
+        Assertions.assertEquals(53.090946f,
             model.getSiblings().get(0).getSiblings().get(0).getSiblings().get(0).getLength());
-        Assertions.assertEquals(1163750271, model.getAge());
-        Assertions.assertEquals(OffsetDateTime.parse("2021-03-18T06:36:17Z"), model.getBirthday());
+        Assertions.assertEquals(1085002799, model.getAge());
+        Assertions.assertEquals(OffsetDateTime.parse("2021-07-24T18:44:29Z"), model.getBirthday());
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/DotFishMarketTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/DotFishMarketTests.java
@@ -12,15 +12,15 @@ public final class DotFishMarketTests {
     @org.junit.jupiter.api.Test
     public void testDeserialize() throws Exception {
         DotFishMarket model = BinaryData.fromString(
-            "{\"sampleSalmon\":{\"fish.type\":\"xypininmayhuybbk\",\"location\":\"pjkjlxofpdv\",\"iswild\":true,\"species\":\"depoog\"},\"salmons\":[{\"fish.type\":\"ciqihnhung\",\"location\":\"heotusiv\",\"iswild\":false,\"species\":\"jzrnf\"},{\"fish.type\":\"e\",\"location\":\"jofxqe\",\"iswild\":false,\"species\":\"hqjbasvmsmj\"},{\"fish.type\":\"cr\",\"location\":\"lxxwrljdouskc\",\"iswild\":true,\"species\":\"dkwt\"},{\"fish.type\":\"wnzlljfmppeeb\",\"location\":\"lssai\",\"iswild\":false,\"species\":\"gxsabkyq\"}],\"sampleFish\":{\"fish.type\":\"jitcjczdzevn\",\"species\":\"krwpdap\"},\"fishes\":[{\"fish.type\":\"dkvwrwjfe\",\"species\":\"nhutjeltmrldhugj\"},{\"fish.type\":\"datqxhocdgeabl\",\"species\":\"huticndvkao\"}]}")
+            "{\"sampleSalmon\":{\"fish.type\":\"DotSalmon\",\"location\":\"paojakhmsbzjh\",\"iswild\":false,\"species\":\"vdphlxaolthqtr\"},\"salmons\":[{\"fish.type\":\"DotSalmon\",\"location\":\"pfzfsinzgvfc\",\"iswild\":false,\"species\":\"oxxjtfelluwf\"}],\"sampleFish\":{\"fish.type\":\"DotFish\",\"species\":\"onpeqfpjkjlxofp\"},\"fishes\":[{\"fish.type\":\"DotFish\",\"species\":\"fxxypininmayhuy\"}]}")
             .toObject(DotFishMarket.class);
-        Assertions.assertEquals("depoog", model.getSampleSalmon().getSpecies());
-        Assertions.assertEquals("pjkjlxofpdv", model.getSampleSalmon().getLocation());
-        Assertions.assertEquals(true, model.getSampleSalmon().iswild());
-        Assertions.assertEquals("jzrnf", model.getSalmons().get(0).getSpecies());
-        Assertions.assertEquals("heotusiv", model.getSalmons().get(0).getLocation());
+        Assertions.assertEquals("vdphlxaolthqtr", model.getSampleSalmon().getSpecies());
+        Assertions.assertEquals("paojakhmsbzjh", model.getSampleSalmon().getLocation());
+        Assertions.assertEquals(false, model.getSampleSalmon().iswild());
+        Assertions.assertEquals("oxxjtfelluwf", model.getSalmons().get(0).getSpecies());
+        Assertions.assertEquals("pfzfsinzgvfc", model.getSalmons().get(0).getLocation());
         Assertions.assertEquals(false, model.getSalmons().get(0).iswild());
-        Assertions.assertEquals("krwpdap", model.getSampleFish().getSpecies());
-        Assertions.assertEquals("nhutjeltmrldhugj", model.getFishes().get(0).getSpecies());
+        Assertions.assertEquals("onpeqfpjkjlxofp", model.getSampleFish().getSpecies());
+        Assertions.assertEquals("fxxypininmayhuy", model.getFishes().get(0).getSpecies());
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/DotFishTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/DotFishTests.java
@@ -12,7 +12,7 @@ public final class DotFishTests {
     @org.junit.jupiter.api.Test
     public void testDeserialize() throws Exception {
         DotFish model
-            = BinaryData.fromString("{\"fish.type\":\"inzgvfcj\",\"species\":\"zoxxjtf\"}").toObject(DotFish.class);
-        Assertions.assertEquals("zoxxjtf", model.getSpecies());
+            = BinaryData.fromString("{\"fish.type\":\"DotFish\",\"species\":\"ryffdfdosy\"}").toObject(DotFish.class);
+        Assertions.assertEquals("ryffdfdosy", model.getSpecies());
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/DotSalmonTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/DotSalmonTests.java
@@ -13,10 +13,10 @@ public final class DotSalmonTests {
     public void testDeserialize() throws Exception {
         DotSalmon model = BinaryData
             .fromString(
-                "{\"fish.type\":\"kgiawxklryplwck\",\"location\":\"tyxolniwpwc\",\"iswild\":true,\"species\":\"syyp\"}")
+                "{\"fish.type\":\"DotSalmon\",\"location\":\"kpode\",\"iswild\":true,\"species\":\"inuvamiheogn\"}")
             .toObject(DotSalmon.class);
-        Assertions.assertEquals("syyp", model.getSpecies());
-        Assertions.assertEquals("tyxolniwpwc", model.getLocation());
+        Assertions.assertEquals("inuvamiheogn", model.getSpecies());
+        Assertions.assertEquals("kpode", model.getLocation());
         Assertions.assertEquals(true, model.iswild());
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/FishTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/FishTests.java
@@ -13,49 +13,57 @@ public final class FishTests {
     @org.junit.jupiter.api.Test
     public void testDeserialize() throws Exception {
         Fish model = BinaryData.fromString(
-            "{\"fishtype\":\"k\",\"species\":\"audccsnhs\",\"length\":97.627846,\"siblings\":[{\"fishtype\":\"j\",\"species\":\"ryhtnapczwlokjy\",\"length\":41.759808,\"siblings\":[{\"fishtype\":\"ni\",\"species\":\"oxzjnchgejspod\",\"length\":92.009636,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":20.998896},{\"fishtype\":\"Fish\",\"length\":31.328451},{\"fishtype\":\"Fish\",\"length\":14.870871},{\"fishtype\":\"Fish\",\"length\":18.151981}]},{\"fishtype\":\"o\",\"species\":\"yahux\",\"length\":97.81198,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":48.674263},{\"fishtype\":\"Fish\",\"length\":69.22819}]},{\"fishtype\":\"aqwi\",\"species\":\"sprozvcput\",\"length\":19.268911,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":94.32142}]}]},{\"fishtype\":\"fdatsc\",\"species\":\"vpjhulsuuv\",\"length\":60.36252,\"siblings\":[{\"fishtype\":\"k\",\"species\":\"f\",\"length\":13.198918,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":36.488388},{\"fishtype\":\"Fish\",\"length\":47.16013},{\"fishtype\":\"Fish\",\"length\":59.751354}]},{\"fishtype\":\"lwejdpv\",\"species\":\"yoqpsoaccta\",\"length\":17.080189,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":2.8880775},{\"fishtype\":\"Fish\",\"length\":55.748093},{\"fishtype\":\"Fish\",\"length\":24.760372}]},{\"fishtype\":\"bcryffdfd\",\"species\":\"ygexpaojakhmsb\",\"length\":25.13494,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":74.25797},{\"fishtype\":\"Fish\",\"length\":45.85249},{\"fishtype\":\"Fish\",\"length\":59.630096}]},{\"fishtype\":\"dphlxaolt\",\"species\":\"trg\",\"length\":14.1341095,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":3.2438397},{\"fishtype\":\"Fish\",\"length\":55.120502},{\"fishtype\":\"Fish\",\"length\":95.85514}]}]}]}")
+            "{\"fishtype\":\"Fish\",\"species\":\"k\",\"length\":32.04869,\"siblings\":[{\"fishtype\":\"Fish\",\"species\":\"ccsnhsjc\",\"length\":26.373684,\"siblings\":[{\"fishtype\":\"Fish\",\"species\":\"kryhtnapczwlokj\",\"length\":68.2114,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":52.976006},{\"fishtype\":\"Fish\",\"length\":38.78496},{\"fishtype\":\"Fish\",\"length\":10.636175}]}]},{\"fishtype\":\"Fish\",\"species\":\"pjoxzjnch\",\"length\":62.1013,\"siblings\":[{\"fishtype\":\"Fish\",\"species\":\"odmailzyd\",\"length\":2.2013366,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":81.72188},{\"fishtype\":\"Fish\",\"length\":29.215246},{\"fishtype\":\"Fish\",\"length\":46.80177},{\"fishtype\":\"Fish\",\"length\":57.05146}]},{\"fishtype\":\"Fish\",\"species\":\"xinpmqnjaq\",\"length\":93.690834,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":58.277805},{\"fishtype\":\"Fish\",\"length\":97.03771},{\"fishtype\":\"Fish\",\"length\":1.6464472}]}]},{\"fishtype\":\"Fish\",\"species\":\"zvcputegjvwmfda\",\"length\":77.05936,\"siblings\":[{\"fishtype\":\"Fish\",\"species\":\"vpjhulsuuv\",\"length\":60.36252,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":35.477917},{\"fishtype\":\"Fish\",\"length\":0.87149143},{\"fishtype\":\"Fish\",\"length\":45.9383},{\"fishtype\":\"Fish\",\"length\":67.264824}]},{\"fishtype\":\"Fish\",\"species\":\"ndiodjpslwejdpv\",\"length\":15.661436,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":74.66286},{\"fishtype\":\"Fish\",\"length\":85.63972}]},{\"fishtype\":\"Fish\",\"species\":\"oacctaza\",\"length\":62.07999,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":24.760372},{\"fishtype\":\"Fish\",\"length\":87.91807},{\"fishtype\":\"Fish\",\"length\":52.05834}]}]}]}")
             .toObject(Fish.class);
-        Assertions.assertEquals("audccsnhs", model.getSpecies());
-        Assertions.assertEquals(97.627846f, model.getLength());
-        Assertions.assertEquals("ryhtnapczwlokjy", model.getSiblings().get(0).getSpecies());
-        Assertions.assertEquals(41.759808f, model.getSiblings().get(0).getLength());
-        Assertions.assertEquals("oxzjnchgejspod", model.getSiblings().get(0).getSiblings().get(0).getSpecies());
-        Assertions.assertEquals(92.009636f, model.getSiblings().get(0).getSiblings().get(0).getLength());
-        Assertions.assertEquals(20.998896f,
+        Assertions.assertEquals("k", model.getSpecies());
+        Assertions.assertEquals(32.04869f, model.getLength());
+        Assertions.assertEquals("ccsnhsjc", model.getSiblings().get(0).getSpecies());
+        Assertions.assertEquals(26.373684f, model.getSiblings().get(0).getLength());
+        Assertions.assertEquals("kryhtnapczwlokj", model.getSiblings().get(0).getSiblings().get(0).getSpecies());
+        Assertions.assertEquals(68.2114f, model.getSiblings().get(0).getSiblings().get(0).getLength());
+        Assertions.assertEquals(52.976006f,
             model.getSiblings().get(0).getSiblings().get(0).getSiblings().get(0).getLength());
     }
 
     @org.junit.jupiter.api.Test
     public void testSerialize() throws Exception {
-        Fish model = new Fish(97.627846f).setSpecies("audccsnhs")
-            .setSiblings(Arrays.asList(
-                new Fish(41.759808f).setSpecies("ryhtnapczwlokjy")
-                    .setSiblings(Arrays.asList(
-                        new Fish(92.009636f).setSpecies("oxzjnchgejspod")
-                            .setSiblings(Arrays.asList(new Fish(20.998896f), new Fish(31.328451f), new Fish(14.870871f),
-                                new Fish(18.151981f))),
-                        new Fish(97.81198f).setSpecies("yahux")
-                            .setSiblings(Arrays.asList(new Fish(48.674263f), new Fish(69.22819f))),
-                        new Fish(19.268911f).setSpecies("sprozvcput").setSiblings(Arrays.asList(new Fish(94.32142f))))),
-                new Fish(60.36252f).setSpecies("vpjhulsuuv")
-                    .setSiblings(Arrays.asList(new Fish(13.198918f).setSpecies("f")
-                        .setSiblings(Arrays.asList(new Fish(36.488388f), new Fish(47.16013f), new Fish(59.751354f))),
-                        new Fish(17.080189f).setSpecies("yoqpsoaccta")
-                            .setSiblings(
-                                Arrays.asList(new Fish(2.8880775f), new Fish(55.748093f), new Fish(24.760372f))),
-                        new Fish(25.13494f).setSpecies("ygexpaojakhmsb")
-                            .setSiblings(Arrays.asList(new Fish(74.25797f), new Fish(45.85249f), new Fish(59.630096f))),
-                        new Fish(14.1341095f).setSpecies("trg")
-                            .setSiblings(
-                                Arrays.asList(new Fish(3.2438397f), new Fish(55.120502f), new Fish(95.85514f)))))));
+        Fish model
+            = new Fish(32.04869f).setSpecies("k")
+                .setSiblings(
+                    Arrays
+                        .asList(
+                            new Fish(26.373684f).setSpecies("ccsnhsjc")
+                                .setSiblings(Arrays.asList(new Fish(68.2114f).setSpecies("kryhtnapczwlokj")
+                                    .setSiblings(Arrays.asList(new Fish(52.976006f), new Fish(38.78496f),
+                                        new Fish(10.636175f))))),
+                            new Fish(62.1013f).setSpecies("pjoxzjnch")
+                                .setSiblings(
+                                    Arrays.asList(
+                                        new Fish(2.2013366f).setSpecies("odmailzyd")
+                                            .setSiblings(Arrays.asList(new Fish(81.72188f), new Fish(29.215246f),
+                                                new Fish(46.80177f), new Fish(57.05146f))),
+                                        new Fish(93.690834f).setSpecies("xinpmqnjaq")
+                                            .setSiblings(Arrays.asList(new Fish(58.277805f), new Fish(97.03771f),
+                                                new Fish(1.6464472f))))),
+                            new Fish(77.05936f).setSpecies("zvcputegjvwmfda")
+                                .setSiblings(Arrays.asList(
+                                    new Fish(60.36252f).setSpecies("vpjhulsuuv")
+                                        .setSiblings(Arrays.asList(new Fish(35.477917f), new Fish(0.87149143f),
+                                            new Fish(45.9383f), new Fish(67.264824f))),
+                                    new Fish(15.661436f)
+                                        .setSpecies("ndiodjpslwejdpv")
+                                        .setSiblings(Arrays.asList(new Fish(74.66286f), new Fish(85.63972f))),
+                                    new Fish(62.07999f).setSpecies("oacctaza")
+                                        .setSiblings(Arrays.asList(new Fish(24.760372f), new Fish(87.91807f),
+                                            new Fish(52.05834f)))))));
         model = BinaryData.fromObject(model).toObject(Fish.class);
-        Assertions.assertEquals("audccsnhs", model.getSpecies());
-        Assertions.assertEquals(97.627846f, model.getLength());
-        Assertions.assertEquals("ryhtnapczwlokjy", model.getSiblings().get(0).getSpecies());
-        Assertions.assertEquals(41.759808f, model.getSiblings().get(0).getLength());
-        Assertions.assertEquals("oxzjnchgejspod", model.getSiblings().get(0).getSiblings().get(0).getSpecies());
-        Assertions.assertEquals(92.009636f, model.getSiblings().get(0).getSiblings().get(0).getLength());
-        Assertions.assertEquals(20.998896f,
+        Assertions.assertEquals("k", model.getSpecies());
+        Assertions.assertEquals(32.04869f, model.getLength());
+        Assertions.assertEquals("ccsnhsjc", model.getSiblings().get(0).getSpecies());
+        Assertions.assertEquals(26.373684f, model.getSiblings().get(0).getLength());
+        Assertions.assertEquals("kryhtnapczwlokj", model.getSiblings().get(0).getSiblings().get(0).getSpecies());
+        Assertions.assertEquals(68.2114f, model.getSiblings().get(0).getSiblings().get(0).getLength());
+        Assertions.assertEquals(52.976006f,
             model.getSiblings().get(0).getSiblings().get(0).getSiblings().get(0).getLength());
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/GoblinsharkTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/GoblinsharkTests.java
@@ -16,50 +16,64 @@ public final class GoblinsharkTests {
     @org.junit.jupiter.api.Test
     public void testDeserialize() throws Exception {
         Goblinshark model = BinaryData.fromString(
-            "{\"fishtype\":\"w\",\"jawsize\":315329773,\"color\":\"brown\",\"age\":1896643633,\"birthday\":\"2021-10-24T08:40:42Z\",\"species\":\"uvcc\",\"length\":44.622604,\"siblings\":[{\"fishtype\":\"bacfionlebxetq\",\"species\":\"zxdpnqbqqw\",\"length\":99.41283,\"siblings\":[{\"fishtype\":\"al\",\"species\":\"wsubisnja\",\"length\":24.825657,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":59.541084},{\"fishtype\":\"Fish\",\"length\":31.798958},{\"fishtype\":\"Fish\",\"length\":44.95027},{\"fishtype\":\"Fish\",\"length\":25.562656}]},{\"fishtype\":\"xaqwoochcbonqv\",\"species\":\"vlrxnjeaseiph\",\"length\":43.413692,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":55.77957},{\"fishtype\":\"Fish\",\"length\":25.870234}]},{\"fishtype\":\"yyien\",\"species\":\"dlwtgrhpdj\",\"length\":32.68333,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":96.20458},{\"fishtype\":\"Fish\",\"length\":41.591675},{\"fishtype\":\"Fish\",\"length\":73.57942},{\"fishtype\":\"Fish\",\"length\":97.117195}]}]}]}")
+            "{\"fishtype\":\"goblin\",\"jawsize\":61317803,\"color\":\"red\",\"age\":726085925,\"birthday\":\"2021-02-01T09:39:18Z\",\"species\":\"vkmijcmmxdcuf\",\"length\":74.31171,\"siblings\":[{\"fishtype\":\"Fish\",\"species\":\"ymzidn\",\"length\":95.387184,\"siblings\":[{\"fishtype\":\"Fish\",\"species\":\"tbzsgfyccs\",\"length\":29.16742,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":54.53775},{\"fishtype\":\"Fish\",\"length\":49.81202},{\"fishtype\":\"Fish\",\"length\":1.0352552},{\"fishtype\":\"Fish\",\"length\":70.25995}]},{\"fishtype\":\"Fish\",\"species\":\"iachbo\",\"length\":57.38645,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":55.106743},{\"fishtype\":\"Fish\",\"length\":8.411604}]}]},{\"fishtype\":\"Fish\",\"species\":\"sfqpteehz\",\"length\":76.311905,\"siblings\":[{\"fishtype\":\"Fish\",\"species\":\"qrimzinpv\",\"length\":23.06351,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":62.599922},{\"fishtype\":\"Fish\",\"length\":96.52387},{\"fishtype\":\"Fish\",\"length\":86.71942},{\"fishtype\":\"Fish\",\"length\":78.64408}]}]},{\"fishtype\":\"Fish\",\"species\":\"od\",\"length\":20.800983,\"siblings\":[{\"fishtype\":\"Fish\",\"species\":\"mnoh\",\"length\":1.3219118,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":65.91078}]},{\"fishtype\":\"Fish\",\"species\":\"dsoifiyipj\",\"length\":44.730534,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":33.986122},{\"fishtype\":\"Fish\",\"length\":7.124424},{\"fishtype\":\"Fish\",\"length\":14.659691}]},{\"fishtype\":\"Fish\",\"species\":\"bznorcjxvsnby\",\"length\":39.604675,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":22.291475}]},{\"fishtype\":\"Fish\",\"species\":\"ocpcy\",\"length\":51.126534,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":19.046957},{\"fishtype\":\"Fish\",\"length\":97.11193},{\"fishtype\":\"Fish\",\"length\":22.825485},{\"fishtype\":\"Fish\",\"length\":8.593702}]}]}]}")
             .toObject(Goblinshark.class);
-        Assertions.assertEquals("uvcc", model.getSpecies());
-        Assertions.assertEquals(44.622604f, model.getLength());
-        Assertions.assertEquals("zxdpnqbqqw", model.getSiblings().get(0).getSpecies());
-        Assertions.assertEquals(99.41283f, model.getSiblings().get(0).getLength());
-        Assertions.assertEquals("wsubisnja", model.getSiblings().get(0).getSiblings().get(0).getSpecies());
-        Assertions.assertEquals(24.825657f, model.getSiblings().get(0).getSiblings().get(0).getLength());
-        Assertions.assertEquals(59.541084f,
+        Assertions.assertEquals("vkmijcmmxdcuf", model.getSpecies());
+        Assertions.assertEquals(74.31171f, model.getLength());
+        Assertions.assertEquals("ymzidn", model.getSiblings().get(0).getSpecies());
+        Assertions.assertEquals(95.387184f, model.getSiblings().get(0).getLength());
+        Assertions.assertEquals("tbzsgfyccs", model.getSiblings().get(0).getSiblings().get(0).getSpecies());
+        Assertions.assertEquals(29.16742f, model.getSiblings().get(0).getSiblings().get(0).getLength());
+        Assertions.assertEquals(54.53775f,
             model.getSiblings().get(0).getSiblings().get(0).getSiblings().get(0).getLength());
-        Assertions.assertEquals(1896643633, model.getAge());
-        Assertions.assertEquals(OffsetDateTime.parse("2021-10-24T08:40:42Z"), model.getBirthday());
-        Assertions.assertEquals(315329773, model.getJawsize());
-        Assertions.assertEquals(GoblinSharkColor.BROWN, model.getColor());
+        Assertions.assertEquals(726085925, model.getAge());
+        Assertions.assertEquals(OffsetDateTime.parse("2021-02-01T09:39:18Z"), model.getBirthday());
+        Assertions.assertEquals(61317803, model.getJawsize());
+        Assertions.assertEquals(GoblinSharkColor.LOWER_RED, model.getColor());
     }
 
     @org.junit.jupiter.api.Test
     public void testSerialize() throws Exception {
-        Goblinshark model = new Goblinshark(44.622604f, OffsetDateTime.parse("2021-10-24T08:40:42Z")).setSpecies("uvcc")
-            .setSiblings(Arrays.asList(new Fish(99.41283f).setSpecies("zxdpnqbqqw")
+        Goblinshark model
+            = new Goblinshark(74.31171f, OffsetDateTime.parse("2021-02-01T09:39:18Z")).setSpecies("vkmijcmmxdcuf")
                 .setSiblings(Arrays.asList(
-                    new Fish(24.825657f).setSpecies("wsubisnja")
-                        .setSiblings(Arrays.asList(new Fish(59.541084f), new Fish(31.798958f), new Fish(44.95027f),
-                            new Fish(25.562656f))),
-                    new Fish(43.413692f).setSpecies("vlrxnjeaseiph")
-                        .setSiblings(Arrays.asList(new Fish(55.77957f), new Fish(25.870234f))),
-                    new Fish(32.68333f).setSpecies("dlwtgrhpdj")
-                        .setSiblings(Arrays.asList(new Fish(96.20458f), new Fish(41.591675f), new Fish(73.57942f),
-                            new Fish(97.117195f)))))))
-            .setAge(1896643633)
-            .setJawsize(315329773)
-            .setColor(GoblinSharkColor.BROWN);
+                    new Fish(95.387184f).setSpecies("ymzidn")
+                        .setSiblings(Arrays.asList(
+                            new Fish(29.16742f).setSpecies("tbzsgfyccs")
+                                .setSiblings(Arrays.asList(new Fish(54.53775f), new Fish(49.81202f),
+                                    new Fish(1.0352552f), new Fish(70.25995f))),
+                            new Fish(57.38645f).setSpecies("iachbo")
+                                .setSiblings(Arrays.asList(new Fish(55.106743f), new Fish(8.411604f))))),
+                    new Fish(76.311905f).setSpecies("sfqpteehz")
+                        .setSiblings(Arrays.asList(new Fish(23.06351f).setSpecies("qrimzinpv")
+                            .setSiblings(Arrays.asList(new Fish(62.599922f), new Fish(96.52387f), new Fish(86.71942f),
+                                new Fish(78.64408f))))),
+                    new Fish(20.800983f).setSpecies("od")
+                        .setSiblings(Arrays.asList(
+                            new Fish(1.3219118f).setSpecies("mnoh").setSiblings(Arrays.asList(new Fish(65.91078f))),
+                            new Fish(44.730534f).setSpecies("dsoifiyipj")
+                                .setSiblings(
+                                    Arrays.asList(new Fish(33.986122f), new Fish(7.124424f), new Fish(14.659691f))),
+                            new Fish(39.604675f).setSpecies("bznorcjxvsnby")
+                                .setSiblings(Arrays.asList(new Fish(22.291475f))),
+                            new Fish(51.126534f).setSpecies("ocpcy")
+                                .setSiblings(Arrays.asList(new Fish(19.046957f), new Fish(97.11193f),
+                                    new Fish(22.825485f), new Fish(8.593702f)))))))
+                .setAge(726085925)
+                .setJawsize(61317803)
+                .setColor(GoblinSharkColor.LOWER_RED);
         model = BinaryData.fromObject(model).toObject(Goblinshark.class);
-        Assertions.assertEquals("uvcc", model.getSpecies());
-        Assertions.assertEquals(44.622604f, model.getLength());
-        Assertions.assertEquals("zxdpnqbqqw", model.getSiblings().get(0).getSpecies());
-        Assertions.assertEquals(99.41283f, model.getSiblings().get(0).getLength());
-        Assertions.assertEquals("wsubisnja", model.getSiblings().get(0).getSiblings().get(0).getSpecies());
-        Assertions.assertEquals(24.825657f, model.getSiblings().get(0).getSiblings().get(0).getLength());
-        Assertions.assertEquals(59.541084f,
+        Assertions.assertEquals("vkmijcmmxdcuf", model.getSpecies());
+        Assertions.assertEquals(74.31171f, model.getLength());
+        Assertions.assertEquals("ymzidn", model.getSiblings().get(0).getSpecies());
+        Assertions.assertEquals(95.387184f, model.getSiblings().get(0).getLength());
+        Assertions.assertEquals("tbzsgfyccs", model.getSiblings().get(0).getSiblings().get(0).getSpecies());
+        Assertions.assertEquals(29.16742f, model.getSiblings().get(0).getSiblings().get(0).getLength());
+        Assertions.assertEquals(54.53775f,
             model.getSiblings().get(0).getSiblings().get(0).getSiblings().get(0).getLength());
-        Assertions.assertEquals(1896643633, model.getAge());
-        Assertions.assertEquals(OffsetDateTime.parse("2021-10-24T08:40:42Z"), model.getBirthday());
-        Assertions.assertEquals(315329773, model.getJawsize());
-        Assertions.assertEquals(GoblinSharkColor.BROWN, model.getColor());
+        Assertions.assertEquals(726085925, model.getAge());
+        Assertions.assertEquals(OffsetDateTime.parse("2021-02-01T09:39:18Z"), model.getBirthday());
+        Assertions.assertEquals(61317803, model.getJawsize());
+        Assertions.assertEquals(GoblinSharkColor.LOWER_RED, model.getColor());
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/MyBaseTypeTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/MyBaseTypeTests.java
@@ -11,9 +11,9 @@ import org.junit.jupiter.api.Assertions;
 public final class MyBaseTypeTests {
     @org.junit.jupiter.api.Test
     public void testDeserialize() throws Exception {
-        MyBaseType model
-            = BinaryData.fromString("{\"kind\":\"Kind1\",\"propB1\":\"wbxgjvt\",\"helper\":{\"propBH1\":\"p\"}}")
-                .toObject(MyBaseType.class);
-        Assertions.assertEquals("wbxgjvt", model.getPropB1());
+        MyBaseType model = BinaryData
+            .fromString("{\"kind\":\"MyBaseType\",\"propB1\":\"kwt\",\"helper\":{\"propBH1\":\"xbnjbiksq\"}}")
+            .toObject(MyBaseType.class);
+        Assertions.assertEquals("kwt", model.getPropB1());
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/MyDerivedTypeTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/MyDerivedTypeTests.java
@@ -12,9 +12,10 @@ public final class MyDerivedTypeTests {
     @org.junit.jupiter.api.Test
     public void testDeserialize() throws Exception {
         MyDerivedType model = BinaryData
-            .fromString("{\"kind\":\"Kind1\",\"propD1\":\"bezy\",\"propB1\":\"ktwh\",\"helper\":{\"propBH1\":\"xw\"}}")
+            .fromString(
+                "{\"kind\":\"Kind1\",\"propD1\":\"xo\",\"propB1\":\"jionpimexgstxgc\",\"helper\":{\"propBH1\":\"dg\"}}")
             .toObject(MyDerivedType.class);
-        Assertions.assertEquals("ktwh", model.getPropB1());
-        Assertions.assertEquals("bezy", model.getPropD1());
+        Assertions.assertEquals("jionpimexgstxgc", model.getPropB1());
+        Assertions.assertEquals("xo", model.getPropD1());
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/ReadonlyObjTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/ReadonlyObjTests.java
@@ -11,15 +11,14 @@ import org.junit.jupiter.api.Assertions;
 public final class ReadonlyObjTests {
     @org.junit.jupiter.api.Test
     public void testDeserialize() throws Exception {
-        ReadonlyObj model
-            = BinaryData.fromString("{\"id\":\"uvfqawrlyxwj\",\"size\":1138788956}").toObject(ReadonlyObj.class);
-        Assertions.assertEquals(1138788956, model.getSize());
+        ReadonlyObj model = BinaryData.fromString("{\"id\":\"qvkoc\",\"size\":1066142513}").toObject(ReadonlyObj.class);
+        Assertions.assertEquals(1066142513, model.getSize());
     }
 
     @org.junit.jupiter.api.Test
     public void testSerialize() throws Exception {
-        ReadonlyObj model = new ReadonlyObj().setSize(1138788956);
+        ReadonlyObj model = new ReadonlyObj().setSize(1066142513);
         model = BinaryData.fromObject(model).toObject(ReadonlyObj.class);
-        Assertions.assertEquals(1138788956, model.getSize());
+        Assertions.assertEquals(1066142513, model.getSize());
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/SalmonTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/SalmonTests.java
@@ -14,47 +14,53 @@ public final class SalmonTests {
     @org.junit.jupiter.api.Test
     public void testDeserialize() throws Exception {
         Salmon model = BinaryData.fromString(
-            "{\"fishtype\":\"likwyqkgfgib\",\"location\":\"hejkotynqgou\",\"iswild\":false,\"species\":\"dgak\",\"length\":66.59647,\"siblings\":[{\"fishtype\":\"yb\",\"species\":\"qedqytbciqfoufl\",\"length\":48.112488,\"siblings\":[{\"fishtype\":\"smodmgloug\",\"species\":\"kwtmutduqktapspw\",\"length\":37.104095,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":56.303608},{\"fishtype\":\"Fish\",\"length\":78.37993}]},{\"fishtype\":\"mkdo\",\"species\":\"qw\",\"length\":22.323168,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":77.20989}]}]},{\"fishtype\":\"bjf\",\"species\":\"gmbmbexppbh\",\"length\":4.9203157,\"siblings\":[{\"fishtype\":\"lfp\",\"species\":\"s\",\"length\":49.08141,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":17.372614},{\"fishtype\":\"Fish\",\"length\":20.176643}]},{\"fishtype\":\"igjyjg\",\"species\":\"aoyfhrtxilnerkuj\",\"length\":1.0115743,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":16.52248}]}]}]}")
+            "{\"fishtype\":\"salmon\",\"location\":\"xzxtheo\",\"iswild\":false,\"species\":\"vyevcciqi\",\"length\":38.31058,\"siblings\":[{\"fishtype\":\"Fish\",\"species\":\"gbwjzrnf\",\"length\":15.608067,\"siblings\":[{\"fishtype\":\"Fish\",\"species\":\"spemvtzfk\",\"length\":30.775976,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":93.34901},{\"fishtype\":\"Fish\",\"length\":33.460037},{\"fishtype\":\"Fish\",\"length\":16.258835}]},{\"fishtype\":\"Fish\",\"species\":\"xqeofjaeqjhqjba\",\"length\":2.1371305,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":53.99528},{\"fishtype\":\"Fish\",\"length\":21.614403},{\"fishtype\":\"Fish\",\"length\":95.46702},{\"fishtype\":\"Fish\",\"length\":48.216724}]},{\"fishtype\":\"Fish\",\"species\":\"ngsntnbybk\",\"length\":9.4591675,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":70.90245},{\"fishtype\":\"Fish\",\"length\":49.255276},{\"fishtype\":\"Fish\",\"length\":57.128227}]},{\"fishtype\":\"Fish\",\"species\":\"xxwr\",\"length\":31.060987,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":72.06065},{\"fishtype\":\"Fish\",\"length\":70.73601},{\"fishtype\":\"Fish\",\"length\":50.07295}]}]}]}")
             .toObject(Salmon.class);
-        Assertions.assertEquals("dgak", model.getSpecies());
-        Assertions.assertEquals(66.59647f, model.getLength());
-        Assertions.assertEquals("qedqytbciqfoufl", model.getSiblings().get(0).getSpecies());
-        Assertions.assertEquals(48.112488f, model.getSiblings().get(0).getLength());
-        Assertions.assertEquals("kwtmutduqktapspw", model.getSiblings().get(0).getSiblings().get(0).getSpecies());
-        Assertions.assertEquals(37.104095f, model.getSiblings().get(0).getSiblings().get(0).getLength());
-        Assertions.assertEquals(56.303608f,
+        Assertions.assertEquals("vyevcciqi", model.getSpecies());
+        Assertions.assertEquals(38.31058f, model.getLength());
+        Assertions.assertEquals("gbwjzrnf", model.getSiblings().get(0).getSpecies());
+        Assertions.assertEquals(15.608067f, model.getSiblings().get(0).getLength());
+        Assertions.assertEquals("spemvtzfk", model.getSiblings().get(0).getSiblings().get(0).getSpecies());
+        Assertions.assertEquals(30.775976f, model.getSiblings().get(0).getSiblings().get(0).getLength());
+        Assertions.assertEquals(93.34901f,
             model.getSiblings().get(0).getSiblings().get(0).getSiblings().get(0).getLength());
-        Assertions.assertEquals("hejkotynqgou", model.getLocation());
+        Assertions.assertEquals("xzxtheo", model.getLocation());
         Assertions.assertEquals(false, model.iswild());
     }
 
     @org.junit.jupiter.api.Test
     public void testSerialize() throws Exception {
-        Salmon model = new Salmon(66.59647f).setSpecies("dgak")
-            .setSiblings(Arrays.asList(
-                new Fish(48.112488f).setSpecies("qedqytbciqfoufl")
-                    .setSiblings(Arrays.asList(
-                        new Fish(37.104095f).setSpecies("kwtmutduqktapspw")
-                            .setSiblings(Arrays.asList(new Fish(56.303608f), new Fish(78.37993f))),
-                        new Fish(22.323168f).setSpecies("qw").setSiblings(Arrays.asList(new Fish(77.20989f))))),
-                new Fish(4.9203157f).setSpecies("gmbmbexppbh")
-                    .setSiblings(Arrays.asList(
-                        new Fish(49.08141f).setSpecies("s")
-                            .setSiblings(Arrays.asList(new Fish(17.372614f), new Fish(20.176643f))),
-                        new Fish(1.0115743f).setSpecies("aoyfhrtxilnerkuj")
-                            .setSiblings(Arrays.asList(new Fish(16.52248f)))))))
-            .setLocation("hejkotynqgou")
-            .setIswild(false);
+        Salmon model
+            = new Salmon(38.31058f).setSpecies("vyevcciqi")
+                .setSiblings(
+                    Arrays
+                        .asList(
+                            new Fish(15.608067f).setSpecies("gbwjzrnf")
+                                .setSiblings(Arrays.asList(
+                                    new Fish(30.775976f).setSpecies("spemvtzfk")
+                                        .setSiblings(Arrays.asList(new Fish(93.34901f), new Fish(33.460037f),
+                                            new Fish(16.258835f))),
+                                    new Fish(2.1371305f).setSpecies("xqeofjaeqjhqjba")
+                                        .setSiblings(Arrays.asList(new Fish(53.99528f), new Fish(21.614403f),
+                                            new Fish(95.46702f), new Fish(48.216724f))),
+                                    new Fish(9.4591675f).setSpecies("ngsntnbybk")
+                                        .setSiblings(Arrays.asList(new Fish(70.90245f), new Fish(49.255276f),
+                                            new Fish(57.128227f))),
+                                    new Fish(31.060987f).setSpecies("xxwr")
+                                        .setSiblings(Arrays.asList(new Fish(72.06065f), new Fish(70.73601f),
+                                            new Fish(50.07295f)))))))
+                .setLocation("xzxtheo")
+                .setIswild(false);
         model = BinaryData.fromObject(model).toObject(Salmon.class);
-        Assertions.assertEquals("dgak", model.getSpecies());
-        Assertions.assertEquals(66.59647f, model.getLength());
-        Assertions.assertEquals("qedqytbciqfoufl", model.getSiblings().get(0).getSpecies());
-        Assertions.assertEquals(48.112488f, model.getSiblings().get(0).getLength());
-        Assertions.assertEquals("kwtmutduqktapspw", model.getSiblings().get(0).getSiblings().get(0).getSpecies());
-        Assertions.assertEquals(37.104095f, model.getSiblings().get(0).getSiblings().get(0).getLength());
-        Assertions.assertEquals(56.303608f,
+        Assertions.assertEquals("vyevcciqi", model.getSpecies());
+        Assertions.assertEquals(38.31058f, model.getLength());
+        Assertions.assertEquals("gbwjzrnf", model.getSiblings().get(0).getSpecies());
+        Assertions.assertEquals(15.608067f, model.getSiblings().get(0).getLength());
+        Assertions.assertEquals("spemvtzfk", model.getSiblings().get(0).getSiblings().get(0).getSpecies());
+        Assertions.assertEquals(30.775976f, model.getSiblings().get(0).getSiblings().get(0).getLength());
+        Assertions.assertEquals(93.34901f,
             model.getSiblings().get(0).getSiblings().get(0).getSiblings().get(0).getLength());
-        Assertions.assertEquals("hejkotynqgou", model.getLocation());
+        Assertions.assertEquals("xzxtheo", model.getLocation());
         Assertions.assertEquals(false, model.iswild());
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/SawsharkTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/SawsharkTests.java
@@ -15,42 +15,78 @@ public final class SawsharkTests {
     @org.junit.jupiter.api.Test
     public void testDeserialize() throws Exception {
         Sawshark model = BinaryData.fromString(
-            "{\"fishtype\":\"opbobj\",\"age\":950690565,\"birthday\":\"2021-10-21T06:57:02Z\",\"species\":\"hm\",\"length\":0.4767537,\"siblings\":[{\"fishtype\":\"a\",\"species\":\"rzayv\",\"length\":4.7570705,\"siblings\":[{\"fishtype\":\"dfgiot\",\"species\":\"tutqxlngxlefgug\",\"length\":49.651463,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":98.89482}]},{\"fishtype\":\"qmi\",\"species\":\"thz\",\"length\":27.019262,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":72.372734},{\"fishtype\":\"Fish\",\"length\":38.072437},{\"fishtype\":\"Fish\",\"length\":12.859451}]},{\"fishtype\":\"jybige\",\"species\":\"qfbow\",\"length\":82.193115,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":22.699678},{\"fishtype\":\"Fish\",\"length\":57.9111},{\"fishtype\":\"Fish\",\"length\":83.07862}]},{\"fishtype\":\"lcuiywgqywgndr\",\"species\":\"nhzgpphrcgyn\",\"length\":68.073944,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":36.553032}]}]}]}")
+            "{\"fishtype\":\"sawshark\",\"age\":835826608,\"birthday\":\"2021-09-01T01:28:54Z\",\"species\":\"gibma\",\"length\":41.75237,\"siblings\":[{\"fishtype\":\"Fish\",\"species\":\"qsrxybzqqed\",\"length\":18.452686,\"siblings\":[{\"fishtype\":\"Fish\",\"species\":\"iqfouflmmnkz\",\"length\":67.5812,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":56.270576},{\"fishtype\":\"Fish\",\"length\":47.130127}]},{\"fishtype\":\"Fish\",\"species\":\"ougpbkwt\",\"length\":88.09739,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":35.76977},{\"fishtype\":\"Fish\",\"length\":86.815414}]},{\"fishtype\":\"Fish\",\"species\":\"ta\",\"length\":94.51547,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":18.805998}]}]},{\"fishtype\":\"Fish\",\"species\":\"uertumk\",\"length\":2.3766458,\"siblings\":[{\"fishtype\":\"Fish\",\"species\":\"whbmd\",\"length\":84.869194,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":0.016152859},{\"fishtype\":\"Fish\",\"length\":25.363232},{\"fishtype\":\"Fish\",\"length\":21.297592}]},{\"fishtype\":\"Fish\",\"species\":\"mbmbexppbh\",\"length\":4.9203157,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":8.5479145},{\"fishtype\":\"Fish\",\"length\":16.483826}]},{\"fishtype\":\"Fish\",\"species\":\"p\",\"length\":54.458298,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":49.08141},{\"fishtype\":\"Fish\",\"length\":49.97902},{\"fishtype\":\"Fish\",\"length\":49.90956},{\"fishtype\":\"Fish\",\"length\":17.372614}]},{\"fishtype\":\"Fish\",\"species\":\"xigjyjgzjaoyfhr\",\"length\":49.60807,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":5.565733},{\"fishtype\":\"Fish\",\"length\":37.739403},{\"fishtype\":\"Fish\",\"length\":27.193933},{\"fishtype\":\"Fish\",\"length\":79.694275}]}]},{\"fishtype\":\"Fish\",\"species\":\"jysvl\",\"length\":22.571384,\"siblings\":[{\"fishtype\":\"Fish\",\"species\":\"qawrlyxwj\",\"length\":15.329713,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":99.249115},{\"fishtype\":\"Fish\",\"length\":89.70539},{\"fishtype\":\"Fish\",\"length\":40.196205},{\"fishtype\":\"Fish\",\"length\":4.2197704}]},{\"fishtype\":\"Fish\",\"species\":\"gjvtbv\",\"length\":77.91465,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":15.425348},{\"fishtype\":\"Fish\",\"length\":97.266785}]},{\"fishtype\":\"Fish\",\"species\":\"rujqg\",\"length\":84.77632,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":44.637882}]},{\"fishtype\":\"Fish\",\"species\":\"qfprwzwbn\",\"length\":48.901512,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":23.633587}]}]},{\"fishtype\":\"Fish\",\"species\":\"uizga\",\"length\":2.362436,\"siblings\":[{\"fishtype\":\"Fish\",\"species\":\"zuckyfi\",\"length\":56.51085,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":68.11774}]},{\"fishtype\":\"Fish\",\"species\":\"vzwdzuhtymwis\",\"length\":66.07407,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":61.41952},{\"fishtype\":\"Fish\",\"length\":60.204166},{\"fishtype\":\"Fish\",\"length\":59.410374},{\"fishtype\":\"Fish\",\"length\":46.825348}]}]}]}")
             .toObject(Sawshark.class);
-        Assertions.assertEquals("hm", model.getSpecies());
-        Assertions.assertEquals(0.4767537f, model.getLength());
-        Assertions.assertEquals("rzayv", model.getSiblings().get(0).getSpecies());
-        Assertions.assertEquals(4.7570705f, model.getSiblings().get(0).getLength());
-        Assertions.assertEquals("tutqxlngxlefgug", model.getSiblings().get(0).getSiblings().get(0).getSpecies());
-        Assertions.assertEquals(49.651463f, model.getSiblings().get(0).getSiblings().get(0).getLength());
-        Assertions.assertEquals(98.89482f,
+        Assertions.assertEquals("gibma", model.getSpecies());
+        Assertions.assertEquals(41.75237f, model.getLength());
+        Assertions.assertEquals("qsrxybzqqed", model.getSiblings().get(0).getSpecies());
+        Assertions.assertEquals(18.452686f, model.getSiblings().get(0).getLength());
+        Assertions.assertEquals("iqfouflmmnkz", model.getSiblings().get(0).getSiblings().get(0).getSpecies());
+        Assertions.assertEquals(67.5812f, model.getSiblings().get(0).getSiblings().get(0).getLength());
+        Assertions.assertEquals(56.270576f,
             model.getSiblings().get(0).getSiblings().get(0).getSiblings().get(0).getLength());
-        Assertions.assertEquals(950690565, model.getAge());
-        Assertions.assertEquals(OffsetDateTime.parse("2021-10-21T06:57:02Z"), model.getBirthday());
+        Assertions.assertEquals(835826608, model.getAge());
+        Assertions.assertEquals(OffsetDateTime.parse("2021-09-01T01:28:54Z"), model.getBirthday());
     }
 
     @org.junit.jupiter.api.Test
     public void testSerialize() throws Exception {
-        Sawshark model = new Sawshark(0.4767537f, OffsetDateTime.parse("2021-10-21T06:57:02Z")).setSpecies("hm")
-            .setSiblings(Arrays.asList(new Fish(4.7570705f).setSpecies("rzayv")
-                .setSiblings(Arrays.asList(
-                    new Fish(49.651463f).setSpecies("tutqxlngxlefgug").setSiblings(Arrays.asList(new Fish(98.89482f))),
-                    new Fish(27.019262f).setSpecies("thz")
-                        .setSiblings(Arrays.asList(new Fish(72.372734f), new Fish(38.072437f), new Fish(12.859451f))),
-                    new Fish(82.193115f).setSpecies("qfbow")
-                        .setSiblings(Arrays.asList(new Fish(22.699678f), new Fish(57.9111f), new Fish(83.07862f))),
-                    new Fish(68.073944f).setSpecies("nhzgpphrcgyn").setSiblings(Arrays.asList(new Fish(36.553032f)))))))
-            .setAge(950690565);
+        Sawshark model
+            = new Sawshark(41.75237f, OffsetDateTime.parse("2021-09-01T01:28:54Z")).setSpecies("gibma")
+                .setSiblings(
+                    Arrays.asList(
+                        new Fish(18.452686f).setSpecies("qsrxybzqqed")
+                            .setSiblings(Arrays.asList(
+                                new Fish(67.5812f).setSpecies("iqfouflmmnkz")
+                                    .setSiblings(Arrays.asList(new Fish(56.270576f), new Fish(47.130127f))),
+                                new Fish(88.09739f).setSpecies("ougpbkwt")
+                                    .setSiblings(Arrays.asList(new Fish(35.76977f), new Fish(86.815414f))),
+                                new Fish(94.51547f).setSpecies("ta").setSiblings(Arrays.asList(new Fish(18.805998f))))),
+                        new Fish(2.3766458f).setSpecies("uertumk")
+                            .setSiblings(Arrays.asList(
+                                new Fish(84.869194f).setSpecies("whbmd")
+                                    .setSiblings(Arrays.asList(new Fish(0.016152859f), new Fish(25.363232f),
+                                        new Fish(21.297592f))),
+                                new Fish(4.9203157f).setSpecies("mbmbexppbh")
+                                    .setSiblings(Arrays.asList(new Fish(8.5479145f), new Fish(16.483826f))),
+                                new Fish(54.458298f).setSpecies("p")
+                                    .setSiblings(Arrays.asList(new Fish(49.08141f), new Fish(49.97902f),
+                                        new Fish(49.90956f), new Fish(17.372614f))),
+                                new Fish(49.60807f)
+                                    .setSpecies("xigjyjgzjaoyfhr")
+                                    .setSiblings(Arrays.asList(new Fish(5.565733f), new Fish(37.739403f),
+                                        new Fish(27.193933f), new Fish(79.694275f))))),
+                        new Fish(22.571384f).setSpecies("jysvl")
+                            .setSiblings(Arrays.asList(
+                                new Fish(15.329713f).setSpecies("qawrlyxwj")
+                                    .setSiblings(Arrays.asList(new Fish(99.249115f), new Fish(89.70539f),
+                                        new Fish(40.196205f), new Fish(4.2197704f))),
+                                new Fish(77.91465f)
+                                    .setSpecies("gjvtbv")
+                                    .setSiblings(Arrays.asList(new Fish(15.425348f), new Fish(97.266785f))),
+                                new Fish(84.77632f).setSpecies("rujqg")
+                                    .setSiblings(Arrays.asList(new Fish(44.637882f))),
+                                new Fish(48.901512f)
+                                    .setSpecies("qfprwzwbn")
+                                    .setSiblings(Arrays.asList(new Fish(23.633587f))))),
+                        new Fish(2.362436f).setSpecies("uizga")
+                            .setSiblings(Arrays.asList(
+                                new Fish(56.51085f).setSpecies("zuckyfi")
+                                    .setSiblings(Arrays.asList(new Fish(68.11774f))),
+                                new Fish(66.07407f).setSpecies("vzwdzuhtymwis")
+                                    .setSiblings(Arrays.asList(new Fish(61.41952f), new Fish(60.204166f),
+                                        new Fish(59.410374f), new Fish(46.825348f)))))))
+                .setAge(835826608);
         model = BinaryData.fromObject(model).toObject(Sawshark.class);
-        Assertions.assertEquals("hm", model.getSpecies());
-        Assertions.assertEquals(0.4767537f, model.getLength());
-        Assertions.assertEquals("rzayv", model.getSiblings().get(0).getSpecies());
-        Assertions.assertEquals(4.7570705f, model.getSiblings().get(0).getLength());
-        Assertions.assertEquals("tutqxlngxlefgug", model.getSiblings().get(0).getSiblings().get(0).getSpecies());
-        Assertions.assertEquals(49.651463f, model.getSiblings().get(0).getSiblings().get(0).getLength());
-        Assertions.assertEquals(98.89482f,
+        Assertions.assertEquals("gibma", model.getSpecies());
+        Assertions.assertEquals(41.75237f, model.getLength());
+        Assertions.assertEquals("qsrxybzqqed", model.getSiblings().get(0).getSpecies());
+        Assertions.assertEquals(18.452686f, model.getSiblings().get(0).getLength());
+        Assertions.assertEquals("iqfouflmmnkz", model.getSiblings().get(0).getSiblings().get(0).getSpecies());
+        Assertions.assertEquals(67.5812f, model.getSiblings().get(0).getSiblings().get(0).getLength());
+        Assertions.assertEquals(56.270576f,
             model.getSiblings().get(0).getSiblings().get(0).getSiblings().get(0).getLength());
-        Assertions.assertEquals(950690565, model.getAge());
-        Assertions.assertEquals(OffsetDateTime.parse("2021-10-21T06:57:02Z"), model.getBirthday());
+        Assertions.assertEquals(835826608, model.getAge());
+        Assertions.assertEquals(OffsetDateTime.parse("2021-09-01T01:28:54Z"), model.getBirthday());
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/SharkTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/SharkTests.java
@@ -15,55 +15,50 @@ public final class SharkTests {
     @org.junit.jupiter.api.Test
     public void testDeserialize() throws Exception {
         Shark model = BinaryData.fromString(
-            "{\"fishtype\":\"bl\",\"age\":818060655,\"birthday\":\"2021-10-01T07:14:45Z\",\"species\":\"gpbtoqcjmklj\",\"length\":28.352106,\"siblings\":[{\"fishtype\":\"dtqajzyulpkudj\",\"species\":\"lkhbz\",\"length\":42.611782,\"siblings\":[{\"fishtype\":\"zgqexz\",\"species\":\"c\",\"length\":30.823957,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":42.87764},{\"fishtype\":\"Fish\",\"length\":93.16337}]},{\"fishtype\":\"rhhbcs\",\"species\":\"ummajtjaod\",\"length\":86.22104,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":62.736557},{\"fishtype\":\"Fish\",\"length\":33.899582}]}]},{\"fishtype\":\"k\",\"species\":\"xo\",\"length\":89.226135,\"siblings\":[{\"fishtype\":\"npime\",\"species\":\"stxgc\",\"length\":84.68226,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":84.1204},{\"fishtype\":\"Fish\",\"length\":25.783592}]},{\"fishtype\":\"jrmvdjwzrlo\",\"species\":\"clwhijcoejctbz\",\"length\":25.220078,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":47.4539},{\"fishtype\":\"Fish\",\"length\":3.9527357},{\"fishtype\":\"Fish\",\"length\":39.88341}]},{\"fishtype\":\"kbfkg\",\"species\":\"dkexxppofm\",\"length\":93.731895,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":90.91013}]}]},{\"fishtype\":\"pg\",\"species\":\"toc\",\"length\":5.059004,\"siblings\":[{\"fishtype\":\"pmouexhdz\",\"species\":\"bqe\",\"length\":75.01583,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":68.61014},{\"fishtype\":\"Fish\",\"length\":12.802905},{\"fishtype\":\"Fish\",\"length\":96.80261}]},{\"fishtype\":\"ddntwndei\",\"species\":\"twnpzaoqvuhrhcf\",\"length\":76.06833,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":69.74643},{\"fishtype\":\"Fish\",\"length\":35.38187}]}]}]}")
+            "{\"fishtype\":\"shark\",\"age\":732372528,\"birthday\":\"2021-05-16T15:44:09Z\",\"species\":\"kao\",\"length\":63.108402,\"siblings\":[{\"fishtype\":\"Fish\",\"species\":\"tyhxhurokft\",\"length\":81.88607,\"siblings\":[{\"fishtype\":\"Fish\",\"species\":\"iwpwcuk\",\"length\":48.25244,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":45.296448},{\"fishtype\":\"Fish\",\"length\":36.07977}]},{\"fishtype\":\"Fish\",\"species\":\"xklrypl\",\"length\":66.94554,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":17.269373},{\"fishtype\":\"Fish\",\"length\":22.518778}]},{\"fishtype\":\"Fish\",\"species\":\"ypnddhsgcb\",\"length\":17.565834,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":17.47195},{\"fishtype\":\"Fish\",\"length\":23.44771},{\"fishtype\":\"Fish\",\"length\":23.57843}]},{\"fishtype\":\"Fish\",\"species\":\"tynqgoul\",\"length\":30.246729,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":5.8344603},{\"fishtype\":\"Fish\",\"length\":16.492962},{\"fishtype\":\"Fish\",\"length\":61.310524}]}]}]}")
             .toObject(Shark.class);
-        Assertions.assertEquals("gpbtoqcjmklj", model.getSpecies());
-        Assertions.assertEquals(28.352106f, model.getLength());
-        Assertions.assertEquals("lkhbz", model.getSiblings().get(0).getSpecies());
-        Assertions.assertEquals(42.611782f, model.getSiblings().get(0).getLength());
-        Assertions.assertEquals("c", model.getSiblings().get(0).getSiblings().get(0).getSpecies());
-        Assertions.assertEquals(30.823957f, model.getSiblings().get(0).getSiblings().get(0).getLength());
-        Assertions.assertEquals(42.87764f,
+        Assertions.assertEquals("kao", model.getSpecies());
+        Assertions.assertEquals(63.108402f, model.getLength());
+        Assertions.assertEquals("tyhxhurokft", model.getSiblings().get(0).getSpecies());
+        Assertions.assertEquals(81.88607f, model.getSiblings().get(0).getLength());
+        Assertions.assertEquals("iwpwcuk", model.getSiblings().get(0).getSiblings().get(0).getSpecies());
+        Assertions.assertEquals(48.25244f, model.getSiblings().get(0).getSiblings().get(0).getLength());
+        Assertions.assertEquals(45.296448f,
             model.getSiblings().get(0).getSiblings().get(0).getSiblings().get(0).getLength());
-        Assertions.assertEquals(818060655, model.getAge());
-        Assertions.assertEquals(OffsetDateTime.parse("2021-10-01T07:14:45Z"), model.getBirthday());
+        Assertions.assertEquals(732372528, model.getAge());
+        Assertions.assertEquals(OffsetDateTime.parse("2021-05-16T15:44:09Z"), model.getBirthday());
     }
 
     @org.junit.jupiter.api.Test
     public void testSerialize() throws Exception {
-        Shark model = new Shark(28.352106f, OffsetDateTime.parse("2021-10-01T07:14:45Z")).setSpecies("gpbtoqcjmklj")
-            .setSiblings(Arrays.asList(
-                new Fish(42.611782f)
-                    .setSpecies("lkhbz")
-                    .setSiblings(Arrays
-                        .asList(new Fish(30.823957f).setSpecies("c")
-                            .setSiblings(Arrays.asList(new Fish(42.87764f), new Fish(93.16337f))),
-                            new Fish(86.22104f).setSpecies("ummajtjaod")
-                                .setSiblings(Arrays.asList(new Fish(62.736557f), new Fish(33.899582f))))),
-                new Fish(89.226135f).setSpecies("xo")
-                    .setSiblings(Arrays.asList(
-                        new Fish(84.68226f).setSpecies("stxgc")
-                            .setSiblings(Arrays.asList(new Fish(84.1204f), new Fish(25.783592f))),
-                        new Fish(25.220078f).setSpecies("clwhijcoejctbz")
-                            .setSiblings(Arrays.asList(new Fish(47.4539f), new Fish(3.9527357f), new Fish(39.88341f))),
-                        new Fish(93.731895f).setSpecies("dkexxppofm").setSiblings(Arrays.asList(new Fish(90.91013f))))),
-                new Fish(5.059004f).setSpecies("toc")
-                    .setSiblings(Arrays.asList(
-                        new Fish(75.01583f).setSpecies("bqe")
-                            .setSiblings(Arrays.asList(new Fish(68.61014f), new Fish(12.802905f), new Fish(96.80261f))),
-                        new Fish(76.06833f).setSpecies("twnpzaoqvuhrhcf")
-                            .setSiblings(Arrays.asList(new Fish(69.74643f), new Fish(35.38187f)))))))
-            .setAge(818060655);
+        Shark model
+            = new Shark(63.108402f, OffsetDateTime.parse("2021-05-16T15:44:09Z")).setSpecies("kao")
+                .setSiblings(
+                    Arrays
+                        .asList(
+                            new Fish(81.88607f).setSpecies("tyhxhurokft")
+                                .setSiblings(Arrays.asList(
+                                    new Fish(48.25244f).setSpecies("iwpwcuk")
+                                        .setSiblings(Arrays.asList(new Fish(45.296448f), new Fish(36.07977f))),
+                                    new Fish(66.94554f).setSpecies("xklrypl")
+                                        .setSiblings(Arrays.asList(new Fish(17.269373f), new Fish(22.518778f))),
+                                    new Fish(17.565834f).setSpecies("ypnddhsgcb")
+                                        .setSiblings(Arrays.asList(new Fish(17.47195f), new Fish(23.44771f),
+                                            new Fish(23.57843f))),
+                                    new Fish(30.246729f).setSpecies("tynqgoul")
+                                        .setSiblings(Arrays.asList(new Fish(5.8344603f), new Fish(16.492962f),
+                                            new Fish(61.310524f)))))))
+                .setAge(732372528);
         model = BinaryData.fromObject(model).toObject(Shark.class);
-        Assertions.assertEquals("gpbtoqcjmklj", model.getSpecies());
-        Assertions.assertEquals(28.352106f, model.getLength());
-        Assertions.assertEquals("lkhbz", model.getSiblings().get(0).getSpecies());
-        Assertions.assertEquals(42.611782f, model.getSiblings().get(0).getLength());
-        Assertions.assertEquals("c", model.getSiblings().get(0).getSiblings().get(0).getSpecies());
-        Assertions.assertEquals(30.823957f, model.getSiblings().get(0).getSiblings().get(0).getLength());
-        Assertions.assertEquals(42.87764f,
+        Assertions.assertEquals("kao", model.getSpecies());
+        Assertions.assertEquals(63.108402f, model.getLength());
+        Assertions.assertEquals("tyhxhurokft", model.getSiblings().get(0).getSpecies());
+        Assertions.assertEquals(81.88607f, model.getSiblings().get(0).getLength());
+        Assertions.assertEquals("iwpwcuk", model.getSiblings().get(0).getSiblings().get(0).getSpecies());
+        Assertions.assertEquals(48.25244f, model.getSiblings().get(0).getSiblings().get(0).getLength());
+        Assertions.assertEquals(45.296448f,
             model.getSiblings().get(0).getSiblings().get(0).getSiblings().get(0).getLength());
-        Assertions.assertEquals(818060655, model.getAge());
-        Assertions.assertEquals(OffsetDateTime.parse("2021-10-01T07:14:45Z"), model.getBirthday());
+        Assertions.assertEquals(732372528, model.getAge());
+        Assertions.assertEquals(OffsetDateTime.parse("2021-05-16T15:44:09Z"), model.getBirthday());
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/SmartSalmonTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/SmartSalmonTests.java
@@ -16,48 +16,47 @@ public final class SmartSalmonTests {
     @org.junit.jupiter.api.Test
     public void testDeserialize() throws Exception {
         SmartSalmon model = BinaryData.fromString(
-            "{\"fishtype\":\"mwisdkfthwxmnt\",\"college_degree\":\"qguhmuo\",\"\":{\"gazxuf\":\"dataprwzwbnguitnwui\"},\"location\":\"rfidfvzwdz\",\"iswild\":false,\"species\":\"waopvkmijcmmxd\",\"length\":42.68887,\"siblings\":[{\"fishtype\":\"srp\",\"species\":\"zidnsezcxtbzsgfy\",\"length\":7.1093616,\"siblings\":[{\"fishtype\":\"wmdwzjeiachboo\",\"species\":\"lnrosfqp\",\"length\":18.581312,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":85.271614},{\"fishtype\":\"Fish\",\"length\":77.50827}]},{\"fishtype\":\"ypyqrimzinp\",\"species\":\"wjdk\",\"length\":86.71942,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":7.825482},{\"fishtype\":\"Fish\",\"length\":94.463844},{\"fishtype\":\"Fish\",\"length\":38.036823}]},{\"fishtype\":\"hc\",\"species\":\"nohjt\",\"length\":13.129669,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":60.293747}]},{\"fishtype\":\"oifiyipjxsqwpgr\",\"species\":\"znorcj\",\"length\":23.660505,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":41.42828}]}]}]}")
+            "{\"fishtype\":\"smart_salmon\",\"college_degree\":\"lssai\",\"\":{\"eebvmgxsab\":\"datajwnzlljfmp\"},\"location\":\"qduujitcjczdz\",\"iswild\":false,\"species\":\"hkr\",\"length\":38.019188,\"siblings\":[{\"fishtype\":\"Fish\",\"species\":\"p\",\"length\":43.59222,\"siblings\":[{\"fishtype\":\"Fish\",\"species\":\"vwrwj\",\"length\":48.286907,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":93.839714}]},{\"fishtype\":\"Fish\",\"species\":\"utjeltmrldhugj\",\"length\":66.317825,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":68.56524},{\"fishtype\":\"Fish\",\"length\":94.724525}]},{\"fishtype\":\"Fish\",\"species\":\"hocdgeab\",\"length\":70.60696,\"siblings\":[{\"fishtype\":\"Fish\",\"length\":91.44667},{\"fishtype\":\"Fish\",\"length\":9.046102},{\"fishtype\":\"Fish\",\"length\":89.55463}]}]}]}")
             .toObject(SmartSalmon.class);
-        Assertions.assertEquals("waopvkmijcmmxd", model.getSpecies());
-        Assertions.assertEquals(42.68887f, model.getLength());
-        Assertions.assertEquals("zidnsezcxtbzsgfy", model.getSiblings().get(0).getSpecies());
-        Assertions.assertEquals(7.1093616f, model.getSiblings().get(0).getLength());
-        Assertions.assertEquals("lnrosfqp", model.getSiblings().get(0).getSiblings().get(0).getSpecies());
-        Assertions.assertEquals(18.581312f, model.getSiblings().get(0).getSiblings().get(0).getLength());
-        Assertions.assertEquals(85.271614f,
+        Assertions.assertEquals("hkr", model.getSpecies());
+        Assertions.assertEquals(38.019188f, model.getLength());
+        Assertions.assertEquals("p", model.getSiblings().get(0).getSpecies());
+        Assertions.assertEquals(43.59222f, model.getSiblings().get(0).getLength());
+        Assertions.assertEquals("vwrwj", model.getSiblings().get(0).getSiblings().get(0).getSpecies());
+        Assertions.assertEquals(48.286907f, model.getSiblings().get(0).getSiblings().get(0).getLength());
+        Assertions.assertEquals(93.839714f,
             model.getSiblings().get(0).getSiblings().get(0).getSiblings().get(0).getLength());
-        Assertions.assertEquals("rfidfvzwdz", model.getLocation());
+        Assertions.assertEquals("qduujitcjczdz", model.getLocation());
         Assertions.assertEquals(false, model.iswild());
-        Assertions.assertEquals("qguhmuo", model.getCollegeDegree());
+        Assertions.assertEquals("lssai", model.getCollegeDegree());
     }
 
     @org.junit.jupiter.api.Test
     public void testSerialize() throws Exception {
-        SmartSalmon model = new SmartSalmon(42.68887f).setSpecies("waopvkmijcmmxd")
-            .setSiblings(Arrays.asList(new Fish(7.1093616f).setSpecies("zidnsezcxtbzsgfy")
+        SmartSalmon model = new SmartSalmon(38.019188f).setSpecies("hkr")
+            .setSiblings(Arrays.asList(new Fish(43.59222f).setSpecies("p")
                 .setSiblings(Arrays.asList(
-                    new Fish(18.581312f).setSpecies("lnrosfqp")
-                        .setSiblings(Arrays.asList(new Fish(85.271614f), new Fish(77.50827f))),
-                    new Fish(86.71942f).setSpecies("wjdk")
-                        .setSiblings(Arrays.asList(new Fish(7.825482f), new Fish(94.463844f), new Fish(38.036823f))),
-                    new Fish(13.129669f).setSpecies("nohjt").setSiblings(Arrays.asList(new Fish(60.293747f))),
-                    new Fish(23.660505f).setSpecies("znorcj").setSiblings(Arrays.asList(new Fish(41.42828f)))))))
-            .setLocation("rfidfvzwdz")
+                    new Fish(48.286907f).setSpecies("vwrwj").setSiblings(Arrays.asList(new Fish(93.839714f))),
+                    new Fish(66.317825f).setSpecies("utjeltmrldhugj")
+                        .setSiblings(Arrays.asList(new Fish(68.56524f), new Fish(94.724525f))),
+                    new Fish(70.60696f).setSpecies("hocdgeab")
+                        .setSiblings(Arrays.asList(new Fish(91.44667f), new Fish(9.046102f), new Fish(89.55463f)))))))
+            .setLocation("qduujitcjczdz")
             .setIswild(false)
-            .setCollegeDegree("qguhmuo")
-            .setAdditionalProperties(mapOf("fishtype", "mwisdkfthwxmnt"));
+            .setCollegeDegree("lssai")
+            .setAdditionalProperties(mapOf("fishtype", "smart_salmon"));
         model = BinaryData.fromObject(model).toObject(SmartSalmon.class);
-        Assertions.assertEquals("waopvkmijcmmxd", model.getSpecies());
-        Assertions.assertEquals(42.68887f, model.getLength());
-        Assertions.assertEquals("zidnsezcxtbzsgfy", model.getSiblings().get(0).getSpecies());
-        Assertions.assertEquals(7.1093616f, model.getSiblings().get(0).getLength());
-        Assertions.assertEquals("lnrosfqp", model.getSiblings().get(0).getSiblings().get(0).getSpecies());
-        Assertions.assertEquals(18.581312f, model.getSiblings().get(0).getSiblings().get(0).getLength());
-        Assertions.assertEquals(85.271614f,
+        Assertions.assertEquals("hkr", model.getSpecies());
+        Assertions.assertEquals(38.019188f, model.getLength());
+        Assertions.assertEquals("p", model.getSiblings().get(0).getSpecies());
+        Assertions.assertEquals(43.59222f, model.getSiblings().get(0).getLength());
+        Assertions.assertEquals("vwrwj", model.getSiblings().get(0).getSiblings().get(0).getSpecies());
+        Assertions.assertEquals(48.286907f, model.getSiblings().get(0).getSiblings().get(0).getLength());
+        Assertions.assertEquals(93.839714f,
             model.getSiblings().get(0).getSiblings().get(0).getSiblings().get(0).getLength());
-        Assertions.assertEquals("rfidfvzwdz", model.getLocation());
+        Assertions.assertEquals("qduujitcjczdz", model.getLocation());
         Assertions.assertEquals(false, model.iswild());
-        Assertions.assertEquals("qguhmuo", model.getCollegeDegree());
+        Assertions.assertEquals("lssai", model.getCollegeDegree());
     }
 
     // Use "Map.of" if available


### PR DESCRIPTION
fix https://github.com/Azure/autorest.java/issues/2725

Previously the clientmodel Model does not include PolymorphicDiscriminator property.

tested in https://github.com/Azure/azure-sdk-for-java/pull/39950

we have this mock test in e.g. https://github.com/Azure/autorest.java/blob/main/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/CookiecuttersharkTests.java but we seems not run it.