### PR TITLE
tsp, mgmt, default to uuid-as-string

### DIFF
--- a/typespec-extension/changelog.md
+++ b/typespec-extension/changelog.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 0.16.4 (Unreleased)
+
+Compatible with compiler 0.56.
+
 ## 0.16.3 (2024-06-03)
 
 Compatible with compiler 0.56.

--- a/typespec-extension/package-lock.json
+++ b/typespec-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/typespec-java",
-      "version": "0.16.3",
+      "version": "0.16.4",
       "license": "MIT",
       "dependencies": {
         "@autorest/codemodel": "~4.20.0",

--- a/typespec-extension/package.json
+++ b/typespec-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "description": "TypeSpec library for emitting Java client from the TypeSpec REST protocol binding",
   "keywords": [
     "TypeSpec"

--- a/typespec-extension/src/main/java/com/azure/autorest/fluent/TypeSpecFluentPlugin.java
+++ b/typespec-extension/src/main/java/com/azure/autorest/fluent/TypeSpecFluentPlugin.java
@@ -51,6 +51,7 @@ public class TypeSpecFluentPlugin extends FluentGen {
         }
         SETTINGS_MAP.put("sdk-integration", sdkIntegration);
         SETTINGS_MAP.put("output-model-immutable", true);
+        SETTINGS_MAP.put("uuid-as-string", true);
         SETTINGS_MAP.put("stream-style-serialization", emitterOptions.getStreamStyleSerialization());
 
         JavaSettingsAccessor.setHost(this);

--- a/typespec-tests/package.json
+++ b/typespec-tests/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@azure-tools/cadl-ranch-specs": "0.33.4",
-    "@azure-tools/typespec-java": "file:/../typespec-extension/azure-tools-typespec-java-0.16.3.tgz"
+    "@azure-tools/typespec-java": "file:/../typespec-extension/azure-tools-typespec-java-0.16.4.tgz"
   },
   "devDependencies": {
     "@typespec/prettier-plugin-typespec": "~0.56.0",


### PR DESCRIPTION
There were discussion in scrum that Java better not use GUID.

Hence, for new lib, we'd better just let them be string.

Brownfield lib (in future) may need an emitter option.