### PR TITLE
mgmt, bug fix on module-info

### DIFF
--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentMapper.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentMapper.java
@@ -30,7 +30,7 @@ import com.azure.autorest.model.clientmodel.ClientModels;
 import com.azure.autorest.model.clientmodel.ModuleInfo;
 import org.slf4j.Logger;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -170,7 +170,11 @@ public class FluentMapper {
         exportModules.add(new ModuleInfo.ExportModule(settings.getPackage(settings.getFluentModelsSubpackage())));
         exportModules.add(new ModuleInfo.ExportModule(settings.getPackage(settings.getModelsSubpackage())));
 
-        List<String> openToModules = Arrays.asList("com.azure.core", "com.fasterxml.jackson.databind");
+        List<String> openToModules = new ArrayList<>();
+        openToModules.add("com.azure.core");
+        if (!settings.isStreamStyleSerialization()) {
+            openToModules.add("com.fasterxml.jackson.databind");
+        }
         List<ModuleInfo.OpenModule> openModules = moduleInfo.getOpenModules();
         openModules.add(new ModuleInfo.OpenModule(settings.getPackage(settings.getFluentModelsSubpackage()), openToModules));
         openModules.add(new ModuleInfo.OpenModule(settings.getPackage(settings.getModelsSubpackage()), openToModules));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@autorest/java",
-  "version": "4.1.33",
+  "version": "4.1.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@autorest/java",
-      "version": "4.1.33",
+      "version": "4.1.34",
       "license": "MIT",
       "devDependencies": {
         "@microsoft.azure/autorest.testserver": "3.3.49",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/java",
-  "version": "4.1.33",
+  "version": "4.1.34",
   "description": "The Java extension for classic generators in AutoRest.",
   "scripts": {
     "autorest": "autorest",


### PR DESCRIPTION
```diff
-    opens com.azure.resourcemanager.oracledatabase.fluent.models to com.azure.core, com.fasterxml.jackson.databind;
-    opens com.azure.resourcemanager.oracledatabase.models to com.azure.core, com.fasterxml.jackson.databind;
+    opens com.azure.resourcemanager.oracledatabase.fluent.models to com.azure.core;
+    opens com.azure.resourcemanager.oracledatabase.models to com.azure.core;
```