### PR TITLE
fix, mgmt shadow properties from Resource/ProxyResource

### DIFF
--- a/fluent-tests/Initialize-Tests.ps1
+++ b/fluent-tests/Initialize-Tests.ps1
@@ -111,6 +111,9 @@ $job = @(
     # ErrorDetails shared in exception and output
     "--version=$AUTOREST_CORE_VERSION $FLUENT_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/8fa9b5051129dd4808c9be1f5b753af226b044db/specification/iothub/resource-manager/Microsoft.Devices/stable/2023-06-30/iothub.json --namespace=com.azure.mgmttest.iothub",
 
+    # resource with writable name
+    "--version=$AUTOREST_CORE_VERSION $FLUENT_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/2548fe40102c9b5aa27a75a126c8367f55cb9e7d/specification/sql/resource-manager/Microsoft.Sql/stable/2021-11-01/FirewallRules.json --java.namespace=com.azure.mgmttest.resourcewithwritablename"
+
     # fluent lite
     "--version=$AUTOREST_CORE_VERSION $FLUENTLITE_ARGUMENTS --pom-file=pom_generated_resources.xml https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/resources/resource-manager/readme.md --tag=package-resources-2021-01 --java.namespace=com.azure.mgmtlitetest.resources",
     "--version=$AUTOREST_CORE_VERSION $FLUENTLITE_ARGUMENTS --regenerate-pom=false https://raw.githubusercontent.com/Azure/azure-rest-api-specs/da0cfefaa0e6c237e1e3819f1cb2e11d7606878d/specification/storage/resource-manager/readme.md --tag=package-2021-01 --java.namespace=com.azure.mgmtlitetest.storage",

--- a/fluent-tests/src/test/java/com/azure/mgmttest/CompilationTests.java
+++ b/fluent-tests/src/test/java/com/azure/mgmttest/CompilationTests.java
@@ -31,6 +31,7 @@ import com.azure.mgmttest.resources.fluent.DeploymentsClient;
 import com.azure.mgmttest.resources.fluent.models.DeploymentExtendedInner;
 import com.azure.mgmttest.resources.fluent.models.ResourceGroupInner;
 import com.azure.mgmttest.resources.models.IdentityUserAssignedIdentities;
+import com.azure.mgmttest.resourcewithwritablename.fluent.models.FirewallRuleInner;
 import com.azure.mgmttest.storage.fluent.StorageAccountsClient;
 import com.azure.mgmttest.storage.fluent.models.StorageAccountInner;
 import com.azure.mgmttest.trafficmanager.fluent.models.EndpointInner;
@@ -169,5 +170,9 @@ public class CompilationTests {
 
     public void testSchemaCleanup() {
         UserAssignedIdentity userAssignedIdentity = new UserAssignedIdentity();
+    }
+
+    public void testResourceWithWritableName() {
+        FirewallRuleInner firewallRuleInner = new FirewallRuleInner();
     }
 }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentStreamStyleSerializationModelTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentStreamStyleSerializationModelTemplate.java
@@ -8,8 +8,11 @@ import com.azure.autorest.fluent.model.arm.ErrorClientModel;
 import com.azure.autorest.fluent.util.FluentUtils;
 import com.azure.autorest.model.clientmodel.ClientModel;
 import com.azure.autorest.model.clientmodel.ClientModelProperty;
+import com.azure.autorest.model.clientmodel.ClientModelPropertyReference;
 import com.azure.autorest.template.StreamSerializationModelTemplate;
 import com.azure.core.util.CoreUtils;
+
+import java.util.List;
 
 public class FluentStreamStyleSerializationModelTemplate extends StreamSerializationModelTemplate {
     private static final FluentModelTemplate FLUENT_MODEL_TEMPLATE = FluentModelTemplate.getInstance();
@@ -44,5 +47,10 @@ public class FluentStreamStyleSerializationModelTemplate extends StreamSerializa
             parentModelName = parentModel.getParentModelName();
         }
         return manageErrorParent;
+    }
+
+    @Override
+    protected List<ClientModelPropertyReference> getClientModelPropertyReferences(ClientModel model) {
+        return FLUENT_MODEL_TEMPLATE.getClientModelPropertyReferences(model);
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -436,7 +436,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
      */
     protected List<ClientModelPropertyAccess> getSuperSetters(ClientModel model, JavaSettings settings,
                                                               List<ClientModelPropertyReference> propertyReferences) {
-        Set<String> modelPropertyNames = getFieldProperties(model, settings).stream().map(ClientModelProperty::getName)
+        Set<String> modelPropertyNames = model.getProperties().stream().map(ClientModelProperty::getName)
             .collect(Collectors.toSet());
         return propertyReferences.stream()
             .filter(ClientModelPropertyReference::isFromParentModel)

--- a/javagen/src/main/java/com/azure/autorest/util/ClientModelUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/ClientModelUtil.java
@@ -481,6 +481,17 @@ public class ClientModelUtil {
      * @return Returns all properties that are defined by super types of the client model.
      */
     public static List<ClientModelProperty> getParentProperties(ClientModel model) {
+        return getParentProperties(model, true);
+    }
+
+    /**
+     * Gets all parent properties.
+     *
+     * @param model The client model.
+     * @param parentPropertiesFirst whether parent properties are in the front of the return list
+     * @return Returns all properties that are defined by super types of the client model.
+     */
+    public static List<ClientModelProperty> getParentProperties(ClientModel model, boolean parentPropertiesFirst) {
         String lastParentName = model.getName();
         ClientModel parentModel = getClientModel(model.getParentModelName());
         List<ClientModelProperty> parentProperties = new ArrayList<>();
@@ -494,7 +505,9 @@ public class ClientModelUtil {
             lastParentName = parentModel.getName();
             parentModel = getClientModel(parentModel.getParentModelName());
         }
-        Collections.reverse(parentProperties);
+        if (parentPropertiesFirst) {
+            Collections.reverse(parentProperties);
+        }
         return parentProperties;
     }
 

--- a/typespec-tests/src/main/java/com/azure/resourcemanager/models/commontypes/managedidentity/fluent/models/ManagedIdentityTrackedResourceInner.java
+++ b/typespec-tests/src/main/java/com/azure/resourcemanager/models/commontypes/managedidentity/fluent/models/ManagedIdentityTrackedResourceInner.java
@@ -37,9 +37,9 @@ public final class ManagedIdentityTrackedResourceInner extends Resource {
     private SystemData systemData;
 
     /*
-     * Fully qualified resource Id for the resource.
+     * The type of the resource.
      */
-    private String id;
+    private String type;
 
     /*
      * The name of the resource.
@@ -47,9 +47,9 @@ public final class ManagedIdentityTrackedResourceInner extends Resource {
     private String name;
 
     /*
-     * The type of the resource.
+     * Fully qualified resource Id for the resource.
      */
-    private String type;
+    private String id;
 
     /**
      * Creates an instance of ManagedIdentityTrackedResourceInner class.
@@ -107,13 +107,13 @@ public final class ManagedIdentityTrackedResourceInner extends Resource {
     }
 
     /**
-     * Get the id property: Fully qualified resource Id for the resource.
+     * Get the type property: The type of the resource.
      * 
-     * @return the id value.
+     * @return the type value.
      */
     @Override
-    public String id() {
-        return this.id;
+    public String type() {
+        return this.type;
     }
 
     /**
@@ -127,13 +127,13 @@ public final class ManagedIdentityTrackedResourceInner extends Resource {
     }
 
     /**
-     * Get the type property: The type of the resource.
+     * Get the id property: Fully qualified resource Id for the resource.
      * 
-     * @return the type value.
+     * @return the id value.
      */
     @Override
-    public String type() {
-        return this.type;
+    public String id() {
+        return this.id;
     }
 
     /**

--- a/typespec-tests/src/main/java/com/azure/resourcemanager/models/resources/fluent/models/NestedProxyResourceInner.java
+++ b/typespec-tests/src/main/java/com/azure/resourcemanager/models/resources/fluent/models/NestedProxyResourceInner.java
@@ -29,9 +29,9 @@ public final class NestedProxyResourceInner extends ProxyResource {
     private SystemData systemData;
 
     /*
-     * Fully qualified resource Id for the resource.
+     * The type of the resource.
      */
-    private String id;
+    private String type;
 
     /*
      * The name of the resource.
@@ -39,9 +39,9 @@ public final class NestedProxyResourceInner extends ProxyResource {
     private String name;
 
     /*
-     * The type of the resource.
+     * Fully qualified resource Id for the resource.
      */
-    private String type;
+    private String id;
 
     /**
      * Creates an instance of NestedProxyResourceInner class.
@@ -79,13 +79,13 @@ public final class NestedProxyResourceInner extends ProxyResource {
     }
 
     /**
-     * Get the id property: Fully qualified resource Id for the resource.
+     * Get the type property: The type of the resource.
      * 
-     * @return the id value.
+     * @return the type value.
      */
     @Override
-    public String id() {
-        return this.id;
+    public String type() {
+        return this.type;
     }
 
     /**
@@ -99,13 +99,13 @@ public final class NestedProxyResourceInner extends ProxyResource {
     }
 
     /**
-     * Get the type property: The type of the resource.
+     * Get the id property: Fully qualified resource Id for the resource.
      * 
-     * @return the type value.
+     * @return the id value.
      */
     @Override
-    public String type() {
-        return this.type;
+    public String id() {
+        return this.id;
     }
 
     /**

--- a/typespec-tests/src/main/java/com/azure/resourcemanager/models/resources/fluent/models/TopLevelTrackedResourceInner.java
+++ b/typespec-tests/src/main/java/com/azure/resourcemanager/models/resources/fluent/models/TopLevelTrackedResourceInner.java
@@ -31,9 +31,9 @@ public final class TopLevelTrackedResourceInner extends Resource {
     private SystemData systemData;
 
     /*
-     * Fully qualified resource Id for the resource.
+     * The type of the resource.
      */
-    private String id;
+    private String type;
 
     /*
      * The name of the resource.
@@ -41,9 +41,9 @@ public final class TopLevelTrackedResourceInner extends Resource {
     private String name;
 
     /*
-     * The type of the resource.
+     * Fully qualified resource Id for the resource.
      */
-    private String type;
+    private String id;
 
     /**
      * Creates an instance of TopLevelTrackedResourceInner class.
@@ -81,13 +81,13 @@ public final class TopLevelTrackedResourceInner extends Resource {
     }
 
     /**
-     * Get the id property: Fully qualified resource Id for the resource.
+     * Get the type property: The type of the resource.
      * 
-     * @return the id value.
+     * @return the type value.
      */
     @Override
-    public String id() {
-        return this.id;
+    public String type() {
+        return this.type;
     }
 
     /**
@@ -101,13 +101,13 @@ public final class TopLevelTrackedResourceInner extends Resource {
     }
 
     /**
-     * Get the type property: The type of the resource.
+     * Get the id property: Fully qualified resource Id for the resource.
      * 
-     * @return the type value.
+     * @return the id value.
      */
     @Override
-    public String type() {
-        return this.type;
+    public String id() {
+        return this.id;
     }
 
     /**

--- a/typespec-tests/src/main/java/com/cadl/armstreamstyleserialization/fluent/models/SalmonInner.java
+++ b/typespec-tests/src/main/java/com/cadl/armstreamstyleserialization/fluent/models/SalmonInner.java
@@ -40,9 +40,9 @@ public final class SalmonInner extends FishInner {
     private FishInner partner;
 
     /*
-     * The dna property.
+     * The anotherProperties property.
      */
-    private String dna;
+    private AnotherFishProperties innerAnotherProperties = new AnotherFishProperties();
 
     /*
      * The properties property.
@@ -50,9 +50,9 @@ public final class SalmonInner extends FishInner {
     private FishProperties innerProperties = new FishProperties();
 
     /*
-     * The anotherProperties property.
+     * The dna property.
      */
-    private AnotherFishProperties innerAnotherProperties = new AnotherFishProperties();
+    private String dna;
 
     /**
      * Creates an instance of SalmonInner class.
@@ -131,13 +131,12 @@ public final class SalmonInner extends FishInner {
     }
 
     /**
-     * Get the dna property: The dna property.
+     * Get the innerAnotherProperties property: The anotherProperties property.
      * 
-     * @return the dna value.
+     * @return the innerAnotherProperties value.
      */
-    @Override
-    public String dna() {
-        return this.dna;
+    private AnotherFishProperties innerAnotherProperties() {
+        return this.innerAnotherProperties;
     }
 
     /**
@@ -150,12 +149,13 @@ public final class SalmonInner extends FishInner {
     }
 
     /**
-     * Get the innerAnotherProperties property: The anotherProperties property.
+     * Get the dna property: The dna property.
      * 
-     * @return the innerAnotherProperties value.
+     * @return the dna value.
      */
-    private AnotherFishProperties innerAnotherProperties() {
-        return this.innerAnotherProperties;
+    @Override
+    public String dna() {
+        return this.dna;
     }
 
     /**

--- a/typespec-tests/src/main/java/com/cadl/armstreamstyleserialization/fluent/models/TopLevelArmResourceInner.java
+++ b/typespec-tests/src/main/java/com/cadl/armstreamstyleserialization/fluent/models/TopLevelArmResourceInner.java
@@ -31,9 +31,9 @@ public final class TopLevelArmResourceInner extends Resource {
     private SystemData systemData;
 
     /*
-     * Fully qualified resource Id for the resource.
+     * The type of the resource.
      */
-    private String id;
+    private String type;
 
     /*
      * The name of the resource.
@@ -41,9 +41,9 @@ public final class TopLevelArmResourceInner extends Resource {
     private String name;
 
     /*
-     * The type of the resource.
+     * Fully qualified resource Id for the resource.
      */
-    private String type;
+    private String id;
 
     /**
      * Creates an instance of TopLevelArmResourceInner class.
@@ -70,13 +70,13 @@ public final class TopLevelArmResourceInner extends Resource {
     }
 
     /**
-     * Get the id property: Fully qualified resource Id for the resource.
+     * Get the type property: The type of the resource.
      * 
-     * @return the id value.
+     * @return the type value.
      */
     @Override
-    public String id() {
-        return this.id;
+    public String type() {
+        return this.type;
     }
 
     /**
@@ -90,13 +90,13 @@ public final class TopLevelArmResourceInner extends Resource {
     }
 
     /**
-     * Get the type property: The type of the resource.
+     * Get the id property: Fully qualified resource Id for the resource.
      * 
-     * @return the type value.
+     * @return the id value.
      */
     @Override
-    public String type() {
-        return this.type;
+    public String id() {
+        return this.id;
     }
 
     /**

--- a/typespec-tests/src/main/java/com/cadl/armstreamstyleserialization/models/Error.java
+++ b/typespec-tests/src/main/java/com/cadl/armstreamstyleserialization/models/Error.java
@@ -29,14 +29,9 @@ public final class Error extends ManagementError {
     private String additionalProperty;
 
     /*
-     * The error code parsed from the body of the http error response.
+     * Additional info for the error.
      */
-    private String code;
-
-    /*
-     * The error message parsed from the body of the http error response.
-     */
-    private String message;
+    private List<AdditionalInfo> additionalInfo;
 
     /*
      * The target of the error.
@@ -44,9 +39,14 @@ public final class Error extends ManagementError {
     private String target;
 
     /*
-     * Additional info for the error.
+     * The error message parsed from the body of the http error response.
      */
-    private List<AdditionalInfo> additionalInfo;
+    private String message;
+
+    /*
+     * The error code parsed from the body of the http error response.
+     */
+    private String code;
 
     /**
      * Creates an instance of Error class.
@@ -74,23 +74,13 @@ public final class Error extends ManagementError {
     }
 
     /**
-     * Get the code property: The error code parsed from the body of the http error response.
+     * Get the additionalInfo property: Additional info for the error.
      * 
-     * @return the code value.
+     * @return the additionalInfo value.
      */
     @Override
-    public String getCode() {
-        return this.code;
-    }
-
-    /**
-     * Get the message property: The error message parsed from the body of the http error response.
-     * 
-     * @return the message value.
-     */
-    @Override
-    public String getMessage() {
-        return this.message;
+    public List<AdditionalInfo> getAdditionalInfo() {
+        return this.additionalInfo;
     }
 
     /**
@@ -104,13 +94,23 @@ public final class Error extends ManagementError {
     }
 
     /**
-     * Get the additionalInfo property: Additional info for the error.
+     * Get the message property: The error message parsed from the body of the http error response.
      * 
-     * @return the additionalInfo value.
+     * @return the message value.
      */
     @Override
-    public List<AdditionalInfo> getAdditionalInfo() {
-        return this.additionalInfo;
+    public String getMessage() {
+        return this.message;
+    }
+
+    /**
+     * Get the code property: The error code parsed from the body of the http error response.
+     * 
+     * @return the code value.
+     */
+    @Override
+    public String getCode() {
+        return this.code;
     }
 
     /**

--- a/typespec-tests/src/main/java/com/cadl/armstreamstyleserialization/models/ErrorMin.java
+++ b/typespec-tests/src/main/java/com/cadl/armstreamstyleserialization/models/ErrorMin.java
@@ -24,19 +24,9 @@ public final class ErrorMin extends ManagementError {
     private String additionalProperty;
 
     /*
-     * The error code parsed from the body of the http error response.
+     * Additional info for the error.
      */
-    private String code;
-
-    /*
-     * The error message parsed from the body of the http error response.
-     */
-    private String message;
-
-    /*
-     * The target of the error.
-     */
-    private String target;
+    private List<AdditionalInfo> additionalInfo;
 
     /*
      * Details for the error.
@@ -44,9 +34,19 @@ public final class ErrorMin extends ManagementError {
     private List<ManagementError> details;
 
     /*
-     * Additional info for the error.
+     * The target of the error.
      */
-    private List<AdditionalInfo> additionalInfo;
+    private String target;
+
+    /*
+     * The error message parsed from the body of the http error response.
+     */
+    private String message;
+
+    /*
+     * The error code parsed from the body of the http error response.
+     */
+    private String code;
 
     /**
      * Creates an instance of ErrorMin class.
@@ -64,33 +64,13 @@ public final class ErrorMin extends ManagementError {
     }
 
     /**
-     * Get the code property: The error code parsed from the body of the http error response.
+     * Get the additionalInfo property: Additional info for the error.
      * 
-     * @return the code value.
+     * @return the additionalInfo value.
      */
     @Override
-    public String getCode() {
-        return this.code;
-    }
-
-    /**
-     * Get the message property: The error message parsed from the body of the http error response.
-     * 
-     * @return the message value.
-     */
-    @Override
-    public String getMessage() {
-        return this.message;
-    }
-
-    /**
-     * Get the target property: The target of the error.
-     * 
-     * @return the target value.
-     */
-    @Override
-    public String getTarget() {
-        return this.target;
+    public List<AdditionalInfo> getAdditionalInfo() {
+        return this.additionalInfo;
     }
 
     /**
@@ -104,13 +84,33 @@ public final class ErrorMin extends ManagementError {
     }
 
     /**
-     * Get the additionalInfo property: Additional info for the error.
+     * Get the target property: The target of the error.
      * 
-     * @return the additionalInfo value.
+     * @return the target value.
      */
     @Override
-    public List<AdditionalInfo> getAdditionalInfo() {
-        return this.additionalInfo;
+    public String getTarget() {
+        return this.target;
+    }
+
+    /**
+     * Get the message property: The error message parsed from the body of the http error response.
+     * 
+     * @return the message value.
+     */
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+
+    /**
+     * Get the code property: The error code parsed from the body of the http error response.
+     * 
+     * @return the code value.
+     */
+    @Override
+    public String getCode() {
+        return this.code;
     }
 
     /**

--- a/typespec-tests/src/main/java/com/cadl/armstreamstyleserialization/models/GoblinShark.java
+++ b/typespec-tests/src/main/java/com/cadl/armstreamstyleserialization/models/GoblinShark.java
@@ -29,9 +29,9 @@ public final class GoblinShark extends Shark {
     private String sharktype = "goblin";
 
     /*
-     * The dna property.
+     * The anotherProperties property.
      */
-    private String dna;
+    private AnotherFishProperties innerAnotherProperties = new AnotherFishProperties();
 
     /*
      * The properties property.
@@ -39,9 +39,9 @@ public final class GoblinShark extends Shark {
     private FishProperties innerProperties = new FishProperties();
 
     /*
-     * The anotherProperties property.
+     * The dna property.
      */
-    private AnotherFishProperties innerAnotherProperties = new AnotherFishProperties();
+    private String dna;
 
     /**
      * Creates an instance of GoblinShark class.
@@ -70,13 +70,12 @@ public final class GoblinShark extends Shark {
     }
 
     /**
-     * Get the dna property: The dna property.
+     * Get the innerAnotherProperties property: The anotherProperties property.
      * 
-     * @return the dna value.
+     * @return the innerAnotherProperties value.
      */
-    @Override
-    public String dna() {
-        return this.dna;
+    private AnotherFishProperties innerAnotherProperties() {
+        return this.innerAnotherProperties;
     }
 
     /**
@@ -89,12 +88,13 @@ public final class GoblinShark extends Shark {
     }
 
     /**
-     * Get the innerAnotherProperties property: The anotherProperties property.
+     * Get the dna property: The dna property.
      * 
-     * @return the innerAnotherProperties value.
+     * @return the dna value.
      */
-    private AnotherFishProperties innerAnotherProperties() {
-        return this.innerAnotherProperties;
+    @Override
+    public String dna() {
+        return this.dna;
     }
 
     /**

--- a/typespec-tests/src/main/java/com/cadl/armstreamstyleserialization/models/OutputOnlyModelChild.java
+++ b/typespec-tests/src/main/java/com/cadl/armstreamstyleserialization/models/OutputOnlyModelChild.java
@@ -29,9 +29,9 @@ public final class OutputOnlyModelChild extends OutputOnlyModelInner {
     private String childName;
 
     /*
-     * The name property.
+     * The properties property.
      */
-    private String name;
+    private OutputOnlyModelProperties innerProperties;
 
     /*
      * The id property.
@@ -39,9 +39,9 @@ public final class OutputOnlyModelChild extends OutputOnlyModelInner {
     private String id;
 
     /*
-     * The properties property.
+     * The name property.
      */
-    private OutputOnlyModelProperties innerProperties;
+    private String name;
 
     /**
      * Creates an instance of OutputOnlyModelChild class.
@@ -69,13 +69,12 @@ public final class OutputOnlyModelChild extends OutputOnlyModelInner {
     }
 
     /**
-     * Get the name property: The name property.
+     * Get the innerProperties property: The properties property.
      * 
-     * @return the name value.
+     * @return the innerProperties value.
      */
-    @Override
-    public String name() {
-        return this.name;
+    private OutputOnlyModelProperties innerProperties() {
+        return this.innerProperties;
     }
 
     /**
@@ -89,12 +88,13 @@ public final class OutputOnlyModelChild extends OutputOnlyModelInner {
     }
 
     /**
-     * Get the innerProperties property: The properties property.
+     * Get the name property: The name property.
      * 
-     * @return the innerProperties value.
+     * @return the name value.
      */
-    private OutputOnlyModelProperties innerProperties() {
-        return this.innerProperties;
+    @Override
+    public String name() {
+        return this.name;
     }
 
     /**

--- a/typespec-tests/src/main/java/com/cadl/armstreamstyleserialization/models/SawShark.java
+++ b/typespec-tests/src/main/java/com/cadl/armstreamstyleserialization/models/SawShark.java
@@ -39,14 +39,14 @@ public final class SawShark extends Shark {
     private int age;
 
     /*
-     * The properties property.
-     */
-    private FishProperties innerProperties = new FishProperties();
-
-    /*
      * The anotherProperties property.
      */
     private AnotherFishProperties innerAnotherProperties = new AnotherFishProperties();
+
+    /*
+     * The properties property.
+     */
+    private FishProperties innerProperties = new FishProperties();
 
     /**
      * Creates an instance of SawShark class.
@@ -115,21 +115,21 @@ public final class SawShark extends Shark {
     }
 
     /**
-     * Get the innerProperties property: The properties property.
-     * 
-     * @return the innerProperties value.
-     */
-    private FishProperties innerProperties() {
-        return this.innerProperties;
-    }
-
-    /**
      * Get the innerAnotherProperties property: The anotherProperties property.
      * 
      * @return the innerAnotherProperties value.
      */
     private AnotherFishProperties innerAnotherProperties() {
         return this.innerAnotherProperties;
+    }
+
+    /**
+     * Get the innerProperties property: The properties property.
+     * 
+     * @return the innerProperties value.
+     */
+    private FishProperties innerProperties() {
+        return this.innerProperties;
     }
 
     /**

--- a/typespec-tests/src/main/java/com/cadl/armstreamstyleserialization/models/Shark.java
+++ b/typespec-tests/src/main/java/com/cadl/armstreamstyleserialization/models/Shark.java
@@ -30,9 +30,9 @@ public class Shark extends FishInner {
     private String sharktype = "shark";
 
     /*
-     * The dna property.
+     * The anotherProperties property.
      */
-    private String dna;
+    private AnotherFishProperties innerAnotherProperties = new AnotherFishProperties();
 
     /*
      * The properties property.
@@ -40,9 +40,9 @@ public class Shark extends FishInner {
     private FishProperties innerProperties = new FishProperties();
 
     /*
-     * The anotherProperties property.
+     * The dna property.
      */
-    private AnotherFishProperties innerAnotherProperties = new AnotherFishProperties();
+    private String dna;
 
     /**
      * Creates an instance of Shark class.
@@ -70,13 +70,12 @@ public class Shark extends FishInner {
     }
 
     /**
-     * Get the dna property: The dna property.
+     * Get the innerAnotherProperties property: The anotherProperties property.
      * 
-     * @return the dna value.
+     * @return the innerAnotherProperties value.
      */
-    @Override
-    public String dna() {
-        return this.dna;
+    private AnotherFishProperties innerAnotherProperties() {
+        return this.innerAnotherProperties;
     }
 
     /**
@@ -89,12 +88,13 @@ public class Shark extends FishInner {
     }
 
     /**
-     * Get the innerAnotherProperties property: The anotherProperties property.
+     * Get the dna property: The dna property.
      * 
-     * @return the innerAnotherProperties value.
+     * @return the dna value.
      */
-    private AnotherFishProperties innerAnotherProperties() {
-        return this.innerAnotherProperties;
+    @Override
+    public String dna() {
+        return this.dna;
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/modelflattening/models/FlattenedProduct.java
+++ b/vanilla-tests/src/main/java/fixtures/modelflattening/models/FlattenedProduct.java
@@ -37,9 +37,9 @@ public class FlattenedProduct extends Resource {
     private String provisioningState;
 
     /*
-     * Resource Id
+     * Resource Name
      */
-    private String id;
+    private String name;
 
     /*
      * Resource Type
@@ -47,9 +47,9 @@ public class FlattenedProduct extends Resource {
     private String type;
 
     /*
-     * Resource Name
+     * Resource Id
      */
-    private String name;
+    private String id;
 
     /**
      * Creates an instance of FlattenedProduct class.
@@ -127,13 +127,13 @@ public class FlattenedProduct extends Resource {
     }
 
     /**
-     * Get the id property: Resource Id.
+     * Get the name property: Resource Name.
      * 
-     * @return the id value.
+     * @return the name value.
      */
     @Override
-    public String getId() {
-        return this.id;
+    public String getName() {
+        return this.name;
     }
 
     /**
@@ -147,13 +147,13 @@ public class FlattenedProduct extends Resource {
     }
 
     /**
-     * Get the name property: Resource Name.
+     * Get the id property: Resource Id.
      * 
-     * @return the name value.
+     * @return the id value.
      */
     @Override
-    public String getName() {
-        return this.name;
+    public String getId() {
+        return this.id;
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/MyDerivedType.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/MyDerivedType.java
@@ -26,14 +26,14 @@ public final class MyDerivedType extends MyBaseType {
     private String propD1;
 
     /*
-     * The propB1 property.
-     */
-    private String propB1;
-
-    /*
      * The propBH1 property.
      */
     private String propBH1;
+
+    /*
+     * The propB1 property.
+     */
+    private String propB1;
 
     /**
      * Creates an instance of MyDerivedType class.
@@ -61,16 +61,6 @@ public final class MyDerivedType extends MyBaseType {
     }
 
     /**
-     * Get the propB1 property: The propB1 property.
-     * 
-     * @return the propB1 value.
-     */
-    @Override
-    public String getPropB1() {
-        return this.propB1;
-    }
-
-    /**
      * Get the propBH1 property: The propBH1 property.
      * 
      * @return the propBH1 value.
@@ -78,6 +68,16 @@ public final class MyDerivedType extends MyBaseType {
     @Override
     public String getPropBH1() {
         return this.propBH1;
+    }
+
+    /**
+     * Get the propB1 property: The propB1 property.
+     * 
+     * @return the propB1 value.
+     */
+    @Override
+    public String getPropB1() {
+        return this.propB1;
     }
 
     /**


### PR DESCRIPTION
The shadow property is in the middle of the inheritance hierarchy. In this case, "ResourceWithWritableName", since it has parent class `ProxyResource`.

Previously, we only check if property is shadowed in the leaf subclass. 
Now, we check if property is shadowed in the inheritance hierarchy, and use the one that's closest to the leaf.

code: 9149f75adc80f837b97267c7eebdc791ebdc917d

generated code diffs are reordering of the shadowed properties(a side effect of the fix logic). Now properties from subclass will come before the ones from parent class. 

```json
"ResourceWithWritableName": {
  "description": "ARM resource.",
  "type": "object",
  "properties": {
    "id": {
      "description": "Resource ID.",
      "type": "string",
      "readOnly": true
    },
    "name": {
      "description": "Resource name.",
      "type": "string"
    },
    "type": {
      "description": "Resource type.",
      "type": "string",
      "readOnly": true
    }
  },
  "x-ms-azure-resource": true
},
"ProxyResourceWithWritableName": {
  "description": "ARM proxy resource.",
  "type": "object",
  "allOf": [
    {
      "$ref": "#/definitions/ResourceWithWritableName"
    }
  ],
  "properties": {}
},
"FirewallRule": {
  "description": "A server firewall rule.",
  "type": "object",
  "allOf": [
    {
      "$ref": "#/definitions/ProxyResourceWithWritableName"
    }
  ],
  "properties": {
    "properties": {
      "$ref": "#/definitions/ServerFirewallRuleProperties",
      "description": "Resource properties.",
      "x-ms-client-flatten": true
    }
  }
}
```