### PR TITLE
azure-json mgmt, fix pageable lro

### DIFF
--- a/fluent-tests/src/test/java/com/azure/mgmttest/LiteCompilationTests.java
+++ b/fluent-tests/src/test/java/com/azure/mgmttest/LiteCompilationTests.java
@@ -40,6 +40,7 @@ import com.azure.mgmtlitetest.storage.models.StorageAccountExpand;
 import com.azure.mgmtlitetest.storage.models.StorageAccountListKeysResult;
 import com.azure.mgmtlitetest.storage.models.StorageAccountRegenerateKeyParameters;
 import com.azure.mgmtlitetest.storage.models.StorageAccounts;
+import com.azure.mgmtlitetest.streamstyleserialization.implementation.CommunityGalleriesClientImpl;
 import com.azure.mgmttest.azurestack.fluent.models.ExtendedProductInner;
 import com.azure.mgmttest.education.fluent.models.LabDetailsInner;
 import reactor.core.publisher.Mono;
@@ -197,5 +198,9 @@ public class LiteCompilationTests {
         CommonPostActionResponseForStateUpdate actionResponse = mock(CommonPostActionResponseForStateUpdate.class);
         ManagementError error = actionResponse.error();
         error = actionResponse.innerModel().error();
+    }
+
+    public void testPageableLroStreamStyle() {
+        Class<CommunityGalleriesClientImpl> clazz = CommunityGalleriesClientImpl.class;
     }
 }

--- a/fluent-tests/swagger/stream-style-serialization.json
+++ b/fluent-tests/swagger/stream-style-serialization.json
@@ -29,6 +29,29 @@
             }
           }
         }
+      },
+      "/communityGalleries": {
+        "get": {
+          "tags": [
+            "CommunityGalleries"
+          ],
+          "operationId": "CommunityGalleries_List",
+          "description": "List community galleries.",
+          "parameters": [
+          ],
+          "responses": {
+            "200": {
+              "description": "OK",
+              "schema": {
+                "$ref": "#/definitions/CommunityGalleryList"
+              }
+            },
+            "202": {
+              "description": "Accepted and the operation will complete asynchronously."
+            }
+          },
+          "x-ms-long-running-operation": true
+        }
       }
     },
     "definitions": {
@@ -93,6 +116,18 @@
           }
         },
         "description": "Describes the properties of a community gallery."
+      },
+      "CommunityGalleryList": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PirCommunityGalleryResource"
+          },
+          "x-ms-identifiers": [],
+          "description": "List of peer routes."
+        },
+        "description": "Map from id to community gallery list."
       }
     },
   "parameters": {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentClientMethodTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentClientMethodTemplate.java
@@ -270,7 +270,14 @@ public class FluentClientMethodTemplate extends ClientMethodTemplate {
             }
             function.line("%s mono = %s(%s);", clientMethod.getProxyMethod().getReturnType().toString(), clientMethod.getProxyMethod().getSimpleAsyncRestResponseMethodName(), clientMethod.getArgumentList());
             if (classType instanceof GenericType) {
-                function.line("return %s.<%s, %s>getLroResult(mono, %s.getHttpPipeline(), new TypeReference<%s>() {}.getType(), new TypeReference<%s>() {}.getType(), %s);", clientMethod.getClientReference(), classType.toString(), classType.toString(), clientMethod.getClientReference(), classType.toString(), classType.toString(), contextParam);
+                // pageable LRO
+                String typeReferenceGetType;
+                if (settings.isStreamStyleSerialization()) {
+                    typeReferenceGetType = "getJavaType";
+                } else {
+                    typeReferenceGetType = "getType";
+                }
+                function.line("return %1$s.<%2$s, %2$s>getLroResult(mono, %1$s.getHttpPipeline(), new TypeReference<%2$s>() {}.%3$s(), new TypeReference<%2$s>() {}.%3$s(), %4$s);", clientMethod.getClientReference(), classType.toString(), typeReferenceGetType, contextParam);
             } else {
                 function.line("return %s.<%s, %s>getLroResult(mono, %s.getHttpPipeline(), %s.class, %s.class, %s);", clientMethod.getClientReference(), classType.toString(), classType.toString(), clientMethod.getClientReference(), classType.toString(), classType.toString(), contextParam);
             }

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientMethod.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientMethod.java
@@ -445,7 +445,12 @@ public class ClientMethod {
                     if (((GenericType) this.getReturnValue()
                         .getType()
                         .getClientType()).getTypeArguments()[0] instanceof GenericType) {
-                        imports.add("com.fasterxml.jackson.core.type.TypeReference");
+                        // pageable LRO
+                        if (settings.isStreamStyleSerialization()) {
+                            imports.add(TypeReference.class.getName());
+                        } else {
+                            imports.add("com.fasterxml.jackson.core.type.TypeReference");
+                        }
                     }
                 } else {
                     imports.add(TypeReference.class.getName());


### PR DESCRIPTION
Switch `TypeReference` from that of Jackson to that of azure-json.
`getType` in Jackson is now `getJavaType` in azure-json.
generated code is like:
```java
private PollerFlux<PollResult<Map<String, List<PirCommunityGalleryResource>>>, Map<String, List<PirCommunityGalleryResource>>>
    beginListAsync() {
    Mono<Response<Flux<ByteBuffer>>> mono = listWithResponseAsync();
    return this.client
        .<Map<String, List<PirCommunityGalleryResource>>, Map<String, List<PirCommunityGalleryResource>>>getLroResult(
            mono, this.client.getHttpPipeline(),
            new TypeReference<Map<String, List<PirCommunityGalleryResource>>>() {
            }.getJavaType(), new TypeReference<Map<String, List<PirCommunityGalleryResource>>>() {
            }.getJavaType(), this.client.getContext());
}
```