### PR TITLE
tsp, generate origin (JSON) example file name in mgmt sample files

### DIFF
--- a/fluentgen/src/test/java/com/azure/autorest/BeforeAllTestsExtension.java
+++ b/fluentgen/src/test/java/com/azure/autorest/BeforeAllTestsExtension.java
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.autorest;
+
+import com.azure.autorest.fluent.FluentGen;
+import com.azure.autorest.fluent.TestUtils;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class BeforeAllTestsExtension implements BeforeAllCallback, ExtensionContext.Store.CloseableResource {
+
+    private static final Lock LOCK = new ReentrantLock();
+    private static volatile boolean started = false;
+
+    @Override
+    public void beforeAll(final ExtensionContext context) throws Exception {
+        // lock the access so only one Thread has access to it
+        LOCK.lock();
+        try {
+            if (!started) {
+                started = true;
+                // Your "before all tests" startup logic goes here
+                // The following line registers a callback hook when the root test context is
+                // shut down
+                context.getRoot().getStore(ExtensionContext.Namespace.GLOBAL).put("any unique name", this);
+
+                FluentGen fluentgen = new TestUtils.MockFluentGen();
+            }
+        } finally {
+            // free the access
+            LOCK.unlock();
+        }
+    }
+
+    @Override
+    public void close() throws Throwable {
+
+    }
+}

--- a/fluentgen/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/fluentgen/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+com.azure.autorest.BeforeAllTestsExtension

--- a/javagen/pom.xml
+++ b/javagen/pom.xml
@@ -17,13 +17,6 @@
   <artifactId>azure-autorest-javagen</artifactId>
   <version>1.0.0-beta.1</version>
 
-<!--  <repositories>-->
-<!--    <repository>-->
-<!--      <id>clientcore</id>-->
-<!--      <url>https://clientcore.blob.core.windows.net/artifacts</url>-->
-<!--    </repository>-->
-<!--  </repositories>-->
-
   <dependencies>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/javagen/pom.xml
+++ b/javagen/pom.xml
@@ -70,9 +70,21 @@
       <version>1.7.36</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.9.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.9.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>5.9.3</version>
       <scope>test</scope>
     </dependency>
 <!--    <dependency>-->

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodExample.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodExample.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class ProxyMethodExample {
@@ -32,6 +33,8 @@ public class ProxyMethodExample {
 
     private static final ObjectMapper PRETTY_PRINTER = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
     private static final ObjectMapper NORMAL_PRINTER = new ObjectMapper();
+    private static final String SLASH = "/";
+    private static final String QUOTED_SLASH = Pattern.quote(SLASH);
 
     // https://azure.github.io/autorest/extensions/#x-ms-examples
     // https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/x-ms-examples.md
@@ -238,20 +241,20 @@ public class ProxyMethodExample {
                     case "http":
                     case "https":
                     {
-                        String[] segments = url.getPath().split("/");
+                        String[] segments = url.getPath().split(QUOTED_SLASH);
                         if (segments.length > 3) {
                             // first 3 should be owner, name, branch
                             originalFileName = Arrays.stream(segments)
                                     .filter(s -> !s.isEmpty())
                                     .skip(3)
-                                    .collect(Collectors.joining("/"));
+                                    .collect(Collectors.joining(SLASH));
                         }
                         break;
                     }
 
                     case "file":
                     {
-                        String[] segments = url.getPath().split("/");
+                        String[] segments = url.getPath().split(QUOTED_SLASH);
                         int resourceManagerOrDataPlaneSegmentIndex = -1;
                         for (int i = 0; i < segments.length; ++i) {
                             if ("resource-manager".equals(segments[i]) || "data-plane".equals(segments[i])) {
@@ -262,7 +265,7 @@ public class ProxyMethodExample {
                         if (resourceManagerOrDataPlaneSegmentIndex > 2) {
                             originalFileName = Arrays.stream(segments)
                                     .skip(resourceManagerOrDataPlaneSegmentIndex - 2)
-                                    .collect(Collectors.joining("/"));
+                                    .collect(Collectors.joining(SLASH));
                         }
                         break;
                     }

--- a/javagen/src/test/java/com/azure/autorest/BeforeAllTestsExtension.java
+++ b/javagen/src/test/java/com/azure/autorest/BeforeAllTestsExtension.java
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.autorest;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class BeforeAllTestsExtension implements BeforeAllCallback, ExtensionContext.Store.CloseableResource {
+
+    private static final Lock LOCK = new ReentrantLock();
+    private static volatile boolean started = false;
+
+    @Override
+    public void beforeAll(final ExtensionContext context) throws Exception {
+        // lock the access so only one Thread has access to it
+        LOCK.lock();
+        try {
+            if (!started) {
+                started = true;
+                // Your "before all tests" startup logic goes here
+                // The following line registers a callback hook when the root test context is
+                // shut down
+                context.getRoot().getStore(ExtensionContext.Namespace.GLOBAL).put("any unique name", this);
+
+                MockUnitJavagen javagen = new MockUnitJavagen();
+            }
+        } finally {
+            // free the access
+            LOCK.unlock();
+        }
+    }
+
+    @Override
+    public void close() throws Throwable {
+
+    }
+}

--- a/javagen/src/test/java/com/azure/autorest/JavagenUnitTests.java
+++ b/javagen/src/test/java/com/azure/autorest/JavagenUnitTests.java
@@ -22,8 +22,8 @@ import com.azure.autorest.model.clientmodel.IType;
 import com.azure.autorest.model.clientmodel.PrimitiveType;
 import com.azure.autorest.model.javamodel.JavaPackage;
 import com.azure.core.http.HttpMethod;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -76,11 +76,11 @@ public class JavagenUnitTests {
         baseType = PrimitiveType.VOID;
         returnType = GenericType.Mono(baseType);
         description = ClientMethodMapperAccessor.getDescription(operation, returnType, baseType);
-        Assert.assertEquals(expectedDescription, description);        // Mono<Boolean>
+        Assertions.assertEquals(expectedDescription, description);        // Mono<Boolean>
         baseType = PrimitiveType.BOOLEAN;
         returnType = GenericType.Mono(baseType);
         description = ClientMethodMapperAccessor.getDescription(operation, returnType, baseType);
-        Assert.assertEquals(expectedDescription, description);
+        Assertions.assertEquals(expectedDescription, description);
         //Response
         operation = operationWithDescOnOperationAndResponseSchema(operationDesc, responseSchemaDesc);
         expectedDescription = String.format("%s along with {@link Response}", operationDesc);
@@ -88,11 +88,11 @@ public class JavagenUnitTests {
         baseType = PrimitiveType.VOID;
         returnType = GenericType.Response(baseType);
         description = ClientMethodMapperAccessor.getDescription(operation, returnType, baseType);
-        Assert.assertEquals(expectedDescription, description);        // Response<Boolean>
+        Assertions.assertEquals(expectedDescription, description);        // Response<Boolean>
         baseType = PrimitiveType.BOOLEAN;
         returnType = GenericType.Response(baseType);
         description = ClientMethodMapperAccessor.getDescription(operation, returnType, baseType);
-        Assert.assertEquals(expectedDescription, description);
+        Assertions.assertEquals(expectedDescription, description);
 
         // description on schema
         // Mono
@@ -103,17 +103,17 @@ public class JavagenUnitTests {
         returnType = GenericType.Mono(baseType);
         description = ClientMethodMapperAccessor.getDescription(operation, returnType, baseType);
         // Mono<Boolean>
-        Assert.assertEquals(expectedDescription, description);
+        Assertions.assertEquals(expectedDescription, description);
         baseType = PrimitiveType.BOOLEAN;
         returnType = GenericType.Mono(baseType);
         description = ClientMethodMapperAccessor.getDescription(operation, returnType, baseType);
         // Mono<T>
-        Assert.assertEquals(expectedDescription, description);
+        Assertions.assertEquals(expectedDescription, description);
         baseType = GenericType.Response(ClassType.STRING);
         returnType = GenericType.Mono(baseType);
         description = ClientMethodMapperAccessor.getDescription(operation, returnType, baseType);
         expectedDescription = "desc from response schema along with {@link Response} on successful completion of {@link Mono}";
-        Assert.assertEquals(expectedDescription, description);
+        Assertions.assertEquals(expectedDescription, description);
 
         // Response
         operation = operationWithDescOnResponseSchema(responseSchemaDesc);
@@ -122,17 +122,17 @@ public class JavagenUnitTests {
         baseType = PrimitiveType.VOID;
         returnType = GenericType.Response(baseType);
         description = ClientMethodMapperAccessor.getDescription(operation, returnType, baseType);
-        Assert.assertEquals(expectedDescription, description);
+        Assertions.assertEquals(expectedDescription, description);
         // Response<Boolean>
         baseType = PrimitiveType.BOOLEAN;
         returnType = GenericType.Response(baseType);
         description = ClientMethodMapperAccessor.getDescription(operation, returnType, baseType);
-        Assert.assertEquals(expectedDescription, description);
+        Assertions.assertEquals(expectedDescription, description);
         // Response<T>
         baseType = GenericType.Mono(ClassType.STRING);
         returnType = GenericType.Response(baseType);
         description = ClientMethodMapperAccessor.getDescription(operation, returnType, baseType);
-        Assert.assertEquals(expectedDescription, description);
+        Assertions.assertEquals(expectedDescription, description);
 
 
         // no description on either operation or schema
@@ -143,19 +143,19 @@ public class JavagenUnitTests {
         returnType = GenericType.Mono(baseType);
         description = ClientMethodMapperAccessor.getDescription(operation, returnType, baseType);
         expectedDescription = "A {@link Mono} that completes when a successful response is received";
-        Assert.assertEquals(expectedDescription, description);
+        Assertions.assertEquals(expectedDescription, description);
         // Mono<Boolean>
         baseType = PrimitiveType.BOOLEAN;
         returnType = GenericType.Mono(baseType);
         description = ClientMethodMapperAccessor.getDescription(operation, returnType, baseType);
         expectedDescription = String.format("%s on successful completion of {@link Mono}", "whether resource exists");
-        Assert.assertEquals(expectedDescription, description);
+        Assertions.assertEquals(expectedDescription, description);
         // Mono<Response>
         baseType = GenericType.Response(ClassType.STRING);
         returnType = GenericType.Mono(baseType);
         description = ClientMethodMapperAccessor.getDescription(operation, returnType, baseType);
         expectedDescription = "the response body along with {@link Response} on successful completion of {@link Mono}";
-        Assert.assertEquals(expectedDescription, description);
+        Assertions.assertEquals(expectedDescription, description);
 
         // Response
         operation = operationWithNoDesc();
@@ -164,19 +164,19 @@ public class JavagenUnitTests {
         returnType = GenericType.Response(baseType);
         description = ClientMethodMapperAccessor.getDescription(operation, returnType, baseType);
         expectedDescription = "the {@link Response}";
-        Assert.assertEquals(expectedDescription, description);
+        Assertions.assertEquals(expectedDescription, description);
         // Response<Boolean>
         baseType = PrimitiveType.BOOLEAN;
         returnType = GenericType.Response(baseType);
         description = ClientMethodMapperAccessor.getDescription(operation, returnType, baseType);
         expectedDescription = String.format("%s along with {@link Response}", "whether resource exists");
-        Assert.assertEquals(expectedDescription, description);
+        Assertions.assertEquals(expectedDescription, description);
         // Response<T>
         baseType = ClassType.STRING;
         returnType = GenericType.Response(baseType);
         description = ClientMethodMapperAccessor.getDescription(operation, returnType, baseType);
         expectedDescription = "the response body along with {@link Response}";
-        Assert.assertEquals(expectedDescription, description);
+        Assertions.assertEquals(expectedDescription, description);
     }
 
     private Operation operationWithNoDesc() {

--- a/javagen/src/test/java/com/azure/autorest/MockUnitJavagen.java
+++ b/javagen/src/test/java/com/azure/autorest/MockUnitJavagen.java
@@ -5,7 +5,6 @@ package com.azure.autorest;
 
 import com.azure.autorest.extension.base.jsonrpc.Connection;
 import com.azure.autorest.extension.base.model.Message;
-import org.junit.Assert;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/javagen/src/test/java/com/azure/autorest/mapper/ClientMethodMapperTests.java
+++ b/javagen/src/test/java/com/azure/autorest/mapper/ClientMethodMapperTests.java
@@ -8,9 +8,9 @@ import com.azure.autorest.model.clientmodel.ClassType;
 import com.azure.autorest.model.clientmodel.ClientMethodParameter;
 import com.azure.autorest.model.clientmodel.MethodParameter;
 import com.azure.autorest.model.clientmodel.Versioning;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 
 public class ClientMethodMapperTests {
 
-    @BeforeClass
+    @BeforeAll
     public static void ensurePlugin() {
         MockUnitJavagen javagen = new MockUnitJavagen();
     }
@@ -64,16 +64,16 @@ public class ClientMethodMapperTests {
                 .build());
 
         List<List<ClientMethodParameter>> signatures = ClientMethodMapper.findOverloadedSignatures(parameters);
-        Assert.assertEquals(4, signatures.size());
+        Assertions.assertEquals(4, signatures.size());
         // API for required-only would be signature of "param0"
         // API for no added (aka "v0")
-        Assert.assertEquals(Arrays.asList("param0", "param1"), signatures.get(0).stream().map(MethodParameter::getName).collect(Collectors.toList()));
+        Assertions.assertEquals(Arrays.asList("param0", "param1"), signatures.get(0).stream().map(MethodParameter::getName).collect(Collectors.toList()));
         // API for v1
-        Assert.assertEquals(Arrays.asList("param0", "param1", "param2"), signatures.get(1).stream().map(MethodParameter::getName).collect(Collectors.toList()));
+        Assertions.assertEquals(Arrays.asList("param0", "param1", "param2"), signatures.get(1).stream().map(MethodParameter::getName).collect(Collectors.toList()));
         // API for v2
-        Assert.assertEquals(Arrays.asList("param0", "param1", "param2", "param3"), signatures.get(2).stream().map(MethodParameter::getName).collect(Collectors.toList()));
+        Assertions.assertEquals(Arrays.asList("param0", "param1", "param2", "param3"), signatures.get(2).stream().map(MethodParameter::getName).collect(Collectors.toList()));
         // API for v3
-        Assert.assertEquals(Arrays.asList("param0", "param1", "param2", "param3", "param4"), signatures.get(3).stream().map(MethodParameter::getName).collect(Collectors.toList()));
+        Assertions.assertEquals(Arrays.asList("param0", "param1", "param2", "param3", "param4"), signatures.get(3).stream().map(MethodParameter::getName).collect(Collectors.toList()));
         // API for v4 be same as v3
         // API for v5 would be same as full parameters
     }

--- a/javagen/src/test/java/com/azure/autorest/mapper/PomMapperTests.java
+++ b/javagen/src/test/java/com/azure/autorest/mapper/PomMapperTests.java
@@ -6,8 +6,8 @@ package com.azure.autorest.mapper;
 import com.azure.autorest.MockUnitJavagen;
 import com.azure.autorest.model.clientmodel.Pom;
 import com.azure.autorest.model.projectmodel.Project;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -29,12 +29,12 @@ public class PomMapperTests {
         MockUnitJavagen javagen = new MockUnitJavagen();
         Project mockProject = new MockProject();
         Pom pom = new PomMapper().map(mockProject);
-        Assert.assertEquals("com.azure", pom.getGroupId());
-        Assert.assertEquals("azure-mock", pom.getArtifactId());
-        Assert.assertEquals("Mock", pom.getServiceName());
+        Assertions.assertEquals("com.azure", pom.getGroupId());
+        Assertions.assertEquals("azure-mock", pom.getArtifactId());
+        Assertions.assertEquals("Mock", pom.getServiceName());
         List<String> dependencies = pom.getDependencyIdentifiers();
-        Assert.assertTrue(dependencies.stream().anyMatch(d -> d.startsWith("com.azure:azure-core:")));
-        Assert.assertTrue(dependencies.stream().anyMatch(d -> d.startsWith("com.azure:azure-core-test:")));
-        Assert.assertTrue(dependencies.stream().noneMatch(d -> d.startsWith("com.azure:azure-core-test:15.0")));    // it should have higher version
+        Assertions.assertTrue(dependencies.stream().anyMatch(d -> d.startsWith("com.azure:azure-core:")));
+        Assertions.assertTrue(dependencies.stream().anyMatch(d -> d.startsWith("com.azure:azure-core-test:")));
+        Assertions.assertTrue(dependencies.stream().noneMatch(d -> d.startsWith("com.azure:azure-core-test:15.0")));    // it should have higher version
     }
 }

--- a/javagen/src/test/java/com/azure/autorest/model/clientmodel/ProxyMethodExampleTests.java
+++ b/javagen/src/test/java/com/azure/autorest/model/clientmodel/ProxyMethodExampleTests.java
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.autorest.model.clientmodel;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class ProxyMethodExampleTests {
+
+    @Test
+    public void testGetRelativeOriginalFileNameForSwagger() throws MalformedURLException {
+        URL url = new URL("file:///C:/github/azure-rest-api-specs/specification/standbypool/resource-manager/Microsoft.StandbyPool/preview/2023-12-01-preview/examples/StandbyVirtualMachinePools_Update.json");
+        String result = ProxyMethodExample.getRelativeOriginalFileNameForSwagger(url);
+        Assertions.assertEquals("specification/standbypool/resource-manager/Microsoft.StandbyPool/preview/2023-12-01-preview/examples/StandbyVirtualMachinePools_Update.json", result);
+    }
+
+    @Test
+    public void testGetRelativeOriginalFileNameForTsp() throws MalformedURLException {
+        ProxyMethodExample.setTspDirectory("specification/standbypool/StandbyPool.Management");
+        URL url = new URL("file:///C:/github/azure-sdk-for-java/sdk/standbypool/azure-resourcemanager-standbypool/TempTypeSpecFiles/StandbyPool.Management/examples/2023-12-01-preview/StandbyVirtualMachinePools_Update.json");
+        String result = ProxyMethodExample.getRelativeOriginalFileNameForTsp(url);
+        Assertions.assertEquals("specification/standbypool/StandbyPool.Management/examples/2023-12-01-preview/StandbyVirtualMachinePools_Update.json", result);
+        ProxyMethodExample.setTspDirectory(null);
+    }
+}

--- a/javagen/src/test/java/com/azure/autorest/template/TestProxyAssertsTemplateTests.java
+++ b/javagen/src/test/java/com/azure/autorest/template/TestProxyAssertsTemplateTests.java
@@ -8,8 +8,8 @@ import com.azure.autorest.model.projectmodel.Project;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestProxyAssertsTemplateTests {
 
@@ -32,9 +32,9 @@ public class TestProxyAssertsTemplateTests {
         String output = new TestProxyAssetsTemplate().write(project);
 
         JsonNode jsonNode = new ObjectMapper().readTree(output);
-        Assert.assertEquals("Azure/azure-sdk-assets", jsonNode.get("AssetsRepo").asText());
-        Assert.assertEquals("java", jsonNode.get("AssetsRepoPrefixPath").asText());
-        Assert.assertEquals("java/openai/azure-ai-openai", jsonNode.get("TagPrefix").asText());
-        Assert.assertNotNull(jsonNode.get("Tag").asText());
+        Assertions.assertEquals("Azure/azure-sdk-assets", jsonNode.get("AssetsRepo").asText());
+        Assertions.assertEquals("java", jsonNode.get("AssetsRepoPrefixPath").asText());
+        Assertions.assertEquals("java/openai/azure-ai-openai", jsonNode.get("TagPrefix").asText());
+        Assertions.assertNotNull(jsonNode.get("Tag").asText());
     }
 }

--- a/javagen/src/test/java/com/azure/autorest/util/ClassNameUtilTests.java
+++ b/javagen/src/test/java/com/azure/autorest/util/ClassNameUtilTests.java
@@ -3,8 +3,8 @@
 
 package com.azure.autorest.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ClassNameUtilTests {
 
@@ -16,7 +16,7 @@ public class ClassNameUtilTests {
                 "src/samples/java",
                 "com.azure.resourcemanager.deviceprovisioningservices.generated",
                 "IotDpsResourceCheckProvisioningServiceNameAvailabilitySamples");
-        Assert.assertEquals("IotDpsResourceCheckProvisioningServiceNameAvailabilit", name);
+        Assertions.assertEquals("IotDpsResourceCheckProvisioningServiceNameAvailabilit", name);
 
         // do nothing as too little remaining length for class name
         name = ClassNameUtil.truncateClassName(
@@ -24,7 +24,7 @@ public class ClassNameUtilTests {
                 "src/samples/java",
                 "com.azure.resourcemanager.deviceprovisioningservicespadpadpadpadpadpad.generated",
                 "IotDpsResourceCheckProvisioningServiceNameAvailabilitySamples");
-        Assert.assertEquals("IotDpsResourceCheckProvisioningServiceNameAvailabilitySamples", name);
+        Assertions.assertEquals("IotDpsResourceCheckProvisioningServiceNameAvailabilitySamples", name);
 
         // no change
         name = ClassNameUtil.truncateClassName(
@@ -32,6 +32,6 @@ public class ClassNameUtilTests {
                 "src/samples/java",
                 "com.azure.resourcemanager.datafactory.generated",
                 "DataFlowDebugSessionAddDataFlowSamples");
-        Assert.assertEquals("DataFlowDebugSessionAddDataFlowSamples", name);
+        Assertions.assertEquals("DataFlowDebugSessionAddDataFlowSamples", name);
     }
 }

--- a/javagen/src/test/java/com/azure/autorest/util/CodeNamerTests.java
+++ b/javagen/src/test/java/com/azure/autorest/util/CodeNamerTests.java
@@ -3,33 +3,33 @@
 
 package com.azure.autorest.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CodeNamerTests {
 
     @Test
     public void testEnumMemberName() {
-        Assert.assertEquals("NINE_NINE_ONE", CodeNamer.getEnumMemberName("991"));
+        Assertions.assertEquals("NINE_NINE_ONE", CodeNamer.getEnumMemberName("991"));
 
-        Assert.assertEquals("TCP", CodeNamer.getEnumMemberName("tcp"));
+        Assertions.assertEquals("TCP", CodeNamer.getEnumMemberName("tcp"));
 
-        Assert.assertEquals("WSDL_LINK", CodeNamer.getEnumMemberName("wsdl-link"));
+        Assertions.assertEquals("WSDL_LINK", CodeNamer.getEnumMemberName("wsdl-link"));
 
-        Assert.assertEquals("CONTENT_TYPE", CodeNamer.getEnumMemberName("content_type"));
+        Assertions.assertEquals("CONTENT_TYPE", CodeNamer.getEnumMemberName("content_type"));
 
-        Assert.assertEquals("MICROSOFT_APP_CONFIGURATION_CONFIGURATION_STORES", CodeNamer.getEnumMemberName("Microsoft.AppConfiguration/configurationStores"));
+        Assertions.assertEquals("MICROSOFT_APP_CONFIGURATION_CONFIGURATION_STORES", CodeNamer.getEnumMemberName("Microsoft.AppConfiguration/configurationStores"));
 
-        Assert.assertEquals("ASTERISK", CodeNamer.getEnumMemberName("*"));
+        Assertions.assertEquals("ASTERISK", CodeNamer.getEnumMemberName("*"));
 
-        Assert.assertEquals("ALL", CodeNamer.getEnumMemberName("$all"));
+        Assertions.assertEquals("ALL", CodeNamer.getEnumMemberName("$all"));
 
-        Assert.assertEquals("ALL", CodeNamer.getEnumMemberName("all*"));
+        Assertions.assertEquals("ALL", CodeNamer.getEnumMemberName("all*"));
 
-        Assert.assertEquals("SYSTEM_ASSIGNED_USER_ASSIGNED", CodeNamer.getEnumMemberName("SystemAssigned, UserAssigned"));
+        Assertions.assertEquals("SYSTEM_ASSIGNED_USER_ASSIGNED", CodeNamer.getEnumMemberName("SystemAssigned, UserAssigned"));
 
-        Assert.assertEquals("ONE_ZEROMINUTELY", CodeNamer.getEnumMemberName("_10minutely"));
+        Assertions.assertEquals("ONE_ZEROMINUTELY", CodeNamer.getEnumMemberName("_10minutely"));
 
-        Assert.assertEquals("_", CodeNamer.getEnumMemberName("_"));
+        Assertions.assertEquals("_", CodeNamer.getEnumMemberName("_"));
     }
 }

--- a/javagen/src/test/java/com/azure/autorest/util/ModelTestCaseUtilTests.java
+++ b/javagen/src/test/java/com/azure/autorest/util/ModelTestCaseUtilTests.java
@@ -6,8 +6,8 @@ package com.azure.autorest.util;
 import com.azure.autorest.model.clientmodel.ClassType;
 import com.azure.autorest.model.clientmodel.ClientEnumValue;
 import com.azure.autorest.model.clientmodel.EnumType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -24,8 +24,8 @@ public class ModelTestCaseUtilTests {
                 .build();
 
         Object jsonObject = ModelTestCaseUtil.jsonFromType(0, type);
-        Assert.assertTrue(jsonObject instanceof String);
-        Assert.assertTrue(Objects.equals("200", jsonObject) || Objects.equals("404", jsonObject));
+        Assertions.assertTrue(jsonObject instanceof String);
+        Assertions.assertTrue(Objects.equals("200", jsonObject) || Objects.equals("404", jsonObject));
 
         type = new EnumType.Builder()
                 .elementType(ClassType.INTEGER)
@@ -35,7 +35,7 @@ public class ModelTestCaseUtilTests {
                 .build();
 
         jsonObject = ModelTestCaseUtil.jsonFromType(0, type);
-        Assert.assertTrue(jsonObject instanceof Integer);
-        Assert.assertTrue(Objects.equals(200, jsonObject) || Objects.equals(404, jsonObject));
+        Assertions.assertTrue(jsonObject instanceof Integer);
+        Assertions.assertTrue(Objects.equals(200, jsonObject) || Objects.equals(404, jsonObject));
     }
 }

--- a/javagen/src/test/java/com/azure/autorest/util/SchemaUtilTests.java
+++ b/javagen/src/test/java/com/azure/autorest/util/SchemaUtilTests.java
@@ -9,8 +9,8 @@ import com.azure.autorest.extension.base.model.codemodel.DictionarySchema;
 import com.azure.autorest.extension.base.model.codemodel.ObjectSchema;
 import com.azure.autorest.extension.base.model.codemodel.Relations;
 import com.azure.autorest.extension.base.model.codemodel.StringSchema;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -56,26 +56,26 @@ public class SchemaUtilTests {
 
     @Test
     public void testObjectSchemaFindParent() {
-        Assert.assertNull(SchemaUtil.getLowestCommonParent(Collections.emptyIterator()));
-        Assert.assertEquals(PET, SchemaUtil.getLowestCommonParent(List.of(PET)));
-        Assert.assertEquals(CORGI, SchemaUtil.getLowestCommonParent(List.of(CORGI)));
-        Assert.assertEquals(PET, SchemaUtil.getLowestCommonParent(List.of(PET, DOG)));
-        Assert.assertEquals(PET, SchemaUtil.getLowestCommonParent(List.of(CAT, DOG)));
-        Assert.assertEquals(DOG, SchemaUtil.getLowestCommonParent(List.of(DOG, CORGI)));
-        Assert.assertEquals(PET, SchemaUtil.getLowestCommonParent(List.of(CAT, CORGI)));
-        Assert.assertEquals(PET, SchemaUtil.getLowestCommonParent(List.of(PET, CORGI)));
-        Assert.assertEquals(PET, SchemaUtil.getLowestCommonParent(List.of(CAT, DOG, CORGI)));
+        Assertions.assertNull(SchemaUtil.getLowestCommonParent(Collections.emptyIterator()));
+        Assertions.assertEquals(PET, SchemaUtil.getLowestCommonParent(List.of(PET)));
+        Assertions.assertEquals(CORGI, SchemaUtil.getLowestCommonParent(List.of(CORGI)));
+        Assertions.assertEquals(PET, SchemaUtil.getLowestCommonParent(List.of(PET, DOG)));
+        Assertions.assertEquals(PET, SchemaUtil.getLowestCommonParent(List.of(CAT, DOG)));
+        Assertions.assertEquals(DOG, SchemaUtil.getLowestCommonParent(List.of(DOG, CORGI)));
+        Assertions.assertEquals(PET, SchemaUtil.getLowestCommonParent(List.of(CAT, CORGI)));
+        Assertions.assertEquals(PET, SchemaUtil.getLowestCommonParent(List.of(PET, CORGI)));
+        Assertions.assertEquals(PET, SchemaUtil.getLowestCommonParent(List.of(CAT, DOG, CORGI)));
         ObjectSchema dummy = new ObjectSchema();
         dummy.set$key("dummy");
-        Assert.assertTrue(SchemaUtil.getLowestCommonParent(List.of(dummy, DOG)) instanceof AnySchema);
+        Assertions.assertTrue(SchemaUtil.getLowestCommonParent(List.of(dummy, DOG)) instanceof AnySchema);
     }
 
     @Test
     public void testAllSchemaFindParent() {
-        Assert.assertTrue(SchemaUtil.getLowestCommonParent(List.of(new ArraySchema(), PET)) instanceof AnySchema);
-        Assert.assertTrue(SchemaUtil.getLowestCommonParent(List.of(new DictionarySchema(), PET)) instanceof AnySchema);
+        Assertions.assertTrue(SchemaUtil.getLowestCommonParent(List.of(new ArraySchema(), PET)) instanceof AnySchema);
+        Assertions.assertTrue(SchemaUtil.getLowestCommonParent(List.of(new DictionarySchema(), PET)) instanceof AnySchema);
         StringSchema stringSchema = new StringSchema();
-        Assert.assertTrue(SchemaUtil.getLowestCommonParent(List.of(stringSchema)) instanceof StringSchema);
-        Assert.assertTrue(SchemaUtil.getLowestCommonParent(List.of(stringSchema, stringSchema)) instanceof StringSchema);
+        Assertions.assertTrue(SchemaUtil.getLowestCommonParent(List.of(stringSchema)) instanceof StringSchema);
+        Assertions.assertTrue(SchemaUtil.getLowestCommonParent(List.of(stringSchema, stringSchema)) instanceof StringSchema);
     }
 }

--- a/javagen/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/javagen/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+com.azure.autorest.BeforeAllTestsExtension

--- a/postprocessor/pom.xml
+++ b/postprocessor/pom.xml
@@ -48,9 +48,21 @@
       <version>3.32.0</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.9.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.9.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>5.9.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/preprocessor/pom.xml
+++ b/preprocessor/pom.xml
@@ -40,9 +40,21 @@
       <version>1.7.36</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.9.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.9.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>5.9.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/preprocessor/src/test/java/com/azure/autorest/PreprocessorTests.java
+++ b/preprocessor/src/test/java/com/azure/autorest/PreprocessorTests.java
@@ -4,8 +4,8 @@
 package com.azure.autorest;
 
 import com.azure.autorest.extension.base.model.codemodel.CodeModel;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * test entry for preprocessor
@@ -23,22 +23,22 @@ public class PreprocessorTests {
         //1.
         CodeModel codeModel = preprocessor.loadCodeModel(codeModelFileName);
 
-        Assert.assertEquals(codeModel.getOperationGroups().size(), 3);
-        Assert.assertTrue(
+        Assertions.assertEquals(codeModel.getOperationGroups().size(), 3);
+        Assertions.assertTrue(
             codeModel.getOperationGroups().stream().anyMatch(operationGroup -> operationGroup.get$key().equals("ContainerRegistryBlob"))
             && codeModel.getOperationGroups().stream().anyMatch(operationGroup -> operationGroup.get$key().equals("ContainerRegistry"))
             && codeModel.getOperationGroups().stream().anyMatch(operationGroup -> operationGroup.get$key().equals("Authentication"))
         );
-        Assert.assertEquals(codeModel.getOperationGroups().get(0).getOperations().size(), 15);
-        Assert.assertEquals(codeModel.getOperationGroups().get(1).getOperations().size(), 11);
-        Assert.assertEquals(codeModel.getOperationGroups().get(2).getOperations().size(), 3);
+        Assertions.assertEquals(codeModel.getOperationGroups().get(0).getOperations().size(), 15);
+        Assertions.assertEquals(codeModel.getOperationGroups().get(1).getOperations().size(), 11);
+        Assertions.assertEquals(codeModel.getOperationGroups().get(2).getOperations().size(), 3);
 
         //2.
         codeModel = preprocessor.transform(codeModel);
 
         // additional 3 pagination operations
-        Assert.assertEquals(codeModel.getOperationGroups().get(0).getOperations().size(), 18);
-        Assert.assertTrue(
+        Assertions.assertEquals(codeModel.getOperationGroups().get(0).getOperations().size(), 18);
+        Assertions.assertTrue(
             codeModel.getOperationGroups().stream().flatMap(operationGroup -> operationGroup.getOperations().stream()).anyMatch(operation -> "getRepositoriesNext".equals(operation.get$key()))
                 && codeModel.getOperationGroups().stream().flatMap(operationGroup -> operationGroup.getOperations().stream()).anyMatch(operation -> "getTagsNext".equals(operation.get$key()))
                 && codeModel.getOperationGroups().stream().flatMap(operationGroup -> operationGroup.getOperations().stream()).anyMatch(operation -> "getManifestsNext".equals(operation.get$key()))

--- a/typespec-extension/changelog.md
+++ b/typespec-extension/changelog.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 0.16.1 (2024-05-29)
+
+Compatible with compiler 0.56.
+
 ## 0.16.0 (2024-05-17)
 
 Compatible with compiler 0.56.

--- a/typespec-extension/package-lock.json
+++ b/typespec-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/typespec-java",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "MIT",
       "dependencies": {
         "@autorest/codemodel": "~4.20.0",

--- a/typespec-extension/package.json
+++ b/typespec-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "TypeSpec library for emitting Java client from the TypeSpec REST protocol binding",
   "keywords": [
     "TypeSpec"

--- a/typespec-extension/src/main/java/com/azure/typespec/util/TspLocationUtil.java
+++ b/typespec-extension/src/main/java/com/azure/typespec/util/TspLocationUtil.java
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.typespec.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class TspLocationUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TspLocationUtil.class);
+
+    public static class TspLocation {
+        private String directory;
+
+        public String getDirectory() {
+            return directory;
+        }
+
+        public void setDirectory(String directory) {
+            this.directory = directory;
+        }
+    }
+
+    public static String getDirectory(Yaml yaml, Path tspLocationPath) {
+        String directory = null;
+        try {
+            LOGGER.info("tsp-location.yaml file: {}", tspLocationPath.toString());
+            String file = Files.readString(tspLocationPath);
+            directory = yaml.loadAs(file, TspLocation.class).getDirectory();
+        } catch (IOException e) {
+            LOGGER.error("Failed to read tsp-location.yaml");
+        }
+        return directory;
+    }
+}

--- a/typespec-extension/src/operation-utils.ts
+++ b/typespec-extension/src/operation-utils.ts
@@ -27,6 +27,7 @@ import { EmitterOptions } from "./emitter.js";
 import { getNamespace, logWarning, pascalCase } from "./utils.js";
 import { modelIs, unionReferredByType } from "./type-utils.js";
 import { SdkContext, getDefaultApiVersion } from "@azure-tools/typespec-client-generator-core";
+import { pathToFileURL } from "url";
 
 export const SPECIAL_HEADER_NAMES = new Set([
   "repeatability-request-id",
@@ -120,7 +121,8 @@ export async function loadExamples(
     const exampleFiles = await program.host.readDir(exampleDir);
     for (const fileName of exampleFiles) {
       try {
-        const exampleFile = await program.host.readFile(resolvePath(exampleDir, fileName));
+        const exampleFilePath = resolvePath(exampleDir, fileName);
+        const exampleFile = await program.host.readFile(exampleFilePath);
         const example = JSON.parse(exampleFile.text);
         if (!example.operationId) {
           logWarning(program, `Example file '${fileName}' is missing operationId.`);
@@ -128,6 +130,7 @@ export async function loadExamples(
         }
 
         if (!operationIdExamplesMap.has(example.operationId)) {
+          example["x-ms-original-file"] = pathToFileURL(exampleFilePath).toString();
           operationIdExamplesMap.set(example.operationId, example);
         }
       } catch (err) {

--- a/typespec-tests/package.json
+++ b/typespec-tests/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@azure-tools/cadl-ranch-specs": "0.33.4",
-    "@azure-tools/typespec-java": "file:/../typespec-extension/azure-tools-typespec-java-0.16.0.tgz"
+    "@azure-tools/typespec-java": "file:/../typespec-extension/azure-tools-typespec-java-0.16.1.tgz"
   },
   "devDependencies": {
     "@typespec/prettier-plugin-typespec": "~0.56.0",

--- a/typespec-tests/src/test/java/com/type/enums/fixed/FixedClientTest.java
+++ b/typespec-tests/src/test/java/com/type/enums/fixed/FixedClientTest.java
@@ -3,13 +3,21 @@
 
 package com.type.enums.fixed;
 
+import com.azure.core.exception.HttpResponseException;
+import com.azure.core.http.policy.FixedDelayOptions;
+import com.azure.core.http.policy.RetryOptions;
+import com.azure.core.util.BinaryData;
 import com.type.enums.fixed.models.DaysOfWeekEnum;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
+
 class FixedClientTest {
 
-    FixedClient client = new FixedClientBuilder().buildClient();
+    FixedClient client = new FixedClientBuilder()
+        .retryOptions(new RetryOptions(new FixedDelayOptions(0, Duration.ZERO)))
+        .buildClient();
 
     @Test
     void getKnownValue() {
@@ -23,9 +31,12 @@ class FixedClientTest {
     }
 
 
-    // Not a valid test for Java, as compiler will fail at "DaysOfWeekEnum.Weekend"
-//    @Test
-//    void putUnknownValue() {
-//        client.putUnknownValue(DaysOfWeekEnum.Weekend);
-//    }
+    @Test
+    void putUnknownValue() {
+        // Not a valid test for Java, as compiler will fail at "DaysOfWeekEnum.WEEKEND"
+        // client.putUnknownValue(DaysOfWeekEnum.WEEKEND);
+
+        Assertions.assertThrowsExactly(HttpResponseException.class,
+            () -> client.putUnknownValueWithResponse(BinaryData.fromObject("Weekend"), null));
+    }
 }


### PR DESCRIPTION
fix https://github.com/Azure/autorest.java/issues/2788

code for `x-ms-original-file` https://github.com/Azure/autorest.java/pull/2789/commits/f6dd96b7a35cac35cdca69e5a68ce3956542840d
code for convert that to the relative path in sample file https://github.com/Azure/autorest.java/pull/2789/commits/979314768a9718465d26b9ad3896a3e4bc942a3e

UT with some refactor https://github.com/Azure/autorest.java/pull/2789/commits/5db62b916bf13ebbfe16a09c6b9bb914ac8da02e

test
```diff
  * Samples for StandbyVirtualMachinePools Update.
  */
 public final class StandbyVirtualMachinePoolsUpdateSamples {
+    /*
+     * x-ms-original-file:
+     * specification/standbypool/StandbyPool.Management/examples/2023-12-01-preview/
+     * StandbyVirtualMachinePools_Update.json
+     */
     /**
      * Sample code: StandbyVirtualMachinePools_Update.
      *
```