### PR TITLE
tsp, temporary use emitter option service-version-exclude-preview to enable "filter out preview if GA api-version"

### DIFF
--- a/typespec-extension/src/code-model-builder.ts
+++ b/typespec-extension/src/code-model-builder.ts
@@ -546,7 +546,11 @@ export class CodeModelBuilder {
         }
 
         codeModelClient.apiVersions = [];
-        for (const version of this.getFilteredApiVersions(this.apiVersion, versioning.getVersions())) {
+        for (const version of this.getFilteredApiVersions(
+          this.apiVersion,
+          versioning.getVersions(),
+          this.options["service-version-exclude-preview"],
+        )) {
           const apiVersion = new ApiVersion();
           apiVersion.version = version.value;
           codeModelClient.apiVersions.push(apiVersion);
@@ -645,19 +649,23 @@ export class CodeModelBuilder {
 
   /**
    * Filter api-versions for "ServiceVersion".
-   * TODO(xiaofei) pending TCGC design: https://github.com/Azure/typespec-azure/issues/746
+   * TODO(xiaofei) pending TCGC design: https://github.com/Azure/typespec-azure/issues/965
    *
    * @param pinnedApiVersion the api-version to use as filter base
    * @param versions api-versions to filter
    * @returns filtered api-versions
    */
-  private getFilteredApiVersions(pinnedApiVersion: Version | undefined, versions: Version[]): Version[] {
+  private getFilteredApiVersions(
+    pinnedApiVersion: Version | undefined,
+    versions: Version[],
+    excludePreview: boolean = false,
+  ): Version[] {
     if (!pinnedApiVersion) {
       return versions;
     }
     return versions
       .slice(0, versions.indexOf(pinnedApiVersion) + 1)
-      .filter((version) => !isStable(pinnedApiVersion) || isStable(version));
+      .filter((version) => !excludePreview || !isStable(pinnedApiVersion) || isStable(version));
   }
 
   /**

--- a/typespec-extension/src/emitter.ts
+++ b/typespec-extension/src/emitter.ts
@@ -45,6 +45,7 @@ export interface EmitterOptions {
 
   "advanced-versioning"?: boolean;
   "api-version"?: string;
+  "service-version-exclude-preview"?: boolean;
 
   "dev-options"?: DevOptions;
 }
@@ -93,8 +94,10 @@ const EmitterOptionsSchema: JSONSchemaType<EmitterOptions> = {
     "polling": { type: "object", additionalProperties: true, nullable: true },
 
     "group-etag-headers": { type: "boolean", nullable: true },
+
     "advanced-versioning": { type: "boolean", nullable: true, default: false },
     "api-version": { type: "string", nullable: true },
+    "service-version-exclude-preview": { type: "boolean", nullable: true, default: false },
 
     "dev-options": { type: "object", additionalProperties: true, nullable: true },
   },

--- a/typespec-tests/Generate.ps1
+++ b/typespec-tests/Generate.ps1
@@ -56,6 +56,8 @@ $generateScript = {
   } elseif ($tspFile -match "tsp[\\/]versioning.tsp") {
     # test generating from specific api-version
     $tspOptions += " --option ""@azure-tools/typespec-java.api-version=2022-09-01"""
+    # exclude preview from service versions
+    $tspOptions += " --option ""@azure-tools/typespec-java.service-version-exclude-preview=true"""
   } elseif ($tspFile -match "arm.tsp") {
     # for mgmt, do not generate tests due to random mock values
     $tspOptions += " --option ""@azure-tools/typespec-java.generate-tests=false"""
@@ -65,6 +67,8 @@ $generateScript = {
     $tspOptions += " --option ""@azure-tools/typespec-java.group-etag-headers=false"""
     # also test generating from specific api-version
     $tspOptions += " --option ""@azure-tools/typespec-java.api-version=2023-11-01"""
+    # exclude preview from service versions
+    $tspOptions += " --option ""@azure-tools/typespec-java.service-version-exclude-preview=true"""
   } elseif ($tspFile -match "arm-stream-style-serialization.tsp") {
     $tspOptions += " --option ""@azure-tools/typespec-java.stream-style-serialization=true"""
     # for mgmt, do not generate tests due to random mock values


### PR DESCRIPTION
Reason for this change: at present, the real case we encountered (2 of them) does not want to filter the preview api-versions.

---

No diff in test, as I added the option to cases that previously do this by default.

If not, versioning would then have

```java
public enum VersioningServiceVersion implements ServiceVersion {
    /**
     * Enum value 2022-06-01-preview.
     */
    V2022_06_01_PREVIEW("2022-06-01-preview"),

    /**
     * Enum value 2022-09-01.
     */
    V2022_09_01("2022-09-01"),

    /**
     * Enum value 2022-12-01-preview.
     */
    V2022_12_01_PREVIEW("2022-12-01-preview");
```