### PR TITLE
eng, add a DevPackage mode to sync sdk pipeline

### DIFF
--- a/eng/pipelines/post-publish-sdk.yaml
+++ b/eng/pipelines/post-publish-sdk.yaml
@@ -36,9 +36,11 @@ jobs:
 
   - task: PowerShell@2
     displayName: 'Build typespec-java'
+    condition: eq(variables['DEV_PACKAGE'], 'true')
     inputs:
       pwsh: true
       filePath: Build-TypeSpec.ps1
+      workingDirectory: $(Build.SourcesDirectory)/autorest.java
 
   - script: npm install -g @azure-tools/typespec-client-generator-cli
     displayName: 'Install tsp-client'

--- a/eng/pipelines/post-publish-sdk.yaml
+++ b/eng/pipelines/post-publish-sdk.yaml
@@ -55,7 +55,7 @@ jobs:
       workingDirectory: $(Build.SourcesDirectory)/autorest.java
 
   - script: |
-      python3 ./eng/sdk/sync_sdk.py --sdk-root=$(Build.SourcesDirectory)/azure-sdk-for-java --package-json-path=$(Build.SourcesDirectory)/autorest.java/typespec-extension/package.json --dev-package=$(DevPackage)
+      python3 ./eng/sdk/sync_sdk.py --sdk-root=$(Build.SourcesDirectory)/azure-sdk-for-java --package-json-path=$(Build.SourcesDirectory)/autorest.java/typespec-extension/package.json --dev-package=$(DEV_PACKAGE)
     displayName: 'Generate SDK'
     workingDirectory: $(Build.SourcesDirectory)/autorest.java
 

--- a/eng/pipelines/post-publish-sdk.yaml
+++ b/eng/pipelines/post-publish-sdk.yaml
@@ -48,7 +48,7 @@ jobs:
 
   - task: PowerShell@2
     displayName: 'Build typespec-java'
-    condition: and(succeeded(), eq(parameters.DevPackage, 'true'))
+    condition: and(succeeded(), eq('${{ parameters.DevPackage }}', 'true'))
     inputs:
       pwsh: true
       filePath: $(Build.SourcesDirectory)/autorest.java/Build-TypeSpec.ps1
@@ -67,7 +67,7 @@ jobs:
       workingDirectory: $(Build.SourcesDirectory)/autorest.java
 
   - script: |
-      python3 ./eng/sdk/sync_sdk.py --sdk-root=$(Build.SourcesDirectory)/azure-sdk-for-java --package-json-path=$(Build.SourcesDirectory)/autorest.java/typespec-extension/package.json --dev-package=$(parameters.DevPackage)
+      python3 ./eng/sdk/sync_sdk.py --sdk-root=$(Build.SourcesDirectory)/azure-sdk-for-java --package-json-path=$(Build.SourcesDirectory)/autorest.java/typespec-extension/package.json --dev-package=${{ parameters.DevPackage }}
     displayName: 'Generate SDK'
     workingDirectory: $(Build.SourcesDirectory)/autorest.java
 

--- a/eng/pipelines/post-publish-sdk.yaml
+++ b/eng/pipelines/post-publish-sdk.yaml
@@ -34,6 +34,12 @@ jobs:
     inputs:
       versionSpec: '$(NodeVersion)'
 
+  - task: PowerShell@2
+    displayName: 'Build typespec-java'
+    inputs:
+      pwsh: true
+      filePath: Build-TypeSpec.ps1
+
   - script: npm install -g @azure-tools/typespec-client-generator-cli
     displayName: 'Install tsp-client'
 
@@ -47,7 +53,7 @@ jobs:
       workingDirectory: $(Build.SourcesDirectory)/autorest.java
 
   - script: |
-      python3 ./eng/sdk/sync_sdk.py --sdk-root=$(Build.SourcesDirectory)/azure-sdk-for-java --package-json-path=$(Build.SourcesDirectory)/autorest.java/typespec-extension/package.json
+      python3 ./eng/sdk/sync_sdk.py --sdk-root=$(Build.SourcesDirectory)/azure-sdk-for-java --package-json-path=$(Build.SourcesDirectory)/autorest.java/typespec-extension/package.json --dev-package=$(DevPackage)
     displayName: 'Generate SDK'
     workingDirectory: $(Build.SourcesDirectory)/autorest.java
 

--- a/eng/pipelines/post-publish-sdk.yaml
+++ b/eng/pipelines/post-publish-sdk.yaml
@@ -1,6 +1,13 @@
 trigger: none
 pr: none
 
+parameters:
+- name: DevPackage
+  default: false
+  values:
+  - false
+  - true
+
 pool:
   name: "azsdk-pool-mms-ubuntu-2004-general"
   vmImage: "MMSUbuntu20.04"
@@ -24,7 +31,7 @@ jobs:
   variables:
   - template: /eng/pipelines/variables/globals.yml
   - name: PullRequestTitleSuffix
-    ${{ if eq(variables['DEV_PACKAGE'], 'true') }}:
+    ${{ if eq(parameters.DevPackage, 'true') }}:
       value: " DEV"
     ${{ else }}:
       value: ""
@@ -41,7 +48,7 @@ jobs:
 
   - task: PowerShell@2
     displayName: 'Build typespec-java'
-    condition: eq(variables['DEV_PACKAGE'], 'true')
+    condition: and(succeeded(), eq(parameters.DevPackage, 'true'))
     inputs:
       pwsh: true
       filePath: $(Build.SourcesDirectory)/autorest.java/Build-TypeSpec.ps1
@@ -60,7 +67,7 @@ jobs:
       workingDirectory: $(Build.SourcesDirectory)/autorest.java
 
   - script: |
-      python3 ./eng/sdk/sync_sdk.py --sdk-root=$(Build.SourcesDirectory)/azure-sdk-for-java --package-json-path=$(Build.SourcesDirectory)/autorest.java/typespec-extension/package.json --dev-package=$(DEV_PACKAGE)
+      python3 ./eng/sdk/sync_sdk.py --sdk-root=$(Build.SourcesDirectory)/azure-sdk-for-java --package-json-path=$(Build.SourcesDirectory)/autorest.java/typespec-extension/package.json --dev-package=$(parameters.DevPackage)
     displayName: 'Generate SDK'
     workingDirectory: $(Build.SourcesDirectory)/autorest.java
 

--- a/eng/pipelines/post-publish-sdk.yaml
+++ b/eng/pipelines/post-publish-sdk.yaml
@@ -23,6 +23,11 @@ jobs:
 
   variables:
   - template: /eng/pipelines/variables/globals.yml
+  - name: PullRequestTitleSuffix
+    ${{ if eq(variables['DEV_PACKAGE'], 'true') }}:
+      value: " DEV"
+    ${{ else }}:
+      value: ""
 
   steps:
   - checkout: self
@@ -66,7 +71,7 @@ jobs:
       RepoName: azure-sdk-for-java
       BaseBranchName: 'refs/heads/main'
       PRBranchName: typespec-java-generation-$(Build.BuildId)
-      CommitMsg: '[Automation] Generate SDK based on TypeSpec $(PackageVersion)'
-      PRTitle: '[Automation] Generate SDK based on TypeSpec $(PackageVersion)'
+      CommitMsg: '[Automation] Generate SDK based on TypeSpec $(PackageVersion)$(PullRequestTitleSuffix)'
+      PRTitle: '[Automation] Generate SDK based on TypeSpec $(PackageVersion)$(PullRequestTitleSuffix)'
       PRLabels: 'DPG'
       OpenAsDraft: 'true'

--- a/eng/pipelines/post-publish-sdk.yaml
+++ b/eng/pipelines/post-publish-sdk.yaml
@@ -39,7 +39,7 @@ jobs:
     condition: eq(variables['DEV_PACKAGE'], 'true')
     inputs:
       pwsh: true
-      filePath: Build-TypeSpec.ps1
+      filePath: $(Build.SourcesDirectory)/autorest.java/Build-TypeSpec.ps1
       workingDirectory: $(Build.SourcesDirectory)/autorest.java
 
   - script: npm install -g @azure-tools/typespec-client-generator-cli

--- a/eng/sdk/sync_sdk.py
+++ b/eng/sdk/sync_sdk.py
@@ -25,18 +25,27 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '--sdk-root',
+        type=str,
         required=True,
         help='azure-sdk-for-java repository root.',
     )
     parser.add_argument(
         '--package-json-path',
+        type=str,
         required=True,
         help='path to package.json of typespec-java.',
+    )
+    parser.add_argument(
+        '--dev-package',
+        type=str,
+        required=False,
+        default='false',
+        help='use build from the branch, instead of published typespec-java.',
     )
     return parser.parse_args()
 
 
-def update_emitter(package_json_path: str):
+def update_emitter(package_json_path: str, use_dev_package: bool):
     logging.info('Update emitter-package.json')
     subprocess.check_call([
         'pwsh',
@@ -46,6 +55,21 @@ def update_emitter(package_json_path: str):
         '-OutputDirectory',
         'eng'],
         cwd=sdk_root)
+
+    if use_dev_package:
+        # replace version with path to dev package
+        dev_package_path = None
+        typespec_extension_path = os.path.dirname(package_json_path)
+        for file in os.listdir(typespec_extension_path):
+            if file.endswith('.tgz'):
+                dev_package_path = os.path.join(typespec_extension_path, file)
+        if dev_package_path:
+            eng_package_path = os.path.join(sdk_root, 'eng', 'emitter-package.json')
+            with open(eng_package_path, 'r') as json_file:
+                package_json = json.load(json_file)
+            package_json['dependencies']['@azure-tools/typespec-java'] = dev_package_path
+            with open(eng_package_path, 'w') as json_file:
+                json.dump(package_json, json_file)
 
     logging.info('Update emitter-package-lock.json')
     subprocess.check_call(['tsp-client', '--generate-lock-file'], cwd=sdk_root)
@@ -109,7 +133,7 @@ def main():
     args = vars(parse_args())
     sdk_root = args['sdk_root']
 
-    update_emitter(args['package_json_path'])
+    update_emitter(args['package_json_path'], args['dev_package'].lower() == 'true')
 
     update_sdks()
 

--- a/eng/sdk/sync_sdk.py
+++ b/eng/sdk/sync_sdk.py
@@ -110,8 +110,14 @@ def update_sdks():
             logging.info('Delete source code of resourcemanager module %s', artifact)
             shutil.rmtree(os.path.join(module_path, 'src', 'main'))
 
-        logging.info('Generate for module %s', artifact)
-        subprocess.check_call(['tsp-client', 'update'], cwd=module_path)
+        logging.info(f'Generate for module {artifact}')
+        try:
+            subprocess.check_call(['tsp-client', 'update'], cwd=module_path)
+        except subprocess.CalledProcessError:
+            # one retry
+            # sometimes customization have intermittent failure
+            logging.warning(f'Retry generate for module {artifact}')
+            subprocess.check_call(['tsp-client', 'update'], cwd=module_path)
 
         if arm_module:
             # revert mock test code


### PR DESCRIPTION
When DevPackage=true, the pipeline would use the local build of the branch, to regen SDKs.

It would let us see what can change, before release typespec-java.

test, dev https://github.com/Azure/azure-sdk-for-java/pull/40173
non-dev https://github.com/Azure/azure-sdk-for-java/pull/40174