### PR TITLE
DPG, add Service API versions section under Examples

### DIFF
--- a/javagen/src/main/resources/Readme_protocol.txt
+++ b/javagen/src/main/resources/Readme_protocol.txt
@@ -46,7 +46,7 @@ Various documentation is available to help you get started
 The client library targets the latest service API version by default.
 The service client builder accepts an optional service API version parameter to specify which API version to communicate.
 
-#### Select a service version
+#### Select a service API version
 
 You have the flexibility to explicitly select a supported service API version when initializing a service client via the service client builder.
 This ensures that the client can communicate with services using the specified API version.

--- a/javagen/src/main/resources/Readme_protocol.txt
+++ b/javagen/src/main/resources/Readme_protocol.txt
@@ -41,6 +41,21 @@ Various documentation is available to help you get started
 ```java {{package-name}}.readme
 ```
 
+### Service API versions
+
+The client library targets the latest service API version by default.
+The service client builder accepts an optional service API version parameter to specify which API version to communicate.
+
+#### Select a service version
+
+You have the flexibility to explicitly select a supported service API version when initializing a service client via the service client builder.
+This ensures that the client can communicate with services using the specified API version.
+
+When selecting an API version, it is important to verify that there are no breaking changes compared to the latest API version.
+If there are significant differences, API calls may fail due to incompatibility.
+
+Always ensure that the chosen API version is fully supported and operational for your specific use case and that it aligns with the service's versioning policy.
+
 ## Troubleshooting
 
 ## Next steps


### PR DESCRIPTION
Fix https://github.com/Azure/autorest.java/issues/2819 except the example code

Generated readme (template for further dev improvement) looks like this.

![image](https://github.com/Azure/autorest.java/assets/53292327/e9e0a862-3b96-4f09-9504-7104c8e17f97)

![image](https://github.com/Azure/autorest.java/assets/53292327/45d9a20c-e9de-4916-847b-b23dc9905f6e)

For the example, we'd first try to put a "recommended" client initialization example first. Then this "not recommended" service version example.