### PR TITLE
mgmt, truncate test file name, if path too long

### DIFF
--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/javamodel/FluentJavaPackage.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/javamodel/FluentJavaPackage.java
@@ -29,6 +29,7 @@ import com.azure.autorest.fluent.template.SampleTemplate;
 import com.azure.autorest.fluent.template.ResourceManagerUtilsTemplate;
 import com.azure.autorest.model.javamodel.JavaFile;
 import com.azure.autorest.model.javamodel.JavaPackage;
+import com.azure.autorest.util.ClassNameUtil;
 import com.azure.autorest.util.CodeNamer;
 
 import java.util.List;
@@ -111,11 +112,22 @@ public class FluentJavaPackage extends JavaPackage {
     }
 
     public void addOperationUnitTest(FluentMethodMockUnitTest unitTest) {
-
+        final String packageName = JavaSettings.getInstance().getPackage("generated");
         String className = unitTest.getResourceCollection().getInterfaceType().getName()
-                + CodeNamer.toPascalCase(unitTest.getCollectionMethod().getMethodName())
-                + "MockTests";
-        JavaFile javaFile = getJavaFileFactory().createTestFile(JavaSettings.getInstance().getPackage("generated"), className);
+                + CodeNamer.toPascalCase(unitTest.getCollectionMethod().getMethodName());
+
+        final String classNameSuffix = "MockTests";
+
+        className = ClassNameUtil.truncateClassName(
+                JavaSettings.getInstance().getPackage(),
+                "src/tests/java"
+                        // a hack to count "MockTests" suffix into the length of the full path
+                        + classNameSuffix,
+                packageName, className);
+
+        className += classNameSuffix;
+
+        JavaFile javaFile = getJavaFileFactory().createTestFile(packageName, className);
         FluentMethodMockTestTemplate.ClientMethodInfo info = new FluentMethodMockTestTemplate.ClientMethodInfo(
                 className, unitTest);
         FluentMethodMockTestTemplate.getInstance().write(info, javaFile);

--- a/javagen/src/main/java/com/azure/autorest/util/ClassNameUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/ClassNameUtil.java
@@ -3,8 +3,19 @@
 
 package com.azure.autorest.util;
 
-public class ClassNameUtil {
+public final class ClassNameUtil {
 
+    /**
+     * Truncate class name to avoid path too long.
+     *
+     * It contains some heuristic logic, and the result may not be exactly correct.
+     *
+     * @param namespace the namespace of the package, used to deduce the artifact id and group id
+     * @param directory the part of directory from maven project
+     * @param packageName the namespace/package of the class
+     * @param className the name of the class
+     * @return the truncated class name
+     */
     public static String truncateClassName(
             String namespace, String directory,
             String packageName, String className) {


### PR DESCRIPTION
The functionality was in samples, but not in tests.

The mock test is usually one with potential long name.

---

before
```
sdk/informaticadatamanagement/azure-resourcemanager-informaticadatamanagement/src/test/java/com/azure/resourcemanager/informaticadatamanagement/generated/ServerlessRuntimesStartFailedServerlessRuntimeWithResponseMockTests.java
```

after
```
sdk/informaticadatamanagement/azure-resourcemanager-informaticadatamanagement/src/test/java/com/azure/resourcemanager/informaticadatamanagement/generated/ServerlessRuntimesStartFailedServerlessRuntimeWitMockTests.java
```