### PR TITLE
tsp, TCGC getHttpOperationWithCache

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/util/ModelExampleUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/ModelExampleUtil.java
@@ -307,7 +307,7 @@ public class ModelExampleUtil {
             }
 
             // fallback, "body" is commonly used in example JSON for request body
-            if (parameterValue == null) {
+            if (parameterValue == null && !"body".equalsIgnoreCase(serializedName)) {
                 serializedName = "body";
                 parameterValue = findParameter(example, serializedName);
             }

--- a/typespec-extension/src/code-model-builder.ts
+++ b/typespec-extension/src/code-model-builder.ts
@@ -63,6 +63,7 @@ import {
   getClientType,
   getCrossLanguageDefinitionId,
   getDefaultApiVersion,
+  getHttpOperationWithCache,
   getWireName,
   isApiVersion,
   isInternal,
@@ -93,7 +94,6 @@ import {
   getProjectedName,
   getSummary,
   getVisibility,
-  ignoreDiagnostics,
   isArrayModelType,
   isErrorModel,
   isRecordModelType,
@@ -113,7 +113,6 @@ import {
   getAuthentication,
   getHeaderFieldName,
   getHeaderFieldOptions,
-  getHttpOperation,
   getPathParamName,
   getQueryParamName,
   getQueryParamOptions,
@@ -709,7 +708,7 @@ export class CodeModelBuilder {
   }
 
   private processOperation(groupName: string, operation: Operation, clientContext: ClientContext): CodeModelOperation {
-    const op = ignoreDiagnostics(getHttpOperation(this.program, operation));
+    const op = getHttpOperationWithCache(this.sdkContext, operation);
 
     const operationGroup = this.codeModel.getOperationGroup(groupName);
     const operationName = this.getName(operation);

--- a/typespec-tests/src/main/java/com/cadl/flatten/FlattenAsyncClient.java
+++ b/typespec-tests/src/main/java/com/cadl/flatten/FlattenAsyncClient.java
@@ -66,7 +66,7 @@ public final class FlattenAsyncClient {
      * }</pre>
      * 
      * @param id The id parameter.
-     * @param request The request parameter.
+     * @param sendRequest The sendRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -76,8 +76,8 @@ public final class FlattenAsyncClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Void>> sendWithResponse(String id, BinaryData request, RequestOptions requestOptions) {
-        return this.serviceClient.sendWithResponseAsync(id, request, requestOptions);
+    public Mono<Response<Void>> sendWithResponse(String id, BinaryData sendRequest, RequestOptions requestOptions) {
+        return this.serviceClient.sendWithResponseAsync(id, sendRequest, requestOptions);
     }
 
     /**
@@ -91,7 +91,7 @@ public final class FlattenAsyncClient {
      * }</pre>
      * 
      * @param id The id parameter.
-     * @param request The request parameter.
+     * @param sendProjectedNameRequest The sendProjectedNameRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -101,9 +101,9 @@ public final class FlattenAsyncClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Void>> sendProjectedNameWithResponse(String id, BinaryData request,
+    public Mono<Response<Void>> sendProjectedNameWithResponse(String id, BinaryData sendProjectedNameRequest,
         RequestOptions requestOptions) {
-        return this.serviceClient.sendProjectedNameWithResponseAsync(id, request, requestOptions);
+        return this.serviceClient.sendProjectedNameWithResponseAsync(id, sendProjectedNameRequest, requestOptions);
     }
 
     /**
@@ -136,7 +136,7 @@ public final class FlattenAsyncClient {
      * }</pre>
      * 
      * @param name The name parameter.
-     * @param request The request parameter.
+     * @param sendLongRequest The sendLongRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -146,8 +146,9 @@ public final class FlattenAsyncClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Void>> sendLongWithResponse(String name, BinaryData request, RequestOptions requestOptions) {
-        return this.serviceClient.sendLongWithResponseAsync(name, request, requestOptions);
+    public Mono<Response<Void>> sendLongWithResponse(String name, BinaryData sendLongRequest,
+        RequestOptions requestOptions) {
+        return this.serviceClient.sendLongWithResponseAsync(name, sendLongRequest, requestOptions);
     }
 
     /**
@@ -180,7 +181,7 @@ public final class FlattenAsyncClient {
      * }</pre>
      * 
      * @param id The id parameter.
-     * @param request The request parameter.
+     * @param updateRequest The updateRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -190,15 +191,16 @@ public final class FlattenAsyncClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<BinaryData>> updateWithResponse(long id, BinaryData request, RequestOptions requestOptions) {
-        return this.serviceClient.updateWithResponseAsync(id, request, requestOptions);
+    public Mono<Response<BinaryData>> updateWithResponse(long id, BinaryData updateRequest,
+        RequestOptions requestOptions) {
+        return this.serviceClient.updateWithResponseAsync(id, updateRequest, requestOptions);
     }
 
     /**
      * The uploadFile operation.
      * 
      * @param name The name parameter.
-     * @param request The request parameter.
+     * @param uploadFileRequest The uploadFileRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -208,16 +210,17 @@ public final class FlattenAsyncClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    Mono<Response<Void>> uploadFileWithResponse(String name, BinaryData request, RequestOptions requestOptions) {
+    Mono<Response<Void>> uploadFileWithResponse(String name, BinaryData uploadFileRequest,
+        RequestOptions requestOptions) {
         // Protocol API requires serialization of parts with content-disposition and data, as operation 'uploadFile' is
         // 'multipart/form-data'
-        return this.serviceClient.uploadFileWithResponseAsync(name, request, requestOptions);
+        return this.serviceClient.uploadFileWithResponseAsync(name, uploadFileRequest, requestOptions);
     }
 
     /**
      * The uploadTodo operation.
      * 
-     * @param request The request parameter.
+     * @param uploadTodoRequest The uploadTodoRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -227,10 +230,10 @@ public final class FlattenAsyncClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    Mono<Response<Void>> uploadTodoWithResponse(BinaryData request, RequestOptions requestOptions) {
+    Mono<Response<Void>> uploadTodoWithResponse(BinaryData uploadTodoRequest, RequestOptions requestOptions) {
         // Protocol API requires serialization of parts with content-disposition and data, as operation 'uploadTodo' is
         // 'multipart/form-data'
-        return this.serviceClient.uploadTodoWithResponseAsync(request, requestOptions);
+        return this.serviceClient.uploadTodoWithResponseAsync(uploadTodoRequest, requestOptions);
     }
 
     /**
@@ -252,9 +255,9 @@ public final class FlattenAsyncClient {
     public Mono<Void> send(String id, String input, User user) {
         // Generated convenience method for sendWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        SendRequest requestObj = new SendRequest(input).setUser(user);
-        BinaryData request = BinaryData.fromObject(requestObj);
-        return sendWithResponse(id, request, requestOptions).flatMap(FluxUtil::toMono);
+        SendRequest sendRequestObj = new SendRequest(input).setUser(user);
+        BinaryData sendRequest = BinaryData.fromObject(sendRequestObj);
+        return sendWithResponse(id, sendRequest, requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**
@@ -275,9 +278,9 @@ public final class FlattenAsyncClient {
     public Mono<Void> send(String id, String input) {
         // Generated convenience method for sendWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        SendRequest requestObj = new SendRequest(input);
-        BinaryData request = BinaryData.fromObject(requestObj);
-        return sendWithResponse(id, request, requestOptions).flatMap(FluxUtil::toMono);
+        SendRequest sendRequestObj = new SendRequest(input);
+        BinaryData sendRequest = BinaryData.fromObject(sendRequestObj);
+        return sendWithResponse(id, sendRequest, requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**
@@ -298,9 +301,9 @@ public final class FlattenAsyncClient {
     public Mono<Void> sendProjectedName(String id, String fileIdentifier) {
         // Generated convenience method for sendProjectedNameWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        SendProjectedNameRequest requestObj = new SendProjectedNameRequest(fileIdentifier);
-        BinaryData request = BinaryData.fromObject(requestObj);
-        return sendProjectedNameWithResponse(id, request, requestOptions).flatMap(FluxUtil::toMono);
+        SendProjectedNameRequest sendProjectedNameRequestObj = new SendProjectedNameRequest(fileIdentifier);
+        BinaryData sendProjectedNameRequest = BinaryData.fromObject(sendProjectedNameRequestObj);
+        return sendProjectedNameWithResponse(id, sendProjectedNameRequest, requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**
@@ -322,7 +325,7 @@ public final class FlattenAsyncClient {
         RequestOptions requestOptions = new RequestOptions();
         String name = options.getName();
         String filter = options.getFilter();
-        SendLongRequest requestObj
+        SendLongRequest sendLongRequestObj
             = new SendLongRequest(options.getInput(), options.getDataInt(), options.getTitle(), options.getStatus())
                 .setUser(options.getUser())
                 .setDataIntOptional(options.getDataIntOptional())
@@ -330,18 +333,18 @@ public final class FlattenAsyncClient {
                 .setDataFloat(options.getDataFloat())
                 .setDescription(options.getDescription())
                 .setDummy(options.getDummy());
-        BinaryData request = BinaryData.fromObject(requestObj);
+        BinaryData sendLongRequest = BinaryData.fromObject(sendLongRequestObj);
         if (filter != null) {
             requestOptions.addQueryParam("filter", filter, false);
         }
-        return sendLongWithResponse(name, request, requestOptions).flatMap(FluxUtil::toMono);
+        return sendLongWithResponse(name, sendLongRequest, requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**
      * The update operation.
      * 
      * @param id The id parameter.
-     * @param request The request parameter.
+     * @param updateRequest The updateRequest parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -352,15 +355,15 @@ public final class FlattenAsyncClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<TodoItem> update(long id, UpdatePatchRequest request) {
+    public Mono<TodoItem> update(long id, UpdatePatchRequest updateRequest) {
         // Generated convenience method for updateWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        JsonMergePatchHelper.getUpdatePatchRequestAccessor().prepareModelForJsonMergePatch(request, true);
-        BinaryData requestInBinaryData = BinaryData.fromObject(request);
+        JsonMergePatchHelper.getUpdatePatchRequestAccessor().prepareModelForJsonMergePatch(updateRequest, true);
+        BinaryData updateRequestInBinaryData = BinaryData.fromObject(updateRequest);
         // BinaryData.fromObject() will not fire serialization, use getLength() to fire serialization.
-        requestInBinaryData.getLength();
-        JsonMergePatchHelper.getUpdatePatchRequestAccessor().prepareModelForJsonMergePatch(request, false);
-        return updateWithResponse(id, requestInBinaryData, requestOptions).flatMap(FluxUtil::toMono)
+        updateRequestInBinaryData.getLength();
+        JsonMergePatchHelper.getUpdatePatchRequestAccessor().prepareModelForJsonMergePatch(updateRequest, false);
+        return updateWithResponse(id, updateRequestInBinaryData, requestOptions).flatMap(FluxUtil::toMono)
             .map(protocolMethodData -> protocolMethodData.toObject(TodoItem.class));
     }
 
@@ -382,14 +385,14 @@ public final class FlattenAsyncClient {
     public Mono<Void> uploadFile(String name, FileDataFileDetails fileData) {
         // Generated convenience method for uploadFileWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        UploadFileRequest requestObj = new UploadFileRequest(fileData);
-        BinaryData request = new MultipartFormDataHelper(requestOptions)
-            .serializeFileField("file_data", requestObj.getFileData().getContent(),
-                requestObj.getFileData().getContentType(), requestObj.getFileData().getFilename())
-            .serializeTextField("constant", requestObj.getConstant())
+        UploadFileRequest uploadFileRequestObj = new UploadFileRequest(fileData);
+        BinaryData uploadFileRequest = new MultipartFormDataHelper(requestOptions)
+            .serializeFileField("file_data", uploadFileRequestObj.getFileData().getContent(),
+                uploadFileRequestObj.getFileData().getContentType(), uploadFileRequestObj.getFileData().getFilename())
+            .serializeTextField("constant", uploadFileRequestObj.getConstant())
             .end()
             .getRequestBody();
-        return uploadFileWithResponse(name, request, requestOptions).flatMap(FluxUtil::toMono);
+        return uploadFileWithResponse(name, uploadFileRequest, requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**
@@ -409,22 +412,22 @@ public final class FlattenAsyncClient {
     public Mono<Void> uploadTodo(UploadTodoOptions options) {
         // Generated convenience method for uploadTodoWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        UploadTodoRequest requestObj
+        UploadTodoRequest uploadTodoRequestObj
             = new UploadTodoRequest(options.getTitle(), options.getStatus()).setDescription(options.getDescription())
                 .setDummy(options.getDummy())
                 .setProp1(options.getProp1())
                 .setProp2(options.getProp2())
                 .setProp3(options.getProp3());
-        BinaryData request
-            = new MultipartFormDataHelper(requestOptions).serializeTextField("title", requestObj.getTitle())
-                .serializeTextField("description", requestObj.getDescription())
-                .serializeTextField("status", Objects.toString(requestObj.getStatus()))
-                .serializeTextField("_dummy", requestObj.getDummy())
-                .serializeTextField("prop1", requestObj.getProp1())
-                .serializeTextField("prop2", requestObj.getProp2())
-                .serializeTextField("prop3", requestObj.getProp3())
+        BinaryData uploadTodoRequest
+            = new MultipartFormDataHelper(requestOptions).serializeTextField("title", uploadTodoRequestObj.getTitle())
+                .serializeTextField("description", uploadTodoRequestObj.getDescription())
+                .serializeTextField("status", Objects.toString(uploadTodoRequestObj.getStatus()))
+                .serializeTextField("_dummy", uploadTodoRequestObj.getDummy())
+                .serializeTextField("prop1", uploadTodoRequestObj.getProp1())
+                .serializeTextField("prop2", uploadTodoRequestObj.getProp2())
+                .serializeTextField("prop3", uploadTodoRequestObj.getProp3())
                 .end()
                 .getRequestBody();
-        return uploadTodoWithResponse(request, requestOptions).flatMap(FluxUtil::toMono);
+        return uploadTodoWithResponse(uploadTodoRequest, requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/typespec-tests/src/main/java/com/cadl/flatten/FlattenClient.java
+++ b/typespec-tests/src/main/java/com/cadl/flatten/FlattenClient.java
@@ -64,7 +64,7 @@ public final class FlattenClient {
      * }</pre>
      * 
      * @param id The id parameter.
-     * @param request The request parameter.
+     * @param sendRequest The sendRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -74,8 +74,8 @@ public final class FlattenClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> sendWithResponse(String id, BinaryData request, RequestOptions requestOptions) {
-        return this.serviceClient.sendWithResponse(id, request, requestOptions);
+    public Response<Void> sendWithResponse(String id, BinaryData sendRequest, RequestOptions requestOptions) {
+        return this.serviceClient.sendWithResponse(id, sendRequest, requestOptions);
     }
 
     /**
@@ -89,7 +89,7 @@ public final class FlattenClient {
      * }</pre>
      * 
      * @param id The id parameter.
-     * @param request The request parameter.
+     * @param sendProjectedNameRequest The sendProjectedNameRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -99,8 +99,9 @@ public final class FlattenClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> sendProjectedNameWithResponse(String id, BinaryData request, RequestOptions requestOptions) {
-        return this.serviceClient.sendProjectedNameWithResponse(id, request, requestOptions);
+    public Response<Void> sendProjectedNameWithResponse(String id, BinaryData sendProjectedNameRequest,
+        RequestOptions requestOptions) {
+        return this.serviceClient.sendProjectedNameWithResponse(id, sendProjectedNameRequest, requestOptions);
     }
 
     /**
@@ -133,7 +134,7 @@ public final class FlattenClient {
      * }</pre>
      * 
      * @param name The name parameter.
-     * @param request The request parameter.
+     * @param sendLongRequest The sendLongRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -143,8 +144,8 @@ public final class FlattenClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> sendLongWithResponse(String name, BinaryData request, RequestOptions requestOptions) {
-        return this.serviceClient.sendLongWithResponse(name, request, requestOptions);
+    public Response<Void> sendLongWithResponse(String name, BinaryData sendLongRequest, RequestOptions requestOptions) {
+        return this.serviceClient.sendLongWithResponse(name, sendLongRequest, requestOptions);
     }
 
     /**
@@ -177,7 +178,7 @@ public final class FlattenClient {
      * }</pre>
      * 
      * @param id The id parameter.
-     * @param request The request parameter.
+     * @param updateRequest The updateRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -187,15 +188,15 @@ public final class FlattenClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> updateWithResponse(long id, BinaryData request, RequestOptions requestOptions) {
-        return this.serviceClient.updateWithResponse(id, request, requestOptions);
+    public Response<BinaryData> updateWithResponse(long id, BinaryData updateRequest, RequestOptions requestOptions) {
+        return this.serviceClient.updateWithResponse(id, updateRequest, requestOptions);
     }
 
     /**
      * The uploadFile operation.
      * 
      * @param name The name parameter.
-     * @param request The request parameter.
+     * @param uploadFileRequest The uploadFileRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -205,16 +206,16 @@ public final class FlattenClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    Response<Void> uploadFileWithResponse(String name, BinaryData request, RequestOptions requestOptions) {
+    Response<Void> uploadFileWithResponse(String name, BinaryData uploadFileRequest, RequestOptions requestOptions) {
         // Protocol API requires serialization of parts with content-disposition and data, as operation 'uploadFile' is
         // 'multipart/form-data'
-        return this.serviceClient.uploadFileWithResponse(name, request, requestOptions);
+        return this.serviceClient.uploadFileWithResponse(name, uploadFileRequest, requestOptions);
     }
 
     /**
      * The uploadTodo operation.
      * 
-     * @param request The request parameter.
+     * @param uploadTodoRequest The uploadTodoRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -224,10 +225,10 @@ public final class FlattenClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    Response<Void> uploadTodoWithResponse(BinaryData request, RequestOptions requestOptions) {
+    Response<Void> uploadTodoWithResponse(BinaryData uploadTodoRequest, RequestOptions requestOptions) {
         // Protocol API requires serialization of parts with content-disposition and data, as operation 'uploadTodo' is
         // 'multipart/form-data'
-        return this.serviceClient.uploadTodoWithResponse(request, requestOptions);
+        return this.serviceClient.uploadTodoWithResponse(uploadTodoRequest, requestOptions);
     }
 
     /**
@@ -248,9 +249,9 @@ public final class FlattenClient {
     public void send(String id, String input, User user) {
         // Generated convenience method for sendWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        SendRequest requestObj = new SendRequest(input).setUser(user);
-        BinaryData request = BinaryData.fromObject(requestObj);
-        sendWithResponse(id, request, requestOptions).getValue();
+        SendRequest sendRequestObj = new SendRequest(input).setUser(user);
+        BinaryData sendRequest = BinaryData.fromObject(sendRequestObj);
+        sendWithResponse(id, sendRequest, requestOptions).getValue();
     }
 
     /**
@@ -270,9 +271,9 @@ public final class FlattenClient {
     public void send(String id, String input) {
         // Generated convenience method for sendWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        SendRequest requestObj = new SendRequest(input);
-        BinaryData request = BinaryData.fromObject(requestObj);
-        sendWithResponse(id, request, requestOptions).getValue();
+        SendRequest sendRequestObj = new SendRequest(input);
+        BinaryData sendRequest = BinaryData.fromObject(sendRequestObj);
+        sendWithResponse(id, sendRequest, requestOptions).getValue();
     }
 
     /**
@@ -292,9 +293,9 @@ public final class FlattenClient {
     public void sendProjectedName(String id, String fileIdentifier) {
         // Generated convenience method for sendProjectedNameWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        SendProjectedNameRequest requestObj = new SendProjectedNameRequest(fileIdentifier);
-        BinaryData request = BinaryData.fromObject(requestObj);
-        sendProjectedNameWithResponse(id, request, requestOptions).getValue();
+        SendProjectedNameRequest sendProjectedNameRequestObj = new SendProjectedNameRequest(fileIdentifier);
+        BinaryData sendProjectedNameRequest = BinaryData.fromObject(sendProjectedNameRequestObj);
+        sendProjectedNameWithResponse(id, sendProjectedNameRequest, requestOptions).getValue();
     }
 
     /**
@@ -315,7 +316,7 @@ public final class FlattenClient {
         RequestOptions requestOptions = new RequestOptions();
         String name = options.getName();
         String filter = options.getFilter();
-        SendLongRequest requestObj
+        SendLongRequest sendLongRequestObj
             = new SendLongRequest(options.getInput(), options.getDataInt(), options.getTitle(), options.getStatus())
                 .setUser(options.getUser())
                 .setDataIntOptional(options.getDataIntOptional())
@@ -323,18 +324,18 @@ public final class FlattenClient {
                 .setDataFloat(options.getDataFloat())
                 .setDescription(options.getDescription())
                 .setDummy(options.getDummy());
-        BinaryData request = BinaryData.fromObject(requestObj);
+        BinaryData sendLongRequest = BinaryData.fromObject(sendLongRequestObj);
         if (filter != null) {
             requestOptions.addQueryParam("filter", filter, false);
         }
-        sendLongWithResponse(name, request, requestOptions).getValue();
+        sendLongWithResponse(name, sendLongRequest, requestOptions).getValue();
     }
 
     /**
      * The update operation.
      * 
      * @param id The id parameter.
-     * @param request The request parameter.
+     * @param updateRequest The updateRequest parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -345,15 +346,15 @@ public final class FlattenClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public TodoItem update(long id, UpdatePatchRequest request) {
+    public TodoItem update(long id, UpdatePatchRequest updateRequest) {
         // Generated convenience method for updateWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        JsonMergePatchHelper.getUpdatePatchRequestAccessor().prepareModelForJsonMergePatch(request, true);
-        BinaryData requestInBinaryData = BinaryData.fromObject(request);
+        JsonMergePatchHelper.getUpdatePatchRequestAccessor().prepareModelForJsonMergePatch(updateRequest, true);
+        BinaryData updateRequestInBinaryData = BinaryData.fromObject(updateRequest);
         // BinaryData.fromObject() will not fire serialization, use getLength() to fire serialization.
-        requestInBinaryData.getLength();
-        JsonMergePatchHelper.getUpdatePatchRequestAccessor().prepareModelForJsonMergePatch(request, false);
-        return updateWithResponse(id, requestInBinaryData, requestOptions).getValue().toObject(TodoItem.class);
+        updateRequestInBinaryData.getLength();
+        JsonMergePatchHelper.getUpdatePatchRequestAccessor().prepareModelForJsonMergePatch(updateRequest, false);
+        return updateWithResponse(id, updateRequestInBinaryData, requestOptions).getValue().toObject(TodoItem.class);
     }
 
     /**
@@ -373,14 +374,14 @@ public final class FlattenClient {
     public void uploadFile(String name, FileDataFileDetails fileData) {
         // Generated convenience method for uploadFileWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        UploadFileRequest requestObj = new UploadFileRequest(fileData);
-        BinaryData request = new MultipartFormDataHelper(requestOptions)
-            .serializeFileField("file_data", requestObj.getFileData().getContent(),
-                requestObj.getFileData().getContentType(), requestObj.getFileData().getFilename())
-            .serializeTextField("constant", requestObj.getConstant())
+        UploadFileRequest uploadFileRequestObj = new UploadFileRequest(fileData);
+        BinaryData uploadFileRequest = new MultipartFormDataHelper(requestOptions)
+            .serializeFileField("file_data", uploadFileRequestObj.getFileData().getContent(),
+                uploadFileRequestObj.getFileData().getContentType(), uploadFileRequestObj.getFileData().getFilename())
+            .serializeTextField("constant", uploadFileRequestObj.getConstant())
             .end()
             .getRequestBody();
-        uploadFileWithResponse(name, request, requestOptions).getValue();
+        uploadFileWithResponse(name, uploadFileRequest, requestOptions).getValue();
     }
 
     /**
@@ -399,22 +400,22 @@ public final class FlattenClient {
     public void uploadTodo(UploadTodoOptions options) {
         // Generated convenience method for uploadTodoWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        UploadTodoRequest requestObj
+        UploadTodoRequest uploadTodoRequestObj
             = new UploadTodoRequest(options.getTitle(), options.getStatus()).setDescription(options.getDescription())
                 .setDummy(options.getDummy())
                 .setProp1(options.getProp1())
                 .setProp2(options.getProp2())
                 .setProp3(options.getProp3());
-        BinaryData request
-            = new MultipartFormDataHelper(requestOptions).serializeTextField("title", requestObj.getTitle())
-                .serializeTextField("description", requestObj.getDescription())
-                .serializeTextField("status", Objects.toString(requestObj.getStatus()))
-                .serializeTextField("_dummy", requestObj.getDummy())
-                .serializeTextField("prop1", requestObj.getProp1())
-                .serializeTextField("prop2", requestObj.getProp2())
-                .serializeTextField("prop3", requestObj.getProp3())
+        BinaryData uploadTodoRequest
+            = new MultipartFormDataHelper(requestOptions).serializeTextField("title", uploadTodoRequestObj.getTitle())
+                .serializeTextField("description", uploadTodoRequestObj.getDescription())
+                .serializeTextField("status", Objects.toString(uploadTodoRequestObj.getStatus()))
+                .serializeTextField("_dummy", uploadTodoRequestObj.getDummy())
+                .serializeTextField("prop1", uploadTodoRequestObj.getProp1())
+                .serializeTextField("prop2", uploadTodoRequestObj.getProp2())
+                .serializeTextField("prop3", uploadTodoRequestObj.getProp3())
                 .end()
                 .getRequestBody();
-        uploadTodoWithResponse(request, requestOptions).getValue();
+        uploadTodoWithResponse(uploadTodoRequest, requestOptions).getValue();
     }
 }

--- a/typespec-tests/src/main/java/com/cadl/flatten/implementation/FlattenClientImpl.java
+++ b/typespec-tests/src/main/java/com/cadl/flatten/implementation/FlattenClientImpl.java
@@ -153,7 +153,7 @@ public final class FlattenClientImpl {
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<Void>> send(@HostParam("endpoint") String endpoint, @QueryParam("id") String id,
             @QueryParam("api-version") String apiVersion, @HeaderParam("accept") String accept,
-            @BodyParam("application/json") BinaryData request, RequestOptions requestOptions, Context context);
+            @BodyParam("application/json") BinaryData sendRequest, RequestOptions requestOptions, Context context);
 
         @Post("/flatten/send")
         @ExpectedResponses({ 200 })
@@ -163,7 +163,7 @@ public final class FlattenClientImpl {
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Response<Void> sendSync(@HostParam("endpoint") String endpoint, @QueryParam("id") String id,
             @QueryParam("api-version") String apiVersion, @HeaderParam("accept") String accept,
-            @BodyParam("application/json") BinaryData request, RequestOptions requestOptions, Context context);
+            @BodyParam("application/json") BinaryData sendRequest, RequestOptions requestOptions, Context context);
 
         @Post("/flatten/send-projected-name")
         @ExpectedResponses({ 200 })
@@ -172,7 +172,7 @@ public final class FlattenClientImpl {
         @UnexpectedResponseExceptionType(value = ResourceModifiedException.class, code = { 409 })
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<Void>> sendProjectedName(@HostParam("endpoint") String endpoint, @QueryParam("id") String id,
-            @HeaderParam("accept") String accept, @BodyParam("application/json") BinaryData request,
+            @HeaderParam("accept") String accept, @BodyParam("application/json") BinaryData sendProjectedNameRequest,
             RequestOptions requestOptions, Context context);
 
         @Post("/flatten/send-projected-name")
@@ -182,7 +182,7 @@ public final class FlattenClientImpl {
         @UnexpectedResponseExceptionType(value = ResourceModifiedException.class, code = { 409 })
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Response<Void> sendProjectedNameSync(@HostParam("endpoint") String endpoint, @QueryParam("id") String id,
-            @HeaderParam("accept") String accept, @BodyParam("application/json") BinaryData request,
+            @HeaderParam("accept") String accept, @BodyParam("application/json") BinaryData sendProjectedNameRequest,
             RequestOptions requestOptions, Context context);
 
         @Post("/flatten/send-long")
@@ -193,7 +193,7 @@ public final class FlattenClientImpl {
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<Void>> sendLong(@HostParam("endpoint") String endpoint, @QueryParam("name") String name,
             @QueryParam("api-version") String apiVersion, @HeaderParam("accept") String accept,
-            @BodyParam("application/json") BinaryData request, RequestOptions requestOptions, Context context);
+            @BodyParam("application/json") BinaryData sendLongRequest, RequestOptions requestOptions, Context context);
 
         @Post("/flatten/send-long")
         @ExpectedResponses({ 200 })
@@ -203,7 +203,7 @@ public final class FlattenClientImpl {
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Response<Void> sendLongSync(@HostParam("endpoint") String endpoint, @QueryParam("name") String name,
             @QueryParam("api-version") String apiVersion, @HeaderParam("accept") String accept,
-            @BodyParam("application/json") BinaryData request, RequestOptions requestOptions, Context context);
+            @BodyParam("application/json") BinaryData sendLongRequest, RequestOptions requestOptions, Context context);
 
         @Patch("/flatten/patch/{id}")
         @ExpectedResponses({ 200 })
@@ -213,7 +213,7 @@ public final class FlattenClientImpl {
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<BinaryData>> update(@HostParam("endpoint") String endpoint,
             @HeaderParam("Content-Type") String contentType, @PathParam("id") long id,
-            @HeaderParam("accept") String accept, @BodyParam("application/merge-patch+json") BinaryData request,
+            @HeaderParam("accept") String accept, @BodyParam("application/merge-patch+json") BinaryData updateRequest,
             RequestOptions requestOptions, Context context);
 
         @Patch("/flatten/patch/{id}")
@@ -224,7 +224,7 @@ public final class FlattenClientImpl {
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Response<BinaryData> updateSync(@HostParam("endpoint") String endpoint,
             @HeaderParam("Content-Type") String contentType, @PathParam("id") long id,
-            @HeaderParam("accept") String accept, @BodyParam("application/merge-patch+json") BinaryData request,
+            @HeaderParam("accept") String accept, @BodyParam("application/merge-patch+json") BinaryData updateRequest,
             RequestOptions requestOptions, Context context);
 
         // @Multipart not supported by RestProxy
@@ -236,7 +236,8 @@ public final class FlattenClientImpl {
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<Void>> uploadFile(@HostParam("endpoint") String endpoint, @PathParam("name") String name,
             @HeaderParam("Content-Type") String contentType, @HeaderParam("accept") String accept,
-            @BodyParam("multipart/form-data") BinaryData request, RequestOptions requestOptions, Context context);
+            @BodyParam("multipart/form-data") BinaryData uploadFileRequest, RequestOptions requestOptions,
+            Context context);
 
         // @Multipart not supported by RestProxy
         @Post("/flatten/upload/{name}")
@@ -247,7 +248,8 @@ public final class FlattenClientImpl {
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Response<Void> uploadFileSync(@HostParam("endpoint") String endpoint, @PathParam("name") String name,
             @HeaderParam("Content-Type") String contentType, @HeaderParam("accept") String accept,
-            @BodyParam("multipart/form-data") BinaryData request, RequestOptions requestOptions, Context context);
+            @BodyParam("multipart/form-data") BinaryData uploadFileRequest, RequestOptions requestOptions,
+            Context context);
 
         // @Multipart not supported by RestProxy
         @Post("/flatten/upload-todo")
@@ -258,7 +260,8 @@ public final class FlattenClientImpl {
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<Void>> uploadTodo(@HostParam("endpoint") String endpoint,
             @HeaderParam("Content-Type") String contentType, @HeaderParam("accept") String accept,
-            @BodyParam("multipart/form-data") BinaryData request, RequestOptions requestOptions, Context context);
+            @BodyParam("multipart/form-data") BinaryData uploadTodoRequest, RequestOptions requestOptions,
+            Context context);
 
         // @Multipart not supported by RestProxy
         @Post("/flatten/upload-todo")
@@ -269,7 +272,8 @@ public final class FlattenClientImpl {
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Response<Void> uploadTodoSync(@HostParam("endpoint") String endpoint,
             @HeaderParam("Content-Type") String contentType, @HeaderParam("accept") String accept,
-            @BodyParam("multipart/form-data") BinaryData request, RequestOptions requestOptions, Context context);
+            @BodyParam("multipart/form-data") BinaryData uploadTodoRequest, RequestOptions requestOptions,
+            Context context);
     }
 
     /**
@@ -287,7 +291,7 @@ public final class FlattenClientImpl {
      * }</pre>
      * 
      * @param id The id parameter.
-     * @param request The request parameter.
+     * @param sendRequest The sendRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -296,10 +300,11 @@ public final class FlattenClientImpl {
      * @return the {@link Response} on successful completion of {@link Mono}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Void>> sendWithResponseAsync(String id, BinaryData request, RequestOptions requestOptions) {
+    public Mono<Response<Void>> sendWithResponseAsync(String id, BinaryData sendRequest,
+        RequestOptions requestOptions) {
         final String accept = "application/json";
         return FluxUtil.withContext(context -> service.send(this.getEndpoint(), id,
-            this.getServiceVersion().getVersion(), accept, request, requestOptions, context));
+            this.getServiceVersion().getVersion(), accept, sendRequest, requestOptions, context));
     }
 
     /**
@@ -317,7 +322,7 @@ public final class FlattenClientImpl {
      * }</pre>
      * 
      * @param id The id parameter.
-     * @param request The request parameter.
+     * @param sendRequest The sendRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -326,9 +331,9 @@ public final class FlattenClientImpl {
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> sendWithResponse(String id, BinaryData request, RequestOptions requestOptions) {
+    public Response<Void> sendWithResponse(String id, BinaryData sendRequest, RequestOptions requestOptions) {
         final String accept = "application/json";
-        return service.sendSync(this.getEndpoint(), id, this.getServiceVersion().getVersion(), accept, request,
+        return service.sendSync(this.getEndpoint(), id, this.getServiceVersion().getVersion(), accept, sendRequest,
             requestOptions, Context.NONE);
     }
 
@@ -343,7 +348,7 @@ public final class FlattenClientImpl {
      * }</pre>
      * 
      * @param id The id parameter.
-     * @param request The request parameter.
+     * @param sendProjectedNameRequest The sendProjectedNameRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -352,11 +357,11 @@ public final class FlattenClientImpl {
      * @return the {@link Response} on successful completion of {@link Mono}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Void>> sendProjectedNameWithResponseAsync(String id, BinaryData request,
+    public Mono<Response<Void>> sendProjectedNameWithResponseAsync(String id, BinaryData sendProjectedNameRequest,
         RequestOptions requestOptions) {
         final String accept = "application/json";
-        return FluxUtil.withContext(
-            context -> service.sendProjectedName(this.getEndpoint(), id, accept, request, requestOptions, context));
+        return FluxUtil.withContext(context -> service.sendProjectedName(this.getEndpoint(), id, accept,
+            sendProjectedNameRequest, requestOptions, context));
     }
 
     /**
@@ -370,7 +375,7 @@ public final class FlattenClientImpl {
      * }</pre>
      * 
      * @param id The id parameter.
-     * @param request The request parameter.
+     * @param sendProjectedNameRequest The sendProjectedNameRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -379,9 +384,11 @@ public final class FlattenClientImpl {
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> sendProjectedNameWithResponse(String id, BinaryData request, RequestOptions requestOptions) {
+    public Response<Void> sendProjectedNameWithResponse(String id, BinaryData sendProjectedNameRequest,
+        RequestOptions requestOptions) {
         final String accept = "application/json";
-        return service.sendProjectedNameSync(this.getEndpoint(), id, accept, request, requestOptions, Context.NONE);
+        return service.sendProjectedNameSync(this.getEndpoint(), id, accept, sendProjectedNameRequest, requestOptions,
+            Context.NONE);
     }
 
     /**
@@ -414,7 +421,7 @@ public final class FlattenClientImpl {
      * }</pre>
      * 
      * @param name The name parameter.
-     * @param request The request parameter.
+     * @param sendLongRequest The sendLongRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -423,11 +430,11 @@ public final class FlattenClientImpl {
      * @return the {@link Response} on successful completion of {@link Mono}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Void>> sendLongWithResponseAsync(String name, BinaryData request,
+    public Mono<Response<Void>> sendLongWithResponseAsync(String name, BinaryData sendLongRequest,
         RequestOptions requestOptions) {
         final String accept = "application/json";
         return FluxUtil.withContext(context -> service.sendLong(this.getEndpoint(), name,
-            this.getServiceVersion().getVersion(), accept, request, requestOptions, context));
+            this.getServiceVersion().getVersion(), accept, sendLongRequest, requestOptions, context));
     }
 
     /**
@@ -460,7 +467,7 @@ public final class FlattenClientImpl {
      * }</pre>
      * 
      * @param name The name parameter.
-     * @param request The request parameter.
+     * @param sendLongRequest The sendLongRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -469,10 +476,10 @@ public final class FlattenClientImpl {
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> sendLongWithResponse(String name, BinaryData request, RequestOptions requestOptions) {
+    public Response<Void> sendLongWithResponse(String name, BinaryData sendLongRequest, RequestOptions requestOptions) {
         final String accept = "application/json";
-        return service.sendLongSync(this.getEndpoint(), name, this.getServiceVersion().getVersion(), accept, request,
-            requestOptions, Context.NONE);
+        return service.sendLongSync(this.getEndpoint(), name, this.getServiceVersion().getVersion(), accept,
+            sendLongRequest, requestOptions, Context.NONE);
     }
 
     /**
@@ -505,7 +512,7 @@ public final class FlattenClientImpl {
      * }</pre>
      * 
      * @param id The id parameter.
-     * @param request The request parameter.
+     * @param updateRequest The updateRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -514,12 +521,12 @@ public final class FlattenClientImpl {
      * @return the response body along with {@link Response} on successful completion of {@link Mono}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<BinaryData>> updateWithResponseAsync(long id, BinaryData request,
+    public Mono<Response<BinaryData>> updateWithResponseAsync(long id, BinaryData updateRequest,
         RequestOptions requestOptions) {
         final String contentType = "application/merge-patch+json";
         final String accept = "application/json";
-        return FluxUtil.withContext(
-            context -> service.update(this.getEndpoint(), contentType, id, accept, request, requestOptions, context));
+        return FluxUtil.withContext(context -> service.update(this.getEndpoint(), contentType, id, accept,
+            updateRequest, requestOptions, context));
     }
 
     /**
@@ -552,7 +559,7 @@ public final class FlattenClientImpl {
      * }</pre>
      * 
      * @param id The id parameter.
-     * @param request The request parameter.
+     * @param updateRequest The updateRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -561,17 +568,18 @@ public final class FlattenClientImpl {
      * @return the response body along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> updateWithResponse(long id, BinaryData request, RequestOptions requestOptions) {
+    public Response<BinaryData> updateWithResponse(long id, BinaryData updateRequest, RequestOptions requestOptions) {
         final String contentType = "application/merge-patch+json";
         final String accept = "application/json";
-        return service.updateSync(this.getEndpoint(), contentType, id, accept, request, requestOptions, Context.NONE);
+        return service.updateSync(this.getEndpoint(), contentType, id, accept, updateRequest, requestOptions,
+            Context.NONE);
     }
 
     /**
      * The uploadFile operation.
      * 
      * @param name The name parameter.
-     * @param request The request parameter.
+     * @param uploadFileRequest The uploadFileRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -580,19 +588,19 @@ public final class FlattenClientImpl {
      * @return the {@link Response} on successful completion of {@link Mono}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Void>> uploadFileWithResponseAsync(String name, BinaryData request,
+    public Mono<Response<Void>> uploadFileWithResponseAsync(String name, BinaryData uploadFileRequest,
         RequestOptions requestOptions) {
         final String contentType = "multipart/form-data";
         final String accept = "application/json";
         return FluxUtil.withContext(context -> service.uploadFile(this.getEndpoint(), name, contentType, accept,
-            request, requestOptions, context));
+            uploadFileRequest, requestOptions, context));
     }
 
     /**
      * The uploadFile operation.
      * 
      * @param name The name parameter.
-     * @param request The request parameter.
+     * @param uploadFileRequest The uploadFileRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -601,17 +609,18 @@ public final class FlattenClientImpl {
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> uploadFileWithResponse(String name, BinaryData request, RequestOptions requestOptions) {
+    public Response<Void> uploadFileWithResponse(String name, BinaryData uploadFileRequest,
+        RequestOptions requestOptions) {
         final String contentType = "multipart/form-data";
         final String accept = "application/json";
-        return service.uploadFileSync(this.getEndpoint(), name, contentType, accept, request, requestOptions,
+        return service.uploadFileSync(this.getEndpoint(), name, contentType, accept, uploadFileRequest, requestOptions,
             Context.NONE);
     }
 
     /**
      * The uploadTodo operation.
      * 
-     * @param request The request parameter.
+     * @param uploadTodoRequest The uploadTodoRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -620,17 +629,18 @@ public final class FlattenClientImpl {
      * @return the {@link Response} on successful completion of {@link Mono}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Void>> uploadTodoWithResponseAsync(BinaryData request, RequestOptions requestOptions) {
+    public Mono<Response<Void>> uploadTodoWithResponseAsync(BinaryData uploadTodoRequest,
+        RequestOptions requestOptions) {
         final String contentType = "multipart/form-data";
         final String accept = "application/json";
-        return FluxUtil.withContext(
-            context -> service.uploadTodo(this.getEndpoint(), contentType, accept, request, requestOptions, context));
+        return FluxUtil.withContext(context -> service.uploadTodo(this.getEndpoint(), contentType, accept,
+            uploadTodoRequest, requestOptions, context));
     }
 
     /**
      * The uploadTodo operation.
      * 
-     * @param request The request parameter.
+     * @param uploadTodoRequest The uploadTodoRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -639,9 +649,10 @@ public final class FlattenClientImpl {
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> uploadTodoWithResponse(BinaryData request, RequestOptions requestOptions) {
+    public Response<Void> uploadTodoWithResponse(BinaryData uploadTodoRequest, RequestOptions requestOptions) {
         final String contentType = "multipart/form-data";
         final String accept = "application/json";
-        return service.uploadTodoSync(this.getEndpoint(), contentType, accept, request, requestOptions, Context.NONE);
+        return service.uploadTodoSync(this.getEndpoint(), contentType, accept, uploadTodoRequest, requestOptions,
+            Context.NONE);
     }
 }

--- a/typespec-tests/src/main/java/com/cadl/union/UnionAsyncClient.java
+++ b/typespec-tests/src/main/java/com/cadl/union/UnionAsyncClient.java
@@ -58,7 +58,7 @@ public final class UnionAsyncClient {
      * }</pre>
      * 
      * @param id The id parameter.
-     * @param request The request parameter.
+     * @param sendRequest The sendRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -68,8 +68,8 @@ public final class UnionAsyncClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Void>> sendWithResponse(String id, BinaryData request, RequestOptions requestOptions) {
-        return this.serviceClient.sendWithResponseAsync(id, request, requestOptions);
+    public Mono<Response<Void>> sendWithResponse(String id, BinaryData sendRequest, RequestOptions requestOptions) {
+        return this.serviceClient.sendWithResponseAsync(id, sendRequest, requestOptions);
     }
 
     /**
@@ -97,7 +97,7 @@ public final class UnionAsyncClient {
      * }</pre>
      * 
      * @param id The id parameter.
-     * @param request The request parameter.
+     * @param sendLongRequest The sendLongRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -107,8 +107,9 @@ public final class UnionAsyncClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Void>> sendLongWithResponse(String id, BinaryData request, RequestOptions requestOptions) {
-        return this.serviceClient.sendLongWithResponseAsync(id, request, requestOptions);
+    public Mono<Response<Void>> sendLongWithResponse(String id, BinaryData sendLongRequest,
+        RequestOptions requestOptions) {
+        return this.serviceClient.sendLongWithResponseAsync(id, sendLongRequest, requestOptions);
     }
 
     /**
@@ -190,9 +191,9 @@ public final class UnionAsyncClient {
     public Mono<Void> send(String id, BinaryData input, User user) {
         // Generated convenience method for sendWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        SendRequest requestObj = new SendRequest(input).setUser(user);
-        BinaryData request = BinaryData.fromObject(requestObj);
-        return sendWithResponse(id, request, requestOptions).flatMap(FluxUtil::toMono);
+        SendRequest sendRequestObj = new SendRequest(input).setUser(user);
+        BinaryData sendRequest = BinaryData.fromObject(sendRequestObj);
+        return sendWithResponse(id, sendRequest, requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**
@@ -213,9 +214,9 @@ public final class UnionAsyncClient {
     public Mono<Void> send(String id, BinaryData input) {
         // Generated convenience method for sendWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        SendRequest requestObj = new SendRequest(input);
-        BinaryData request = BinaryData.fromObject(requestObj);
-        return sendWithResponse(id, request, requestOptions).flatMap(FluxUtil::toMono);
+        SendRequest sendRequestObj = new SendRequest(input);
+        BinaryData sendRequest = BinaryData.fromObject(sendRequestObj);
+        return sendWithResponse(id, sendRequest, requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**
@@ -237,16 +238,16 @@ public final class UnionAsyncClient {
         RequestOptions requestOptions = new RequestOptions();
         String id = options.getId();
         String filter = options.getFilter();
-        SendLongRequest requestObj
+        SendLongRequest sendLongRequestObj
             = new SendLongRequest(options.getInput(), options.getDataInt()).setUser(options.getUser())
                 .setDataUnion(options.getDataUnion())
                 .setDataLong(options.getDataLong())
                 .setDataFloat(options.getDataFloat());
-        BinaryData request = BinaryData.fromObject(requestObj);
+        BinaryData sendLongRequest = BinaryData.fromObject(sendLongRequestObj);
         if (filter != null) {
             requestOptions.addQueryParam("filter", filter, false);
         }
-        return sendLongWithResponse(id, request, requestOptions).flatMap(FluxUtil::toMono);
+        return sendLongWithResponse(id, sendLongRequest, requestOptions).flatMap(FluxUtil::toMono);
     }
 
     /**

--- a/typespec-tests/src/main/java/com/cadl/union/UnionClient.java
+++ b/typespec-tests/src/main/java/com/cadl/union/UnionClient.java
@@ -56,7 +56,7 @@ public final class UnionClient {
      * }</pre>
      * 
      * @param id The id parameter.
-     * @param request The request parameter.
+     * @param sendRequest The sendRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -66,8 +66,8 @@ public final class UnionClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> sendWithResponse(String id, BinaryData request, RequestOptions requestOptions) {
-        return this.serviceClient.sendWithResponse(id, request, requestOptions);
+    public Response<Void> sendWithResponse(String id, BinaryData sendRequest, RequestOptions requestOptions) {
+        return this.serviceClient.sendWithResponse(id, sendRequest, requestOptions);
     }
 
     /**
@@ -95,7 +95,7 @@ public final class UnionClient {
      * }</pre>
      * 
      * @param id The id parameter.
-     * @param request The request parameter.
+     * @param sendLongRequest The sendLongRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -105,8 +105,8 @@ public final class UnionClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> sendLongWithResponse(String id, BinaryData request, RequestOptions requestOptions) {
-        return this.serviceClient.sendLongWithResponse(id, request, requestOptions);
+    public Response<Void> sendLongWithResponse(String id, BinaryData sendLongRequest, RequestOptions requestOptions) {
+        return this.serviceClient.sendLongWithResponse(id, sendLongRequest, requestOptions);
     }
 
     /**
@@ -187,9 +187,9 @@ public final class UnionClient {
     public void send(String id, BinaryData input, User user) {
         // Generated convenience method for sendWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        SendRequest requestObj = new SendRequest(input).setUser(user);
-        BinaryData request = BinaryData.fromObject(requestObj);
-        sendWithResponse(id, request, requestOptions).getValue();
+        SendRequest sendRequestObj = new SendRequest(input).setUser(user);
+        BinaryData sendRequest = BinaryData.fromObject(sendRequestObj);
+        sendWithResponse(id, sendRequest, requestOptions).getValue();
     }
 
     /**
@@ -209,9 +209,9 @@ public final class UnionClient {
     public void send(String id, BinaryData input) {
         // Generated convenience method for sendWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        SendRequest requestObj = new SendRequest(input);
-        BinaryData request = BinaryData.fromObject(requestObj);
-        sendWithResponse(id, request, requestOptions).getValue();
+        SendRequest sendRequestObj = new SendRequest(input);
+        BinaryData sendRequest = BinaryData.fromObject(sendRequestObj);
+        sendWithResponse(id, sendRequest, requestOptions).getValue();
     }
 
     /**
@@ -232,16 +232,16 @@ public final class UnionClient {
         RequestOptions requestOptions = new RequestOptions();
         String id = options.getId();
         String filter = options.getFilter();
-        SendLongRequest requestObj
+        SendLongRequest sendLongRequestObj
             = new SendLongRequest(options.getInput(), options.getDataInt()).setUser(options.getUser())
                 .setDataUnion(options.getDataUnion())
                 .setDataLong(options.getDataLong())
                 .setDataFloat(options.getDataFloat());
-        BinaryData request = BinaryData.fromObject(requestObj);
+        BinaryData sendLongRequest = BinaryData.fromObject(sendLongRequestObj);
         if (filter != null) {
             requestOptions.addQueryParam("filter", filter, false);
         }
-        sendLongWithResponse(id, request, requestOptions).getValue();
+        sendLongWithResponse(id, sendLongRequest, requestOptions).getValue();
     }
 
     /**

--- a/typespec-tests/src/main/java/com/cadl/union/implementation/UnionFlattenOpsImpl.java
+++ b/typespec-tests/src/main/java/com/cadl/union/implementation/UnionFlattenOpsImpl.java
@@ -85,7 +85,7 @@ public final class UnionFlattenOpsImpl {
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<Void>> send(@HostParam("endpoint") String endpoint, @QueryParam("id") String id,
             @QueryParam("api-version") String apiVersion, @HeaderParam("accept") String accept,
-            @BodyParam("application/json") BinaryData request, RequestOptions requestOptions, Context context);
+            @BodyParam("application/json") BinaryData sendRequest, RequestOptions requestOptions, Context context);
 
         @Post("/union/send")
         @ExpectedResponses({ 200 })
@@ -95,7 +95,7 @@ public final class UnionFlattenOpsImpl {
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Response<Void> sendSync(@HostParam("endpoint") String endpoint, @QueryParam("id") String id,
             @QueryParam("api-version") String apiVersion, @HeaderParam("accept") String accept,
-            @BodyParam("application/json") BinaryData request, RequestOptions requestOptions, Context context);
+            @BodyParam("application/json") BinaryData sendRequest, RequestOptions requestOptions, Context context);
 
         @Post("/union/send-long")
         @ExpectedResponses({ 200 })
@@ -105,7 +105,7 @@ public final class UnionFlattenOpsImpl {
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<Void>> sendLong(@HostParam("endpoint") String endpoint, @QueryParam("id") String id,
             @QueryParam("api-version") String apiVersion, @HeaderParam("accept") String accept,
-            @BodyParam("application/json") BinaryData request, RequestOptions requestOptions, Context context);
+            @BodyParam("application/json") BinaryData sendLongRequest, RequestOptions requestOptions, Context context);
 
         @Post("/union/send-long")
         @ExpectedResponses({ 200 })
@@ -115,7 +115,7 @@ public final class UnionFlattenOpsImpl {
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Response<Void> sendLongSync(@HostParam("endpoint") String endpoint, @QueryParam("id") String id,
             @QueryParam("api-version") String apiVersion, @HeaderParam("accept") String accept,
-            @BodyParam("application/json") BinaryData request, RequestOptions requestOptions, Context context);
+            @BodyParam("application/json") BinaryData sendLongRequest, RequestOptions requestOptions, Context context);
 
         @Get("/union/param")
         @ExpectedResponses({ 200 })
@@ -170,7 +170,7 @@ public final class UnionFlattenOpsImpl {
      * }</pre>
      * 
      * @param id The id parameter.
-     * @param request The request parameter.
+     * @param sendRequest The sendRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -179,10 +179,11 @@ public final class UnionFlattenOpsImpl {
      * @return the {@link Response} on successful completion of {@link Mono}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Void>> sendWithResponseAsync(String id, BinaryData request, RequestOptions requestOptions) {
+    public Mono<Response<Void>> sendWithResponseAsync(String id, BinaryData sendRequest,
+        RequestOptions requestOptions) {
         final String accept = "application/json";
         return FluxUtil.withContext(context -> service.send(this.client.getEndpoint(), id,
-            this.client.getServiceVersion().getVersion(), accept, request, requestOptions, context));
+            this.client.getServiceVersion().getVersion(), accept, sendRequest, requestOptions, context));
     }
 
     /**
@@ -199,7 +200,7 @@ public final class UnionFlattenOpsImpl {
      * }</pre>
      * 
      * @param id The id parameter.
-     * @param request The request parameter.
+     * @param sendRequest The sendRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -208,10 +209,10 @@ public final class UnionFlattenOpsImpl {
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> sendWithResponse(String id, BinaryData request, RequestOptions requestOptions) {
+    public Response<Void> sendWithResponse(String id, BinaryData sendRequest, RequestOptions requestOptions) {
         final String accept = "application/json";
         return service.sendSync(this.client.getEndpoint(), id, this.client.getServiceVersion().getVersion(), accept,
-            request, requestOptions, Context.NONE);
+            sendRequest, requestOptions, Context.NONE);
     }
 
     /**
@@ -239,7 +240,7 @@ public final class UnionFlattenOpsImpl {
      * }</pre>
      * 
      * @param id The id parameter.
-     * @param request The request parameter.
+     * @param sendLongRequest The sendLongRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -248,11 +249,11 @@ public final class UnionFlattenOpsImpl {
      * @return the {@link Response} on successful completion of {@link Mono}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Void>> sendLongWithResponseAsync(String id, BinaryData request,
+    public Mono<Response<Void>> sendLongWithResponseAsync(String id, BinaryData sendLongRequest,
         RequestOptions requestOptions) {
         final String accept = "application/json";
         return FluxUtil.withContext(context -> service.sendLong(this.client.getEndpoint(), id,
-            this.client.getServiceVersion().getVersion(), accept, request, requestOptions, context));
+            this.client.getServiceVersion().getVersion(), accept, sendLongRequest, requestOptions, context));
     }
 
     /**
@@ -280,7 +281,7 @@ public final class UnionFlattenOpsImpl {
      * }</pre>
      * 
      * @param id The id parameter.
-     * @param request The request parameter.
+     * @param sendLongRequest The sendLongRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -289,10 +290,10 @@ public final class UnionFlattenOpsImpl {
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> sendLongWithResponse(String id, BinaryData request, RequestOptions requestOptions) {
+    public Response<Void> sendLongWithResponse(String id, BinaryData sendLongRequest, RequestOptions requestOptions) {
         final String accept = "application/json";
         return service.sendLongSync(this.client.getEndpoint(), id, this.client.getServiceVersion().getVersion(), accept,
-            request, requestOptions, Context.NONE);
+            sendLongRequest, requestOptions, Context.NONE);
     }
 
     /**

--- a/typespec-tests/src/main/java/com/parameters/spread/AliasAsyncClient.java
+++ b/typespec-tests/src/main/java/com/parameters/spread/AliasAsyncClient.java
@@ -78,7 +78,7 @@ public final class AliasAsyncClient {
      * 
      * @param id The id parameter.
      * @param xMsTestHeader The xMsTestHeader parameter.
-     * @param request The request parameter.
+     * @param spreadAsRequestParameterRequest The spreadAsRequestParameterRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -89,8 +89,9 @@ public final class AliasAsyncClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> spreadAsRequestParameterWithResponse(String id, String xMsTestHeader,
-        BinaryData request, RequestOptions requestOptions) {
-        return this.serviceClient.spreadAsRequestParameterWithResponseAsync(id, xMsTestHeader, request, requestOptions);
+        BinaryData spreadAsRequestParameterRequest, RequestOptions requestOptions) {
+        return this.serviceClient.spreadAsRequestParameterWithResponseAsync(id, xMsTestHeader,
+            spreadAsRequestParameterRequest, requestOptions);
     }
 
     /**
@@ -110,7 +111,7 @@ public final class AliasAsyncClient {
      * 
      * @param id The id parameter.
      * @param xMsTestHeader The xMsTestHeader parameter.
-     * @param request The request parameter.
+     * @param spreadWithMultipleParametersRequest The spreadWithMultipleParametersRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -121,9 +122,9 @@ public final class AliasAsyncClient {
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> spreadWithMultipleParametersWithResponse(String id, String xMsTestHeader,
-        BinaryData request, RequestOptions requestOptions) {
-        return this.serviceClient.spreadWithMultipleParametersWithResponseAsync(id, xMsTestHeader, request,
-            requestOptions);
+        BinaryData spreadWithMultipleParametersRequest, RequestOptions requestOptions) {
+        return this.serviceClient.spreadWithMultipleParametersWithResponseAsync(id, xMsTestHeader,
+            spreadWithMultipleParametersRequest, requestOptions);
     }
 
     /**
@@ -167,9 +168,9 @@ public final class AliasAsyncClient {
     public Mono<Void> spreadAsRequestParameter(String id, String xMsTestHeader, String name) {
         // Generated convenience method for spreadAsRequestParameterWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        SpreadAsRequestParameterRequest requestObj = new SpreadAsRequestParameterRequest(name);
-        BinaryData request = BinaryData.fromObject(requestObj);
-        return spreadAsRequestParameterWithResponse(id, xMsTestHeader, request, requestOptions)
+        SpreadAsRequestParameterRequest spreadAsRequestParameterRequestObj = new SpreadAsRequestParameterRequest(name);
+        BinaryData spreadAsRequestParameterRequest = BinaryData.fromObject(spreadAsRequestParameterRequestObj);
+        return spreadAsRequestParameterWithResponse(id, xMsTestHeader, spreadAsRequestParameterRequest, requestOptions)
             .flatMap(FluxUtil::toMono);
     }
 
@@ -192,10 +193,11 @@ public final class AliasAsyncClient {
         RequestOptions requestOptions = new RequestOptions();
         String id = options.getId();
         String xMsTestHeader = options.getXMsTestHeader();
-        SpreadWithMultipleParametersRequest requestObj = new SpreadWithMultipleParametersRequest(options.getProp1(),
-            options.getProp2(), options.getProp3(), options.getProp4(), options.getProp5(), options.getProp6());
-        BinaryData request = BinaryData.fromObject(requestObj);
-        return spreadWithMultipleParametersWithResponse(id, xMsTestHeader, request, requestOptions)
-            .flatMap(FluxUtil::toMono);
+        SpreadWithMultipleParametersRequest spreadWithMultipleParametersRequestObj
+            = new SpreadWithMultipleParametersRequest(options.getProp1(), options.getProp2(), options.getProp3(),
+                options.getProp4(), options.getProp5(), options.getProp6());
+        BinaryData spreadWithMultipleParametersRequest = BinaryData.fromObject(spreadWithMultipleParametersRequestObj);
+        return spreadWithMultipleParametersWithResponse(id, xMsTestHeader, spreadWithMultipleParametersRequest,
+            requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/typespec-tests/src/main/java/com/parameters/spread/AliasClient.java
+++ b/typespec-tests/src/main/java/com/parameters/spread/AliasClient.java
@@ -76,7 +76,7 @@ public final class AliasClient {
      * 
      * @param id The id parameter.
      * @param xMsTestHeader The xMsTestHeader parameter.
-     * @param request The request parameter.
+     * @param spreadAsRequestParameterRequest The spreadAsRequestParameterRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -86,9 +86,10 @@ public final class AliasClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> spreadAsRequestParameterWithResponse(String id, String xMsTestHeader, BinaryData request,
-        RequestOptions requestOptions) {
-        return this.serviceClient.spreadAsRequestParameterWithResponse(id, xMsTestHeader, request, requestOptions);
+    public Response<Void> spreadAsRequestParameterWithResponse(String id, String xMsTestHeader,
+        BinaryData spreadAsRequestParameterRequest, RequestOptions requestOptions) {
+        return this.serviceClient.spreadAsRequestParameterWithResponse(id, xMsTestHeader,
+            spreadAsRequestParameterRequest, requestOptions);
     }
 
     /**
@@ -108,7 +109,7 @@ public final class AliasClient {
      * 
      * @param id The id parameter.
      * @param xMsTestHeader The xMsTestHeader parameter.
-     * @param request The request parameter.
+     * @param spreadWithMultipleParametersRequest The spreadWithMultipleParametersRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -118,9 +119,10 @@ public final class AliasClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> spreadWithMultipleParametersWithResponse(String id, String xMsTestHeader, BinaryData request,
-        RequestOptions requestOptions) {
-        return this.serviceClient.spreadWithMultipleParametersWithResponse(id, xMsTestHeader, request, requestOptions);
+    public Response<Void> spreadWithMultipleParametersWithResponse(String id, String xMsTestHeader,
+        BinaryData spreadWithMultipleParametersRequest, RequestOptions requestOptions) {
+        return this.serviceClient.spreadWithMultipleParametersWithResponse(id, xMsTestHeader,
+            spreadWithMultipleParametersRequest, requestOptions);
     }
 
     /**
@@ -162,9 +164,10 @@ public final class AliasClient {
     public void spreadAsRequestParameter(String id, String xMsTestHeader, String name) {
         // Generated convenience method for spreadAsRequestParameterWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        SpreadAsRequestParameterRequest requestObj = new SpreadAsRequestParameterRequest(name);
-        BinaryData request = BinaryData.fromObject(requestObj);
-        spreadAsRequestParameterWithResponse(id, xMsTestHeader, request, requestOptions).getValue();
+        SpreadAsRequestParameterRequest spreadAsRequestParameterRequestObj = new SpreadAsRequestParameterRequest(name);
+        BinaryData spreadAsRequestParameterRequest = BinaryData.fromObject(spreadAsRequestParameterRequestObj);
+        spreadAsRequestParameterWithResponse(id, xMsTestHeader, spreadAsRequestParameterRequest, requestOptions)
+            .getValue();
     }
 
     /**
@@ -185,9 +188,11 @@ public final class AliasClient {
         RequestOptions requestOptions = new RequestOptions();
         String id = options.getId();
         String xMsTestHeader = options.getXMsTestHeader();
-        SpreadWithMultipleParametersRequest requestObj = new SpreadWithMultipleParametersRequest(options.getProp1(),
-            options.getProp2(), options.getProp3(), options.getProp4(), options.getProp5(), options.getProp6());
-        BinaryData request = BinaryData.fromObject(requestObj);
-        spreadWithMultipleParametersWithResponse(id, xMsTestHeader, request, requestOptions).getValue();
+        SpreadWithMultipleParametersRequest spreadWithMultipleParametersRequestObj
+            = new SpreadWithMultipleParametersRequest(options.getProp1(), options.getProp2(), options.getProp3(),
+                options.getProp4(), options.getProp5(), options.getProp6());
+        BinaryData spreadWithMultipleParametersRequest = BinaryData.fromObject(spreadWithMultipleParametersRequestObj);
+        spreadWithMultipleParametersWithResponse(id, xMsTestHeader, spreadWithMultipleParametersRequest, requestOptions)
+            .getValue();
     }
 }

--- a/typespec-tests/src/main/java/com/parameters/spread/implementation/AliasImpl.java
+++ b/typespec-tests/src/main/java/com/parameters/spread/implementation/AliasImpl.java
@@ -85,7 +85,8 @@ public final class AliasImpl {
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<Void>> spreadAsRequestParameter(@PathParam("id") String id,
             @HeaderParam("x-ms-test-header") String xMsTestHeader, @HeaderParam("accept") String accept,
-            @BodyParam("application/json") BinaryData request, RequestOptions requestOptions, Context context);
+            @BodyParam("application/json") BinaryData spreadAsRequestParameterRequest, RequestOptions requestOptions,
+            Context context);
 
         @Put("/parameters/spread/alias/request-parameter/{id}")
         @ExpectedResponses({ 204 })
@@ -95,7 +96,8 @@ public final class AliasImpl {
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Response<Void> spreadAsRequestParameterSync(@PathParam("id") String id,
             @HeaderParam("x-ms-test-header") String xMsTestHeader, @HeaderParam("accept") String accept,
-            @BodyParam("application/json") BinaryData request, RequestOptions requestOptions, Context context);
+            @BodyParam("application/json") BinaryData spreadAsRequestParameterRequest, RequestOptions requestOptions,
+            Context context);
 
         @Put("/parameters/spread/alias/multiple-parameters/{id}")
         @ExpectedResponses({ 204 })
@@ -105,7 +107,8 @@ public final class AliasImpl {
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<Void>> spreadWithMultipleParameters(@PathParam("id") String id,
             @HeaderParam("x-ms-test-header") String xMsTestHeader, @HeaderParam("accept") String accept,
-            @BodyParam("application/json") BinaryData request, RequestOptions requestOptions, Context context);
+            @BodyParam("application/json") BinaryData spreadWithMultipleParametersRequest,
+            RequestOptions requestOptions, Context context);
 
         @Put("/parameters/spread/alias/multiple-parameters/{id}")
         @ExpectedResponses({ 204 })
@@ -115,7 +118,8 @@ public final class AliasImpl {
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Response<Void> spreadWithMultipleParametersSync(@PathParam("id") String id,
             @HeaderParam("x-ms-test-header") String xMsTestHeader, @HeaderParam("accept") String accept,
-            @BodyParam("application/json") BinaryData request, RequestOptions requestOptions, Context context);
+            @BodyParam("application/json") BinaryData spreadWithMultipleParametersRequest,
+            RequestOptions requestOptions, Context context);
     }
 
     /**
@@ -181,7 +185,7 @@ public final class AliasImpl {
      * 
      * @param id The id parameter.
      * @param xMsTestHeader The xMsTestHeader parameter.
-     * @param request The request parameter.
+     * @param spreadAsRequestParameterRequest The spreadAsRequestParameterRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -191,10 +195,10 @@ public final class AliasImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> spreadAsRequestParameterWithResponseAsync(String id, String xMsTestHeader,
-        BinaryData request, RequestOptions requestOptions) {
+        BinaryData spreadAsRequestParameterRequest, RequestOptions requestOptions) {
         final String accept = "application/json";
-        return FluxUtil.withContext(
-            context -> service.spreadAsRequestParameter(id, xMsTestHeader, accept, request, requestOptions, context));
+        return FluxUtil.withContext(context -> service.spreadAsRequestParameter(id, xMsTestHeader, accept,
+            spreadAsRequestParameterRequest, requestOptions, context));
     }
 
     /**
@@ -209,7 +213,7 @@ public final class AliasImpl {
      * 
      * @param id The id parameter.
      * @param xMsTestHeader The xMsTestHeader parameter.
-     * @param request The request parameter.
+     * @param spreadAsRequestParameterRequest The spreadAsRequestParameterRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -218,10 +222,11 @@ public final class AliasImpl {
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> spreadAsRequestParameterWithResponse(String id, String xMsTestHeader, BinaryData request,
-        RequestOptions requestOptions) {
+    public Response<Void> spreadAsRequestParameterWithResponse(String id, String xMsTestHeader,
+        BinaryData spreadAsRequestParameterRequest, RequestOptions requestOptions) {
         final String accept = "application/json";
-        return service.spreadAsRequestParameterSync(id, xMsTestHeader, accept, request, requestOptions, Context.NONE);
+        return service.spreadAsRequestParameterSync(id, xMsTestHeader, accept, spreadAsRequestParameterRequest,
+            requestOptions, Context.NONE);
     }
 
     /**
@@ -241,7 +246,7 @@ public final class AliasImpl {
      * 
      * @param id The id parameter.
      * @param xMsTestHeader The xMsTestHeader parameter.
-     * @param request The request parameter.
+     * @param spreadWithMultipleParametersRequest The spreadWithMultipleParametersRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -251,10 +256,10 @@ public final class AliasImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> spreadWithMultipleParametersWithResponseAsync(String id, String xMsTestHeader,
-        BinaryData request, RequestOptions requestOptions) {
+        BinaryData spreadWithMultipleParametersRequest, RequestOptions requestOptions) {
         final String accept = "application/json";
-        return FluxUtil.withContext(context -> service.spreadWithMultipleParameters(id, xMsTestHeader, accept, request,
-            requestOptions, context));
+        return FluxUtil.withContext(context -> service.spreadWithMultipleParameters(id, xMsTestHeader, accept,
+            spreadWithMultipleParametersRequest, requestOptions, context));
     }
 
     /**
@@ -274,7 +279,7 @@ public final class AliasImpl {
      * 
      * @param id The id parameter.
      * @param xMsTestHeader The xMsTestHeader parameter.
-     * @param request The request parameter.
+     * @param spreadWithMultipleParametersRequest The spreadWithMultipleParametersRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -283,10 +288,10 @@ public final class AliasImpl {
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> spreadWithMultipleParametersWithResponse(String id, String xMsTestHeader, BinaryData request,
-        RequestOptions requestOptions) {
+    public Response<Void> spreadWithMultipleParametersWithResponse(String id, String xMsTestHeader,
+        BinaryData spreadWithMultipleParametersRequest, RequestOptions requestOptions) {
         final String accept = "application/json";
-        return service.spreadWithMultipleParametersSync(id, xMsTestHeader, accept, request, requestOptions,
-            Context.NONE);
+        return service.spreadWithMultipleParametersSync(id, xMsTestHeader, accept, spreadWithMultipleParametersRequest,
+            requestOptions, Context.NONE);
     }
 }

--- a/typespec-tests/src/main/java/com/payload/multipart/MultiPartAsyncClient.java
+++ b/typespec-tests/src/main/java/com/payload/multipart/MultiPartAsyncClient.java
@@ -184,7 +184,7 @@ public final class MultiPartAsyncClient {
     /**
      * Test content-type: multipart/form-data.
      * 
-     * @param request The request parameter.
+     * @param anonymousModelRequest The anonymousModelRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -194,10 +194,10 @@ public final class MultiPartAsyncClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    Mono<Response<Void>> anonymousModelWithResponse(BinaryData request, RequestOptions requestOptions) {
+    Mono<Response<Void>> anonymousModelWithResponse(BinaryData anonymousModelRequest, RequestOptions requestOptions) {
         // Protocol API requires serialization of parts with content-disposition and data, as operation 'anonymousModel'
         // is 'multipart/form-data'
-        return this.serviceClient.anonymousModelWithResponseAsync(request, requestOptions);
+        return this.serviceClient.anonymousModelWithResponseAsync(anonymousModelRequest, requestOptions);
     }
 
     /**
@@ -403,12 +403,14 @@ public final class MultiPartAsyncClient {
     public Mono<Void> anonymousModel(ProfileImageFileDetails profileImage) {
         // Generated convenience method for anonymousModelWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        AnonymousModelRequest requestObj = new AnonymousModelRequest(profileImage);
-        BinaryData request = new MultipartFormDataHelper(requestOptions)
-            .serializeFileField("profileImage", requestObj.getProfileImage().getContent(),
-                requestObj.getProfileImage().getContentType(), requestObj.getProfileImage().getFilename())
-            .end()
-            .getRequestBody();
-        return anonymousModelWithResponse(request, requestOptions).flatMap(FluxUtil::toMono);
+        AnonymousModelRequest anonymousModelRequestObj = new AnonymousModelRequest(profileImage);
+        BinaryData anonymousModelRequest
+            = new MultipartFormDataHelper(requestOptions)
+                .serializeFileField("profileImage", anonymousModelRequestObj.getProfileImage().getContent(),
+                    anonymousModelRequestObj.getProfileImage().getContentType(),
+                    anonymousModelRequestObj.getProfileImage().getFilename())
+                .end()
+                .getRequestBody();
+        return anonymousModelWithResponse(anonymousModelRequest, requestOptions).flatMap(FluxUtil::toMono);
     }
 }

--- a/typespec-tests/src/main/java/com/payload/multipart/MultiPartClient.java
+++ b/typespec-tests/src/main/java/com/payload/multipart/MultiPartClient.java
@@ -182,7 +182,7 @@ public final class MultiPartClient {
     /**
      * Test content-type: multipart/form-data.
      * 
-     * @param request The request parameter.
+     * @param anonymousModelRequest The anonymousModelRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -192,10 +192,10 @@ public final class MultiPartClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    Response<Void> anonymousModelWithResponse(BinaryData request, RequestOptions requestOptions) {
+    Response<Void> anonymousModelWithResponse(BinaryData anonymousModelRequest, RequestOptions requestOptions) {
         // Protocol API requires serialization of parts with content-disposition and data, as operation 'anonymousModel'
         // is 'multipart/form-data'
-        return this.serviceClient.anonymousModelWithResponse(request, requestOptions);
+        return this.serviceClient.anonymousModelWithResponse(anonymousModelRequest, requestOptions);
     }
 
     /**
@@ -391,12 +391,14 @@ public final class MultiPartClient {
     public void anonymousModel(ProfileImageFileDetails profileImage) {
         // Generated convenience method for anonymousModelWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        AnonymousModelRequest requestObj = new AnonymousModelRequest(profileImage);
-        BinaryData request = new MultipartFormDataHelper(requestOptions)
-            .serializeFileField("profileImage", requestObj.getProfileImage().getContent(),
-                requestObj.getProfileImage().getContentType(), requestObj.getProfileImage().getFilename())
-            .end()
-            .getRequestBody();
-        anonymousModelWithResponse(request, requestOptions).getValue();
+        AnonymousModelRequest anonymousModelRequestObj = new AnonymousModelRequest(profileImage);
+        BinaryData anonymousModelRequest
+            = new MultipartFormDataHelper(requestOptions)
+                .serializeFileField("profileImage", anonymousModelRequestObj.getProfileImage().getContent(),
+                    anonymousModelRequestObj.getProfileImage().getContentType(),
+                    anonymousModelRequestObj.getProfileImage().getFilename())
+                .end()
+                .getRequestBody();
+        anonymousModelWithResponse(anonymousModelRequest, requestOptions).getValue();
     }
 }

--- a/typespec-tests/src/main/java/com/payload/multipart/implementation/FormDatasImpl.java
+++ b/typespec-tests/src/main/java/com/payload/multipart/implementation/FormDatasImpl.java
@@ -218,7 +218,7 @@ public final class FormDatasImpl {
         @UnexpectedResponseExceptionType(value = ResourceModifiedException.class, code = { 409 })
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<Void>> anonymousModel(@HeaderParam("Content-Type") String contentType,
-            @HeaderParam("accept") String accept, @BodyParam("multipart/form-data") BinaryData request,
+            @HeaderParam("accept") String accept, @BodyParam("multipart/form-data") BinaryData anonymousModelRequest,
             RequestOptions requestOptions, Context context);
 
         // @Multipart not supported by RestProxy
@@ -229,7 +229,7 @@ public final class FormDatasImpl {
         @UnexpectedResponseExceptionType(value = ResourceModifiedException.class, code = { 409 })
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Response<Void> anonymousModelSync(@HeaderParam("Content-Type") String contentType,
-            @HeaderParam("accept") String accept, @BodyParam("multipart/form-data") BinaryData request,
+            @HeaderParam("accept") String accept, @BodyParam("multipart/form-data") BinaryData anonymousModelRequest,
             RequestOptions requestOptions, Context context);
     }
 
@@ -493,7 +493,7 @@ public final class FormDatasImpl {
     /**
      * Test content-type: multipart/form-data.
      * 
-     * @param request The request parameter.
+     * @param anonymousModelRequest The anonymousModelRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -502,17 +502,18 @@ public final class FormDatasImpl {
      * @return the {@link Response} on successful completion of {@link Mono}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Void>> anonymousModelWithResponseAsync(BinaryData request, RequestOptions requestOptions) {
+    public Mono<Response<Void>> anonymousModelWithResponseAsync(BinaryData anonymousModelRequest,
+        RequestOptions requestOptions) {
         final String contentType = "multipart/form-data";
         final String accept = "application/json";
-        return FluxUtil
-            .withContext(context -> service.anonymousModel(contentType, accept, request, requestOptions, context));
+        return FluxUtil.withContext(
+            context -> service.anonymousModel(contentType, accept, anonymousModelRequest, requestOptions, context));
     }
 
     /**
      * Test content-type: multipart/form-data.
      * 
-     * @param request The request parameter.
+     * @param anonymousModelRequest The anonymousModelRequest parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -521,9 +522,9 @@ public final class FormDatasImpl {
      * @return the {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> anonymousModelWithResponse(BinaryData request, RequestOptions requestOptions) {
+    public Response<Void> anonymousModelWithResponse(BinaryData anonymousModelRequest, RequestOptions requestOptions) {
         final String contentType = "multipart/form-data";
         final String accept = "application/json";
-        return service.anonymousModelSync(contentType, accept, request, requestOptions, Context.NONE);
+        return service.anonymousModelSync(contentType, accept, anonymousModelRequest, requestOptions, Context.NONE);
     }
 }

--- a/typespec-tests/tsp/examples/2022-06-01-preview/FlattenOp_Send.json
+++ b/typespec-tests/tsp/examples/2022-06-01-preview/FlattenOp_Send.json
@@ -3,7 +3,7 @@
   "title": "FlattenOp Send",
   "parameters": {
     "id":  "myRequiredId",
-    "request": {
+    "sendRequest": {
       "user": {
         "user": "myOptionalUser"
       },

--- a/typespec-tests/tsp/examples/2022-06-01-preview/FlattenOp_SendLong.json
+++ b/typespec-tests/tsp/examples/2022-06-01-preview/FlattenOp_SendLong.json
@@ -4,7 +4,7 @@
   "parameters": {
     "name":  "myRequiredId",
     "filter": "name=myName",
-    "sendLongRequest": {
+    "body": {
       "user": {
         "user": "myOptionalUser"
       },

--- a/typespec-tests/tsp/examples/2022-06-01-preview/FlattenOp_SendLong.json
+++ b/typespec-tests/tsp/examples/2022-06-01-preview/FlattenOp_SendLong.json
@@ -4,7 +4,7 @@
   "parameters": {
     "name":  "myRequiredId",
     "filter": "name=myName",
-    "request": {
+    "sendLongRequest": {
       "user": {
         "user": "myOptionalUser"
       },


### PR DESCRIPTION
Chenjie asks emitter to use this `getHttpOperationWithCache` (I guess the lots of diff in generated code is the reason -- calling `getHttpOperation` twice causes problem on anonymous models)
https://github.com/Azure/autorest.java/pull/2849/commits/be2195beac81348c0d4849ae27843293e4171c7d

Also fix an issue of not fallback to "body" parameter name, in grouping case.
https://github.com/Azure/autorest.java/pull/2849/commits/dff4f57d9036dadb430a8ee615119656af0aba76

The issue that emitter generate sample that cannot compile (if there is missing required values) be  https://github.com/Azure/autorest.java/issues/2611