### PR TITLE
mgmt, schemacleanup bug fix

### DIFF
--- a/fluent-tests/src/test/java/com/azure/mgmttest/CompilationTests.java
+++ b/fluent-tests/src/test/java/com/azure/mgmttest/CompilationTests.java
@@ -8,6 +8,7 @@ import com.azure.core.management.SystemData;
 import com.azure.core.management.exception.ManagementError;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.mgmtlitetest.consumption.models.LegacyReservationRecommendation;
+import com.azure.mgmtlitetest.schemacleanup.models.UserAssignedIdentity;
 import com.azure.mgmttest.appservice.fluent.WebSiteManagementClient;
 import com.azure.mgmttest.appservice.models.DefaultErrorResponseErrorException;
 import com.azure.mgmttest.authorization.models.GraphError;
@@ -164,5 +165,9 @@ public class CompilationTests {
 
     public void testPolymophicSubClass() {
         LegacyReservationRecommendation legacyReservationRecommendation = new LegacyReservationRecommendation();
+    }
+
+    public void testSchemaCleanup() {
+        UserAssignedIdentity userAssignedIdentity = new UserAssignedIdentity();
     }
 }

--- a/fluent-tests/swagger/schema-cleanup.json
+++ b/fluent-tests/swagger/schema-cleanup.json
@@ -33,7 +33,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Retrieved entities"
+            "description": "Retrieved entities",
+            "schema": {
+              "$ref": "#/definitions/Application"
+            }
           }
         }
       }
@@ -63,6 +66,42 @@
         }
       },
       "required": ["type", "referenceName"]
+    },
+    "Application": {
+      "description": "Application.",
+      "type": "object",
+      "properties": {
+        "userAssignedIdentities": {
+          "$ref": "#/definitions/UserAssignedIdentities",
+          "description": "The identities assigned to this resource by the user."
+        }
+      }
+    },
+    "Record": {
+      "type": "object",
+      "description": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests.\",",
+      "additionalProperties": {
+        "$ref": "#/definitions/UserAssignedIdentity"
+      }
+    },
+    "UserAssignedIdentities": {
+      "allOf": [{
+        "$ref": "#/definitions/Record"
+      }]
+    },
+    "UserAssignedIdentity": {
+      "type": "object",
+      "description": "A managed identity assigned by the user.",
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "description": "The active directory client identifier for this principal."
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The active directory identifier for this principal."
+        }
+      }
     },
     "CloudError": {
       "x-ms-external": true,

--- a/fluent-tests/swagger/schema-cleanup.json
+++ b/fluent-tests/swagger/schema-cleanup.json
@@ -86,6 +86,11 @@
     },
     "UserAssignedIdentities": {
       "allOf": [{
+        "$ref": "#/definitions/UserAssignedIdentitiesIntermediate"
+      }]
+    },
+    "UserAssignedIdentitiesIntermediate": {
+      "allOf": [{
         "$ref": "#/definitions/Record"
       }]
     },

--- a/fluentnamer/src/main/java/com/azure/autorest/fluent/transformer/SchemaCleanup.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluent/transformer/SchemaCleanup.java
@@ -81,7 +81,7 @@ public class SchemaCleanup {
                                     .map(Property::getSchema)
                                     .map(SchemaCleanup::schemaOrElementInCollection)
                                     .filter(Objects::nonNull)
-                                    .filter(s1 -> !Objects.equals(s, s1))  // schema of property is not the same of itself, solve the simplest recursive reference case
+                                    .filter(s1 -> !Objects.equals(s, s1))   // schema of property is not the same of itself, solve the simplest recursive reference case
                     )
                     .collect(Collectors.toSet());
             schemasNotInUse.removeAll(propertiesOfObject);

--- a/fluentnamer/src/main/java/com/azure/autorest/fluent/transformer/SchemaCleanup.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluent/transformer/SchemaCleanup.java
@@ -76,13 +76,12 @@ public class SchemaCleanup {
                         String name = Utils.getJavaName(o);
                         return FluentType.nonSystemData(name) && FluentType.nonManagementError(name);
                     })
-                    .flatMap(s -> s.getProperties()
-                                    .stream()
+                    .flatMap(s -> s.getProperties().stream()
 //                                    .filter(Utils::nonFlattenedProperty)
                                     .map(Property::getSchema)
                                     .map(SchemaCleanup::schemaOrElementInCollection)
                                     .filter(Objects::nonNull)
-                                    .filter(s1 -> !Objects.equals(s, s1)) // schema of property is not the same of itself, solve the simplest recursive reference case
+                                    .filter(s1 -> !Objects.equals(s, s1))  // schema of property is not the same of itself, solve the simplest recursive reference case
                     )
                     .collect(Collectors.toSet());
             schemasNotInUse.removeAll(propertiesOfObject);


### PR DESCRIPTION
fix https://github.com/Azure/autorest.java/pull/2698#discussion_r1596521990

~~Currently, include all schema's parents into calculation. Yet to see whether this is an overkill...~~

Previous schema clean up logic:
1. Rough calculate unused schemas set
2. Properties of schemas are in use, remove them from unused schemas set
3. Schemas in operation requests are in use, remove them from unused schemas set
4. Schemas in operation responses are in use, remove them from unused schemas set
5. Schemas in Exceptions are in use, remove them from unused schemas set

This PR adds an extra schema in use:
For schema in schemasInUse, its collection parents(Dictionary, Array)'s element schemas are in use, remove them from unused schemas set.
