### PR TITLE
Remove JSON merge patch usage from output only models

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
@@ -73,6 +73,13 @@ public class ModelMapper implements IMapper<ObjectSchema, ClientModel> {
                 }
             }
 
+            if (usages.contains(ImplementationDetails.Usage.JSON_MERGE_PATCH)
+                && !usages.contains(ImplementationDetails.Usage.INPUT)) {
+                // Remove the usage of JSON merge patch if the model isn't used as INPUT to the service. JSON merge
+                // patch logic is only used for INPUT.
+                usages.remove(ImplementationDetails.Usage.JSON_MERGE_PATCH);
+            }
+
             ClientModel.Builder builder = createModelBuilder().name(modelName)
                 .packageName(modelType.getPackage())
                 .type(modelType)


### PR DESCRIPTION
Remove the JSON merge patch usage from models that are only used for output (read-only). The special code for JSON merge patch is only used when the model is serialized, no need to generate it if the model will never be serialized in an API request.