### PR TITLE
eng, ignore warning of deprecation on typescript in nightly build

### DIFF
--- a/eng/pipelines/ci-typespec-java-dev-nightly.yaml
+++ b/eng/pipelines/ci-typespec-java-dev-nightly.yaml
@@ -56,6 +56,13 @@ jobs:
         displayName: 'Install dev TypeSpec Dependencies'
         workingDirectory: ./typespec-extension
 
+      - script: |
+          $file = '.eslintrc.cjs'
+          $regex = '(?<="deprecation/deprecation": ")[^"]*'
+          (Get-Content $file) -replace $regex, 'off' | Set-Content $file
+        displayName: 'Disable warn on deprecation'
+        workingDirectory: ./typespec-extension
+
       - task: PowerShell@2
         retryCountOnTaskFailure: 1
         displayName: 'Generate Code'


### PR DESCRIPTION
dev release of typespec may deprecate some of their APIs.

We would avoid lint on this, to make the nightly build pass.

the pass job https://dev.azure.com/azure-sdk/public/_build/results?buildId=4035068&view=results