### PR TITLE
Add typespec rulesets package as emitter dependency

### DIFF
--- a/typespec-extension/package-lock.json
+++ b/typespec-extension/package-lock.json
@@ -17,6 +17,7 @@
         "@azure-tools/typespec-autorest": "0.42.1",
         "@azure-tools/typespec-azure-core": "0.42.0",
         "@azure-tools/typespec-azure-resource-manager": "0.42.1",
+        "@azure-tools/typespec-azure-rulesets": "0.42.1",
         "@azure-tools/typespec-client-generator-core": "0.42.3",
         "@types/js-yaml": "~4.0.9",
         "@types/lodash": "~4.17.1",
@@ -43,6 +44,7 @@
       "peerDependencies": {
         "@azure-tools/typespec-azure-core": ">=0.42.0 <1.0.0",
         "@azure-tools/typespec-azure-resource-manager": ">=0.42.1 <1.0.0",
+        "@azure-tools/typespec-azure-rulesets": ">=0.42.1 <1.0.0",
         "@azure-tools/typespec-client-generator-core": ">=0.42.2 <1.0.0",
         "@typespec/compiler": ">=0.56.0 <1.0.0",
         "@typespec/http": ">=0.56.0 <1.0.0",
@@ -167,6 +169,21 @@
         "@typespec/openapi": "~0.56.0",
         "@typespec/rest": "~0.56.0",
         "@typespec/versioning": "~0.56.0"
+      }
+    },
+    "node_modules/@azure-tools/typespec-azure-rulesets": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.42.1.tgz",
+      "integrity": "sha512-GRiMErWJ96DvDBQMVgGI1sgMTOegXxpx7w6enZyEF0BaodxGfObJyl1TrMb9Pj6NAZfV5Q6uJAfXFbpF1MVDCw==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@azure-tools/typespec-azure-core": "~0.42.0",
+        "@azure-tools/typespec-azure-resource-manager": "~0.42.1",
+        "@azure-tools/typespec-client-generator-core": "~0.42.3",
+        "@typespec/compiler": "~0.56.0"
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {

--- a/typespec-extension/package.json
+++ b/typespec-extension/package.json
@@ -45,42 +45,44 @@
     "target/emitter.jar"
   ],
   "peerDependencies": {
+    "@azure-tools/typespec-azure-core": ">=0.42.0 <1.0.0",
+    "@azure-tools/typespec-azure-resource-manager": ">=0.42.1 <1.0.0",
+    "@azure-tools/typespec-azure-rulesets": ">=0.42.1 <1.0.0",
+    "@azure-tools/typespec-client-generator-core": ">=0.42.2 <1.0.0",
     "@typespec/compiler": ">=0.56.0 <1.0.0",
     "@typespec/http": ">=0.56.0 <1.0.0",
-    "@typespec/rest": ">=0.56.0 <1.0.0",
     "@typespec/openapi": ">=0.56.0 <1.0.0",
-    "@typespec/versioning": ">=0.56.0 <1.0.0",
-    "@azure-tools/typespec-azure-core": ">=0.42.0 <1.0.0",
-    "@azure-tools/typespec-client-generator-core": ">=0.42.2 <1.0.0",
-    "@azure-tools/typespec-azure-resource-manager": ">=0.42.1 <1.0.0"
+    "@typespec/rest": ">=0.56.0 <1.0.0",
+    "@typespec/versioning": ">=0.56.0 <1.0.0"
   },
   "dependencies": {
     "@autorest/codemodel": "~4.20.0",
-    "lodash": "~4.17.21",
-    "js-yaml": "~4.1.0"
+    "js-yaml": "~4.1.0",
+    "lodash": "~4.17.21"
   },
   "devDependencies": {
-    "prettier": "~3.2.5",
-    "@types/lodash": "~4.17.1",
+    "@azure-tools/typespec-autorest": "0.42.1",
+    "@azure-tools/typespec-azure-core": "0.42.0",
+    "@azure-tools/typespec-azure-resource-manager": "0.42.1",
+    "@azure-tools/typespec-azure-rulesets": "0.42.1",
+    "@azure-tools/typespec-client-generator-core": "0.42.3",
     "@types/js-yaml": "~4.0.9",
+    "@types/lodash": "~4.17.1",
     "@types/mocha": "~10.0.6",
     "@types/node": "~20.12.10",
-    "c8": "~9.1.0",
-    "eslint": "~8.57.0",
-    "mocha": "~10.4.0",
-    "rimraf": "~5.0.5",
-    "typescript": "~5.4.5",
-    "@typescript-eslint/parser": "~7.8.0",
     "@typescript-eslint/eslint-plugin": "~7.8.0",
-    "eslint-plugin-deprecation": "~2.0.0",
+    "@typescript-eslint/parser": "~7.8.0",
     "@typespec/compiler": "0.56.0",
     "@typespec/http": "0.56.0",
     "@typespec/openapi": "0.56.0",
     "@typespec/rest": "0.56.0",
     "@typespec/versioning": "0.56.0",
-    "@azure-tools/typespec-azure-core": "0.42.0",
-    "@azure-tools/typespec-client-generator-core": "0.42.3",
-    "@azure-tools/typespec-azure-resource-manager": "0.42.1",
-    "@azure-tools/typespec-autorest": "0.42.1"
+    "c8": "~9.1.0",
+    "eslint": "~8.57.0",
+    "eslint-plugin-deprecation": "~2.0.0",
+    "mocha": "~10.4.0",
+    "prettier": "~3.2.5",
+    "rimraf": "~5.0.5",
+    "typescript": "~5.4.5"
   }
 }


### PR DESCRIPTION
This change transitively adds typespec-azure-rulesets as a dependency to azure-sdk-java's emitter-package.json by adding a pinned peer dependency to the emitter's package.json file.

The constructed emitter-package.json:
```json
{
  "main": "dist/src/index.js",
  "dependencies": {
    "@azure-tools/typespec-java": "0.16.2"
  },
  "devDependencies": {
    "@azure-tools/typespec-azure-core": "0.42.0",
    "@azure-tools/typespec-azure-resource-manager": "0.42.1",
    "@azure-tools/typespec-azure-rulesets": "0.42.1",
    "@azure-tools/typespec-client-generator-core": "0.42.3",
    "@typespec/compiler": "0.56.0",
    "@typespec/http": "0.56.0",
    "@typespec/openapi": "0.56.0",
    "@typespec/rest": "0.56.0",
    "@typespec/versioning": "0.56.0"
  }
}
```