### PR TITLE
Fix references to generic-core

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/mapper/PomMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/PomMapper.java
@@ -93,9 +93,9 @@ public class PomMapper implements IMapper<Project, Pom> {
         List<String> dependencyIdentifiers = new ArrayList<>();
         // for generic pom, stream style is always true
         addDependencyIdentifier(dependencyIdentifiers, addedDependencyPrefixes,
-                Project.Dependency.GENERIC_CORE, false);
+                Project.Dependency.CLIENTCORE, false);
         addDependencyIdentifier(dependencyIdentifiers, addedDependencyPrefixes,
-                Project.Dependency.GENERIC_JSON, false);
+                Project.Dependency.CLIENTCORE_JSON, false);
 
         // merge dependencies in POM and dependencies added above
         dependencyIdentifiers.addAll(project.getPomDependencyIdentifiers().stream()

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/Annotation.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/Annotation.java
@@ -8,74 +8,60 @@ import com.azure.autorest.extension.base.plugin.JavaSettings;
 import java.util.Set;
 
 public class Annotation {
+    private static final String CLIENTCORE_PACKAGE = "io.clientcore.core.http.annotation";
 
-    public static final Annotation GENERATED = new Annotation.Builder()
-            .knownClass(com.azure.core.annotation.Generated.class)
-            .build();
+    public static final Annotation GENERATED = new Annotation.Builder().knownClass(
+        com.azure.core.annotation.Generated.class).build();
 
-    public static final Annotation HOST = new Annotation.Builder()
-            .knownClass(com.azure.core.annotation.Host.class)
-            .build();
+    public static final Annotation HOST = new Annotation.Builder().knownClass(com.azure.core.annotation.Host.class)
+        .build();
 
-    public static final Annotation SERVICE_INTERFACE = new Annotation.Builder()
-            .knownClass(com.azure.core.annotation.ServiceInterface.class)
-            .build();
+    public static final Annotation SERVICE_INTERFACE = new Annotation.Builder().knownClass(
+        com.azure.core.annotation.ServiceInterface.class).build();
 
-    public static final Annotation SERVICE_CLIENT = new Annotation.Builder()
-            .knownClass(com.azure.core.annotation.ServiceClient.class)
-            .build();
+    public static final Annotation SERVICE_CLIENT = new Annotation.Builder().knownClass(
+        com.azure.core.annotation.ServiceClient.class).build();
 
-    public static final Annotation SERVICE_METHOD = new Annotation.Builder()
-            .knownClass(com.azure.core.annotation.ServiceMethod.class)
-            .build();
+    public static final Annotation SERVICE_METHOD = new Annotation.Builder().knownClass(
+        com.azure.core.annotation.ServiceMethod.class).build();
 
-    public static final Annotation SERVICE_CLIENT_BUILDER = new Annotation.Builder()
-            .knownClass(com.azure.core.annotation.ServiceClientBuilder.class)
-            .build();
+    public static final Annotation SERVICE_CLIENT_BUILDER = new Annotation.Builder().knownClass(
+        com.azure.core.annotation.ServiceClientBuilder.class).build();
 
-    public static final Annotation UNEXPECTED_RESPONSE_EXCEPTION_TYPE = new Annotation.Builder()
-            .knownClass(com.azure.core.annotation.UnexpectedResponseExceptionType.class)
-            .build();
+    public static final Annotation UNEXPECTED_RESPONSE_EXCEPTION_TYPE = new Annotation.Builder().knownClass(
+        com.azure.core.annotation.UnexpectedResponseExceptionType.class).build();
 
-    public static final Annotation EXPECTED_RESPONSE = new Annotation.Builder()
-            .knownClass(com.azure.core.annotation.ExpectedResponses.class)
-            .build();
+    public static final Annotation EXPECTED_RESPONSE = new Annotation.Builder().knownClass(
+        com.azure.core.annotation.ExpectedResponses.class).build();
 
-    public static final Annotation HEADERS = new Annotation.Builder()
-            .knownClass(com.azure.core.annotation.Headers.class)
-            .build();
+    public static final Annotation HEADERS = new Annotation.Builder().knownClass(
+        com.azure.core.annotation.Headers.class).build();
 
-    public static final Annotation FORM_PARAM = new Annotation.Builder()
-            .knownClass(com.azure.core.annotation.FormParam.class)
-            .build();
+    public static final Annotation FORM_PARAM = new Annotation.Builder().knownClass(
+        com.azure.core.annotation.FormParam.class).build();
 
-    public static final Annotation RETURN_VALUE_WIRE_TYPE = new Annotation.Builder()
-            .knownClass(com.azure.core.annotation.ReturnValueWireType.class)
-            .build();
+    public static final Annotation RETURN_VALUE_WIRE_TYPE = new Annotation.Builder().knownClass(
+        com.azure.core.annotation.ReturnValueWireType.class).build();
 
-    public static final Annotation RETURN_TYPE = new Annotation.Builder()
-            .knownClass(com.azure.core.annotation.ReturnType.class)
-            .build();
+    public static final Annotation RETURN_TYPE = new Annotation.Builder().knownClass(
+        com.azure.core.annotation.ReturnType.class).build();
 
-    public static final Annotation IMMUTABLE = new Annotation.Builder()
-            .knownClass(com.azure.core.annotation.Immutable.class)
-            .build();
+    public static final Annotation IMMUTABLE = new Annotation.Builder().knownClass(
+        com.azure.core.annotation.Immutable.class).build();
 
-    public static final Annotation FLUENT = new Annotation.Builder()
-            .knownClass(com.azure.core.annotation.Fluent.class)
-            .build();
+    public static final Annotation FLUENT = new Annotation.Builder().knownClass(com.azure.core.annotation.Fluent.class)
+        .build();
 
-    public static final Annotation HEADER_COLLECTION = new Annotation.Builder()
-            .knownClass(com.azure.core.annotation.HeaderCollection.class)
-            .build();
+    public static final Annotation HEADER_COLLECTION = new Annotation.Builder().knownClass(
+        com.azure.core.annotation.HeaderCollection.class).build();
 
     public static final Annotation METADATA = new Annotation("io.clientcore.core.annotation", "Metadata");
 
-    public static final Annotation HTTP_REQUEST_INFORMATION
-            = new Annotation("com.generic.core.http.annotation", "HttpRequestInformation");
-    public static final Annotation UNEXPECTED_RESPONSE_EXCEPTION_INFORMATION
-            = new Annotation("com.generic.core.http.annotation", "UnexpectedResponseExceptionDetail");
-    public static final Annotation TYPE_CONDITIONS = new Annotation("com.generic.core.annotation", "TypeConditions");
+    public static final Annotation HTTP_REQUEST_INFORMATION = new Annotation(CLIENTCORE_PACKAGE,
+        "HttpRequestInformation");
+    public static final Annotation UNEXPECTED_RESPONSE_EXCEPTION_INFORMATION = new Annotation(CLIENTCORE_PACKAGE,
+        "UnexpectedResponseExceptionDetail");
+    public static final Annotation TYPE_CONDITIONS = new Annotation(CLIENTCORE_PACKAGE, "TypeConditions");
 
     private final String fullName;
     private final String packageName;
@@ -115,13 +101,13 @@ public class Annotation {
         }
 
         public Builder knownClass(Class<?> clazz) {
-            this.packageName(clazz.getPackage().getName())
-                    .name(clazz.getSimpleName());
+            this.packageName(clazz.getPackage().getName()).name(clazz.getSimpleName());
 
             if (!JavaSettings.getInstance().isBranded()) {
-                this.packageName(clazz.getPackage().getName()
-                        .replace(ExternalPackage.AZURE_CORE_PACKAGE_NAME, ExternalPackage.GENERIC_CORE_PACKAGE_NAME)
-                        .replace(ExternalPackage.AZURE_JSON_PACKAGE_NAME, ExternalPackage.GENERIC_JSON_PACKAGE_NAME));
+                this.packageName(clazz.getPackage()
+                    .getName()
+                    .replace(ExternalPackage.AZURE_CORE_PACKAGE_NAME, ExternalPackage.CLIENTCORE_PACKAGE_NAME)
+                    .replace(ExternalPackage.AZURE_JSON_PACKAGE_NAME, ExternalPackage.CLIENTCORE_JSON_PACKAGE_NAME));
             }
 
             return this;

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
@@ -140,8 +140,8 @@ public class ClassType implements IType {
                 return new ClassType.Builder(false).knownClass(CLASS_TYPE_MAPPING.get(classKey).getGenericClass());
             } else {
                 return new Builder(false).packageName(classKey.getPackage().getName()
-                        .replace(ExternalPackage.AZURE_CORE_PACKAGE_NAME, ExternalPackage.GENERIC_CORE_PACKAGE_NAME)
-                        .replace(ExternalPackage.AZURE_JSON_PACKAGE_NAME, ExternalPackage.GENERIC_JSON_PACKAGE_NAME))
+                        .replace(ExternalPackage.AZURE_CORE_PACKAGE_NAME, ExternalPackage.CLIENTCORE_PACKAGE_NAME)
+                        .replace(ExternalPackage.AZURE_JSON_PACKAGE_NAME, ExternalPackage.CLIENTCORE_JSON_PACKAGE_NAME))
                         .name(classKey.getSimpleName());
             }
         } else {

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModel.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModel.java
@@ -152,7 +152,6 @@ public class ClientModel {
      * @param implementationDetails The implementation details for the model.
      * @param usedInXml Whether the model is used in XML serialization.
      * @param crossLanguageDefinitionId The cross language definition id for the model.
-     *
      */
     protected ClientModel(String packageKeyword, String name, List<String> imports, String description,
         boolean isPolymorphic, ClientModelProperty polymorphicDiscriminator, String polymorphicDiscriminatorName,
@@ -476,8 +475,8 @@ public class ClientModel {
      */
     protected void addImmutableAnnotationImport(Set<String> imports) {
         Annotation.IMMUTABLE.addImportsTo(imports);
-        Annotation.TYPE_CONDITIONS.addImportsTo(imports);
         if (!JavaSettings.getInstance().isBranded()) {
+            Annotation.TYPE_CONDITIONS.addImportsTo(imports);
             Annotation.METADATA.addImportsTo(imports);
         }
     }
@@ -489,7 +488,7 @@ public class ClientModel {
      */
     protected void addFluentAnnotationImport(Set<String> imports) {
         Annotation.FLUENT.addImportsTo(imports);
-        if(!JavaSettings.getInstance().isBranded()) {
+        if (!JavaSettings.getInstance().isBranded()) {
             Annotation.METADATA.addImportsTo(imports);
         }
     }

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ExternalPackage.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ExternalPackage.java
@@ -7,24 +7,21 @@ import com.azure.autorest.extension.base.plugin.JavaSettings;
 
 public class ExternalPackage {
 
-    public static final String GENERIC_CORE_PACKAGE_NAME = "io.clientcore.core";
-    public static final String GENERIC_JSON_PACKAGE_NAME = "io.clientcore.core.json";
+    public static final String CLIENTCORE_PACKAGE_NAME = "io.clientcore.core";
+    public static final String CLIENTCORE_JSON_PACKAGE_NAME = "io.clientcore.core.json";
 
     public static final String AZURE_CORE_PACKAGE_NAME = "com.azure.core";
     public static final String AZURE_JSON_PACKAGE_NAME = "com.azure.json";
 
+    public static final ExternalPackage CORE = new Builder().packageName(CLIENTCORE_PACKAGE_NAME)
+        .groupId("io.clientcore")
+        .artifactId("core")
+        .build();
 
-    public static final ExternalPackage CORE = new Builder()
-            .packageName(GENERIC_CORE_PACKAGE_NAME)
-            .groupId("io.clientcore")
-            .artifactId("core")
-            .build();
-
-    public static final ExternalPackage JSON = new Builder()
-            .packageName(GENERIC_JSON_PACKAGE_NAME)
-            .groupId("io.clientcore")
-            .artifactId("core-json")
-            .build();
+    public static final ExternalPackage JSON = new Builder().packageName(CLIENTCORE_JSON_PACKAGE_NAME)
+        .groupId("io.clientcore")
+        .artifactId("core-json")
+        .build();
 
     private final String packageName;
     private final String groupId;
@@ -74,13 +71,13 @@ public class ExternalPackage {
         public ExternalPackage build() {
             if (JavaSettings.getInstance().isBranded()) {
                 switch (packageName) {
-                    case GENERIC_CORE_PACKAGE_NAME:
+                    case CLIENTCORE_PACKAGE_NAME:
                         packageName = AZURE_CORE_PACKAGE_NAME;
                         groupId = "com.azure";
                         artifactId = "azure-core";
                         break;
 
-                    case GENERIC_JSON_PACKAGE_NAME:
+                    case CLIENTCORE_JSON_PACKAGE_NAME:
                         packageName = AZURE_JSON_PACKAGE_NAME;
                         groupId = "com.azure";
                         artifactId = "azure-json";

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/GenericType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/GenericType.java
@@ -45,7 +45,7 @@ public class GenericType implements IType {
                 packageKeyword = "io.clientcore.core.http";
             } else {
                 packageKeyword = packageKeyword
-                        .replace(ExternalPackage.AZURE_CORE_PACKAGE_NAME, ExternalPackage.GENERIC_CORE_PACKAGE_NAME);
+                        .replace(ExternalPackage.AZURE_CORE_PACKAGE_NAME, ExternalPackage.CLIENTCORE_PACKAGE_NAME);
             }
         }
 

--- a/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
+++ b/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
@@ -66,8 +66,8 @@ public class Project {
         AZURE_IDENTITY("com.azure", "azure-identity", "1.12.2"),
         AZURE_CORE_EXPERIMENTAL("com.azure", "azure-core-experimental", "1.0.0-beta.51"),
 
-        GENERIC_CORE("io.clientcore", "core", "1.0.0-beta.1"),
-        GENERIC_JSON("io.clientcore", "core-json", "1.0.0-beta.1"),
+        CLIENTCORE("io.clientcore", "core", "1.0.0-beta.1"),
+        CLIENTCORE_JSON("io.clientcore", "core-json", "1.0.0-beta.1"),
 
         // external
         JUNIT_JUPITER_API("org.junit.jupiter", "junit-jupiter-api", "5.9.3"),

--- a/javagen/src/main/java/com/azure/autorest/template/EnumTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/EnumTemplate.java
@@ -298,14 +298,16 @@ public class EnumTemplate implements IJavaTemplate<EnumType, JavaFile> {
 
     protected void addGeneratedImport(Set<String> imports) {
         if (JavaSettings.getInstance().isDataPlaneClient()) {
-            Annotation.GENERATED.addImportsTo(imports);
-            Annotation.METADATA.addImportsTo(imports);
+            if (JavaSettings.getInstance().isBranded()) {
+                Annotation.GENERATED.addImportsTo(imports);
+            } else {
+                Annotation.METADATA.addImportsTo(imports);
+            }
         }
     }
 
     protected void addGeneratedAnnotation(JavaContext classBlock) {
         if (JavaSettings.getInstance().isDataPlaneClient()) {
-
             if (JavaSettings.getInstance().isBranded()) {
                 classBlock.annotation(Annotation.GENERATED.getName());
             } else {

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -1248,8 +1248,11 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
 
     protected void addGeneratedImport(Set<String> imports) {
         if (JavaSettings.getInstance().isDataPlaneClient()) {
-            Annotation.GENERATED.addImportsTo(imports);
-            Annotation.METADATA.addImportsTo(imports);
+            if (JavaSettings.getInstance().isBranded()) {
+                Annotation.GENERATED.addImportsTo(imports);
+            } else {
+                Annotation.METADATA.addImportsTo(imports);
+            }
         }
     }
 

--- a/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
@@ -581,8 +581,11 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ClientBuilder
     }
 
     protected void addGeneratedImport(Set<String> imports) {
-        Annotation.GENERATED.addImportsTo(imports);
-        Annotation.METADATA.addImportsTo(imports);
+        if (JavaSettings.getInstance().isBranded()) {
+            Annotation.GENERATED.addImportsTo(imports);
+        } else {
+            Annotation.METADATA.addImportsTo(imports);
+        }
     }
 
     protected void addGeneratedAnnotation(JavaContext classBlock) {

--- a/javagen/src/main/java/com/azure/autorest/template/ServiceSyncClientTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceSyncClientTemplate.java
@@ -170,8 +170,11 @@ public class ServiceSyncClientTemplate implements IJavaTemplate<AsyncSyncClient,
 
   protected void addServiceClientAnnotationImport(Set<String> imports) {
     Annotation.SERVICE_CLIENT.addImportsTo(imports);
-    Annotation.GENERATED.addImportsTo(imports);
-    Annotation.METADATA.addImportsTo(imports);
+    if (JavaSettings.getInstance().isBranded()) {
+      Annotation.GENERATED.addImportsTo(imports);
+    } else {
+      Annotation.METADATA.addImportsTo(imports);
+    }
   }
 
   protected void addGeneratedAnnotation(JavaContext classBlock) {


### PR DESCRIPTION
Replace references to `generic-core` with `clientcore` as `generic-core` has been renamed to `clientcore`.