### PR TITLE
mgmt tsp, fix listByParent

### DIFF
--- a/typespec-tests/src/main/java/com/cadl/armresourceprovider/fluent/ChildResourcesInterfacesClient.java
+++ b/typespec-tests/src/main/java/com/cadl/armresourceprovider/fluent/ChildResourcesInterfacesClient.java
@@ -206,35 +206,6 @@ public interface ChildResourcesInterfacesClient {
     void delete(String resourceGroupName, String topLevelArmResourceName, String childResourceName, Context context);
 
     /**
-     * List ChildResource resources by TopLevelArmResource.
-     * 
-     * @param resourceGroupName The name of the resource group. The name is case insensitive.
-     * @param topLevelArmResourceName arm resource name for path.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response of a ChildResource list operation as paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    PagedIterable<ChildResourceInner> listByTopLevelArmResource(String resourceGroupName,
-        String topLevelArmResourceName);
-
-    /**
-     * List ChildResource resources by TopLevelArmResource.
-     * 
-     * @param resourceGroupName The name of the resource group. The name is case insensitive.
-     * @param topLevelArmResourceName arm resource name for path.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response of a ChildResource list operation as paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    PagedIterable<ChildResourceInner> listByTopLevelArmResource(String resourceGroupName,
-        String topLevelArmResourceName, Context context);
-
-    /**
      * A long-running resource action.
      * 
      * @param resourceGroupName The name of the resource group. The name is case insensitive.
@@ -292,4 +263,33 @@ public interface ChildResourcesInterfacesClient {
     @ServiceMethod(returns = ReturnType.SINGLE)
     void actionWithoutBody(String resourceGroupName, String topLevelArmResourceName, String childResourceName,
         Context context);
+
+    /**
+     * List ChildResource resources by TopLevelArmResource.
+     * 
+     * @param resourceGroupName The name of the resource group. The name is case insensitive.
+     * @param topLevelArmResourceName arm resource name for path.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response of a ChildResource list operation as paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    PagedIterable<ChildResourceInner> listByTopLevelArmResource(String resourceGroupName,
+        String topLevelArmResourceName);
+
+    /**
+     * List ChildResource resources by TopLevelArmResource.
+     * 
+     * @param resourceGroupName The name of the resource group. The name is case insensitive.
+     * @param topLevelArmResourceName arm resource name for path.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response of a ChildResource list operation as paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    PagedIterable<ChildResourceInner> listByTopLevelArmResource(String resourceGroupName,
+        String topLevelArmResourceName, Context context);
 }

--- a/typespec-tests/src/main/java/com/cadl/armresourceprovider/implementation/ChildResourcesInterfacesClientImpl.java
+++ b/typespec-tests/src/main/java/com/cadl/armresourceprovider/implementation/ChildResourcesInterfacesClientImpl.java
@@ -118,16 +118,6 @@ public final class ChildResourcesInterfacesClientImpl implements ChildResourcesI
             Context context);
 
         @Headers({ "Content-Type: application/json" })
-        @Get("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Cadl.ArmResourceProvider/topLevelArmResources/{topLevelArmResourceName}/childResources")
-        @ExpectedResponses({ 200 })
-        @UnexpectedResponseExceptionType(ManagementException.class)
-        Mono<Response<ChildResourceListResult>> listByTopLevelArmResource(@HostParam("endpoint") String endpoint,
-            @QueryParam("api-version") String apiVersion, @PathParam("subscriptionId") String subscriptionId,
-            @PathParam("resourceGroupName") String resourceGroupName,
-            @PathParam("topLevelArmResourceName") String topLevelArmResourceName, @HeaderParam("accept") String accept,
-            Context context);
-
-        @Headers({ "Content-Type: application/json" })
         @Post("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Cadl.ArmResourceProvider/topLevelArmResources/{topLevelArmResourceName}/childResources/{childResourceName}/actionWithoutBody")
         @ExpectedResponses({ 202, 204 })
         @UnexpectedResponseExceptionType(ManagementException.class)
@@ -136,6 +126,16 @@ public final class ChildResourcesInterfacesClientImpl implements ChildResourcesI
             @PathParam("resourceGroupName") String resourceGroupName,
             @PathParam("topLevelArmResourceName") String topLevelArmResourceName,
             @PathParam("childResourceName") String childResourceName, @HeaderParam("accept") String accept,
+            Context context);
+
+        @Headers({ "Content-Type: application/json" })
+        @Get("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Cadl.ArmResourceProvider/topLevelArmResources/{topLevelArmResourceName}/childResources")
+        @ExpectedResponses({ 200 })
+        @UnexpectedResponseExceptionType(ManagementException.class)
+        Mono<Response<ChildResourceListResult>> listByTopLevelArmResource(@HostParam("endpoint") String endpoint,
+            @QueryParam("api-version") String apiVersion, @PathParam("subscriptionId") String subscriptionId,
+            @PathParam("resourceGroupName") String resourceGroupName,
+            @PathParam("topLevelArmResourceName") String topLevelArmResourceName, @HeaderParam("accept") String accept,
             Context context);
 
         @Headers({ "Content-Type: application/json" })
@@ -928,156 +928,6 @@ public final class ChildResourcesInterfacesClientImpl implements ChildResourcesI
     }
 
     /**
-     * List ChildResource resources by TopLevelArmResource.
-     * 
-     * @param resourceGroupName The name of the resource group. The name is case insensitive.
-     * @param topLevelArmResourceName arm resource name for path.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws ManagementException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response of a ChildResource list operation along with {@link PagedResponse} on successful completion
-     * of {@link Mono}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<ChildResourceInner>> listByTopLevelArmResourceSinglePageAsync(String resourceGroupName,
-        String topLevelArmResourceName) {
-        if (this.client.getEndpoint() == null) {
-            return Mono.error(
-                new IllegalArgumentException("Parameter this.client.getEndpoint() is required and cannot be null."));
-        }
-        if (this.client.getSubscriptionId() == null) {
-            return Mono.error(new IllegalArgumentException(
-                "Parameter this.client.getSubscriptionId() is required and cannot be null."));
-        }
-        if (resourceGroupName == null) {
-            return Mono
-                .error(new IllegalArgumentException("Parameter resourceGroupName is required and cannot be null."));
-        }
-        if (topLevelArmResourceName == null) {
-            return Mono.error(
-                new IllegalArgumentException("Parameter topLevelArmResourceName is required and cannot be null."));
-        }
-        final String accept = "application/json";
-        return FluxUtil
-            .withContext(
-                context -> service.listByTopLevelArmResource(this.client.getEndpoint(), this.client.getApiVersion(),
-                    this.client.getSubscriptionId(), resourceGroupName, topLevelArmResourceName, accept, context))
-            .<PagedResponse<ChildResourceInner>>map(res -> new PagedResponseBase<>(res.getRequest(),
-                res.getStatusCode(), res.getHeaders(), res.getValue().value(), res.getValue().nextLink(), null))
-            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
-    }
-
-    /**
-     * List ChildResource resources by TopLevelArmResource.
-     * 
-     * @param resourceGroupName The name of the resource group. The name is case insensitive.
-     * @param topLevelArmResourceName arm resource name for path.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws ManagementException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response of a ChildResource list operation along with {@link PagedResponse} on successful completion
-     * of {@link Mono}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<ChildResourceInner>> listByTopLevelArmResourceSinglePageAsync(String resourceGroupName,
-        String topLevelArmResourceName, Context context) {
-        if (this.client.getEndpoint() == null) {
-            return Mono.error(
-                new IllegalArgumentException("Parameter this.client.getEndpoint() is required and cannot be null."));
-        }
-        if (this.client.getSubscriptionId() == null) {
-            return Mono.error(new IllegalArgumentException(
-                "Parameter this.client.getSubscriptionId() is required and cannot be null."));
-        }
-        if (resourceGroupName == null) {
-            return Mono
-                .error(new IllegalArgumentException("Parameter resourceGroupName is required and cannot be null."));
-        }
-        if (topLevelArmResourceName == null) {
-            return Mono.error(
-                new IllegalArgumentException("Parameter topLevelArmResourceName is required and cannot be null."));
-        }
-        final String accept = "application/json";
-        context = this.client.mergeContext(context);
-        return service
-            .listByTopLevelArmResource(this.client.getEndpoint(), this.client.getApiVersion(),
-                this.client.getSubscriptionId(), resourceGroupName, topLevelArmResourceName, accept, context)
-            .map(res -> new PagedResponseBase<>(res.getRequest(), res.getStatusCode(), res.getHeaders(),
-                res.getValue().value(), res.getValue().nextLink(), null));
-    }
-
-    /**
-     * List ChildResource resources by TopLevelArmResource.
-     * 
-     * @param resourceGroupName The name of the resource group. The name is case insensitive.
-     * @param topLevelArmResourceName arm resource name for path.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws ManagementException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response of a ChildResource list operation as paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    private PagedFlux<ChildResourceInner> listByTopLevelArmResourceAsync(String resourceGroupName,
-        String topLevelArmResourceName) {
-        return new PagedFlux<>(
-            () -> listByTopLevelArmResourceSinglePageAsync(resourceGroupName, topLevelArmResourceName),
-            nextLink -> listByTopLevelArmResourceNextSinglePageAsync(nextLink));
-    }
-
-    /**
-     * List ChildResource resources by TopLevelArmResource.
-     * 
-     * @param resourceGroupName The name of the resource group. The name is case insensitive.
-     * @param topLevelArmResourceName arm resource name for path.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws ManagementException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response of a ChildResource list operation as paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    private PagedFlux<ChildResourceInner> listByTopLevelArmResourceAsync(String resourceGroupName,
-        String topLevelArmResourceName, Context context) {
-        return new PagedFlux<>(
-            () -> listByTopLevelArmResourceSinglePageAsync(resourceGroupName, topLevelArmResourceName, context),
-            nextLink -> listByTopLevelArmResourceNextSinglePageAsync(nextLink, context));
-    }
-
-    /**
-     * List ChildResource resources by TopLevelArmResource.
-     * 
-     * @param resourceGroupName The name of the resource group. The name is case insensitive.
-     * @param topLevelArmResourceName arm resource name for path.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws ManagementException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response of a ChildResource list operation as paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<ChildResourceInner> listByTopLevelArmResource(String resourceGroupName,
-        String topLevelArmResourceName) {
-        return new PagedIterable<>(listByTopLevelArmResourceAsync(resourceGroupName, topLevelArmResourceName));
-    }
-
-    /**
-     * List ChildResource resources by TopLevelArmResource.
-     * 
-     * @param resourceGroupName The name of the resource group. The name is case insensitive.
-     * @param topLevelArmResourceName arm resource name for path.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws ManagementException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response of a ChildResource list operation as paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<ChildResourceInner> listByTopLevelArmResource(String resourceGroupName,
-        String topLevelArmResourceName, Context context) {
-        return new PagedIterable<>(listByTopLevelArmResourceAsync(resourceGroupName, topLevelArmResourceName, context));
-    }
-
-    /**
      * A long-running resource action.
      * 
      * @param resourceGroupName The name of the resource group. The name is case insensitive.
@@ -1308,6 +1158,156 @@ public final class ChildResourcesInterfacesClientImpl implements ChildResourcesI
     public void actionWithoutBody(String resourceGroupName, String topLevelArmResourceName, String childResourceName,
         Context context) {
         actionWithoutBodyAsync(resourceGroupName, topLevelArmResourceName, childResourceName, context).block();
+    }
+
+    /**
+     * List ChildResource resources by TopLevelArmResource.
+     * 
+     * @param resourceGroupName The name of the resource group. The name is case insensitive.
+     * @param topLevelArmResourceName arm resource name for path.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ManagementException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response of a ChildResource list operation along with {@link PagedResponse} on successful completion
+     * of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    private Mono<PagedResponse<ChildResourceInner>> listByTopLevelArmResourceSinglePageAsync(String resourceGroupName,
+        String topLevelArmResourceName) {
+        if (this.client.getEndpoint() == null) {
+            return Mono.error(
+                new IllegalArgumentException("Parameter this.client.getEndpoint() is required and cannot be null."));
+        }
+        if (this.client.getSubscriptionId() == null) {
+            return Mono.error(new IllegalArgumentException(
+                "Parameter this.client.getSubscriptionId() is required and cannot be null."));
+        }
+        if (resourceGroupName == null) {
+            return Mono
+                .error(new IllegalArgumentException("Parameter resourceGroupName is required and cannot be null."));
+        }
+        if (topLevelArmResourceName == null) {
+            return Mono.error(
+                new IllegalArgumentException("Parameter topLevelArmResourceName is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil
+            .withContext(
+                context -> service.listByTopLevelArmResource(this.client.getEndpoint(), this.client.getApiVersion(),
+                    this.client.getSubscriptionId(), resourceGroupName, topLevelArmResourceName, accept, context))
+            .<PagedResponse<ChildResourceInner>>map(res -> new PagedResponseBase<>(res.getRequest(),
+                res.getStatusCode(), res.getHeaders(), res.getValue().value(), res.getValue().nextLink(), null))
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
+    }
+
+    /**
+     * List ChildResource resources by TopLevelArmResource.
+     * 
+     * @param resourceGroupName The name of the resource group. The name is case insensitive.
+     * @param topLevelArmResourceName arm resource name for path.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ManagementException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response of a ChildResource list operation along with {@link PagedResponse} on successful completion
+     * of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    private Mono<PagedResponse<ChildResourceInner>> listByTopLevelArmResourceSinglePageAsync(String resourceGroupName,
+        String topLevelArmResourceName, Context context) {
+        if (this.client.getEndpoint() == null) {
+            return Mono.error(
+                new IllegalArgumentException("Parameter this.client.getEndpoint() is required and cannot be null."));
+        }
+        if (this.client.getSubscriptionId() == null) {
+            return Mono.error(new IllegalArgumentException(
+                "Parameter this.client.getSubscriptionId() is required and cannot be null."));
+        }
+        if (resourceGroupName == null) {
+            return Mono
+                .error(new IllegalArgumentException("Parameter resourceGroupName is required and cannot be null."));
+        }
+        if (topLevelArmResourceName == null) {
+            return Mono.error(
+                new IllegalArgumentException("Parameter topLevelArmResourceName is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        context = this.client.mergeContext(context);
+        return service
+            .listByTopLevelArmResource(this.client.getEndpoint(), this.client.getApiVersion(),
+                this.client.getSubscriptionId(), resourceGroupName, topLevelArmResourceName, accept, context)
+            .map(res -> new PagedResponseBase<>(res.getRequest(), res.getStatusCode(), res.getHeaders(),
+                res.getValue().value(), res.getValue().nextLink(), null));
+    }
+
+    /**
+     * List ChildResource resources by TopLevelArmResource.
+     * 
+     * @param resourceGroupName The name of the resource group. The name is case insensitive.
+     * @param topLevelArmResourceName arm resource name for path.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ManagementException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response of a ChildResource list operation as paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    private PagedFlux<ChildResourceInner> listByTopLevelArmResourceAsync(String resourceGroupName,
+        String topLevelArmResourceName) {
+        return new PagedFlux<>(
+            () -> listByTopLevelArmResourceSinglePageAsync(resourceGroupName, topLevelArmResourceName),
+            nextLink -> listByTopLevelArmResourceNextSinglePageAsync(nextLink));
+    }
+
+    /**
+     * List ChildResource resources by TopLevelArmResource.
+     * 
+     * @param resourceGroupName The name of the resource group. The name is case insensitive.
+     * @param topLevelArmResourceName arm resource name for path.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ManagementException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response of a ChildResource list operation as paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    private PagedFlux<ChildResourceInner> listByTopLevelArmResourceAsync(String resourceGroupName,
+        String topLevelArmResourceName, Context context) {
+        return new PagedFlux<>(
+            () -> listByTopLevelArmResourceSinglePageAsync(resourceGroupName, topLevelArmResourceName, context),
+            nextLink -> listByTopLevelArmResourceNextSinglePageAsync(nextLink, context));
+    }
+
+    /**
+     * List ChildResource resources by TopLevelArmResource.
+     * 
+     * @param resourceGroupName The name of the resource group. The name is case insensitive.
+     * @param topLevelArmResourceName arm resource name for path.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ManagementException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response of a ChildResource list operation as paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<ChildResourceInner> listByTopLevelArmResource(String resourceGroupName,
+        String topLevelArmResourceName) {
+        return new PagedIterable<>(listByTopLevelArmResourceAsync(resourceGroupName, topLevelArmResourceName));
+    }
+
+    /**
+     * List ChildResource resources by TopLevelArmResource.
+     * 
+     * @param resourceGroupName The name of the resource group. The name is case insensitive.
+     * @param topLevelArmResourceName arm resource name for path.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ManagementException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response of a ChildResource list operation as paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<ChildResourceInner> listByTopLevelArmResource(String resourceGroupName,
+        String topLevelArmResourceName, Context context) {
+        return new PagedIterable<>(listByTopLevelArmResourceAsync(resourceGroupName, topLevelArmResourceName, context));
     }
 
     /**

--- a/typespec-tests/src/main/java/com/cadl/armresourceprovider/implementation/ChildResourcesInterfacesImpl.java
+++ b/typespec-tests/src/main/java/com/cadl/armresourceprovider/implementation/ChildResourcesInterfacesImpl.java
@@ -58,6 +58,15 @@ public final class ChildResourcesInterfacesImpl implements ChildResourcesInterfa
         this.serviceClient().delete(resourceGroupName, topLevelArmResourceName, childResourceName, context);
     }
 
+    public void actionWithoutBody(String resourceGroupName, String topLevelArmResourceName, String childResourceName) {
+        this.serviceClient().actionWithoutBody(resourceGroupName, topLevelArmResourceName, childResourceName);
+    }
+
+    public void actionWithoutBody(String resourceGroupName, String topLevelArmResourceName, String childResourceName,
+        Context context) {
+        this.serviceClient().actionWithoutBody(resourceGroupName, topLevelArmResourceName, childResourceName, context);
+    }
+
     public PagedIterable<ChildResource> listByTopLevelArmResource(String resourceGroupName,
         String topLevelArmResourceName) {
         PagedIterable<ChildResourceInner> inner
@@ -70,15 +79,6 @@ public final class ChildResourcesInterfacesImpl implements ChildResourcesInterfa
         PagedIterable<ChildResourceInner> inner
             = this.serviceClient().listByTopLevelArmResource(resourceGroupName, topLevelArmResourceName, context);
         return ResourceManagerUtils.mapPage(inner, inner1 -> new ChildResourceImpl(inner1, this.manager()));
-    }
-
-    public void actionWithoutBody(String resourceGroupName, String topLevelArmResourceName, String childResourceName) {
-        this.serviceClient().actionWithoutBody(resourceGroupName, topLevelArmResourceName, childResourceName);
-    }
-
-    public void actionWithoutBody(String resourceGroupName, String topLevelArmResourceName, String childResourceName,
-        Context context) {
-        this.serviceClient().actionWithoutBody(resourceGroupName, topLevelArmResourceName, childResourceName, context);
     }
 
     public ChildResource getById(String id) {

--- a/typespec-tests/src/main/java/com/cadl/armresourceprovider/models/ChildResourcesInterfaces.java
+++ b/typespec-tests/src/main/java/com/cadl/armresourceprovider/models/ChildResourcesInterfaces.java
@@ -66,32 +66,6 @@ public interface ChildResourcesInterfaces {
     void delete(String resourceGroupName, String topLevelArmResourceName, String childResourceName, Context context);
 
     /**
-     * List ChildResource resources by TopLevelArmResource.
-     * 
-     * @param resourceGroupName The name of the resource group. The name is case insensitive.
-     * @param topLevelArmResourceName arm resource name for path.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response of a ChildResource list operation as paginated response with {@link PagedIterable}.
-     */
-    PagedIterable<ChildResource> listByTopLevelArmResource(String resourceGroupName, String topLevelArmResourceName);
-
-    /**
-     * List ChildResource resources by TopLevelArmResource.
-     * 
-     * @param resourceGroupName The name of the resource group. The name is case insensitive.
-     * @param topLevelArmResourceName arm resource name for path.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response of a ChildResource list operation as paginated response with {@link PagedIterable}.
-     */
-    PagedIterable<ChildResource> listByTopLevelArmResource(String resourceGroupName, String topLevelArmResourceName,
-        Context context);
-
-    /**
      * A long-running resource action.
      * 
      * @param resourceGroupName The name of the resource group. The name is case insensitive.
@@ -115,6 +89,32 @@ public interface ChildResourcesInterfaces {
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     void actionWithoutBody(String resourceGroupName, String topLevelArmResourceName, String childResourceName,
+        Context context);
+
+    /**
+     * List ChildResource resources by TopLevelArmResource.
+     * 
+     * @param resourceGroupName The name of the resource group. The name is case insensitive.
+     * @param topLevelArmResourceName arm resource name for path.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response of a ChildResource list operation as paginated response with {@link PagedIterable}.
+     */
+    PagedIterable<ChildResource> listByTopLevelArmResource(String resourceGroupName, String topLevelArmResourceName);
+
+    /**
+     * List ChildResource resources by TopLevelArmResource.
+     * 
+     * @param resourceGroupName The name of the resource group. The name is case insensitive.
+     * @param topLevelArmResourceName arm resource name for path.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response of a ChildResource list operation as paginated response with {@link PagedIterable}.
+     */
+    PagedIterable<ChildResource> listByTopLevelArmResource(String resourceGroupName, String topLevelArmResourceName,
         Context context);
 
     /**

--- a/typespec-tests/tsp/arm.tsp
+++ b/typespec-tests/tsp/arm.tsp
@@ -214,9 +214,9 @@ model ChildExtensionResourceProperties {
 //----------------------- Paths -----------------------
 @armResourceOperations
 interface ChildResourcesInterface
-  extends ResourceInstanceOperations<ChildResource, ChildResourceProperties>,
-    ResourceListByParent<ChildResource> {
+  extends ResourceInstanceOperations<ChildResource, ChildResourceProperties> {
   actionWithoutBody is ArmResourceActionAsync<ChildResource, void, void>;
+  listByTopLevelTrackedResource is ArmResourceListByParent<ChildResource>;
 }
 
 @armResourceOperations


### PR DESCRIPTION
fix https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3960525&view=logs&j=ca395085-040a-526b-2ce8-bdc85f692774&t=738c417a-4a48-5620-b571-4f9e77e0bfd2&l=25 for next `typespec-azure-resource-manager`.

Tried to make interface `ResourceListByParent` work, all in vain.. Switched to using operation instead.
code: https://github.com/Azure/autorest.java/pull/2860/commits/c557444bee4df61dedf592230565f8b62b48586d