### PR TITLE
arm, remove special handling for ARM types

### DIFF
--- a/typespec-extension/src/code-model-builder.ts
+++ b/typespec-extension/src/code-model-builder.ts
@@ -37,7 +37,6 @@ import {
   getEncode,
   getOverloadedOperation,
   EnumMember,
-  walkPropertiesInherited,
   isVoidType,
   isErrorModel,
 } from "@typespec/compiler";

--- a/typespec-extension/src/code-model-builder.ts
+++ b/typespec-extension/src/code-model-builder.ts
@@ -489,10 +489,6 @@ export class CodeModelBuilder {
     // deduplicate model name
     const nameCount = new Map<string, number>();
     const deduplicateName = (schema: Schema) => {
-      // skip models under "Azure.ResourceManager"
-      if (this.isArm() && schema.language.default?.namespace?.startsWith("Azure.ResourceManager")) {
-        return;
-      }
       const name = schema.language.default.name;
       // skip models under "com.azure.core."
       if (name && !schema.language.java?.namespace?.startsWith("com.azure.core.")) {

--- a/typespec-extension/src/code-model-builder.ts
+++ b/typespec-extension/src/code-model-builder.ts
@@ -2146,21 +2146,6 @@ export class CodeModelBuilder {
 
   private processObjectSchema(type: Model, name: string): ObjectSchema {
     const namespace = getNamespace(type);
-    if (
-      (this.isArm() &&
-        namespace?.startsWith("Azure.ResourceManager") &&
-        // there's ResourceListResult under Azure.ResourceManager namespace,
-        // which shouldn't be considered Resource schema parent
-        (name?.startsWith("TrackedResource") ||
-          name?.startsWith("ExtensionResource") ||
-          name?.startsWith("ProxyResource"))) ||
-      name === "ArmResource"
-    ) {
-      const objectSchema = this.dummyResourceSchema(type, name, namespace);
-      this.codeModel.schemas.add(objectSchema);
-
-      return objectSchema;
-    }
     const objectSchema = new ObjectScheme(name, this.getDoc(type), {
       summary: this.getSummary(type),
       language: {
@@ -2335,32 +2320,6 @@ export class CodeModelBuilder {
       }
     }
     return type;
-  }
-
-  private dummyResourceSchema(type: Model, name?: string, namespace?: string): ObjectSchema {
-    const resourceModelName = name?.startsWith("TrackedResource") ? "Resource" : "ProxyResource";
-    const resource = this.dummyObjectSchema(type, resourceModelName, namespace);
-    const declaredProperties = walkPropertiesInherited(type);
-    for (const prop of declaredProperties) {
-      resource.addProperty(this.processModelProperty(prop));
-    }
-    return resource;
-  }
-
-  private dummyObjectSchema(type: Model, name: string, namespace?: string): ObjectSchema {
-    return new ObjectScheme(name, this.getDoc(type), {
-      summary: this.getSummary(type),
-      language: {
-        default: {
-          name: name,
-          namespace: namespace,
-        },
-        java: {
-          name: name,
-          namespace: getJavaNamespace(namespace),
-        },
-      },
-    });
   }
 
   private applyModelPropertyDecorators(prop: ModelProperty, nameHint: string, schema: Schema): Schema {

--- a/typespec-tests/src/main/resources/META-INF/native-image/com.azure.resourcemanager/azure-resourcemanager-armresourceprovider-generated/reflect-config.json
+++ b/typespec-tests/src/main/resources/META-INF/native-image/com.azure.resourcemanager/azure-resourcemanager-armresourceprovider-generated/reflect-config.json
@@ -4,42 +4,12 @@
   "allDeclaredFields" : true,
   "allDeclaredMethods" : true
 }, {
-  "name" : "com.cadl.armresourceprovider.fluent.models.ChildResourceProperties",
-  "allDeclaredConstructors" : true,
-  "allDeclaredFields" : true,
-  "allDeclaredMethods" : true
-}, {
-  "name" : "com.cadl.armresourceprovider.models.ChildResourceUpdate",
-  "allDeclaredConstructors" : true,
-  "allDeclaredFields" : true,
-  "allDeclaredMethods" : true
-}, {
-  "name" : "com.cadl.armresourceprovider.implementation.models.ChildResourceListResult",
-  "allDeclaredConstructors" : true,
-  "allDeclaredFields" : true,
-  "allDeclaredMethods" : true
-}, {
   "name" : "com.cadl.armresourceprovider.fluent.models.TopLevelArmResourceInner",
   "allDeclaredConstructors" : true,
   "allDeclaredFields" : true,
   "allDeclaredMethods" : true
 }, {
   "name" : "com.cadl.armresourceprovider.fluent.models.TopLevelArmResourceProperties",
-  "allDeclaredConstructors" : true,
-  "allDeclaredFields" : true,
-  "allDeclaredMethods" : true
-}, {
-  "name" : "com.cadl.armresourceprovider.models.TopLevelArmResourceUpdate",
-  "allDeclaredConstructors" : true,
-  "allDeclaredFields" : true,
-  "allDeclaredMethods" : true
-}, {
-  "name" : "com.cadl.armresourceprovider.models.TopLevelArmResourceUpdateProperties",
-  "allDeclaredConstructors" : true,
-  "allDeclaredFields" : true,
-  "allDeclaredMethods" : true
-}, {
-  "name" : "com.cadl.armresourceprovider.implementation.models.TopLevelArmResourceListResult",
   "allDeclaredConstructors" : true,
   "allDeclaredFields" : true,
   "allDeclaredMethods" : true
@@ -60,6 +30,36 @@
   "allDeclaredMethods" : true
 }, {
   "name" : "com.cadl.armresourceprovider.models.UserAssignedIdentity",
+  "allDeclaredConstructors" : true,
+  "allDeclaredFields" : true,
+  "allDeclaredMethods" : true
+}, {
+  "name" : "com.cadl.armresourceprovider.fluent.models.ChildResourceProperties",
+  "allDeclaredConstructors" : true,
+  "allDeclaredFields" : true,
+  "allDeclaredMethods" : true
+}, {
+  "name" : "com.cadl.armresourceprovider.models.ChildResourceUpdate",
+  "allDeclaredConstructors" : true,
+  "allDeclaredFields" : true,
+  "allDeclaredMethods" : true
+}, {
+  "name" : "com.cadl.armresourceprovider.implementation.models.ChildResourceListResult",
+  "allDeclaredConstructors" : true,
+  "allDeclaredFields" : true,
+  "allDeclaredMethods" : true
+}, {
+  "name" : "com.cadl.armresourceprovider.models.TopLevelArmResourceUpdate",
+  "allDeclaredConstructors" : true,
+  "allDeclaredFields" : true,
+  "allDeclaredMethods" : true
+}, {
+  "name" : "com.cadl.armresourceprovider.models.TopLevelArmResourceUpdateProperties",
+  "allDeclaredConstructors" : true,
+  "allDeclaredFields" : true,
+  "allDeclaredMethods" : true
+}, {
+  "name" : "com.cadl.armresourceprovider.implementation.models.TopLevelArmResourceListResult",
   "allDeclaredConstructors" : true,
   "allDeclaredFields" : true,
   "allDeclaredMethods" : true

--- a/typespec-tests/tsp/arm.tsp
+++ b/typespec-tests/tsp/arm.tsp
@@ -199,7 +199,7 @@ interface Operations extends Azure.ResourceManager.Operations {}
 @armResourceCreateOrUpdate(TResource)
 @patch
 op ArmResourceUpdateSync<
-  TResource extends Azure.ResourceManager.Foundations.Resource,
+  TResource extends Azure.ResourceManager.Foundations.ArmResource,
   TBaseParameters = Azure.ResourceManager.Foundations.BaseParameters<TResource>
 >(
   ...ResourceInstanceParameters<TResource, TBaseParameters>,


### PR DESCRIPTION
`typespec-azure-resource-manager` has fixed the naming issue: https://github.com/Azure/typespec-azure/pull/762
Our special handling for `Resource`, `ProxyResource` and `ArmResource` is no longer needed. 