### PR TITLE
Fix polymorphic XML stream-style serialization

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/implementation/ClientModelPropertiesManager.java
+++ b/javagen/src/main/java/com/azure/autorest/implementation/ClientModelPropertiesManager.java
@@ -150,7 +150,9 @@ public final class ClientModelPropertiesManager {
             possibleXmlNameVariableNames.remove(property.getName());
 
             if (property.isXmlAttribute()) {
-                superXmlAttributes.add(property);
+                if (!property.isPolymorphicDiscriminator()) {
+                    superXmlAttributes.add(property);
+                }
             } else if (property.isXmlText()) {
                 hasXmlTexts = true;
                 superXmlTexts.add(property);
@@ -209,7 +211,9 @@ public final class ClientModelPropertiesManager {
             possibleXmlNameVariableNames.remove(property.getName());
 
             if (property.isXmlAttribute()) {
-                xmlAttributes.add(property);
+                if (!property.isPolymorphicDiscriminator()) {
+                    xmlAttributes.add(property);
+                }
             } else if (property.isXmlText()) {
                 hasXmlTexts = true;
                 xmlTexts.add(property);
@@ -260,10 +264,10 @@ public final class ClientModelPropertiesManager {
     }
 
     private static void superPropertyConsumer(ClientModelProperty property,
-        LinkedHashMap<String, ClientModelProperty> superRequiredProperties,
-        LinkedHashMap<String, ClientModelProperty> superConstructorProperties,
-        LinkedHashMap<String, ClientModelProperty> superReadOnlyProperties,
-        LinkedHashMap<String, ClientModelProperty> superSetterProperties, JavaSettings settings) {
+        Map<String, ClientModelProperty> superRequiredProperties,
+        Map<String, ClientModelProperty> superConstructorProperties,
+        Map<String, ClientModelProperty> superReadOnlyProperties,
+        Map<String, ClientModelProperty> superSetterProperties, JavaSettings settings) {
         if (property.isRequired()) {
             superRequiredProperties.put(property.getSerializedName(), property);
 

--- a/javagen/src/main/java/com/azure/autorest/template/StreamSerializationModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/StreamSerializationModelTemplate.java
@@ -1435,6 +1435,12 @@ hasConstructorArguments, settings));
                 methodBlock.line("xmlWriter.writeNamespace(\"" + prefix + "\", " + propertiesManager.getXmlNamespaceConstant(namespace) + ");"));
 
             String modelName = propertiesManager.getModel().getName();
+            // Assumption for XML is polymorphic discriminators are attributes.
+            if (propertiesManager.getDiscriminatorProperty() != null) {
+                serializeXml(methodBlock, propertiesManager.getDiscriminatorProperty().getProperty(), false, modelName,
+                    propertiesManager);
+            }
+
             propertiesManager.forEachSuperXmlAttribute(property -> serializeXml(methodBlock, property, true, modelName, propertiesManager));
             propertiesManager.forEachXmlAttribute(property -> serializeXml(methodBlock, property, false, modelName, propertiesManager));
 
@@ -1615,23 +1621,20 @@ hasConstructorArguments, settings));
             for (ClientModel childType : childTypes) {
                 ifBlock = ifOrElseIf(methodBlock, ifBlock, "\"" + childType.getSerializedName() + "\".equals(discriminatorValue)",
                     ifStatement -> ifStatement.methodReturn(childType.getName() + (isSuperTypeWithDiscriminator(childType)
-                        ? ".fromXmlKnownDiscriminator(reader, finalRootElementName)"
+                        ? ".fromXmlInternal(reader, finalRootElementName)"
                         : ".fromXml(reader, finalRootElementName)")));
             }
 
             if (ifBlock == null) {
-                methodBlock.methodReturn("fromXmlKnownDiscriminator(reader, finalRootElementName)");
+                methodBlock.methodReturn("fromXmlInternal(reader, finalRootElementName)");
             } else {
-                ifBlock.elseBlock(
-                    elseBlock -> elseBlock.methodReturn("fromXmlKnownDiscriminator(reader, finalRootElementName)"));
+                ifBlock.elseBlock(elseBlock -> elseBlock.methodReturn("fromXmlInternal(reader, finalRootElementName)"));
             }
         }, addGeneratedAnnotation);
 
-        if (!CoreUtils.isNullOrEmpty(discriminatorProperty.getDefaultValue())) {
-            readXmlObject(classBlock, propertiesManager, true,
-                methodBlock -> writeFromXmlDeserialization(methodBlock, propertiesManager, settings),
-                addGeneratedAnnotation);
-        }
+        readXmlObject(classBlock, propertiesManager, true,
+            methodBlock -> writeFromXmlDeserialization(methodBlock, propertiesManager, settings),
+            addGeneratedAnnotation);
     }
 
     /**
@@ -1655,11 +1658,12 @@ hasConstructorArguments, settings));
         boolean superTypeReading, Consumer<JavaBlock> deserializationBlock,
         Consumer<JavaClass> addGeneratedAnnotation) {
         JavaVisibility visibility = superTypeReading ? JavaVisibility.PackagePrivate : JavaVisibility.Public;
-        String methodName = superTypeReading ? "fromXmlKnownDiscriminator" : "fromXml";
+        String methodName = superTypeReading ? "fromXmlInternal" : "fromXml";
 
         String modelName = propertiesManager.getModel().getName();
-        boolean hasRequiredProperties = propertiesManager.hasRequiredProperties();
-        boolean isPolymorphic = propertiesManager.getDiscriminatorProperty() != null;
+        boolean hasRequiredProperties = propertiesManager.hasConstructorArguments();
+        boolean isPolymorphic = propertiesManager.getDiscriminatorProperty() != null
+            && CoreUtils.isNullOrEmpty(propertiesManager.getModel().getDerivedModels());
 
         if (!superTypeReading) {
             fromXmlJavadoc(classBlock, modelName, false, hasRequiredProperties, isPolymorphic);
@@ -1668,10 +1672,6 @@ hasConstructorArguments, settings));
                 methodBlock -> methodBlock.methodReturn("fromXml(xmlReader, null)"));
 
             fromXmlJavadoc(classBlock, modelName, true, hasRequiredProperties, isPolymorphic);
-        } else {
-            addGeneratedAnnotation.accept(classBlock);
-            classBlock.publicStaticMethod(modelName + " fromXmlKnownDiscriminator(XmlReader xmlReader) throws XMLStreamException",
-                methodBlock -> methodBlock.methodReturn("fromXmlKnownDiscriminator(xmlReader, null)"));
         }
 
         addGeneratedAnnotation.accept(classBlock);
@@ -1715,11 +1715,11 @@ hasConstructorArguments, settings));
             String throwsStatement = null;
             if (hasRequiredProperties && isPolymorphic) {
                 throwsStatement = "If the deserialized XML object was missing any required properties or the "
-                    + "polymorphic discriminator.";
+                    + "polymorphic discriminator value is invalid.";
             } else if (hasRequiredProperties) {
                 throwsStatement = "If the deserialized XML object was missing any required properties.";
             } else if (isPolymorphic) {
-                throwsStatement = "If the deserialized XML object was missing the polymorphic discriminator.";
+                throwsStatement = "If the deserialized XML object has an invalid polymorphic discriminator value.";
             }
 
             if (throwsStatement != null) {
@@ -1754,6 +1754,12 @@ hasConstructorArguments, settings));
         methodBlock.indent(() -> {
             // Initialize local variables to track what has been deserialized.
             initializeLocalVariables(methodBlock, propertiesManager, true, settings);
+
+            // Assumption for XML is polymorphic discriminators are attributes.
+            if (propertiesManager.getDiscriminatorProperty() != null) {
+                deserializeXmlAttribute(methodBlock, propertiesManager.getDiscriminatorProperty().getProperty(),
+                    propertiesManager, false);
+            }
 
             // Read the XML attribute properties first.
             propertiesManager.forEachSuperXmlAttribute(attribute -> deserializeXmlAttribute(methodBlock, attribute,
@@ -1826,7 +1832,10 @@ hasConstructorArguments, settings));
         String xmlAttributeDeserialization = getSimpleXmlDeserialization(attribute.getWireType(), "reader", null,
                 attribute.getXmlName(), propertiesManager.getXmlNamespaceConstant(attribute.getXmlNamespace()), true);
 
-        if (attribute.isPolymorphicDiscriminator()) {
+        if (attribute.isPolymorphicDiscriminator()
+            && CoreUtils.isNullOrEmpty(propertiesManager.getModel().getDerivedModels())) {
+            // Only validate the discriminator if the model has no derived models.
+            // Super types will deserialize as themselves if the discriminator doesn't match what's expected.
             methodBlock.line("String discriminatorValue = " + xmlAttributeDeserialization + ";");
             String ifStatement = String.format("!%s.equals(discriminatorValue)", attribute.getDefaultValue());
             methodBlock.ifBlock(ifStatement, ifAction2 -> ifAction2.line(
@@ -1834,7 +1843,8 @@ hasConstructorArguments, settings));
                     + "The found '%s' was '\" + discriminatorValue + \"'.\");",
                 attribute.getSerializedName(), propertiesManager.getExpectedDiscriminator(),
                 attribute.getSerializedName()));
-            return;
+
+            xmlAttributeDeserialization = "discriminatorValue";
         }
 
         if (propertiesManager.hasConstructorArguments()) {

--- a/javagen/src/main/java/com/azure/autorest/template/StreamSerializationModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/StreamSerializationModelTemplate.java
@@ -1434,23 +1434,22 @@ hasConstructorArguments, settings));
             propertiesManager.forEachXmlNamespaceWithPrefix((prefix, namespace) ->
                 methodBlock.line("xmlWriter.writeNamespace(\"" + prefix + "\", " + propertiesManager.getXmlNamespaceConstant(namespace) + ");"));
 
-            String modelName = propertiesManager.getModel().getName();
             // Assumption for XML is polymorphic discriminators are attributes.
             if (propertiesManager.getDiscriminatorProperty() != null) {
-                serializeXml(methodBlock, propertiesManager.getDiscriminatorProperty().getProperty(), false, modelName,
+                serializeXml(methodBlock, propertiesManager.getDiscriminatorProperty().getProperty(), false,
                     propertiesManager);
             }
 
-            propertiesManager.forEachSuperXmlAttribute(property -> serializeXml(methodBlock, property, true, modelName, propertiesManager));
-            propertiesManager.forEachXmlAttribute(property -> serializeXml(methodBlock, property, false, modelName, propertiesManager));
+            propertiesManager.forEachSuperXmlAttribute(property -> serializeXml(methodBlock, property, true, propertiesManager));
+            propertiesManager.forEachXmlAttribute(property -> serializeXml(methodBlock, property, false, propertiesManager));
 
             // Valid XML should only either have elements or text.
             if (propertiesManager.hasXmlElements()) {
-                propertiesManager.forEachSuperXmlElement(property -> serializeXml(methodBlock, property, true, modelName, propertiesManager));
-                propertiesManager.forEachXmlElement(property -> serializeXml(methodBlock, property, false, modelName, propertiesManager));
+                propertiesManager.forEachSuperXmlElement(property -> serializeXml(methodBlock, property, true, propertiesManager));
+                propertiesManager.forEachXmlElement(property -> serializeXml(methodBlock, property, false, propertiesManager));
             } else {
-                propertiesManager.forEachSuperXmlText(property -> serializeXml(methodBlock, property, true, modelName, propertiesManager));
-                propertiesManager.forEachXmlText(property -> serializeXml(methodBlock, property, false, modelName, propertiesManager));
+                propertiesManager.forEachSuperXmlText(property -> serializeXml(methodBlock, property, true, propertiesManager));
+                propertiesManager.forEachXmlText(property -> serializeXml(methodBlock, property, false, propertiesManager));
             }
 
             methodBlock.methodReturn("xmlWriter.writeEndElement()");
@@ -1465,18 +1464,11 @@ hasConstructorArguments, settings));
      * @param fromSuperType Whether the property is defined in the super type.
      */
     private static void serializeXml(JavaBlock methodBlock, ClientModelProperty element, boolean fromSuperType,
-        String modelName, ClientModelPropertiesManager propertiesManager) {
+        ClientModelPropertiesManager propertiesManager) {
         IType clientType = element.getClientType();
         IType wireType = element.getWireType();
         String propertyValueGetter;
-        if (element.isPolymorphicDiscriminator()) {
-            // The most super type won't have a value for the polymorphic discriminator, use the model name.
-            if (CoreUtils.isNullOrEmpty(element.getDefaultValue())) {
-                propertyValueGetter = "\"" + modelName + "\"";
-            } else {
-                propertyValueGetter = element.getDefaultValue();
-            }
-        } else if (fromSuperType) {
+        if (fromSuperType) {
             propertyValueGetter = (clientType != wireType)
                     ? wireType.convertFromClientType(element.getGetterName() + "()")
                     : element.getGetterName() + "()";

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/AccessPolicy.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/AccessPolicy.java
@@ -141,7 +141,6 @@ public final class AccessPolicy implements XmlSerializable<AccessPolicy> {
      * @param xmlReader The XmlReader being read.
      * @return An instance of AccessPolicy if the XmlReader was pointing to an instance of it, or null if it was
      * pointing to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the AccessPolicy.
      */
     public static AccessPolicy fromXml(XmlReader xmlReader) throws XMLStreamException {
@@ -156,7 +155,6 @@ public final class AccessPolicy implements XmlSerializable<AccessPolicy> {
      * cases where the model can deserialize from different root element names.
      * @return An instance of AccessPolicy if the XmlReader was pointing to an instance of it, or null if it was
      * pointing to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the AccessPolicy.
      */
     public static AccessPolicy fromXml(XmlReader xmlReader, String rootElementName) throws XMLStreamException {

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/Blob.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/Blob.java
@@ -199,7 +199,6 @@ public final class Blob implements XmlSerializable<Blob> {
      * @param xmlReader The XmlReader being read.
      * @return An instance of Blob if the XmlReader was pointing to an instance of it, or null if it was pointing to XML
      * null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the Blob.
      */
     public static Blob fromXml(XmlReader xmlReader) throws XMLStreamException {
@@ -214,7 +213,6 @@ public final class Blob implements XmlSerializable<Blob> {
      * cases where the model can deserialize from different root element names.
      * @return An instance of Blob if the XmlReader was pointing to an instance of it, or null if it was pointing to XML
      * null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the Blob.
      */
     public static Blob fromXml(XmlReader xmlReader, String rootElementName) throws XMLStreamException {

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/BlobPrefix.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/BlobPrefix.java
@@ -79,7 +79,6 @@ public final class BlobPrefix implements XmlSerializable<BlobPrefix> {
      * @param xmlReader The XmlReader being read.
      * @return An instance of BlobPrefix if the XmlReader was pointing to an instance of it, or null if it was pointing
      * to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the BlobPrefix.
      */
     public static BlobPrefix fromXml(XmlReader xmlReader) throws XMLStreamException {
@@ -94,7 +93,6 @@ public final class BlobPrefix implements XmlSerializable<BlobPrefix> {
      * cases where the model can deserialize from different root element names.
      * @return An instance of BlobPrefix if the XmlReader was pointing to an instance of it, or null if it was pointing
      * to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the BlobPrefix.
      */
     public static BlobPrefix fromXml(XmlReader xmlReader, String rootElementName) throws XMLStreamException {

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/BlobProperties.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/BlobProperties.java
@@ -810,7 +810,6 @@ public final class BlobProperties implements XmlSerializable<BlobProperties> {
      * @param xmlReader The XmlReader being read.
      * @return An instance of BlobProperties if the XmlReader was pointing to an instance of it, or null if it was
      * pointing to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the BlobProperties.
      */
     public static BlobProperties fromXml(XmlReader xmlReader) throws XMLStreamException {
@@ -825,7 +824,6 @@ public final class BlobProperties implements XmlSerializable<BlobProperties> {
      * cases where the model can deserialize from different root element names.
      * @return An instance of BlobProperties if the XmlReader was pointing to an instance of it, or null if it was
      * pointing to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the BlobProperties.
      */
     public static BlobProperties fromXml(XmlReader xmlReader, String rootElementName) throws XMLStreamException {

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/Container.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/Container.java
@@ -144,7 +144,6 @@ public final class Container implements XmlSerializable<Container> {
      * @param xmlReader The XmlReader being read.
      * @return An instance of Container if the XmlReader was pointing to an instance of it, or null if it was pointing
      * to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the Container.
      */
     public static Container fromXml(XmlReader xmlReader) throws XMLStreamException {
@@ -159,7 +158,6 @@ public final class Container implements XmlSerializable<Container> {
      * cases where the model can deserialize from different root element names.
      * @return An instance of Container if the XmlReader was pointing to an instance of it, or null if it was pointing
      * to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the Container.
      */
     public static Container fromXml(XmlReader xmlReader, String rootElementName) throws XMLStreamException {

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/ContainerProperties.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/ContainerProperties.java
@@ -223,7 +223,6 @@ public final class ContainerProperties implements XmlSerializable<ContainerPrope
      * @param xmlReader The XmlReader being read.
      * @return An instance of ContainerProperties if the XmlReader was pointing to an instance of it, or null if it was
      * pointing to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the ContainerProperties.
      */
     public static ContainerProperties fromXml(XmlReader xmlReader) throws XMLStreamException {
@@ -238,7 +237,6 @@ public final class ContainerProperties implements XmlSerializable<ContainerPrope
      * cases where the model can deserialize from different root element names.
      * @return An instance of ContainerProperties if the XmlReader was pointing to an instance of it, or null if it was
      * pointing to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the ContainerProperties.
      */
     public static ContainerProperties fromXml(XmlReader xmlReader, String rootElementName) throws XMLStreamException {

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/CorsRule.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/CorsRule.java
@@ -207,7 +207,6 @@ public final class CorsRule implements XmlSerializable<CorsRule> {
      * @param xmlReader The XmlReader being read.
      * @return An instance of CorsRule if the XmlReader was pointing to an instance of it, or null if it was pointing to
      * XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the CorsRule.
      */
     public static CorsRule fromXml(XmlReader xmlReader) throws XMLStreamException {
@@ -222,7 +221,6 @@ public final class CorsRule implements XmlSerializable<CorsRule> {
      * cases where the model can deserialize from different root element names.
      * @return An instance of CorsRule if the XmlReader was pointing to an instance of it, or null if it was pointing to
      * XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the CorsRule.
      */
     public static CorsRule fromXml(XmlReader xmlReader, String rootElementName) throws XMLStreamException {

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/ListBlobsResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/ListBlobsResponse.java
@@ -278,7 +278,6 @@ public final class ListBlobsResponse implements XmlSerializable<ListBlobsRespons
      * @param xmlReader The XmlReader being read.
      * @return An instance of ListBlobsResponse if the XmlReader was pointing to an instance of it, or null if it was
      * pointing to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the ListBlobsResponse.
      */
     public static ListBlobsResponse fromXml(XmlReader xmlReader) throws XMLStreamException {
@@ -293,7 +292,6 @@ public final class ListBlobsResponse implements XmlSerializable<ListBlobsRespons
      * cases where the model can deserialize from different root element names.
      * @return An instance of ListBlobsResponse if the XmlReader was pointing to an instance of it, or null if it was
      * pointing to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the ListBlobsResponse.
      */
     public static ListBlobsResponse fromXml(XmlReader xmlReader, String rootElementName) throws XMLStreamException {

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/ListContainersResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/ListContainersResponse.java
@@ -230,7 +230,6 @@ public final class ListContainersResponse implements XmlSerializable<ListContain
      * @param xmlReader The XmlReader being read.
      * @return An instance of ListContainersResponse if the XmlReader was pointing to an instance of it, or null if it
      * was pointing to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the ListContainersResponse.
      */
     public static ListContainersResponse fromXml(XmlReader xmlReader) throws XMLStreamException {
@@ -245,7 +244,6 @@ public final class ListContainersResponse implements XmlSerializable<ListContain
      * cases where the model can deserialize from different root element names.
      * @return An instance of ListContainersResponse if the XmlReader was pointing to an instance of it, or null if it
      * was pointing to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the ListContainersResponse.
      */
     public static ListContainersResponse fromXml(XmlReader xmlReader, String rootElementName)

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/Logging.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/Logging.java
@@ -188,7 +188,6 @@ public final class Logging implements XmlSerializable<Logging> {
      * @param xmlReader The XmlReader being read.
      * @return An instance of Logging if the XmlReader was pointing to an instance of it, or null if it was pointing to
      * XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the Logging.
      */
     public static Logging fromXml(XmlReader xmlReader) throws XMLStreamException {
@@ -203,7 +202,6 @@ public final class Logging implements XmlSerializable<Logging> {
      * cases where the model can deserialize from different root element names.
      * @return An instance of Logging if the XmlReader was pointing to an instance of it, or null if it was pointing to
      * XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the Logging.
      */
     public static Logging fromXml(XmlReader xmlReader, String rootElementName) throws XMLStreamException {

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/Metrics.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/Metrics.java
@@ -159,7 +159,6 @@ public final class Metrics implements XmlSerializable<Metrics> {
      * @param xmlReader The XmlReader being read.
      * @return An instance of Metrics if the XmlReader was pointing to an instance of it, or null if it was pointing to
      * XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the Metrics.
      */
     public static Metrics fromXml(XmlReader xmlReader) throws XMLStreamException {
@@ -174,7 +173,6 @@ public final class Metrics implements XmlSerializable<Metrics> {
      * cases where the model can deserialize from different root element names.
      * @return An instance of Metrics if the XmlReader was pointing to an instance of it, or null if it was pointing to
      * XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the Metrics.
      */
     public static Metrics fromXml(XmlReader xmlReader, String rootElementName) throws XMLStreamException {

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/RetentionPolicy.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/RetentionPolicy.java
@@ -104,7 +104,6 @@ public final class RetentionPolicy implements XmlSerializable<RetentionPolicy> {
      * @param xmlReader The XmlReader being read.
      * @return An instance of RetentionPolicy if the XmlReader was pointing to an instance of it, or null if it was
      * pointing to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the RetentionPolicy.
      */
     public static RetentionPolicy fromXml(XmlReader xmlReader) throws XMLStreamException {
@@ -119,7 +118,6 @@ public final class RetentionPolicy implements XmlSerializable<RetentionPolicy> {
      * cases where the model can deserialize from different root element names.
      * @return An instance of RetentionPolicy if the XmlReader was pointing to an instance of it, or null if it was
      * pointing to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the RetentionPolicy.
      */
     public static RetentionPolicy fromXml(XmlReader xmlReader, String rootElementName) throws XMLStreamException {

--- a/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/SignedIdentifier.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstylexmlserialization/models/SignedIdentifier.java
@@ -110,7 +110,6 @@ public final class SignedIdentifier implements XmlSerializable<SignedIdentifier>
      * @param xmlReader The XmlReader being read.
      * @return An instance of SignedIdentifier if the XmlReader was pointing to an instance of it, or null if it was
      * pointing to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the SignedIdentifier.
      */
     public static SignedIdentifier fromXml(XmlReader xmlReader) throws XMLStreamException {
@@ -125,7 +124,6 @@ public final class SignedIdentifier implements XmlSerializable<SignedIdentifier>
      * cases where the model can deserialize from different root element names.
      * @return An instance of SignedIdentifier if the XmlReader was pointing to an instance of it, or null if it was
      * pointing to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the SignedIdentifier.
      */
     public static SignedIdentifier fromXml(XmlReader xmlReader, String rootElementName) throws XMLStreamException {

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/AccessPolicy.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/AccessPolicy.java
@@ -141,7 +141,6 @@ public final class AccessPolicy implements XmlSerializable<AccessPolicy> {
      * @param xmlReader The XmlReader being read.
      * @return An instance of AccessPolicy if the XmlReader was pointing to an instance of it, or null if it was
      * pointing to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the AccessPolicy.
      */
     public static AccessPolicy fromXml(XmlReader xmlReader) throws XMLStreamException {
@@ -156,7 +155,6 @@ public final class AccessPolicy implements XmlSerializable<AccessPolicy> {
      * cases where the model can deserialize from different root element names.
      * @return An instance of AccessPolicy if the XmlReader was pointing to an instance of it, or null if it was
      * pointing to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the AccessPolicy.
      */
     public static AccessPolicy fromXml(XmlReader xmlReader, String rootElementName) throws XMLStreamException {

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/Blob.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/Blob.java
@@ -199,7 +199,6 @@ public final class Blob implements XmlSerializable<Blob> {
      * @param xmlReader The XmlReader being read.
      * @return An instance of Blob if the XmlReader was pointing to an instance of it, or null if it was pointing to XML
      * null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the Blob.
      */
     public static Blob fromXml(XmlReader xmlReader) throws XMLStreamException {
@@ -214,7 +213,6 @@ public final class Blob implements XmlSerializable<Blob> {
      * cases where the model can deserialize from different root element names.
      * @return An instance of Blob if the XmlReader was pointing to an instance of it, or null if it was pointing to XML
      * null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the Blob.
      */
     public static Blob fromXml(XmlReader xmlReader, String rootElementName) throws XMLStreamException {

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/BlobPrefix.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/BlobPrefix.java
@@ -79,7 +79,6 @@ public final class BlobPrefix implements XmlSerializable<BlobPrefix> {
      * @param xmlReader The XmlReader being read.
      * @return An instance of BlobPrefix if the XmlReader was pointing to an instance of it, or null if it was pointing
      * to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the BlobPrefix.
      */
     public static BlobPrefix fromXml(XmlReader xmlReader) throws XMLStreamException {
@@ -94,7 +93,6 @@ public final class BlobPrefix implements XmlSerializable<BlobPrefix> {
      * cases where the model can deserialize from different root element names.
      * @return An instance of BlobPrefix if the XmlReader was pointing to an instance of it, or null if it was pointing
      * to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the BlobPrefix.
      */
     public static BlobPrefix fromXml(XmlReader xmlReader, String rootElementName) throws XMLStreamException {

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/BlobProperties.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/BlobProperties.java
@@ -810,7 +810,6 @@ public final class BlobProperties implements XmlSerializable<BlobProperties> {
      * @param xmlReader The XmlReader being read.
      * @return An instance of BlobProperties if the XmlReader was pointing to an instance of it, or null if it was
      * pointing to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the BlobProperties.
      */
     public static BlobProperties fromXml(XmlReader xmlReader) throws XMLStreamException {
@@ -825,7 +824,6 @@ public final class BlobProperties implements XmlSerializable<BlobProperties> {
      * cases where the model can deserialize from different root element names.
      * @return An instance of BlobProperties if the XmlReader was pointing to an instance of it, or null if it was
      * pointing to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the BlobProperties.
      */
     public static BlobProperties fromXml(XmlReader xmlReader, String rootElementName) throws XMLStreamException {

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/Container.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/Container.java
@@ -144,7 +144,6 @@ public final class Container implements XmlSerializable<Container> {
      * @param xmlReader The XmlReader being read.
      * @return An instance of Container if the XmlReader was pointing to an instance of it, or null if it was pointing
      * to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the Container.
      */
     public static Container fromXml(XmlReader xmlReader) throws XMLStreamException {
@@ -159,7 +158,6 @@ public final class Container implements XmlSerializable<Container> {
      * cases where the model can deserialize from different root element names.
      * @return An instance of Container if the XmlReader was pointing to an instance of it, or null if it was pointing
      * to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the Container.
      */
     public static Container fromXml(XmlReader xmlReader, String rootElementName) throws XMLStreamException {

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/ContainerProperties.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/ContainerProperties.java
@@ -223,7 +223,6 @@ public final class ContainerProperties implements XmlSerializable<ContainerPrope
      * @param xmlReader The XmlReader being read.
      * @return An instance of ContainerProperties if the XmlReader was pointing to an instance of it, or null if it was
      * pointing to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the ContainerProperties.
      */
     public static ContainerProperties fromXml(XmlReader xmlReader) throws XMLStreamException {
@@ -238,7 +237,6 @@ public final class ContainerProperties implements XmlSerializable<ContainerPrope
      * cases where the model can deserialize from different root element names.
      * @return An instance of ContainerProperties if the XmlReader was pointing to an instance of it, or null if it was
      * pointing to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the ContainerProperties.
      */
     public static ContainerProperties fromXml(XmlReader xmlReader, String rootElementName) throws XMLStreamException {

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/CorsRule.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/CorsRule.java
@@ -207,7 +207,6 @@ public final class CorsRule implements XmlSerializable<CorsRule> {
      * @param xmlReader The XmlReader being read.
      * @return An instance of CorsRule if the XmlReader was pointing to an instance of it, or null if it was pointing to
      * XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the CorsRule.
      */
     public static CorsRule fromXml(XmlReader xmlReader) throws XMLStreamException {
@@ -222,7 +221,6 @@ public final class CorsRule implements XmlSerializable<CorsRule> {
      * cases where the model can deserialize from different root element names.
      * @return An instance of CorsRule if the XmlReader was pointing to an instance of it, or null if it was pointing to
      * XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the CorsRule.
      */
     public static CorsRule fromXml(XmlReader xmlReader, String rootElementName) throws XMLStreamException {

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/ListBlobsResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/ListBlobsResponse.java
@@ -278,7 +278,6 @@ public final class ListBlobsResponse implements XmlSerializable<ListBlobsRespons
      * @param xmlReader The XmlReader being read.
      * @return An instance of ListBlobsResponse if the XmlReader was pointing to an instance of it, or null if it was
      * pointing to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the ListBlobsResponse.
      */
     public static ListBlobsResponse fromXml(XmlReader xmlReader) throws XMLStreamException {
@@ -293,7 +292,6 @@ public final class ListBlobsResponse implements XmlSerializable<ListBlobsRespons
      * cases where the model can deserialize from different root element names.
      * @return An instance of ListBlobsResponse if the XmlReader was pointing to an instance of it, or null if it was
      * pointing to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the ListBlobsResponse.
      */
     public static ListBlobsResponse fromXml(XmlReader xmlReader, String rootElementName) throws XMLStreamException {

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/ListContainersResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/ListContainersResponse.java
@@ -230,7 +230,6 @@ public final class ListContainersResponse implements XmlSerializable<ListContain
      * @param xmlReader The XmlReader being read.
      * @return An instance of ListContainersResponse if the XmlReader was pointing to an instance of it, or null if it
      * was pointing to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the ListContainersResponse.
      */
     public static ListContainersResponse fromXml(XmlReader xmlReader) throws XMLStreamException {
@@ -245,7 +244,6 @@ public final class ListContainersResponse implements XmlSerializable<ListContain
      * cases where the model can deserialize from different root element names.
      * @return An instance of ListContainersResponse if the XmlReader was pointing to an instance of it, or null if it
      * was pointing to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the ListContainersResponse.
      */
     public static ListContainersResponse fromXml(XmlReader xmlReader, String rootElementName)

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/Logging.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/Logging.java
@@ -188,7 +188,6 @@ public final class Logging implements XmlSerializable<Logging> {
      * @param xmlReader The XmlReader being read.
      * @return An instance of Logging if the XmlReader was pointing to an instance of it, or null if it was pointing to
      * XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the Logging.
      */
     public static Logging fromXml(XmlReader xmlReader) throws XMLStreamException {
@@ -203,7 +202,6 @@ public final class Logging implements XmlSerializable<Logging> {
      * cases where the model can deserialize from different root element names.
      * @return An instance of Logging if the XmlReader was pointing to an instance of it, or null if it was pointing to
      * XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the Logging.
      */
     public static Logging fromXml(XmlReader xmlReader, String rootElementName) throws XMLStreamException {

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/Metrics.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/Metrics.java
@@ -159,7 +159,6 @@ public final class Metrics implements XmlSerializable<Metrics> {
      * @param xmlReader The XmlReader being read.
      * @return An instance of Metrics if the XmlReader was pointing to an instance of it, or null if it was pointing to
      * XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the Metrics.
      */
     public static Metrics fromXml(XmlReader xmlReader) throws XMLStreamException {
@@ -174,7 +173,6 @@ public final class Metrics implements XmlSerializable<Metrics> {
      * cases where the model can deserialize from different root element names.
      * @return An instance of Metrics if the XmlReader was pointing to an instance of it, or null if it was pointing to
      * XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the Metrics.
      */
     public static Metrics fromXml(XmlReader xmlReader, String rootElementName) throws XMLStreamException {

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/RetentionPolicy.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/RetentionPolicy.java
@@ -104,7 +104,6 @@ public final class RetentionPolicy implements XmlSerializable<RetentionPolicy> {
      * @param xmlReader The XmlReader being read.
      * @return An instance of RetentionPolicy if the XmlReader was pointing to an instance of it, or null if it was
      * pointing to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the RetentionPolicy.
      */
     public static RetentionPolicy fromXml(XmlReader xmlReader) throws XMLStreamException {
@@ -119,7 +118,6 @@ public final class RetentionPolicy implements XmlSerializable<RetentionPolicy> {
      * cases where the model can deserialize from different root element names.
      * @return An instance of RetentionPolicy if the XmlReader was pointing to an instance of it, or null if it was
      * pointing to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the RetentionPolicy.
      */
     public static RetentionPolicy fromXml(XmlReader xmlReader, String rootElementName) throws XMLStreamException {

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/SignedIdentifier.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/SignedIdentifier.java
@@ -110,7 +110,6 @@ public final class SignedIdentifier implements XmlSerializable<SignedIdentifier>
      * @param xmlReader The XmlReader being read.
      * @return An instance of SignedIdentifier if the XmlReader was pointing to an instance of it, or null if it was
      * pointing to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the SignedIdentifier.
      */
     public static SignedIdentifier fromXml(XmlReader xmlReader) throws XMLStreamException {
@@ -125,7 +124,6 @@ public final class SignedIdentifier implements XmlSerializable<SignedIdentifier>
      * cases where the model can deserialize from different root element names.
      * @return An instance of SignedIdentifier if the XmlReader was pointing to an instance of it, or null if it was
      * pointing to XML null.
-     * @throws IllegalStateException If the deserialized XML object was missing any required properties.
      * @throws XMLStreamException If an error occurs while reading the SignedIdentifier.
      */
     public static SignedIdentifier fromXml(XmlReader xmlReader, String rootElementName) throws XMLStreamException {


### PR DESCRIPTION
Fixes an issue where XML stream-style serialization was serializing and deserializing the polymorphic property multiple times. This was due to a recent change where polymorphic properties are now retained as formal properties within the `ClientModel` rather than being inferred. Resulting in a polymorphic property each time there was a super type and again for the model itself.