### PR TITLE
Remove polymorphic discriminator from JSON merge patch tracking

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -822,17 +822,20 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                 constructor.line("super(" + superProperties + ");");
             }
 
+            // If we're always adding the polymorphic discriminator to updated properties, may as well just make the
+            // serialization always add them. This will remove the need to track them, further reducing Set updating and
+            // querying, which can improve performance in high throughput scenarios.
             // If there is a polymorphic discriminator , add a line to initialize the discriminator.
-            ClientModelProperty polymorphicProperty = model.getPolymorphicDiscriminator();
-            if (polymorphicProperty != null && !polymorphicProperty.isRequired()) {
-                if (ClientModelUtil.isJsonMergePatchModel(model, settings)) {
-                    for (ClientModelProperty property : model.getParentPolymorphicDiscriminators()) {
-                        constructor.line("this.updatedProperties.add(\"" + property.getName() + "\");");
-                    }
-
-                    constructor.line("this.updatedProperties.add(\"" + polymorphicProperty.getName() + "\");");
-                }
-            }
+//            ClientModelProperty polymorphicProperty = model.getPolymorphicDiscriminator();
+//            if (polymorphicProperty != null && !polymorphicProperty.isRequired()) {
+//                if (ClientModelUtil.isJsonMergePatchModel(model, settings)) {
+//                    for (ClientModelProperty property : model.getParentPolymorphicDiscriminators()) {
+//                        constructor.line("this.updatedProperties.add(\"" + property.getName() + "\");");
+//                    }
+//
+//                    constructor.line("this.updatedProperties.add(\"" + polymorphicProperty.getName() + "\");");
+//                }
+//            }
 
             // constant properties should already be initialized in class variable definition
 //            // Then, add all constant properties.

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -201,26 +201,26 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                         methodBlock -> addSetterMethod(propertyWireType, propertyClientType, property, treatAsXml,
                             methodBlock, settings, ClientModelUtil.isJsonMergePatchModel(model, settings)));
                 } else {
-                    // If stream-style serialization is being generated or the property is the polymorphic
-                    // discriminator, some additional setters may need to be added to support read-only properties that
-                    // aren't included in the constructor.
+                    // If stream-style serialization is being generated, some additional setters may need to be added to
+                    // support read-only properties that aren't included in the constructor.
                     // Jackson handles this by reflectively setting the value in the parent model, but stream-style
                     // serialization doesn't perform reflective cracking like Jackson Databind does, so it needs a way
                     // to access the readonly property (aka one without a public setter method).
                     //
                     // The package-private setter is added when the property isn't included in the constructor and is
-                    // defined by this model.
+                    // defined by this model, except for JSON merge patch models as those use the access helper pattern
+                    // to enable subtypes to set the property.
                     boolean streamStyle = settings.isStreamStyleSerialization();
                     boolean hasDerivedTypes = !CoreUtils.isNullOrEmpty(model.getDerivedModels());
                     boolean notIncludedInConstructor = !ClientModelUtil.includePropertyInConstructor(property,
                         settings);
                     boolean definedByModel = modelDefinesProperty(model, property);
+                    boolean modelIsJsonMergePatch = ClientModelUtil.isJsonMergePatchModel(model, settings);
                     if (hasDerivedTypes && notIncludedInConstructor && definedByModel
-                        && streamStyle && !property.isPolymorphicDiscriminator()) {
-                        methodVisibility = JavaVisibility.PackagePrivate;
+                        && streamStyle && !property.isPolymorphicDiscriminator() && !modelIsJsonMergePatch) {
                         generateSetterJavadoc(classBlock, model, property);
                         addGeneratedAnnotation(classBlock);
-                        classBlock.method(methodVisibility, null,
+                        classBlock.method(JavaVisibility.PackagePrivate, null,
                             model.getName() + " " + property.getSetterName() + "(" + propertyWireType + " "
                                 + property.getName() + ")",
                             methodBlock -> addSetterMethod(propertyWireType, propertyWireType, property, treatAsXml,

--- a/javagen/src/main/java/com/azure/autorest/template/StreamSerializationModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/StreamSerializationModelTemplate.java
@@ -353,16 +353,21 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
         }
 
         if (isJsonMergePatch) {
-            if (property.getClientType().isNullable()) {
-                methodBlock.ifBlock("updatedProperties.contains(\"" + property.getName() + "\")", codeBlock ->
-                    codeBlock.ifBlock(getPropertyGetterStatement(property, fromSuperType) + " == null",
-                            ifBlock -> ifBlock.line("jsonWriter.writeNullField(\"" + property.getSerializedName() + "\");"))
-                        .elseBlock(elseBlock -> serializeJsonProperty(codeBlock, property, serializedName, fromSuperType, isJsonMergePatch)));
+            if (!property.isPolymorphicDiscriminator()) {
+                methodBlock.ifBlock("updatedProperties.contains(\"" + property.getName() + "\")", codeBlock -> {
+                    if (property.getClientType().isNullable()) {
+                        codeBlock.ifBlock(getPropertyGetterStatement(property, fromSuperType) + " == null",
+                                ifBlock -> ifBlock.line("jsonWriter.writeNullField(\"" + property.getSerializedName() + "\");"))
+                            .elseBlock(elseBlock -> serializeJsonProperty(codeBlock, property, serializedName, fromSuperType, true));
+                    } else {
+                        serializeJsonProperty(codeBlock, property, serializedName, fromSuperType, true, false);
+                    }
+                });
             } else {
-                serializeJsonProperty(methodBlock, property, serializedName, fromSuperType, isJsonMergePatch);
+                serializeJsonProperty(methodBlock, property, serializedName, fromSuperType, true);
             }
         } else {
-            serializeJsonProperty(methodBlock, property, serializedName, fromSuperType, isJsonMergePatch);
+            serializeJsonProperty(methodBlock, property, serializedName, fromSuperType, false);
         }
     }
 

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/basic/models/UserOrder.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/basic/models/UserOrder.java
@@ -151,7 +151,9 @@ public final class UserOrder implements JsonSerializable<UserOrder> {
     @Generated
     private JsonWriter toJsonMergePatch(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeIntField("userId", this.userId);
+        if (updatedProperties.contains("userId")) {
+            jsonWriter.writeIntField("userId", this.userId);
+        }
         if (updatedProperties.contains("detail")) {
             if (this.detail == null) {
                 jsonWriter.writeNullField("detail");

--- a/typespec-tests/src/main/java/com/cadl/patch/models/Fish.java
+++ b/typespec-tests/src/main/java/com/cadl/patch/models/Fish.java
@@ -127,19 +127,6 @@ public class Fish implements JsonSerializable<Fish> {
     }
 
     /**
-     * Set the id property: The id property.
-     * 
-     * @param id the id value to set.
-     * @return the Fish object itself.
-     */
-    @Generated
-    Fish setId(String id) {
-        this.id = id;
-        this.updatedProperties.add("id");
-        return this;
-    }
-
-    /**
      * Get the name property: The name property.
      * 
      * @return the name value.
@@ -147,19 +134,6 @@ public class Fish implements JsonSerializable<Fish> {
     @Generated
     public String getName() {
         return this.name;
-    }
-
-    /**
-     * Set the name property: The name property.
-     * 
-     * @param name the name value to set.
-     * @return the Fish object itself.
-     */
-    @Generated
-    Fish setName(String name) {
-        this.name = name;
-        this.updatedProperties.add("name");
-        return this;
     }
 
     /**

--- a/typespec-tests/src/main/java/com/cadl/patch/models/Fish.java
+++ b/typespec-tests/src/main/java/com/cadl/patch/models/Fish.java
@@ -104,7 +104,6 @@ public class Fish implements JsonSerializable<Fish> {
      */
     @Generated
     public Fish() {
-        this.updatedProperties.add("kind");
     }
 
     /**
@@ -230,14 +229,10 @@ public class Fish implements JsonSerializable<Fish> {
     @Generated
     private JsonWriter toJsonMergePatch(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        if (updatedProperties.contains("kind")) {
-            if (this.kind == null) {
-                jsonWriter.writeNullField("kind");
-            } else {
-                jsonWriter.writeStringField("kind", this.kind);
-            }
+        jsonWriter.writeStringField("kind", this.kind);
+        if (updatedProperties.contains("age")) {
+            jsonWriter.writeIntField("age", this.age);
         }
-        jsonWriter.writeIntField("age", this.age);
         if (updatedProperties.contains("color")) {
             if (this.color == null) {
                 jsonWriter.writeNullField("color");

--- a/typespec-tests/src/main/java/com/cadl/patch/models/Salmon.java
+++ b/typespec-tests/src/main/java/com/cadl/patch/models/Salmon.java
@@ -57,7 +57,6 @@ public final class Salmon extends Fish {
      */
     @Generated
     public Salmon() {
-        this.updatedProperties.add("kind");
     }
 
     /**
@@ -185,7 +184,9 @@ public final class Salmon extends Fish {
     @Generated
     private JsonWriter toJsonMergePatch(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        jsonWriter.writeIntField("age", getAge());
+        if (updatedProperties.contains("age")) {
+            jsonWriter.writeIntField("age", getAge());
+        }
         if (updatedProperties.contains("color")) {
             if (getColor() == null) {
                 jsonWriter.writeNullField("color");
@@ -193,13 +194,7 @@ public final class Salmon extends Fish {
                 jsonWriter.writeStringField("color", getColor());
             }
         }
-        if (updatedProperties.contains("kind")) {
-            if (this.kind == null) {
-                jsonWriter.writeNullField("kind");
-            } else {
-                jsonWriter.writeStringField("kind", this.kind);
-            }
-        }
+        jsonWriter.writeStringField("kind", this.kind);
         if (updatedProperties.contains("friends")) {
             if (this.friends == null) {
                 jsonWriter.writeNullField("friends");

--- a/typespec-tests/src/main/java/com/cadl/patch/models/SawShark.java
+++ b/typespec-tests/src/main/java/com/cadl/patch/models/SawShark.java
@@ -42,8 +42,6 @@ public final class SawShark extends Shark {
      */
     @Generated
     public SawShark() {
-        this.updatedProperties.add("kind");
-        this.updatedProperties.add("sharktype");
     }
 
     /**
@@ -112,14 +110,10 @@ public final class SawShark extends Shark {
     @Generated
     private JsonWriter toJsonMergePatch(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        if (updatedProperties.contains("kind")) {
-            if (this.kind == null) {
-                jsonWriter.writeNullField("kind");
-            } else {
-                jsonWriter.writeStringField("kind", this.kind);
-            }
+        jsonWriter.writeStringField("kind", this.kind);
+        if (updatedProperties.contains("age")) {
+            jsonWriter.writeIntField("age", getAge());
         }
-        jsonWriter.writeIntField("age", getAge());
         if (updatedProperties.contains("color")) {
             if (getColor() == null) {
                 jsonWriter.writeNullField("color");
@@ -134,13 +128,7 @@ public final class SawShark extends Shark {
                 jsonWriter.writeNumberField("weight", getWeight());
             }
         }
-        if (updatedProperties.contains("sharktype")) {
-            if (this.sharktype == null) {
-                jsonWriter.writeNullField("sharktype");
-            } else {
-                jsonWriter.writeStringField("sharktype", this.sharktype);
-            }
-        }
+        jsonWriter.writeStringField("sharktype", this.sharktype);
         return jsonWriter.writeEndObject();
     }
 

--- a/typespec-tests/src/main/java/com/cadl/patch/models/Shark.java
+++ b/typespec-tests/src/main/java/com/cadl/patch/models/Shark.java
@@ -57,8 +57,6 @@ public class Shark extends Fish {
      */
     @Generated
     public Shark() {
-        this.updatedProperties.add("kind");
-        this.updatedProperties.add("sharktype");
     }
 
     /**
@@ -138,14 +136,10 @@ public class Shark extends Fish {
     @Generated
     private JsonWriter toJsonMergePatch(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        if (updatedProperties.contains("kind")) {
-            if (this.kind == null) {
-                jsonWriter.writeNullField("kind");
-            } else {
-                jsonWriter.writeStringField("kind", this.kind);
-            }
+        jsonWriter.writeStringField("kind", this.kind);
+        if (updatedProperties.contains("age")) {
+            jsonWriter.writeIntField("age", getAge());
         }
-        jsonWriter.writeIntField("age", getAge());
         if (updatedProperties.contains("color")) {
             if (getColor() == null) {
                 jsonWriter.writeNullField("color");
@@ -153,13 +147,7 @@ public class Shark extends Fish {
                 jsonWriter.writeStringField("color", getColor());
             }
         }
-        if (updatedProperties.contains("sharktype")) {
-            if (this.sharktype == null) {
-                jsonWriter.writeNullField("sharktype");
-            } else {
-                jsonWriter.writeStringField("sharktype", this.sharktype);
-            }
-        }
+        jsonWriter.writeStringField("sharktype", this.sharktype);
         if (updatedProperties.contains("weight")) {
             if (this.weight == null) {
                 jsonWriter.writeNullField("weight");


### PR DESCRIPTION
- Removes polymorphic discriminators from JSON merge patch tracking as they will always be serialized. So, instead of tracking them they have special handling in serialization to always include them.
- Fix where non-nullable properties weren't being checked to be included in JSON merge patch serialization.
- Removed package-private setters from polymorphic JSON merge patch models as they use access helpers instead.