### PR TITLE
Change deserialization and merge patch to bitwise

### DIFF
--- a/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/DocumentModelBuildOperationDetails.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/DocumentModelBuildOperationDetails.java
@@ -36,36 +36,6 @@ public final class DocumentModelBuildOperationDetails extends OperationDetails {
     }
 
     /**
-     * Get the kind property: Type of operation.
-     * 
-     * @return the kind value.
-     */
-    @Override
-    public String getKind() {
-        return this.kind;
-    }
-
-    /**
-     * Get the result property: Operation result upon success.
-     * 
-     * @return the result value.
-     */
-    public DocumentModelDetails getResult() {
-        return this.result;
-    }
-
-    /**
-     * Set the result property: Operation result upon success.
-     * 
-     * @param result the result value to set.
-     * @return the DocumentModelBuildOperationDetails object itself.
-     */
-    public DocumentModelBuildOperationDetails setResult(DocumentModelDetails result) {
-        this.result = result;
-        return this;
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override
@@ -143,6 +113,36 @@ public final class DocumentModelBuildOperationDetails extends OperationDetails {
     @Override
     public DocumentModelBuildOperationDetails setError(Error error) {
         super.setError(error);
+        return this;
+    }
+
+    /**
+     * Get the kind property: Type of operation.
+     * 
+     * @return the kind value.
+     */
+    @Override
+    public String getKind() {
+        return this.kind;
+    }
+
+    /**
+     * Get the result property: Operation result upon success.
+     * 
+     * @return the result value.
+     */
+    public DocumentModelDetails getResult() {
+        return this.result;
+    }
+
+    /**
+     * Set the result property: Operation result upon success.
+     * 
+     * @param result the result value to set.
+     * @return the DocumentModelBuildOperationDetails object itself.
+     */
+    public DocumentModelBuildOperationDetails setResult(DocumentModelDetails result) {
+        this.result = result;
         return this;
     }
 

--- a/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/DocumentModelComposeOperationDetails.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/DocumentModelComposeOperationDetails.java
@@ -36,36 +36,6 @@ public final class DocumentModelComposeOperationDetails extends OperationDetails
     }
 
     /**
-     * Get the kind property: Type of operation.
-     * 
-     * @return the kind value.
-     */
-    @Override
-    public String getKind() {
-        return this.kind;
-    }
-
-    /**
-     * Get the result property: Operation result upon success.
-     * 
-     * @return the result value.
-     */
-    public DocumentModelDetails getResult() {
-        return this.result;
-    }
-
-    /**
-     * Set the result property: Operation result upon success.
-     * 
-     * @param result the result value to set.
-     * @return the DocumentModelComposeOperationDetails object itself.
-     */
-    public DocumentModelComposeOperationDetails setResult(DocumentModelDetails result) {
-        this.result = result;
-        return this;
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override
@@ -143,6 +113,36 @@ public final class DocumentModelComposeOperationDetails extends OperationDetails
     @Override
     public DocumentModelComposeOperationDetails setError(Error error) {
         super.setError(error);
+        return this;
+    }
+
+    /**
+     * Get the kind property: Type of operation.
+     * 
+     * @return the kind value.
+     */
+    @Override
+    public String getKind() {
+        return this.kind;
+    }
+
+    /**
+     * Get the result property: Operation result upon success.
+     * 
+     * @return the result value.
+     */
+    public DocumentModelDetails getResult() {
+        return this.result;
+    }
+
+    /**
+     * Set the result property: Operation result upon success.
+     * 
+     * @param result the result value to set.
+     * @return the DocumentModelComposeOperationDetails object itself.
+     */
+    public DocumentModelComposeOperationDetails setResult(DocumentModelDetails result) {
+        this.result = result;
         return this;
     }
 

--- a/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/DocumentModelCopyToOperationDetails.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/DocumentModelCopyToOperationDetails.java
@@ -36,36 +36,6 @@ public final class DocumentModelCopyToOperationDetails extends OperationDetails 
     }
 
     /**
-     * Get the kind property: Type of operation.
-     * 
-     * @return the kind value.
-     */
-    @Override
-    public String getKind() {
-        return this.kind;
-    }
-
-    /**
-     * Get the result property: Operation result upon success.
-     * 
-     * @return the result value.
-     */
-    public DocumentModelDetails getResult() {
-        return this.result;
-    }
-
-    /**
-     * Set the result property: Operation result upon success.
-     * 
-     * @param result the result value to set.
-     * @return the DocumentModelCopyToOperationDetails object itself.
-     */
-    public DocumentModelCopyToOperationDetails setResult(DocumentModelDetails result) {
-        this.result = result;
-        return this;
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override
@@ -143,6 +113,36 @@ public final class DocumentModelCopyToOperationDetails extends OperationDetails 
     @Override
     public DocumentModelCopyToOperationDetails setError(Error error) {
         super.setError(error);
+        return this;
+    }
+
+    /**
+     * Get the kind property: Type of operation.
+     * 
+     * @return the kind value.
+     */
+    @Override
+    public String getKind() {
+        return this.kind;
+    }
+
+    /**
+     * Get the result property: Operation result upon success.
+     * 
+     * @return the result value.
+     */
+    public DocumentModelDetails getResult() {
+        return this.result;
+    }
+
+    /**
+     * Set the result property: Operation result upon success.
+     * 
+     * @param result the result value to set.
+     * @return the DocumentModelCopyToOperationDetails object itself.
+     */
+    public DocumentModelCopyToOperationDetails setResult(DocumentModelDetails result) {
+        this.result = result;
         return this;
     }
 

--- a/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/ManifestList.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/ManifestList.java
@@ -33,6 +33,15 @@ public final class ManifestList extends Manifest {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ManifestList setSchemaVersion(Integer schemaVersion) {
+        super.setSchemaVersion(schemaVersion);
+        return this;
+    }
+
+    /**
      * Get the mediaType property: Media type for this Manifest.
      * 
      * @return the mediaType value.
@@ -69,15 +78,6 @@ public final class ManifestList extends Manifest {
      */
     public ManifestList setManifests(List<ManifestListAttributes> manifests) {
         this.manifests = manifests;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public ManifestList setSchemaVersion(Integer schemaVersion) {
-        super.setSchemaVersion(schemaVersion);
         return this;
     }
 

--- a/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/ManifestWrapper.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/ManifestWrapper.java
@@ -80,6 +80,15 @@ public final class ManifestWrapper extends Manifest {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ManifestWrapper setSchemaVersion(Integer schemaVersion) {
+        super.setSchemaVersion(schemaVersion);
+        return this;
+    }
+
+    /**
      * Get the mediaType property: Media type for this Manifest.
      * 
      * @return the mediaType value.
@@ -296,15 +305,6 @@ public final class ManifestWrapper extends Manifest {
      */
     public ManifestWrapper setSignatures(List<ImageSignature> signatures) {
         this.signatures = signatures;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public ManifestWrapper setSchemaVersion(Integer schemaVersion) {
-        super.setSchemaVersion(schemaVersion);
         return this;
     }
 

--- a/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/OCIIndex.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/OCIIndex.java
@@ -34,6 +34,15 @@ public final class OCIIndex extends Manifest {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public OCIIndex setSchemaVersion(Integer schemaVersion) {
+        super.setSchemaVersion(schemaVersion);
+        return this;
+    }
+
+    /**
      * Get the manifests property: List of OCI image layer information.
      * 
      * @return the manifests value.
@@ -70,15 +79,6 @@ public final class OCIIndex extends Manifest {
      */
     public OCIIndex setAnnotations(OciAnnotations annotations) {
         this.annotations = annotations;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public OCIIndex setSchemaVersion(Integer schemaVersion) {
-        super.setSchemaVersion(schemaVersion);
         return this;
     }
 

--- a/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/V1Manifest.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/V1Manifest.java
@@ -53,6 +53,15 @@ public final class V1Manifest extends Manifest {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public V1Manifest setSchemaVersion(Integer schemaVersion) {
+        super.setSchemaVersion(schemaVersion);
+        return this;
+    }
+
+    /**
      * Get the architecture property: CPU architecture.
      * 
      * @return the architecture value.
@@ -169,15 +178,6 @@ public final class V1Manifest extends Manifest {
      */
     public V1Manifest setSignatures(List<ImageSignature> signatures) {
         this.signatures = signatures;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public V1Manifest setSchemaVersion(Integer schemaVersion) {
-        super.setSchemaVersion(schemaVersion);
         return this;
     }
 

--- a/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/V2Manifest.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/V2Manifest.java
@@ -39,6 +39,15 @@ public final class V2Manifest extends Manifest {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public V2Manifest setSchemaVersion(Integer schemaVersion) {
+        super.setSchemaVersion(schemaVersion);
+        return this;
+    }
+
+    /**
      * Get the mediaType property: Media type for this Manifest.
      * 
      * @return the mediaType value.
@@ -95,15 +104,6 @@ public final class V2Manifest extends Manifest {
      */
     public V2Manifest setLayers(List<OciDescriptor> layers) {
         this.layers = layers;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public V2Manifest setSchemaVersion(Integer schemaVersion) {
-        super.setSchemaVersion(schemaVersion);
         return this;
     }
 

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Cat.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Cat.java
@@ -33,6 +33,24 @@ public class Cat extends Pet {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Cat setId(Integer id) {
+        super.setId(id);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Cat setName(String name) {
+        super.setName(name);
+        return this;
+    }
+
+    /**
      * Get the color property: The color property.
      * 
      * @return the color value.
@@ -69,24 +87,6 @@ public class Cat extends Pet {
      */
     public Cat setHates(List<Dog> hates) {
         this.hates = hates;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Cat setId(Integer id) {
-        super.setId(id);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Cat setName(String name) {
-        super.setName(name);
         return this;
     }
 

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Cookiecuttershark.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Cookiecuttershark.java
@@ -31,16 +31,6 @@ public final class Cookiecuttershark extends Shark {
     }
 
     /**
-     * Get the fishtype property: The fishtype property.
-     * 
-     * @return the fishtype value.
-     */
-    @Override
-    public String getFishtype() {
-        return this.fishtype;
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override
@@ -83,6 +73,16 @@ public final class Cookiecuttershark extends Shark {
     public Cookiecuttershark setSiblings(List<Fish> siblings) {
         super.setSiblings(siblings);
         return this;
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Dog.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Dog.java
@@ -27,6 +27,24 @@ public final class Dog extends Pet {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Dog setId(Integer id) {
+        super.setId(id);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Dog setName(String name) {
+        super.setName(name);
+        return this;
+    }
+
+    /**
      * Get the food property: The food property.
      * 
      * @return the food value.
@@ -43,24 +61,6 @@ public final class Dog extends Pet {
      */
     public Dog setFood(String food) {
         this.food = food;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Dog setId(Integer id) {
-        super.setId(id);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Dog setName(String name) {
-        super.setName(name);
         return this;
     }
 

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/DotSalmon.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/DotSalmon.java
@@ -40,6 +40,15 @@ public final class DotSalmon extends DotFish {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public DotSalmon setSpecies(String species) {
+        super.setSpecies(species);
+        return this;
+    }
+
+    /**
      * Get the fishType property: The fish.type property.
      * 
      * @return the fishType value.
@@ -86,15 +95,6 @@ public final class DotSalmon extends DotFish {
      */
     public void setWild(Boolean iswild) {
         this.isWild = iswild;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public DotSalmon setSpecies(String species) {
-        super.setSpecies(species);
-        return this;
     }
 
     /**

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/GoblinShark.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/GoblinShark.java
@@ -41,6 +41,51 @@ public final class GoblinShark extends Shark {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GoblinShark setAge(Integer age) {
+        super.setAge(age);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GoblinShark setBirthday(OffsetDateTime birthday) {
+        super.setBirthday(birthday);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GoblinShark setSpecies(String species) {
+        super.setSpecies(species);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GoblinShark setLength(float length) {
+        super.setLength(length);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GoblinShark setSiblings(List<Fish> siblings) {
+        super.setSiblings(siblings);
+        return this;
+    }
+
+    /**
      * Get the fishtype property: The fishtype property.
      * 
      * @return the fishtype value.
@@ -87,51 +132,6 @@ public final class GoblinShark extends Shark {
      */
     public GoblinShark setColor(GoblinSharkColor color) {
         this.color = color;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public GoblinShark setAge(Integer age) {
-        super.setAge(age);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public GoblinShark setBirthday(OffsetDateTime birthday) {
-        super.setBirthday(birthday);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public GoblinShark setSpecies(String species) {
-        super.setSpecies(species);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public GoblinShark setLength(float length) {
-        super.setLength(length);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public GoblinShark setSiblings(List<Fish> siblings) {
-        super.setSiblings(siblings);
         return this;
     }
 

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/MyDerivedType.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/MyDerivedType.java
@@ -32,6 +32,24 @@ public final class MyDerivedType extends MyBaseType {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public MyDerivedType setPropB1(String propB1) {
+        super.setPropB1(propB1);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public MyDerivedType setPropBH1(String propBH1) {
+        super.setPropBH1(propBH1);
+        return this;
+    }
+
+    /**
      * Get the kind property: The kind property.
      * 
      * @return the kind value.
@@ -58,24 +76,6 @@ public final class MyDerivedType extends MyBaseType {
      */
     public MyDerivedType setPropD1(String propD1) {
         this.propD1 = propD1;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public MyDerivedType setPropB1(String propB1) {
-        super.setPropB1(propB1);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public MyDerivedType setPropBH1(String propBH1) {
-        super.setPropBH1(propBH1);
         return this;
     }
 

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Salmon.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Salmon.java
@@ -38,6 +38,33 @@ public class Salmon extends Fish {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Salmon setSpecies(String species) {
+        super.setSpecies(species);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Salmon setLength(float length) {
+        super.setLength(length);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Salmon setSiblings(List<Fish> siblings) {
+        super.setSiblings(siblings);
+        return this;
+    }
+
+    /**
      * Get the fishtype property: The fishtype property.
      * 
      * @return the fishtype value.
@@ -84,33 +111,6 @@ public class Salmon extends Fish {
      */
     public Salmon setIswild(Boolean iswild) {
         this.iswild = iswild;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Salmon setSpecies(String species) {
-        super.setSpecies(species);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Salmon setLength(float length) {
-        super.setLength(length);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Salmon setSiblings(List<Fish> siblings) {
-        super.setSiblings(siblings);
         return this;
     }
 

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Sawshark.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Sawshark.java
@@ -36,36 +36,6 @@ public final class Sawshark extends Shark {
     }
 
     /**
-     * Get the fishtype property: The fishtype property.
-     * 
-     * @return the fishtype value.
-     */
-    @Override
-    public String getFishtype() {
-        return this.fishtype;
-    }
-
-    /**
-     * Get the picture property: The picture property.
-     * 
-     * @return the picture value.
-     */
-    public byte[] getPicture() {
-        return CoreUtils.clone(this.picture);
-    }
-
-    /**
-     * Set the picture property: The picture property.
-     * 
-     * @param picture the picture value to set.
-     * @return the Sawshark object itself.
-     */
-    public Sawshark setPicture(byte[] picture) {
-        this.picture = CoreUtils.clone(picture);
-        return this;
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override
@@ -107,6 +77,36 @@ public final class Sawshark extends Shark {
     @Override
     public Sawshark setSiblings(List<Fish> siblings) {
         super.setSiblings(siblings);
+        return this;
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
+    }
+
+    /**
+     * Get the picture property: The picture property.
+     * 
+     * @return the picture value.
+     */
+    public byte[] getPicture() {
+        return CoreUtils.clone(this.picture);
+    }
+
+    /**
+     * Set the picture property: The picture property.
+     * 
+     * @param picture the picture value to set.
+     * @return the Sawshark object itself.
+     */
+    public Sawshark setPicture(byte[] picture) {
+        this.picture = CoreUtils.clone(picture);
         return this;
     }
 

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Shark.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Shark.java
@@ -41,6 +41,33 @@ public class Shark extends Fish {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Shark setSpecies(String species) {
+        super.setSpecies(species);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Shark setLength(float length) {
+        super.setLength(length);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Shark setSiblings(List<Fish> siblings) {
+        super.setSiblings(siblings);
+        return this;
+    }
+
+    /**
      * Get the fishtype property: The fishtype property.
      * 
      * @return the fishtype value.
@@ -87,33 +114,6 @@ public class Shark extends Fish {
      */
     public Shark setBirthday(OffsetDateTime birthday) {
         this.birthday = birthday;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Shark setSpecies(String species) {
-        super.setSpecies(species);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Shark setLength(float length) {
-        super.setLength(length);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Shark setSiblings(List<Fish> siblings) {
-        super.setSiblings(siblings);
         return this;
     }
 

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Siamese.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Siamese.java
@@ -28,26 +28,6 @@ public final class Siamese extends Cat {
     }
 
     /**
-     * Get the breed property: The breed property.
-     * 
-     * @return the breed value.
-     */
-    public String getBreed() {
-        return this.breed;
-    }
-
-    /**
-     * Set the breed property: The breed property.
-     * 
-     * @param breed the breed value to set.
-     * @return the Siamese object itself.
-     */
-    public Siamese setBreed(String breed) {
-        this.breed = breed;
-        return this;
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override
@@ -80,6 +60,26 @@ public final class Siamese extends Cat {
     @Override
     public Siamese setName(String name) {
         super.setName(name);
+        return this;
+    }
+
+    /**
+     * Get the breed property: The breed property.
+     * 
+     * @return the breed value.
+     */
+    public String getBreed() {
+        return this.breed;
+    }
+
+    /**
+     * Set the breed property: The breed property.
+     * 
+     * @param breed the breed value to set.
+     * @return the Siamese object itself.
+     */
+    public Siamese setBreed(String breed) {
+        this.breed = breed;
         return this;
     }
 

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/SmartSalmon.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/SmartSalmon.java
@@ -40,6 +40,51 @@ public final class SmartSalmon extends Salmon {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SmartSalmon setLocation(String location) {
+        super.setLocation(location);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SmartSalmon setIswild(Boolean iswild) {
+        super.setIswild(iswild);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SmartSalmon setSpecies(String species) {
+        super.setSpecies(species);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SmartSalmon setLength(float length) {
+        super.setLength(length);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SmartSalmon setSiblings(List<Fish> siblings) {
+        super.setSiblings(siblings);
+        return this;
+    }
+
+    /**
      * Get the fishtype property: The fishtype property.
      * 
      * @return the fishtype value.
@@ -86,51 +131,6 @@ public final class SmartSalmon extends Salmon {
      */
     public SmartSalmon setAdditionalProperties(Map<String, Object> additionalProperties) {
         this.additionalProperties = additionalProperties;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SmartSalmon setLocation(String location) {
-        super.setLocation(location);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SmartSalmon setIswild(Boolean iswild) {
-        super.setIswild(iswild);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SmartSalmon setSpecies(String species) {
-        super.setSpecies(species);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SmartSalmon setLength(float length) {
-        super.setLength(length);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SmartSalmon setSiblings(List<Fish> siblings) {
-        super.setSiblings(siblings);
         return this;
     }
 

--- a/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/access/implementation/models/AbstractModel.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/access/implementation/models/AbstractModel.java
@@ -109,6 +109,7 @@ public class AbstractModel implements JsonSerializable<AbstractModel> {
     @Generated
     static AbstractModel fromJsonKnownDiscriminator(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             String kind = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/access/implementation/models/BaseModel.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/access/implementation/models/BaseModel.java
@@ -66,6 +66,7 @@ public class BaseModel implements JsonSerializable<BaseModel> {
     @Generated
     public static BaseModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/access/implementation/models/InnerModel.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/access/implementation/models/InnerModel.java
@@ -66,6 +66,7 @@ public final class InnerModel implements JsonSerializable<InnerModel> {
     @Generated
     public static InnerModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/access/implementation/models/InternalDecoratorModelInInternal.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/access/implementation/models/InternalDecoratorModelInInternal.java
@@ -66,6 +66,7 @@ public final class InternalDecoratorModelInInternal implements JsonSerializable<
     @Generated
     public static InternalDecoratorModelInInternal fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/access/implementation/models/NoDecoratorModelInInternal.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/access/implementation/models/NoDecoratorModelInInternal.java
@@ -66,6 +66,7 @@ public final class NoDecoratorModelInInternal implements JsonSerializable<NoDeco
     @Generated
     public static NoDecoratorModelInInternal fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/access/implementation/models/OuterModel.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/access/implementation/models/OuterModel.java
@@ -68,6 +68,7 @@ public final class OuterModel extends BaseModel {
     @Generated
     public static OuterModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             InnerModel inner = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/access/implementation/models/RealModel.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/access/implementation/models/RealModel.java
@@ -67,6 +67,7 @@ public final class RealModel extends AbstractModel {
     @Generated
     public static RealModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             String kind = "real";
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/access/models/NoDecoratorModelInPublic.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/access/models/NoDecoratorModelInPublic.java
@@ -66,6 +66,7 @@ public final class NoDecoratorModelInPublic implements JsonSerializable<NoDecora
     @Generated
     public static NoDecoratorModelInPublic fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/access/models/PublicDecoratorModelInInternal.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/access/models/PublicDecoratorModelInInternal.java
@@ -66,6 +66,7 @@ public final class PublicDecoratorModelInInternal implements JsonSerializable<Pu
     @Generated
     public static PublicDecoratorModelInInternal fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/access/models/PublicDecoratorModelInPublic.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/access/models/PublicDecoratorModelInPublic.java
@@ -66,6 +66,7 @@ public final class PublicDecoratorModelInPublic implements JsonSerializable<Publ
     @Generated
     public static PublicDecoratorModelInPublic fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/access/models/SharedModel.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/access/models/SharedModel.java
@@ -66,6 +66,7 @@ public final class SharedModel implements JsonSerializable<SharedModel> {
     @Generated
     public static SharedModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/usage/models/InputModel.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/usage/models/InputModel.java
@@ -66,6 +66,7 @@ public final class InputModel implements JsonSerializable<InputModel> {
     @Generated
     public static InputModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/usage/models/OrphanModel.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/usage/models/OrphanModel.java
@@ -66,6 +66,7 @@ public final class OrphanModel implements JsonSerializable<OrphanModel> {
     @Generated
     public static OrphanModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/usage/models/OutputModel.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/usage/models/OutputModel.java
@@ -66,6 +66,7 @@ public final class OutputModel implements JsonSerializable<OutputModel> {
     @Generated
     public static OutputModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/usage/models/ResultModel.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/clientgenerator/core/usage/models/ResultModel.java
@@ -66,6 +66,7 @@ public final class ResultModel implements JsonSerializable<ResultModel> {
     @Generated
     public static ResultModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/basic/models/User.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/basic/models/User.java
@@ -12,9 +12,7 @@ import com.azure.json.JsonSerializable;
 import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 /**
  * Details about a user.
@@ -49,7 +47,7 @@ public final class User implements JsonSerializable<User> {
      * Stores updated model property, the value is property name, not serialized name.
      */
     @Generated
-    private final Set<String> updatedProperties = new HashSet<>();
+    private long updatedProperties = 0L;
 
     @Generated
     private boolean jsonMergePatch;
@@ -111,7 +109,7 @@ public final class User implements JsonSerializable<User> {
     @Generated
     public User setName(String name) {
         this.name = name;
-        this.updatedProperties.add("name");
+        this.updatedProperties |= 1;
         return this;
     }
 
@@ -134,7 +132,7 @@ public final class User implements JsonSerializable<User> {
     @Generated
     public User setOrders(List<UserOrder> orders) {
         this.orders = orders;
-        this.updatedProperties.add("orders");
+        this.updatedProperties |= 2;
         return this;
     }
 
@@ -167,14 +165,14 @@ public final class User implements JsonSerializable<User> {
     @Generated
     private JsonWriter toJsonMergePatch(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        if (updatedProperties.contains("name")) {
+        if ((this.updatedProperties & 1) == 1) {
             if (this.name == null) {
                 jsonWriter.writeNullField("name");
             } else {
                 jsonWriter.writeStringField("name", this.name);
             }
         }
-        if (updatedProperties.contains("orders")) {
+        if ((this.updatedProperties & 2) == 2) {
             if (this.orders == null) {
                 jsonWriter.writeNullField("orders");
             } else {

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/basic/models/UserOrder.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/basic/models/UserOrder.java
@@ -12,8 +12,6 @@ import com.azure.json.JsonSerializable;
 import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * UserOrder for testing list with expand.
@@ -42,7 +40,7 @@ public final class UserOrder implements JsonSerializable<UserOrder> {
      * Stores updated model property, the value is property name, not serialized name.
      */
     @Generated
-    private final Set<String> updatedProperties = new HashSet<>();
+    private long updatedProperties = 0L;
 
     @Generated
     private boolean jsonMergePatch;
@@ -104,7 +102,7 @@ public final class UserOrder implements JsonSerializable<UserOrder> {
     @Generated
     public UserOrder setUserId(int userId) {
         this.userId = userId;
-        this.updatedProperties.add("userId");
+        this.updatedProperties |= 1;
         return this;
     }
 
@@ -128,7 +126,7 @@ public final class UserOrder implements JsonSerializable<UserOrder> {
     @Generated
     public UserOrder setDetail(String detail) {
         this.detail = detail;
-        this.updatedProperties.add("detail");
+        this.updatedProperties |= 2;
         return this;
     }
 
@@ -151,10 +149,10 @@ public final class UserOrder implements JsonSerializable<UserOrder> {
     @Generated
     private JsonWriter toJsonMergePatch(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        if (updatedProperties.contains("userId")) {
+        if ((this.updatedProperties & 1) == 1) {
             jsonWriter.writeIntField("userId", this.userId);
         }
-        if (updatedProperties.contains("detail")) {
+        if ((this.updatedProperties & 2) == 2) {
             if (this.detail == null) {
                 jsonWriter.writeNullField("detail");
             } else {

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/lro/rpc/models/GenerationOptions.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/lro/rpc/models/GenerationOptions.java
@@ -66,6 +66,7 @@ public final class GenerationOptions implements JsonSerializable<GenerationOptio
     @Generated
     public static GenerationOptions fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String prompt = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/lro/rpc/models/GenerationResult.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/lro/rpc/models/GenerationResult.java
@@ -66,6 +66,7 @@ public final class GenerationResult implements JsonSerializable<GenerationResult
     @Generated
     public static GenerationResult fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String data = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/lro/standard/models/ExportedUser.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/lro/standard/models/ExportedUser.java
@@ -85,6 +85,7 @@ public final class ExportedUser implements JsonSerializable<ExportedUser> {
     @Generated
     public static ExportedUser fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             String resourceUri = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/lro/standard/models/User.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/lro/standard/models/User.java
@@ -82,6 +82,7 @@ public final class User implements JsonSerializable<User> {
     @Generated
     public static User fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             String role = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/model/models/AzureEmbeddingModel.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/model/models/AzureEmbeddingModel.java
@@ -67,6 +67,7 @@ public final class AzureEmbeddingModel implements JsonSerializable<AzureEmbeddin
     @Generated
     public static AzureEmbeddingModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             List<Integer> embedding = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/page/models/ListItemInputBody.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/page/models/ListItemInputBody.java
@@ -66,6 +66,7 @@ public final class ListItemInputBody implements JsonSerializable<ListItemInputBo
     @Generated
     public static ListItemInputBody fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String inputName = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/page/models/User.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/page/models/User.java
@@ -116,6 +116,7 @@ public final class User implements JsonSerializable<User> {
     @Generated
     public static User fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             int id = 0;
             String name = null;
             String etag = null;

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/page/models/UserOrder.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/page/models/UserOrder.java
@@ -101,6 +101,7 @@ public final class UserOrder implements JsonSerializable<UserOrder> {
     @Generated
     public static UserOrder fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             int id = 0;
             int userId = 0;
             String detail = null;

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/scalar/models/AzureLocationModel.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/scalar/models/AzureLocationModel.java
@@ -66,6 +66,7 @@ public final class AzureLocationModel implements JsonSerializable<AzureLocationM
     @Generated
     public static AzureLocationModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String location = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/traits/models/UserActionParam.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/traits/models/UserActionParam.java
@@ -66,6 +66,7 @@ public final class UserActionParam implements JsonSerializable<UserActionParam> 
     @Generated
     public static UserActionParam fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String userActionValue = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/_specs_/azure/core/traits/models/UserActionResponse.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/core/traits/models/UserActionResponse.java
@@ -66,6 +66,7 @@ public final class UserActionResponse implements JsonSerializable<UserActionResp
     @Generated
     public static UserActionResponse fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String userActionResult = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/_specs_/azure/example/basic/models/ActionRequest.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/example/basic/models/ActionRequest.java
@@ -157,6 +157,7 @@ public final class ActionRequest implements JsonSerializable<ActionRequest> {
     @Generated
     public static ActionRequest fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String stringProperty = null;
             Model modelProperty = null;
             List<String> arrayProperty = null;

--- a/typespec-tests/src/main/java/com/_specs_/azure/example/basic/models/ActionResponse.java
+++ b/typespec-tests/src/main/java/com/_specs_/azure/example/basic/models/ActionResponse.java
@@ -121,6 +121,7 @@ public final class ActionResponse implements JsonSerializable<ActionResponse> {
     @Generated
     public static ActionResponse fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String stringProperty = null;
             Model modelProperty = null;
             List<String> arrayProperty = null;

--- a/typespec-tests/src/main/java/com/azure/resourcemanager/models/commontypes/managedidentity/fluent/models/ManagedIdentityTrackedResourceInner.java
+++ b/typespec-tests/src/main/java/com/azure/resourcemanager/models/commontypes/managedidentity/fluent/models/ManagedIdentityTrackedResourceInner.java
@@ -58,6 +58,24 @@ public final class ManagedIdentityTrackedResourceInner extends Resource {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ManagedIdentityTrackedResourceInner withLocation(String location) {
+        super.withLocation(location);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ManagedIdentityTrackedResourceInner withTags(Map<String, String> tags) {
+        super.withTags(tags);
+        return this;
+    }
+
+    /**
      * Get the properties property: The resource-specific properties for this resource.
      * 
      * @return the properties value.
@@ -134,24 +152,6 @@ public final class ManagedIdentityTrackedResourceInner extends Resource {
     @Override
     public String id() {
         return this.id;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public ManagedIdentityTrackedResourceInner withLocation(String location) {
-        super.withLocation(location);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public ManagedIdentityTrackedResourceInner withTags(Map<String, String> tags) {
-        super.withTags(tags);
-        return this;
     }
 
     /**

--- a/typespec-tests/src/main/java/com/azure/resourcemanager/models/resources/fluent/models/TopLevelTrackedResourceInner.java
+++ b/typespec-tests/src/main/java/com/azure/resourcemanager/models/resources/fluent/models/TopLevelTrackedResourceInner.java
@@ -52,6 +52,24 @@ public final class TopLevelTrackedResourceInner extends Resource {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public TopLevelTrackedResourceInner withLocation(String location) {
+        super.withLocation(location);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public TopLevelTrackedResourceInner withTags(Map<String, String> tags) {
+        super.withTags(tags);
+        return this;
+    }
+
+    /**
      * Get the properties property: The resource-specific properties for this resource.
      * 
      * @return the properties value.
@@ -108,24 +126,6 @@ public final class TopLevelTrackedResourceInner extends Resource {
     @Override
     public String id() {
         return this.id;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TopLevelTrackedResourceInner withLocation(String location) {
-        super.withLocation(location);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TopLevelTrackedResourceInner withTags(Map<String, String> tags) {
-        super.withTags(tags);
-        return this;
     }
 
     /**

--- a/typespec-tests/src/main/java/com/cadl/armresourceprovider/fluent/models/ChildResourceInner.java
+++ b/typespec-tests/src/main/java/com/cadl/armresourceprovider/fluent/models/ChildResourceInner.java
@@ -35,24 +35,6 @@ public final class ChildResourceInner extends Resource {
     }
 
     /**
-     * Get the innerProperties property: The resource-specific properties for this resource.
-     * 
-     * @return the innerProperties value.
-     */
-    private ChildResourceProperties innerProperties() {
-        return this.innerProperties;
-    }
-
-    /**
-     * Get the systemData property: Azure Resource Manager metadata containing createdBy and modifiedBy information.
-     * 
-     * @return the systemData value.
-     */
-    public SystemData systemData() {
-        return this.systemData;
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override
@@ -68,6 +50,24 @@ public final class ChildResourceInner extends Resource {
     public ChildResourceInner withTags(Map<String, String> tags) {
         super.withTags(tags);
         return this;
+    }
+
+    /**
+     * Get the innerProperties property: The resource-specific properties for this resource.
+     * 
+     * @return the innerProperties value.
+     */
+    private ChildResourceProperties innerProperties() {
+        return this.innerProperties;
+    }
+
+    /**
+     * Get the systemData property: Azure Resource Manager metadata containing createdBy and modifiedBy information.
+     * 
+     * @return the systemData value.
+     */
+    public SystemData systemData() {
+        return this.systemData;
     }
 
     /**

--- a/typespec-tests/src/main/java/com/cadl/armresourceprovider/fluent/models/CustomTemplateResourceInner.java
+++ b/typespec-tests/src/main/java/com/cadl/armresourceprovider/fluent/models/CustomTemplateResourceInner.java
@@ -45,6 +45,24 @@ public final class CustomTemplateResourceInner extends Resource {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CustomTemplateResourceInner withLocation(String location) {
+        super.withLocation(location);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CustomTemplateResourceInner withTags(Map<String, String> tags) {
+        super.withTags(tags);
+        return this;
+    }
+
+    /**
      * Get the innerProperties property: The resource-specific properties for this resource.
      * 
      * @return the innerProperties value.
@@ -80,24 +98,6 @@ public final class CustomTemplateResourceInner extends Resource {
      */
     public SystemData systemData() {
         return this.systemData;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public CustomTemplateResourceInner withLocation(String location) {
-        super.withLocation(location);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public CustomTemplateResourceInner withTags(Map<String, String> tags) {
-        super.withTags(tags);
-        return this;
     }
 
     /**

--- a/typespec-tests/src/main/java/com/cadl/armresourceprovider/fluent/models/TopLevelArmResourceInner.java
+++ b/typespec-tests/src/main/java/com/cadl/armresourceprovider/fluent/models/TopLevelArmResourceInner.java
@@ -37,24 +37,6 @@ public final class TopLevelArmResourceInner extends Resource {
     }
 
     /**
-     * Get the innerProperties property: The resource-specific properties for this resource.
-     * 
-     * @return the innerProperties value.
-     */
-    private TopLevelArmResourceProperties innerProperties() {
-        return this.innerProperties;
-    }
-
-    /**
-     * Get the systemData property: Azure Resource Manager metadata containing createdBy and modifiedBy information.
-     * 
-     * @return the systemData value.
-     */
-    public SystemData systemData() {
-        return this.systemData;
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override
@@ -70,6 +52,24 @@ public final class TopLevelArmResourceInner extends Resource {
     public TopLevelArmResourceInner withTags(Map<String, String> tags) {
         super.withTags(tags);
         return this;
+    }
+
+    /**
+     * Get the innerProperties property: The resource-specific properties for this resource.
+     * 
+     * @return the innerProperties value.
+     */
+    private TopLevelArmResourceProperties innerProperties() {
+        return this.innerProperties;
+    }
+
+    /**
+     * Get the systemData property: Azure Resource Manager metadata containing createdBy and modifiedBy information.
+     * 
+     * @return the systemData value.
+     */
+    public SystemData systemData() {
+        return this.systemData;
     }
 
     /**

--- a/typespec-tests/src/main/java/com/cadl/armresourceprovider/models/Golden.java
+++ b/typespec-tests/src/main/java/com/cadl/armresourceprovider/models/Golden.java
@@ -31,6 +31,15 @@ public final class Golden extends Dog {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Golden withWeight(int weight) {
+        super.withWeight(weight);
+        return this;
+    }
+
+    /**
      * Get the kind property: discriminator property.
      * 
      * @return the kind value.
@@ -38,15 +47,6 @@ public final class Golden extends Dog {
     @Override
     public DogKind kind() {
         return this.kind;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Golden withWeight(int weight) {
-        super.withWeight(weight);
-        return this;
     }
 
     /**

--- a/typespec-tests/src/main/java/com/cadl/armstreamstyleserialization/fluent/models/SalmonInner.java
+++ b/typespec-tests/src/main/java/com/cadl/armstreamstyleserialization/fluent/models/SalmonInner.java
@@ -61,6 +61,15 @@ public final class SalmonInner extends FishInner {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SalmonInner withAge(int age) {
+        super.withAge(age);
+        return this;
+    }
+
+    /**
      * Get the kind property: Discriminator property for Fish.
      * 
      * @return the kind value.
@@ -156,15 +165,6 @@ public final class SalmonInner extends FishInner {
     @Override
     public String dna() {
         return this.dna;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SalmonInner withAge(int age) {
-        super.withAge(age);
-        return this;
     }
 
     /**

--- a/typespec-tests/src/main/java/com/cadl/armstreamstyleserialization/models/GoblinShark.java
+++ b/typespec-tests/src/main/java/com/cadl/armstreamstyleserialization/models/GoblinShark.java
@@ -50,6 +50,15 @@ public final class GoblinShark extends Shark {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GoblinShark withAge(int age) {
+        super.withAge(age);
+        return this;
+    }
+
+    /**
      * Get the kind property: Discriminator property for Fish.
      * 
      * @return the kind value.
@@ -95,15 +104,6 @@ public final class GoblinShark extends Shark {
     @Override
     public String dna() {
         return this.dna;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public GoblinShark withAge(int age) {
-        super.withAge(age);
-        return this;
     }
 
     /**

--- a/typespec-tests/src/main/java/com/cadl/armstreamstyleserialization/models/Shark.java
+++ b/typespec-tests/src/main/java/com/cadl/armstreamstyleserialization/models/Shark.java
@@ -51,6 +51,15 @@ public class Shark extends FishInner {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Shark withAge(int age) {
+        super.withAge(age);
+        return this;
+    }
+
+    /**
      * Get the kind property: Discriminator property for Fish.
      * 
      * @return the kind value.
@@ -95,15 +104,6 @@ public class Shark extends FishInner {
     @Override
     public String dna() {
         return this.dna;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Shark withAge(int age) {
-        super.withAge(age);
-        return this;
     }
 
     /**

--- a/typespec-tests/src/main/java/com/cadl/builtin/models/Builtin.java
+++ b/typespec-tests/src/main/java/com/cadl/builtin/models/Builtin.java
@@ -384,6 +384,7 @@ public final class Builtin implements JsonSerializable<Builtin> {
     @Generated
     public static Builtin fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             boolean booleanProperty = false;
             String string = null;
             byte[] bytes = null;

--- a/typespec-tests/src/main/java/com/cadl/enumservice/models/Operation.java
+++ b/typespec-tests/src/main/java/com/cadl/enumservice/models/Operation.java
@@ -238,6 +238,7 @@ public final class Operation implements JsonSerializable<Operation> {
     @Generated
     public static Operation fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             OperationName name = null;
             Priority priority = null;
             ColorModel color = null;

--- a/typespec-tests/src/main/java/com/cadl/errormodel/models/Diagnostic.java
+++ b/typespec-tests/src/main/java/com/cadl/errormodel/models/Diagnostic.java
@@ -86,6 +86,7 @@ public final class Diagnostic implements JsonSerializable<Diagnostic> {
     @Generated
     public static Diagnostic fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             ResponseError error = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/cadl/flatten/implementation/models/SendLongRequest.java
+++ b/typespec-tests/src/main/java/com/cadl/flatten/implementation/models/SendLongRequest.java
@@ -316,6 +316,7 @@ public final class SendLongRequest implements JsonSerializable<SendLongRequest> 
     @Generated
     public static SendLongRequest fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String input = null;
             int dataInt = 0;
             String title = null;

--- a/typespec-tests/src/main/java/com/cadl/flatten/implementation/models/SendProjectedNameRequest.java
+++ b/typespec-tests/src/main/java/com/cadl/flatten/implementation/models/SendProjectedNameRequest.java
@@ -66,6 +66,7 @@ public final class SendProjectedNameRequest implements JsonSerializable<SendProj
     @Generated
     public static SendProjectedNameRequest fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String fileIdentifier = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/cadl/flatten/implementation/models/SendRequest.java
+++ b/typespec-tests/src/main/java/com/cadl/flatten/implementation/models/SendRequest.java
@@ -113,6 +113,7 @@ public final class SendRequest implements JsonSerializable<SendRequest> {
     @Generated
     public static SendRequest fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String input = null;
             User user = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/cadl/flatten/models/TodoItem.java
+++ b/typespec-tests/src/main/java/com/cadl/flatten/models/TodoItem.java
@@ -185,6 +185,7 @@ public final class TodoItem implements JsonSerializable<TodoItem> {
     @Generated
     public static TodoItem fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             long id = 0L;
             String title = null;
             SendLongRequestStatus status = null;

--- a/typespec-tests/src/main/java/com/cadl/flatten/models/TodoItemPatch.java
+++ b/typespec-tests/src/main/java/com/cadl/flatten/models/TodoItemPatch.java
@@ -12,8 +12,6 @@ import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
 import com.cadl.flatten.implementation.JsonMergePatchHelper;
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * The TodoItemPatch model.
@@ -42,7 +40,7 @@ public final class TodoItemPatch implements JsonSerializable<TodoItemPatch> {
      * Stores updated model property, the value is property name, not serialized name.
      */
     @Generated
-    private final Set<String> updatedProperties = new HashSet<>();
+    private long updatedProperties = 0L;
 
     @Generated
     private boolean jsonMergePatch;
@@ -93,7 +91,7 @@ public final class TodoItemPatch implements JsonSerializable<TodoItemPatch> {
     @Generated
     public TodoItemPatch setTitle(String title) {
         this.title = title;
-        this.updatedProperties.add("title");
+        this.updatedProperties |= 1;
         return this;
     }
 
@@ -116,7 +114,7 @@ public final class TodoItemPatch implements JsonSerializable<TodoItemPatch> {
     @Generated
     public TodoItemPatch setDescription(String description) {
         this.description = description;
-        this.updatedProperties.add("description");
+        this.updatedProperties |= 2;
         return this;
     }
 
@@ -139,7 +137,7 @@ public final class TodoItemPatch implements JsonSerializable<TodoItemPatch> {
     @Generated
     public TodoItemPatch setStatus(TodoItemPatchStatus status) {
         this.status = status;
-        this.updatedProperties.add("status");
+        this.updatedProperties |= 4;
         return this;
     }
 
@@ -163,21 +161,21 @@ public final class TodoItemPatch implements JsonSerializable<TodoItemPatch> {
     @Generated
     private JsonWriter toJsonMergePatch(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        if (updatedProperties.contains("title")) {
+        if ((this.updatedProperties & 1) == 1) {
             if (this.title == null) {
                 jsonWriter.writeNullField("title");
             } else {
                 jsonWriter.writeStringField("title", this.title);
             }
         }
-        if (updatedProperties.contains("description")) {
+        if ((this.updatedProperties & 2) == 2) {
             if (this.description == null) {
                 jsonWriter.writeNullField("description");
             } else {
                 jsonWriter.writeStringField("description", this.description);
             }
         }
-        if (updatedProperties.contains("status")) {
+        if ((this.updatedProperties & 4) == 4) {
             if (this.status == null) {
                 jsonWriter.writeNullField("status");
             } else {

--- a/typespec-tests/src/main/java/com/cadl/flatten/models/UpdatePatchRequest.java
+++ b/typespec-tests/src/main/java/com/cadl/flatten/models/UpdatePatchRequest.java
@@ -12,8 +12,6 @@ import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
 import com.cadl.flatten.implementation.JsonMergePatchHelper;
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * The UpdatePatchRequest model.
@@ -30,7 +28,7 @@ public final class UpdatePatchRequest implements JsonSerializable<UpdatePatchReq
      * Stores updated model property, the value is property name, not serialized name.
      */
     @Generated
-    private final Set<String> updatedProperties = new HashSet<>();
+    private long updatedProperties = 0L;
 
     @Generated
     private boolean jsonMergePatch;
@@ -83,7 +81,7 @@ public final class UpdatePatchRequest implements JsonSerializable<UpdatePatchReq
     @Generated
     public UpdatePatchRequest setPatch(TodoItemPatch patch) {
         this.patch = patch;
-        this.updatedProperties.add("patch");
+        this.updatedProperties |= 1;
         return this;
     }
 
@@ -105,7 +103,7 @@ public final class UpdatePatchRequest implements JsonSerializable<UpdatePatchReq
     @Generated
     private JsonWriter toJsonMergePatch(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        if (updatedProperties.contains("patch")) {
+        if ((this.updatedProperties & 1) == 1) {
             if (this.patch == null) {
                 jsonWriter.writeNullField("patch");
             } else {

--- a/typespec-tests/src/main/java/com/cadl/flatten/models/User.java
+++ b/typespec-tests/src/main/java/com/cadl/flatten/models/User.java
@@ -66,6 +66,7 @@ public final class User implements JsonSerializable<User> {
     @Generated
     public static User fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String user = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/cadl/internal/implementation/models/ResponseInternal.java
+++ b/typespec-tests/src/main/java/com/cadl/internal/implementation/models/ResponseInternal.java
@@ -66,6 +66,7 @@ public final class ResponseInternal implements JsonSerializable<ResponseInternal
     @Generated
     public static ResponseInternal fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             ResponseInternalInner property = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/cadl/internal/implementation/models/ResponseInternalInner.java
+++ b/typespec-tests/src/main/java/com/cadl/internal/implementation/models/ResponseInternalInner.java
@@ -66,6 +66,7 @@ public final class ResponseInternalInner implements JsonSerializable<ResponseInt
     @Generated
     public static ResponseInternalInner fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/cadl/internal/models/ApiRequest.java
+++ b/typespec-tests/src/main/java/com/cadl/internal/models/ApiRequest.java
@@ -66,6 +66,7 @@ public final class ApiRequest implements JsonSerializable<ApiRequest> {
     @Generated
     public static ApiRequest fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             RequestInner property = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/cadl/internal/models/ApiResponse.java
+++ b/typespec-tests/src/main/java/com/cadl/internal/models/ApiResponse.java
@@ -66,6 +66,7 @@ public final class ApiResponse implements JsonSerializable<ApiResponse> {
     @Generated
     public static ApiResponse fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/cadl/internal/models/RequestInner.java
+++ b/typespec-tests/src/main/java/com/cadl/internal/models/RequestInner.java
@@ -66,6 +66,7 @@ public final class RequestInner implements JsonSerializable<RequestInner> {
     @Generated
     public static RequestInner fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/cadl/internal/models/StandAloneData.java
+++ b/typespec-tests/src/main/java/com/cadl/internal/models/StandAloneData.java
@@ -66,6 +66,7 @@ public final class StandAloneData implements JsonSerializable<StandAloneData> {
     @Generated
     public static StandAloneData fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             StandAloneDataInner property = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/cadl/internal/models/StandAloneDataInner.java
+++ b/typespec-tests/src/main/java/com/cadl/internal/models/StandAloneDataInner.java
@@ -66,6 +66,7 @@ public final class StandAloneDataInner implements JsonSerializable<StandAloneDat
     @Generated
     public static StandAloneDataInner fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/cadl/longrunning/models/JobData.java
+++ b/typespec-tests/src/main/java/com/cadl/longrunning/models/JobData.java
@@ -97,6 +97,7 @@ public final class JobData implements JsonSerializable<JobData> {
     @Generated
     public static JobData fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             Map<String, Double> nullableFloatDict = null;
             String configuration = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/cadl/longrunning/models/JobResultResult.java
+++ b/typespec-tests/src/main/java/com/cadl/longrunning/models/JobResultResult.java
@@ -66,6 +66,7 @@ public final class JobResultResult implements JsonSerializable<JobResultResult> 
     @Generated
     public static JobResultResult fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String data = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/cadl/longrunning/models/PollResponse.java
+++ b/typespec-tests/src/main/java/com/cadl/longrunning/models/PollResponse.java
@@ -85,6 +85,7 @@ public final class PollResponse implements JsonSerializable<PollResponse> {
     @Generated
     public static PollResponse fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String operationId = null;
             OperationState status = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/cadl/model/models/InputOutputData2.java
+++ b/typespec-tests/src/main/java/com/cadl/model/models/InputOutputData2.java
@@ -66,6 +66,7 @@ public final class InputOutputData2 implements JsonSerializable<InputOutputData2
     @Generated
     public static InputOutputData2 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String data = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/cadl/model/models/NestedModel.java
+++ b/typespec-tests/src/main/java/com/cadl/model/models/NestedModel.java
@@ -66,6 +66,7 @@ public final class NestedModel implements JsonSerializable<NestedModel> {
     @Generated
     public static NestedModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             NestedModel1 nested1 = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/cadl/model/models/NestedModel1.java
+++ b/typespec-tests/src/main/java/com/cadl/model/models/NestedModel1.java
@@ -66,6 +66,7 @@ public final class NestedModel1 implements JsonSerializable<NestedModel1> {
     @Generated
     public static NestedModel1 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             NestedModel2 nested2 = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/cadl/model/models/NestedModel2.java
+++ b/typespec-tests/src/main/java/com/cadl/model/models/NestedModel2.java
@@ -66,6 +66,7 @@ public final class NestedModel2 implements JsonSerializable<NestedModel2> {
     @Generated
     public static NestedModel2 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String data = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/cadl/model/models/OutputData.java
+++ b/typespec-tests/src/main/java/com/cadl/model/models/OutputData.java
@@ -66,6 +66,7 @@ public final class OutputData implements JsonSerializable<OutputData> {
     @Generated
     public static OutputData fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String data = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/cadl/model/models/OutputData3.java
+++ b/typespec-tests/src/main/java/com/cadl/model/models/OutputData3.java
@@ -66,6 +66,7 @@ public final class OutputData3 implements JsonSerializable<OutputData3> {
     @Generated
     public static OutputData3 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String data = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/cadl/model/models/Resource1.java
+++ b/typespec-tests/src/main/java/com/cadl/model/models/Resource1.java
@@ -98,6 +98,7 @@ public final class Resource1 implements JsonSerializable<Resource1> {
     @Generated
     public static Resource1 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             OutputData outputData = null;
             InputOutputData2 outputData2 = null;

--- a/typespec-tests/src/main/java/com/cadl/model/models/Resource2.java
+++ b/typespec-tests/src/main/java/com/cadl/model/models/Resource2.java
@@ -85,6 +85,7 @@ public final class Resource2 implements JsonSerializable<Resource2> {
     @Generated
     public static Resource2 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             InputOutputData2 data2 = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/cadl/model/models/Resource3.java
+++ b/typespec-tests/src/main/java/com/cadl/model/models/Resource3.java
@@ -85,6 +85,7 @@ public final class Resource3 implements JsonSerializable<Resource3> {
     @Generated
     public static Resource3 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             OutputData3 outputData3 = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/cadl/multipart/models/Size.java
+++ b/typespec-tests/src/main/java/com/cadl/multipart/models/Size.java
@@ -85,6 +85,7 @@ public final class Size implements JsonSerializable<Size> {
     @Generated
     public static Size fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             int width = 0;
             int height = 0;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/cadl/multipleapiversion/models/Resource.java
+++ b/typespec-tests/src/main/java/com/cadl/multipleapiversion/models/Resource.java
@@ -98,6 +98,7 @@ public final class Resource implements JsonSerializable<Resource> {
     @Generated
     public static Resource fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String id = null;
             String name = null;
             String type = null;

--- a/typespec-tests/src/main/java/com/cadl/multipleapiversion/models/Resource2.java
+++ b/typespec-tests/src/main/java/com/cadl/multipleapiversion/models/Resource2.java
@@ -98,6 +98,7 @@ public final class Resource2 implements JsonSerializable<Resource2> {
     @Generated
     public static Resource2 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String id = null;
             String name = null;
             String type = null;

--- a/typespec-tests/src/main/java/com/cadl/naming/models/BinaryData.java
+++ b/typespec-tests/src/main/java/com/cadl/naming/models/BinaryData.java
@@ -72,6 +72,7 @@ public final class BinaryData implements JsonSerializable<BinaryData> {
     @Generated
     public static BinaryData fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             Data data = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/cadl/naming/models/BytesData.java
+++ b/typespec-tests/src/main/java/com/cadl/naming/models/BytesData.java
@@ -84,6 +84,7 @@ public final class BytesData extends Data {
     @Generated
     public static BytesData fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             byte[] dataAsBytes = null;
             String type = "bytes";
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/cadl/naming/models/DataResponse.java
+++ b/typespec-tests/src/main/java/com/cadl/naming/models/DataResponse.java
@@ -160,6 +160,7 @@ public final class DataResponse implements JsonSerializable<DataResponse> {
     @Generated
     public static DataResponse fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             BinaryData data = null;
             TypesModel dataType = null;

--- a/typespec-tests/src/main/java/com/cadl/naming/models/GetAnonymousResponse.java
+++ b/typespec-tests/src/main/java/com/cadl/naming/models/GetAnonymousResponse.java
@@ -66,6 +66,7 @@ public final class GetAnonymousResponse implements JsonSerializable<GetAnonymous
     @Generated
     public static GetAnonymousResponse fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/cadl/naming/models/RequestParameters.java
+++ b/typespec-tests/src/main/java/com/cadl/naming/models/RequestParameters.java
@@ -66,6 +66,7 @@ public final class RequestParameters implements JsonSerializable<RequestParamete
     @Generated
     public static RequestParameters fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             RequestParametersType type = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/cadl/naming/models/RunObject.java
+++ b/typespec-tests/src/main/java/com/cadl/naming/models/RunObject.java
@@ -66,6 +66,7 @@ public final class RunObject implements JsonSerializable<RunObject> {
     @Generated
     public static RunObject fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             RunObjectLastError lastError = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/cadl/naming/models/RunObjectLastError.java
+++ b/typespec-tests/src/main/java/com/cadl/naming/models/RunObjectLastError.java
@@ -66,6 +66,7 @@ public final class RunObjectLastError implements JsonSerializable<RunObjectLastE
     @Generated
     public static RunObjectLastError fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             RunObjectLastErrorCode code = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/cadl/optional/models/ImmutableModel.java
+++ b/typespec-tests/src/main/java/com/cadl/optional/models/ImmutableModel.java
@@ -82,6 +82,7 @@ public final class ImmutableModel implements JsonSerializable<ImmutableModel> {
     @Generated
     public static ImmutableModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String stringReadWriteRequired = null;
             String stringReadOnlyOptional = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/cadl/optional/models/Optional.java
+++ b/typespec-tests/src/main/java/com/cadl/optional/models/Optional.java
@@ -572,6 +572,7 @@ public final class Optional implements JsonSerializable<Optional> {
     @Generated
     public static Optional fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             boolean booleanRequired = false;
             Boolean booleanRequiredNullable = null;
             String stringRequired = null;

--- a/typespec-tests/src/main/java/com/cadl/patch/models/Fish.java
+++ b/typespec-tests/src/main/java/com/cadl/patch/models/Fish.java
@@ -12,8 +12,6 @@ import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
 import com.cadl.patch.implementation.JsonMergePatchHelper;
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * This is base model for polymorphic multiple levels inheritance with a discriminator.
@@ -54,7 +52,7 @@ public class Fish implements JsonSerializable<Fish> {
      * Stores updated model property, the value is property name, not serialized name.
      */
     @Generated
-    private final Set<String> updatedProperties = new HashSet<>();
+    private long updatedProperties = 0L;
 
     @Generated
     private boolean jsonMergePatch;
@@ -156,7 +154,7 @@ public class Fish implements JsonSerializable<Fish> {
     @Generated
     public Fish setAge(int age) {
         this.age = age;
-        this.updatedProperties.add("age");
+        this.updatedProperties |= 1;
         return this;
     }
 
@@ -179,7 +177,7 @@ public class Fish implements JsonSerializable<Fish> {
     @Generated
     public Fish setColor(String color) {
         this.color = color;
-        this.updatedProperties.add("color");
+        this.updatedProperties |= 2;
         return this;
     }
 
@@ -204,10 +202,10 @@ public class Fish implements JsonSerializable<Fish> {
     private JsonWriter toJsonMergePatch(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeStringField("kind", this.kind);
-        if (updatedProperties.contains("age")) {
+        if ((this.updatedProperties & 1) == 1) {
             jsonWriter.writeIntField("age", this.age);
         }
-        if (updatedProperties.contains("color")) {
+        if ((this.updatedProperties & 2) == 2) {
             if (this.color == null) {
                 jsonWriter.writeNullField("color");
             } else {

--- a/typespec-tests/src/main/java/com/cadl/patch/models/InnerModel.java
+++ b/typespec-tests/src/main/java/com/cadl/patch/models/InnerModel.java
@@ -12,8 +12,6 @@ import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
 import com.cadl.patch.implementation.JsonMergePatchHelper;
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * The InnerModel model.
@@ -36,7 +34,7 @@ public final class InnerModel implements JsonSerializable<InnerModel> {
      * Stores updated model property, the value is property name, not serialized name.
      */
     @Generated
-    private final Set<String> updatedProperties = new HashSet<>();
+    private long updatedProperties = 0L;
 
     @Generated
     private boolean jsonMergePatch;
@@ -88,7 +86,7 @@ public final class InnerModel implements JsonSerializable<InnerModel> {
     @Generated
     public InnerModel setName(String name) {
         this.name = name;
-        this.updatedProperties.add("name");
+        this.updatedProperties |= 1;
         return this;
     }
 
@@ -111,7 +109,7 @@ public final class InnerModel implements JsonSerializable<InnerModel> {
     @Generated
     public InnerModel setDescription(String description) {
         this.description = description;
-        this.updatedProperties.add("description");
+        this.updatedProperties |= 2;
         return this;
     }
 
@@ -134,14 +132,14 @@ public final class InnerModel implements JsonSerializable<InnerModel> {
     @Generated
     private JsonWriter toJsonMergePatch(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        if (updatedProperties.contains("name")) {
+        if ((this.updatedProperties & 1) == 1) {
             if (this.name == null) {
                 jsonWriter.writeNullField("name");
             } else {
                 jsonWriter.writeStringField("name", this.name);
             }
         }
-        if (updatedProperties.contains("description")) {
+        if ((this.updatedProperties & 2) == 2) {
             if (this.description == null) {
                 jsonWriter.writeNullField("description");
             } else {

--- a/typespec-tests/src/main/java/com/cadl/patch/models/Resource.java
+++ b/typespec-tests/src/main/java/com/cadl/patch/models/Resource.java
@@ -12,10 +12,8 @@ import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
 import com.cadl.patch.implementation.JsonMergePatchHelper;
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * The Resource model.
@@ -86,7 +84,7 @@ public final class Resource implements JsonSerializable<Resource> {
      * Stores updated model property, the value is property name, not serialized name.
      */
     @Generated
-    private final Set<String> updatedProperties = new HashSet<>();
+    private long updatedProperties = 0L;
 
     @Generated
     private boolean jsonMergePatch;
@@ -157,7 +155,7 @@ public final class Resource implements JsonSerializable<Resource> {
     @Generated
     public Resource setDescription(String description) {
         this.description = description;
-        this.updatedProperties.add("description");
+        this.updatedProperties |= 1;
         return this;
     }
 
@@ -181,7 +179,7 @@ public final class Resource implements JsonSerializable<Resource> {
     @Generated
     public Resource setMap(Map<String, InnerModel> map) {
         this.map = map;
-        this.updatedProperties.add("map");
+        this.updatedProperties |= 2;
         return this;
     }
 
@@ -204,7 +202,7 @@ public final class Resource implements JsonSerializable<Resource> {
     @Generated
     public Resource setLongValue(Long longValue) {
         this.longValue = longValue;
-        this.updatedProperties.add("longValue");
+        this.updatedProperties |= 4;
         return this;
     }
 
@@ -227,7 +225,7 @@ public final class Resource implements JsonSerializable<Resource> {
     @Generated
     public Resource setIntValue(Integer intValue) {
         this.intValue = intValue;
-        this.updatedProperties.add("intValue");
+        this.updatedProperties |= 8;
         return this;
     }
 
@@ -250,7 +248,7 @@ public final class Resource implements JsonSerializable<Resource> {
     @Generated
     public Resource setEnumValue(ResourceEnumValue enumValue) {
         this.enumValue = enumValue;
-        this.updatedProperties.add("enumValue");
+        this.updatedProperties |= 16;
         return this;
     }
 
@@ -273,7 +271,7 @@ public final class Resource implements JsonSerializable<Resource> {
     @Generated
     public Resource setInnerModelProperty(InnerModel innerModelProperty) {
         this.innerModelProperty = innerModelProperty;
-        this.updatedProperties.add("innerModelProperty");
+        this.updatedProperties |= 32;
         return this;
     }
 
@@ -296,7 +294,7 @@ public final class Resource implements JsonSerializable<Resource> {
     @Generated
     public Resource setArray(List<InnerModel> array) {
         this.array = array;
-        this.updatedProperties.add("array");
+        this.updatedProperties |= 64;
         return this;
     }
 
@@ -319,7 +317,7 @@ public final class Resource implements JsonSerializable<Resource> {
     @Generated
     public Resource setFish(Fish fish) {
         this.fish = fish;
-        this.updatedProperties.add("fish");
+        this.updatedProperties |= 128;
         return this;
     }
 
@@ -348,14 +346,14 @@ public final class Resource implements JsonSerializable<Resource> {
     @Generated
     private JsonWriter toJsonMergePatch(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        if (updatedProperties.contains("description")) {
+        if ((this.updatedProperties & 1) == 1) {
             if (this.description == null) {
                 jsonWriter.writeNullField("description");
             } else {
                 jsonWriter.writeStringField("description", this.description);
             }
         }
-        if (updatedProperties.contains("map")) {
+        if ((this.updatedProperties & 2) == 2) {
             if (this.map == null) {
                 jsonWriter.writeNullField("map");
             } else {
@@ -370,28 +368,28 @@ public final class Resource implements JsonSerializable<Resource> {
                 });
             }
         }
-        if (updatedProperties.contains("longValue")) {
+        if ((this.updatedProperties & 4) == 4) {
             if (this.longValue == null) {
                 jsonWriter.writeNullField("longValue");
             } else {
                 jsonWriter.writeNumberField("longValue", this.longValue);
             }
         }
-        if (updatedProperties.contains("intValue")) {
+        if ((this.updatedProperties & 8) == 8) {
             if (this.intValue == null) {
                 jsonWriter.writeNullField("intValue");
             } else {
                 jsonWriter.writeNumberField("intValue", this.intValue);
             }
         }
-        if (updatedProperties.contains("enumValue")) {
+        if ((this.updatedProperties & 16) == 16) {
             if (this.enumValue == null) {
                 jsonWriter.writeNullField("enumValue");
             } else {
                 jsonWriter.writeStringField("enumValue", this.enumValue.toString());
             }
         }
-        if (updatedProperties.contains("innerModelProperty")) {
+        if ((this.updatedProperties & 32) == 32) {
             if (this.innerModelProperty == null) {
                 jsonWriter.writeNullField("wireNameForInnerModelProperty");
             } else {
@@ -402,14 +400,14 @@ public final class Resource implements JsonSerializable<Resource> {
                     .prepareModelForJsonMergePatch(this.innerModelProperty, false);
             }
         }
-        if (updatedProperties.contains("array")) {
+        if ((this.updatedProperties & 64) == 64) {
             if (this.array == null) {
                 jsonWriter.writeNullField("array");
             } else {
                 jsonWriter.writeArrayField("array", this.array, (writer, element) -> writer.writeJson(element));
             }
         }
-        if (updatedProperties.contains("fish")) {
+        if ((this.updatedProperties & 128) == 128) {
             if (this.fish == null) {
                 jsonWriter.writeNullField("fish");
             } else {

--- a/typespec-tests/src/main/java/com/cadl/patch/models/Salmon.java
+++ b/typespec-tests/src/main/java/com/cadl/patch/models/Salmon.java
@@ -11,10 +11,8 @@ import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
 import com.cadl.patch.implementation.JsonMergePatchHelper;
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * The second level model in polymorphic multiple levels inheritance which contains references to other polymorphic
@@ -50,13 +48,35 @@ public final class Salmon extends Fish {
      * Stores updated model property, the value is property name, not serialized name.
      */
     @Generated
-    private final Set<String> updatedProperties = new HashSet<>();
+    private long updatedProperties = 0L;
 
     /**
      * Creates an instance of Salmon class.
      */
     @Generated
     public Salmon() {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Generated
+    @Override
+    public Salmon setAge(int age) {
+        super.setAge(age);
+        this.updatedProperties |= 1;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Generated
+    @Override
+    public Salmon setColor(String color) {
+        super.setColor(color);
+        this.updatedProperties |= 2;
+        return this;
     }
 
     /**
@@ -89,7 +109,7 @@ public final class Salmon extends Fish {
     @Generated
     public Salmon setFriends(List<Fish> friends) {
         this.friends = friends;
-        this.updatedProperties.add("friends");
+        this.updatedProperties |= 4;
         return this;
     }
 
@@ -112,7 +132,7 @@ public final class Salmon extends Fish {
     @Generated
     public Salmon setHate(Map<String, Fish> hate) {
         this.hate = hate;
-        this.updatedProperties.add("hate");
+        this.updatedProperties |= 8;
         return this;
     }
 
@@ -135,29 +155,7 @@ public final class Salmon extends Fish {
     @Generated
     public Salmon setPartner(Fish partner) {
         this.partner = partner;
-        this.updatedProperties.add("partner");
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Generated
-    @Override
-    public Salmon setAge(int age) {
-        super.setAge(age);
-        this.updatedProperties.add("age");
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Generated
-    @Override
-    public Salmon setColor(String color) {
-        super.setColor(color);
-        this.updatedProperties.add("color");
+        this.updatedProperties |= 16;
         return this;
     }
 
@@ -184,10 +182,10 @@ public final class Salmon extends Fish {
     @Generated
     private JsonWriter toJsonMergePatch(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        if (updatedProperties.contains("age")) {
+        if ((this.updatedProperties & 1) == 1) {
             jsonWriter.writeIntField("age", getAge());
         }
-        if (updatedProperties.contains("color")) {
+        if ((this.updatedProperties & 2) == 2) {
             if (getColor() == null) {
                 jsonWriter.writeNullField("color");
             } else {
@@ -195,14 +193,14 @@ public final class Salmon extends Fish {
             }
         }
         jsonWriter.writeStringField("kind", this.kind);
-        if (updatedProperties.contains("friends")) {
+        if ((this.updatedProperties & 4) == 4) {
             if (this.friends == null) {
                 jsonWriter.writeNullField("friends");
             } else {
                 jsonWriter.writeArrayField("friends", this.friends, (writer, element) -> writer.writeJson(element));
             }
         }
-        if (updatedProperties.contains("hate")) {
+        if ((this.updatedProperties & 8) == 8) {
             if (this.hate == null) {
                 jsonWriter.writeNullField("hate");
             } else {
@@ -217,7 +215,7 @@ public final class Salmon extends Fish {
                 });
             }
         }
-        if (updatedProperties.contains("partner")) {
+        if ((this.updatedProperties & 16) == 16) {
             if (this.partner == null) {
                 jsonWriter.writeNullField("partner");
             } else {

--- a/typespec-tests/src/main/java/com/cadl/patch/models/SawShark.java
+++ b/typespec-tests/src/main/java/com/cadl/patch/models/SawShark.java
@@ -11,8 +11,6 @@ import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
 import com.cadl.patch.implementation.JsonMergePatchHelper;
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * The third level model SawShark in polymorphic multiple levels inheritance.
@@ -35,13 +33,46 @@ public final class SawShark extends Shark {
      * Stores updated model property, the value is property name, not serialized name.
      */
     @Generated
-    private final Set<String> updatedProperties = new HashSet<>();
+    private long updatedProperties = 0L;
 
     /**
      * Creates an instance of SawShark class.
      */
     @Generated
     public SawShark() {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Generated
+    @Override
+    public SawShark setWeight(Integer weight) {
+        super.setWeight(weight);
+        this.updatedProperties |= 1;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Generated
+    @Override
+    public SawShark setAge(int age) {
+        super.setAge(age);
+        this.updatedProperties |= 2;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Generated
+    @Override
+    public SawShark setColor(String color) {
+        super.setColor(color);
+        this.updatedProperties |= 4;
+        return this;
     }
 
     /**
@@ -71,39 +102,6 @@ public final class SawShark extends Shark {
      */
     @Generated
     @Override
-    public SawShark setWeight(Integer weight) {
-        super.setWeight(weight);
-        this.updatedProperties.add("weight");
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Generated
-    @Override
-    public SawShark setAge(int age) {
-        super.setAge(age);
-        this.updatedProperties.add("age");
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Generated
-    @Override
-    public SawShark setColor(String color) {
-        super.setColor(color);
-        this.updatedProperties.add("color");
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Generated
-    @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         if (JsonMergePatchHelper.getFishAccessor().isJsonMergePatch(this)) {
             return toJsonMergePatch(jsonWriter);
@@ -122,17 +120,17 @@ public final class SawShark extends Shark {
     private JsonWriter toJsonMergePatch(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeStringField("kind", this.kind);
-        if (updatedProperties.contains("age")) {
+        if ((this.updatedProperties & 1) == 1) {
             jsonWriter.writeIntField("age", getAge());
         }
-        if (updatedProperties.contains("color")) {
+        if ((this.updatedProperties & 2) == 2) {
             if (getColor() == null) {
                 jsonWriter.writeNullField("color");
             } else {
                 jsonWriter.writeStringField("color", getColor());
             }
         }
-        if (updatedProperties.contains("weight")) {
+        if ((this.updatedProperties & 4) == 4) {
             if (getWeight() == null) {
                 jsonWriter.writeNullField("weight");
             } else {

--- a/typespec-tests/src/main/java/com/cadl/patch/models/Shark.java
+++ b/typespec-tests/src/main/java/com/cadl/patch/models/Shark.java
@@ -11,8 +11,6 @@ import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
 import com.cadl.patch.implementation.JsonMergePatchHelper;
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * The second level model in polymorphic multiple levels inheritance and it defines a new discriminator.
@@ -41,7 +39,7 @@ public class Shark extends Fish {
      * Stores updated model property, the value is property name, not serialized name.
      */
     @Generated
-    private final Set<String> updatedProperties = new HashSet<>();
+    private long updatedProperties = 0L;
 
     static {
         JsonMergePatchHelper.setSharkAccessor(new JsonMergePatchHelper.SharkAccessor() {
@@ -57,6 +55,28 @@ public class Shark extends Fish {
      */
     @Generated
     public Shark() {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Generated
+    @Override
+    public Shark setAge(int age) {
+        super.setAge(age);
+        this.updatedProperties |= 1;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Generated
+    @Override
+    public Shark setColor(String color) {
+        super.setColor(color);
+        this.updatedProperties |= 2;
+        return this;
     }
 
     /**
@@ -99,29 +119,7 @@ public class Shark extends Fish {
     @Generated
     public Shark setWeight(Integer weight) {
         this.weight = weight;
-        this.updatedProperties.add("weight");
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Generated
-    @Override
-    public Shark setAge(int age) {
-        super.setAge(age);
-        this.updatedProperties.add("age");
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Generated
-    @Override
-    public Shark setColor(String color) {
-        super.setColor(color);
-        this.updatedProperties.add("color");
+        this.updatedProperties |= 4;
         return this;
     }
 
@@ -148,10 +146,10 @@ public class Shark extends Fish {
     private JsonWriter toJsonMergePatch(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeStringField("kind", this.kind);
-        if (updatedProperties.contains("age")) {
+        if ((this.updatedProperties & 1) == 1) {
             jsonWriter.writeIntField("age", getAge());
         }
-        if (updatedProperties.contains("color")) {
+        if ((this.updatedProperties & 2) == 2) {
             if (getColor() == null) {
                 jsonWriter.writeNullField("color");
             } else {
@@ -159,7 +157,7 @@ public class Shark extends Fish {
             }
         }
         jsonWriter.writeStringField("sharktype", this.sharktype);
-        if (updatedProperties.contains("weight")) {
+        if ((this.updatedProperties & 4) == 4) {
             if (this.weight == null) {
                 jsonWriter.writeNullField("weight");
             } else {

--- a/typespec-tests/src/main/java/com/cadl/protocolandconvenient/models/ResourceA.java
+++ b/typespec-tests/src/main/java/com/cadl/protocolandconvenient/models/ResourceA.java
@@ -82,6 +82,7 @@ public final class ResourceA implements JsonSerializable<ResourceA> {
     @Generated
     public static ResourceA fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String id = null;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/cadl/protocolandconvenient/models/ResourceB.java
+++ b/typespec-tests/src/main/java/com/cadl/protocolandconvenient/models/ResourceB.java
@@ -82,6 +82,7 @@ public final class ResourceB implements JsonSerializable<ResourceB> {
     @Generated
     public static ResourceB fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String id = null;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/cadl/protocolandconvenient/models/ResourceE.java
+++ b/typespec-tests/src/main/java/com/cadl/protocolandconvenient/models/ResourceE.java
@@ -82,6 +82,7 @@ public final class ResourceE implements JsonSerializable<ResourceE> {
     @Generated
     public static ResourceE fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String id = null;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/cadl/protocolandconvenient/models/ResourceF.java
+++ b/typespec-tests/src/main/java/com/cadl/protocolandconvenient/models/ResourceF.java
@@ -82,6 +82,7 @@ public final class ResourceF implements JsonSerializable<ResourceF> {
     @Generated
     public static ResourceF fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String id = null;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/cadl/protocolandconvenient/models/ResourceI.java
+++ b/typespec-tests/src/main/java/com/cadl/protocolandconvenient/models/ResourceI.java
@@ -98,6 +98,7 @@ public final class ResourceI implements JsonSerializable<ResourceI> {
     @Generated
     public static ResourceI fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String id = null;
             String name = null;
             String type = null;

--- a/typespec-tests/src/main/java/com/cadl/protocolandconvenient/models/ResourceJ.java
+++ b/typespec-tests/src/main/java/com/cadl/protocolandconvenient/models/ResourceJ.java
@@ -98,6 +98,7 @@ public final class ResourceJ implements JsonSerializable<ResourceJ> {
     @Generated
     public static ResourceJ fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String id = null;
             String name = null;
             String type = null;

--- a/typespec-tests/src/main/java/com/cadl/response/models/OperationDetails1.java
+++ b/typespec-tests/src/main/java/com/cadl/response/models/OperationDetails1.java
@@ -120,6 +120,7 @@ public final class OperationDetails1 implements JsonSerializable<OperationDetail
     @Generated
     public static OperationDetails1 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String operationId = null;
             OperationState status = null;
             ResponseError error = null;

--- a/typespec-tests/src/main/java/com/cadl/response/models/OperationDetails2.java
+++ b/typespec-tests/src/main/java/com/cadl/response/models/OperationDetails2.java
@@ -120,6 +120,7 @@ public final class OperationDetails2 implements JsonSerializable<OperationDetail
     @Generated
     public static OperationDetails2 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String id = null;
             OperationState status = null;
             ResponseError error = null;

--- a/typespec-tests/src/main/java/com/cadl/response/models/Resource.java
+++ b/typespec-tests/src/main/java/com/cadl/response/models/Resource.java
@@ -127,6 +127,7 @@ public final class Resource implements JsonSerializable<Resource> {
     @Generated
     public static Resource fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String id = null;
             String name = null;
             String type = null;

--- a/typespec-tests/src/main/java/com/cadl/specialchars/implementation/models/ReadRequest.java
+++ b/typespec-tests/src/main/java/com/cadl/specialchars/implementation/models/ReadRequest.java
@@ -66,6 +66,7 @@ public final class ReadRequest implements JsonSerializable<ReadRequest> {
     @Generated
     public static ReadRequest fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String id = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/cadl/specialchars/models/Resource.java
+++ b/typespec-tests/src/main/java/com/cadl/specialchars/models/Resource.java
@@ -142,6 +142,7 @@ public final class Resource implements JsonSerializable<Resource> {
     @Generated
     public static Resource fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String id = null;
             String aggregate = null;
             String condition = null;

--- a/typespec-tests/src/main/java/com/cadl/specialheaders/models/Resource.java
+++ b/typespec-tests/src/main/java/com/cadl/specialheaders/models/Resource.java
@@ -12,8 +12,6 @@ import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
 import com.cadl.specialheaders.implementation.JsonMergePatchHelper;
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * The Resource model.
@@ -48,7 +46,7 @@ public final class Resource implements JsonSerializable<Resource> {
      * Stores updated model property, the value is property name, not serialized name.
      */
     @Generated
-    private final Set<String> updatedProperties = new HashSet<>();
+    private long updatedProperties = 0L;
 
     @Generated
     private boolean jsonMergePatch;
@@ -119,7 +117,7 @@ public final class Resource implements JsonSerializable<Resource> {
     @Generated
     public Resource setDescription(String description) {
         this.description = description;
-        this.updatedProperties.add("description");
+        this.updatedProperties |= 1;
         return this;
     }
 
@@ -143,7 +141,7 @@ public final class Resource implements JsonSerializable<Resource> {
     @Generated
     public Resource setType(String type) {
         this.type = type;
-        this.updatedProperties.add("type");
+        this.updatedProperties |= 2;
         return this;
     }
 
@@ -166,14 +164,14 @@ public final class Resource implements JsonSerializable<Resource> {
     @Generated
     private JsonWriter toJsonMergePatch(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        if (updatedProperties.contains("description")) {
+        if ((this.updatedProperties & 1) == 1) {
             if (this.description == null) {
                 jsonWriter.writeNullField("description");
             } else {
                 jsonWriter.writeStringField("description", this.description);
             }
         }
-        if (updatedProperties.contains("type")) {
+        if ((this.updatedProperties & 2) == 2) {
             if (this.type == null) {
                 jsonWriter.writeNullField("type");
             } else {

--- a/typespec-tests/src/main/java/com/cadl/union/implementation/models/SendLongRequest.java
+++ b/typespec-tests/src/main/java/com/cadl/union/implementation/models/SendLongRequest.java
@@ -205,6 +205,7 @@ public final class SendLongRequest implements JsonSerializable<SendLongRequest> 
     @Generated
     public static SendLongRequest fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String input = null;
             int dataInt = 0;
             User user = null;

--- a/typespec-tests/src/main/java/com/cadl/union/implementation/models/SendRequest.java
+++ b/typespec-tests/src/main/java/com/cadl/union/implementation/models/SendRequest.java
@@ -97,6 +97,7 @@ public final class SendRequest implements JsonSerializable<SendRequest> {
     @Generated
     public static SendRequest fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             BinaryData input = null;
             User user = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/cadl/union/implementation/models/SubResult.java
+++ b/typespec-tests/src/main/java/com/cadl/union/implementation/models/SubResult.java
@@ -42,6 +42,16 @@ public final class SubResult extends Result {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Generated
+    @Override
+    public SubResult setResult(Result result) {
+        super.setResult(result);
+        return this;
+    }
+
+    /**
      * Get the text property: The text property.
      * 
      * @return the text value.
@@ -82,16 +92,6 @@ public final class SubResult extends Result {
     @Generated
     public SubResult setArrayData(BinaryData arrayData) {
         this.arrayData = arrayData;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Generated
-    @Override
-    public SubResult setResult(Result result) {
-        super.setResult(result);
         return this;
     }
 

--- a/typespec-tests/src/main/java/com/cadl/union/implementation/models/SubResult.java
+++ b/typespec-tests/src/main/java/com/cadl/union/implementation/models/SubResult.java
@@ -124,6 +124,7 @@ public final class SubResult extends Result {
     @Generated
     public static SubResult fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             BinaryData data = null;
             Result result = null;

--- a/typespec-tests/src/main/java/com/cadl/union/models/ArrayData.java
+++ b/typespec-tests/src/main/java/com/cadl/union/models/ArrayData.java
@@ -67,6 +67,7 @@ public final class ArrayData implements JsonSerializable<ArrayData> {
     @Generated
     public static ArrayData fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             List<String> data = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/cadl/union/models/Result.java
+++ b/typespec-tests/src/main/java/com/cadl/union/models/Result.java
@@ -115,6 +115,7 @@ public class Result implements JsonSerializable<Result> {
     @Generated
     public static Result fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             BinaryData data = null;
             Result result = null;

--- a/typespec-tests/src/main/java/com/cadl/union/models/User.java
+++ b/typespec-tests/src/main/java/com/cadl/union/models/User.java
@@ -66,6 +66,7 @@ public final class User implements JsonSerializable<User> {
     @Generated
     public static User fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String user = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/cadl/versioning/models/ExportedResource.java
+++ b/typespec-tests/src/main/java/com/cadl/versioning/models/ExportedResource.java
@@ -85,6 +85,7 @@ public final class ExportedResource implements JsonSerializable<ExportedResource
     @Generated
     public static ExportedResource fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String id = null;
             String resourceUri = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/cadl/versioning/models/Resource.java
+++ b/typespec-tests/src/main/java/com/cadl/versioning/models/Resource.java
@@ -98,6 +98,7 @@ public final class Resource implements JsonSerializable<Resource> {
     @Generated
     public static Resource fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String id = null;
             String name = null;
             String type = null;

--- a/typespec-tests/src/main/java/com/cadl/visibility/models/Dog.java
+++ b/typespec-tests/src/main/java/com/cadl/visibility/models/Dog.java
@@ -101,6 +101,7 @@ public final class Dog implements JsonSerializable<Dog> {
     @Generated
     public static Dog fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             int id = 0;
             String secretName = null;
             String name = null;

--- a/typespec-tests/src/main/java/com/cadl/visibility/models/ReadDog.java
+++ b/typespec-tests/src/main/java/com/cadl/visibility/models/ReadDog.java
@@ -85,6 +85,7 @@ public final class ReadDog implements JsonSerializable<ReadDog> {
     @Generated
     public static ReadDog fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             int id = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/cadl/visibility/models/RoundTripModel.java
+++ b/typespec-tests/src/main/java/com/cadl/visibility/models/RoundTripModel.java
@@ -85,6 +85,7 @@ public final class RoundTripModel implements JsonSerializable<RoundTripModel> {
     @Generated
     public static RoundTripModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             String secretName = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/cadl/visibility/models/WriteDog.java
+++ b/typespec-tests/src/main/java/com/cadl/visibility/models/WriteDog.java
@@ -66,6 +66,7 @@ public final class WriteDog implements JsonSerializable<WriteDog> {
     @Generated
     public static WriteDog fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/cadl/wiretype/models/SubClass.java
+++ b/typespec-tests/src/main/java/com/cadl/wiretype/models/SubClass.java
@@ -77,6 +77,7 @@ public final class SubClass extends SuperClassMismatch {
     @Generated
     public static SubClass fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             OffsetDateTime dateTimeRfc7231 = null;
             OffsetDateTime dateTime = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/cadl/wiretype/models/SubClassBothMismatch.java
+++ b/typespec-tests/src/main/java/com/cadl/wiretype/models/SubClassBothMismatch.java
@@ -82,6 +82,7 @@ public final class SubClassBothMismatch extends SuperClassMismatch {
     @Generated
     public static SubClassBothMismatch fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             OffsetDateTime dateTimeRfc7231 = null;
             byte[] base64url = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/cadl/wiretype/models/SubClassMismatch.java
+++ b/typespec-tests/src/main/java/com/cadl/wiretype/models/SubClassMismatch.java
@@ -81,6 +81,7 @@ public final class SubClassMismatch extends SuperClass {
     @Generated
     public static SubClassMismatch fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             OffsetDateTime dateTime = null;
             OffsetDateTime dateTimeRfc7231 = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/cadl/wiretype/models/SuperClass.java
+++ b/typespec-tests/src/main/java/com/cadl/wiretype/models/SuperClass.java
@@ -70,6 +70,7 @@ public class SuperClass implements JsonSerializable<SuperClass> {
     @Generated
     public static SuperClass fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             OffsetDateTime dateTime = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/cadl/wiretype/models/SuperClassMismatch.java
+++ b/typespec-tests/src/main/java/com/cadl/wiretype/models/SuperClassMismatch.java
@@ -76,6 +76,7 @@ public class SuperClassMismatch implements JsonSerializable<SuperClassMismatch> 
     @Generated
     public static SuperClassMismatch fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             OffsetDateTime dateTimeRfc7231 = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/client/naming/models/ClientModel.java
+++ b/typespec-tests/src/main/java/com/client/naming/models/ClientModel.java
@@ -66,6 +66,7 @@ public final class ClientModel implements JsonSerializable<ClientModel> {
     @Generated
     public static ClientModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             boolean defaultName = false;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/client/naming/models/ClientNameAndJsonEncodedNameModel.java
+++ b/typespec-tests/src/main/java/com/client/naming/models/ClientNameAndJsonEncodedNameModel.java
@@ -66,6 +66,7 @@ public final class ClientNameAndJsonEncodedNameModel implements JsonSerializable
     @Generated
     public static ClientNameAndJsonEncodedNameModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             boolean clientName = false;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/client/naming/models/ClientNameModel.java
+++ b/typespec-tests/src/main/java/com/client/naming/models/ClientNameModel.java
@@ -66,6 +66,7 @@ public final class ClientNameModel implements JsonSerializable<ClientNameModel> 
     @Generated
     public static ClientNameModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             boolean clientName = false;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/client/naming/models/JavaModel.java
+++ b/typespec-tests/src/main/java/com/client/naming/models/JavaModel.java
@@ -66,6 +66,7 @@ public final class JavaModel implements JsonSerializable<JavaModel> {
     @Generated
     public static JavaModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             boolean defaultName = false;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/client/naming/models/LanguageClientNameModel.java
+++ b/typespec-tests/src/main/java/com/client/naming/models/LanguageClientNameModel.java
@@ -66,6 +66,7 @@ public final class LanguageClientNameModel implements JsonSerializable<LanguageC
     @Generated
     public static LanguageClientNameModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             boolean javaName = false;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/encode/bytes/models/Base64BytesProperty.java
+++ b/typespec-tests/src/main/java/com/encode/bytes/models/Base64BytesProperty.java
@@ -67,6 +67,7 @@ public final class Base64BytesProperty implements JsonSerializable<Base64BytesPr
     @Generated
     public static Base64BytesProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             byte[] value = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/encode/bytes/models/Base64urlArrayBytesProperty.java
+++ b/typespec-tests/src/main/java/com/encode/bytes/models/Base64urlArrayBytesProperty.java
@@ -77,6 +77,7 @@ public final class Base64urlArrayBytesProperty implements JsonSerializable<Base6
     @Generated
     public static Base64urlArrayBytesProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             List<byte[]> value = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/encode/bytes/models/Base64urlBytesProperty.java
+++ b/typespec-tests/src/main/java/com/encode/bytes/models/Base64urlBytesProperty.java
@@ -75,6 +75,7 @@ public final class Base64urlBytesProperty implements JsonSerializable<Base64urlB
     @Generated
     public static Base64urlBytesProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             byte[] value = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/encode/bytes/models/DefaultBytesProperty.java
+++ b/typespec-tests/src/main/java/com/encode/bytes/models/DefaultBytesProperty.java
@@ -67,6 +67,7 @@ public final class DefaultBytesProperty implements JsonSerializable<DefaultBytes
     @Generated
     public static DefaultBytesProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             byte[] value = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/encode/datetime/models/DefaultDatetimeProperty.java
+++ b/typespec-tests/src/main/java/com/encode/datetime/models/DefaultDatetimeProperty.java
@@ -70,6 +70,7 @@ public final class DefaultDatetimeProperty implements JsonSerializable<DefaultDa
     @Generated
     public static DefaultDatetimeProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             OffsetDateTime value = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/encode/datetime/models/Rfc3339DatetimeProperty.java
+++ b/typespec-tests/src/main/java/com/encode/datetime/models/Rfc3339DatetimeProperty.java
@@ -70,6 +70,7 @@ public final class Rfc3339DatetimeProperty implements JsonSerializable<Rfc3339Da
     @Generated
     public static Rfc3339DatetimeProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             OffsetDateTime value = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/encode/datetime/models/Rfc7231DatetimeProperty.java
+++ b/typespec-tests/src/main/java/com/encode/datetime/models/Rfc7231DatetimeProperty.java
@@ -76,6 +76,7 @@ public final class Rfc7231DatetimeProperty implements JsonSerializable<Rfc7231Da
     @Generated
     public static Rfc7231DatetimeProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             OffsetDateTime value = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/encode/datetime/models/UnixTimestampArrayDatetimeProperty.java
+++ b/typespec-tests/src/main/java/com/encode/datetime/models/UnixTimestampArrayDatetimeProperty.java
@@ -79,6 +79,7 @@ public final class UnixTimestampArrayDatetimeProperty implements JsonSerializabl
     @Generated
     public static UnixTimestampArrayDatetimeProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             List<OffsetDateTime> value = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/encode/datetime/models/UnixTimestampDatetimeProperty.java
+++ b/typespec-tests/src/main/java/com/encode/datetime/models/UnixTimestampDatetimeProperty.java
@@ -73,6 +73,7 @@ public final class UnixTimestampDatetimeProperty implements JsonSerializable<Uni
     @Generated
     public static UnixTimestampDatetimeProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             OffsetDateTime value = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/encode/duration/models/DefaultDurationProperty.java
+++ b/typespec-tests/src/main/java/com/encode/duration/models/DefaultDurationProperty.java
@@ -68,6 +68,7 @@ public final class DefaultDurationProperty implements JsonSerializable<DefaultDu
     @Generated
     public static DefaultDurationProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             Duration value = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/encode/duration/models/Float64SecondsDurationProperty.java
+++ b/typespec-tests/src/main/java/com/encode/duration/models/Float64SecondsDurationProperty.java
@@ -71,6 +71,7 @@ public final class Float64SecondsDurationProperty implements JsonSerializable<Fl
     @Generated
     public static Float64SecondsDurationProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             Duration value = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/encode/duration/models/FloatSecondsDurationArrayProperty.java
+++ b/typespec-tests/src/main/java/com/encode/duration/models/FloatSecondsDurationArrayProperty.java
@@ -79,6 +79,7 @@ public final class FloatSecondsDurationArrayProperty implements JsonSerializable
     @Generated
     public static FloatSecondsDurationArrayProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             List<Duration> value = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/encode/duration/models/FloatSecondsDurationProperty.java
+++ b/typespec-tests/src/main/java/com/encode/duration/models/FloatSecondsDurationProperty.java
@@ -71,6 +71,7 @@ public final class FloatSecondsDurationProperty implements JsonSerializable<Floa
     @Generated
     public static FloatSecondsDurationProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             Duration value = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/encode/duration/models/ISO8601DurationProperty.java
+++ b/typespec-tests/src/main/java/com/encode/duration/models/ISO8601DurationProperty.java
@@ -68,6 +68,7 @@ public final class ISO8601DurationProperty implements JsonSerializable<ISO8601Du
     @Generated
     public static ISO8601DurationProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             Duration value = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/encode/duration/models/Int32SecondsDurationProperty.java
+++ b/typespec-tests/src/main/java/com/encode/duration/models/Int32SecondsDurationProperty.java
@@ -71,6 +71,7 @@ public final class Int32SecondsDurationProperty implements JsonSerializable<Int3
     @Generated
     public static Int32SecondsDurationProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             Duration value = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/parameters/basic/implementation/models/SimpleRequest.java
+++ b/typespec-tests/src/main/java/com/parameters/basic/implementation/models/SimpleRequest.java
@@ -66,6 +66,7 @@ public final class SimpleRequest implements JsonSerializable<SimpleRequest> {
     @Generated
     public static SimpleRequest fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/parameters/basic/models/User.java
+++ b/typespec-tests/src/main/java/com/parameters/basic/models/User.java
@@ -66,6 +66,7 @@ public final class User implements JsonSerializable<User> {
     @Generated
     public static User fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/parameters/bodyoptionality/implementation/models/RequiredImplicitRequest.java
+++ b/typespec-tests/src/main/java/com/parameters/bodyoptionality/implementation/models/RequiredImplicitRequest.java
@@ -66,6 +66,7 @@ public final class RequiredImplicitRequest implements JsonSerializable<RequiredI
     @Generated
     public static RequiredImplicitRequest fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/parameters/bodyoptionality/models/BodyModel.java
+++ b/typespec-tests/src/main/java/com/parameters/bodyoptionality/models/BodyModel.java
@@ -66,6 +66,7 @@ public final class BodyModel implements JsonSerializable<BodyModel> {
     @Generated
     public static BodyModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/parameters/spread/implementation/models/SpreadAsRequestBodyRequest.java
+++ b/typespec-tests/src/main/java/com/parameters/spread/implementation/models/SpreadAsRequestBodyRequest.java
@@ -66,6 +66,7 @@ public final class SpreadAsRequestBodyRequest implements JsonSerializable<Spread
     @Generated
     public static SpreadAsRequestBodyRequest fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/parameters/spread/implementation/models/SpreadAsRequestBodyRequest1.java
+++ b/typespec-tests/src/main/java/com/parameters/spread/implementation/models/SpreadAsRequestBodyRequest1.java
@@ -66,6 +66,7 @@ public final class SpreadAsRequestBodyRequest1 implements JsonSerializable<Sprea
     @Generated
     public static SpreadAsRequestBodyRequest1 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/parameters/spread/implementation/models/SpreadAsRequestParameterRequest.java
+++ b/typespec-tests/src/main/java/com/parameters/spread/implementation/models/SpreadAsRequestParameterRequest.java
@@ -66,6 +66,7 @@ public final class SpreadAsRequestParameterRequest implements JsonSerializable<S
     @Generated
     public static SpreadAsRequestParameterRequest fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/parameters/spread/implementation/models/SpreadCompositeRequestMixRequest.java
+++ b/typespec-tests/src/main/java/com/parameters/spread/implementation/models/SpreadCompositeRequestMixRequest.java
@@ -66,6 +66,7 @@ public final class SpreadCompositeRequestMixRequest implements JsonSerializable<
     @Generated
     public static SpreadCompositeRequestMixRequest fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String prop = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/parameters/spread/implementation/models/SpreadParameterWithInnerAliasRequest.java
+++ b/typespec-tests/src/main/java/com/parameters/spread/implementation/models/SpreadParameterWithInnerAliasRequest.java
@@ -86,6 +86,7 @@ public final class SpreadParameterWithInnerAliasRequest
     @Generated
     public static SpreadParameterWithInnerAliasRequest fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             int age = 0;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/parameters/spread/implementation/models/SpreadParameterWithInnerModelRequest.java
+++ b/typespec-tests/src/main/java/com/parameters/spread/implementation/models/SpreadParameterWithInnerModelRequest.java
@@ -67,6 +67,7 @@ public final class SpreadParameterWithInnerModelRequest
     @Generated
     public static SpreadParameterWithInnerModelRequest fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/parameters/spread/implementation/models/SpreadWithMultipleParametersRequest.java
+++ b/typespec-tests/src/main/java/com/parameters/spread/implementation/models/SpreadWithMultipleParametersRequest.java
@@ -147,6 +147,7 @@ public final class SpreadWithMultipleParametersRequest
     @Generated
     public static SpreadWithMultipleParametersRequest fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String requiredString = null;
             List<Integer> requiredIntList = null;
             Integer optionalInt = null;

--- a/typespec-tests/src/main/java/com/parameters/spread/models/BodyParameter.java
+++ b/typespec-tests/src/main/java/com/parameters/spread/models/BodyParameter.java
@@ -66,6 +66,7 @@ public final class BodyParameter implements JsonSerializable<BodyParameter> {
     @Generated
     public static BodyParameter fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/payload/contentnegotiation/models/PngImageAsJson.java
+++ b/typespec-tests/src/main/java/com/payload/contentnegotiation/models/PngImageAsJson.java
@@ -67,6 +67,7 @@ public final class PngImageAsJson implements JsonSerializable<PngImageAsJson> {
     @Generated
     public static PngImageAsJson fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             byte[] content = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/payload/jsonmergepatch/models/InnerModel.java
+++ b/typespec-tests/src/main/java/com/payload/jsonmergepatch/models/InnerModel.java
@@ -12,8 +12,6 @@ import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
 import com.payload.jsonmergepatch.implementation.JsonMergePatchHelper;
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * It is the model used by Resource model.
@@ -36,7 +34,7 @@ public final class InnerModel implements JsonSerializable<InnerModel> {
      * Stores updated model property, the value is property name, not serialized name.
      */
     @Generated
-    private final Set<String> updatedProperties = new HashSet<>();
+    private long updatedProperties = 0L;
 
     @Generated
     private boolean jsonMergePatch;
@@ -87,7 +85,7 @@ public final class InnerModel implements JsonSerializable<InnerModel> {
     @Generated
     public InnerModel setName(String name) {
         this.name = name;
-        this.updatedProperties.add("name");
+        this.updatedProperties |= 1;
         return this;
     }
 
@@ -110,7 +108,7 @@ public final class InnerModel implements JsonSerializable<InnerModel> {
     @Generated
     public InnerModel setDescription(String description) {
         this.description = description;
-        this.updatedProperties.add("description");
+        this.updatedProperties |= 2;
         return this;
     }
 
@@ -133,14 +131,14 @@ public final class InnerModel implements JsonSerializable<InnerModel> {
     @Generated
     private JsonWriter toJsonMergePatch(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        if (updatedProperties.contains("name")) {
+        if ((this.updatedProperties & 1) == 1) {
             if (this.name == null) {
                 jsonWriter.writeNullField("name");
             } else {
                 jsonWriter.writeStringField("name", this.name);
             }
         }
-        if (updatedProperties.contains("description")) {
+        if ((this.updatedProperties & 2) == 2) {
             if (this.description == null) {
                 jsonWriter.writeNullField("description");
             } else {

--- a/typespec-tests/src/main/java/com/payload/jsonmergepatch/models/Resource.java
+++ b/typespec-tests/src/main/java/com/payload/jsonmergepatch/models/Resource.java
@@ -271,6 +271,7 @@ public final class Resource implements JsonSerializable<Resource> {
     @Generated
     public static Resource fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             String description = null;
             Map<String, InnerModel> map = null;

--- a/typespec-tests/src/main/java/com/payload/jsonmergepatch/models/ResourcePatch.java
+++ b/typespec-tests/src/main/java/com/payload/jsonmergepatch/models/ResourcePatch.java
@@ -12,10 +12,8 @@ import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
 import com.payload.jsonmergepatch.implementation.JsonMergePatchHelper;
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Details about a resource for patch operation.
@@ -68,7 +66,7 @@ public final class ResourcePatch implements JsonSerializable<ResourcePatch> {
      * Stores updated model property, the value is property name, not serialized name.
      */
     @Generated
-    private final Set<String> updatedProperties = new HashSet<>();
+    private long updatedProperties = 0L;
 
     @Generated
     private boolean jsonMergePatch;
@@ -119,7 +117,7 @@ public final class ResourcePatch implements JsonSerializable<ResourcePatch> {
     @Generated
     public ResourcePatch setDescription(String description) {
         this.description = description;
-        this.updatedProperties.add("description");
+        this.updatedProperties |= 1;
         return this;
     }
 
@@ -142,7 +140,7 @@ public final class ResourcePatch implements JsonSerializable<ResourcePatch> {
     @Generated
     public ResourcePatch setMap(Map<String, InnerModel> map) {
         this.map = map;
-        this.updatedProperties.add("map");
+        this.updatedProperties |= 2;
         return this;
     }
 
@@ -165,7 +163,7 @@ public final class ResourcePatch implements JsonSerializable<ResourcePatch> {
     @Generated
     public ResourcePatch setArray(List<InnerModel> array) {
         this.array = array;
-        this.updatedProperties.add("array");
+        this.updatedProperties |= 4;
         return this;
     }
 
@@ -188,7 +186,7 @@ public final class ResourcePatch implements JsonSerializable<ResourcePatch> {
     @Generated
     public ResourcePatch setIntValue(Integer intValue) {
         this.intValue = intValue;
-        this.updatedProperties.add("intValue");
+        this.updatedProperties |= 8;
         return this;
     }
 
@@ -211,7 +209,7 @@ public final class ResourcePatch implements JsonSerializable<ResourcePatch> {
     @Generated
     public ResourcePatch setFloatValue(Double floatValue) {
         this.floatValue = floatValue;
-        this.updatedProperties.add("floatValue");
+        this.updatedProperties |= 16;
         return this;
     }
 
@@ -234,7 +232,7 @@ public final class ResourcePatch implements JsonSerializable<ResourcePatch> {
     @Generated
     public ResourcePatch setInnerModel(InnerModel innerModel) {
         this.innerModel = innerModel;
-        this.updatedProperties.add("innerModel");
+        this.updatedProperties |= 32;
         return this;
     }
 
@@ -257,7 +255,7 @@ public final class ResourcePatch implements JsonSerializable<ResourcePatch> {
     @Generated
     public ResourcePatch setIntArray(List<Integer> intArray) {
         this.intArray = intArray;
-        this.updatedProperties.add("intArray");
+        this.updatedProperties |= 64;
         return this;
     }
 
@@ -285,14 +283,14 @@ public final class ResourcePatch implements JsonSerializable<ResourcePatch> {
     @Generated
     private JsonWriter toJsonMergePatch(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        if (updatedProperties.contains("description")) {
+        if ((this.updatedProperties & 1) == 1) {
             if (this.description == null) {
                 jsonWriter.writeNullField("description");
             } else {
                 jsonWriter.writeStringField("description", this.description);
             }
         }
-        if (updatedProperties.contains("map")) {
+        if ((this.updatedProperties & 2) == 2) {
             if (this.map == null) {
                 jsonWriter.writeNullField("map");
             } else {
@@ -307,28 +305,28 @@ public final class ResourcePatch implements JsonSerializable<ResourcePatch> {
                 });
             }
         }
-        if (updatedProperties.contains("array")) {
+        if ((this.updatedProperties & 4) == 4) {
             if (this.array == null) {
                 jsonWriter.writeNullField("array");
             } else {
                 jsonWriter.writeArrayField("array", this.array, (writer, element) -> writer.writeJson(element));
             }
         }
-        if (updatedProperties.contains("intValue")) {
+        if ((this.updatedProperties & 8) == 8) {
             if (this.intValue == null) {
                 jsonWriter.writeNullField("intValue");
             } else {
                 jsonWriter.writeNumberField("intValue", this.intValue);
             }
         }
-        if (updatedProperties.contains("floatValue")) {
+        if ((this.updatedProperties & 16) == 16) {
             if (this.floatValue == null) {
                 jsonWriter.writeNullField("floatValue");
             } else {
                 jsonWriter.writeNumberField("floatValue", this.floatValue);
             }
         }
-        if (updatedProperties.contains("innerModel")) {
+        if ((this.updatedProperties & 32) == 32) {
             if (this.innerModel == null) {
                 jsonWriter.writeNullField("innerModel");
             } else {
@@ -337,7 +335,7 @@ public final class ResourcePatch implements JsonSerializable<ResourcePatch> {
                 JsonMergePatchHelper.getInnerModelAccessor().prepareModelForJsonMergePatch(this.innerModel, false);
             }
         }
-        if (updatedProperties.contains("intArray")) {
+        if ((this.updatedProperties & 64) == 64) {
             if (this.intArray == null) {
                 jsonWriter.writeNullField("intArray");
             } else {

--- a/typespec-tests/src/main/java/com/payload/multipart/models/Address.java
+++ b/typespec-tests/src/main/java/com/payload/multipart/models/Address.java
@@ -66,6 +66,7 @@ public final class Address implements JsonSerializable<Address> {
     @Generated
     public static Address fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String city = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/payload/pageable/models/User.java
+++ b/typespec-tests/src/main/java/com/payload/pageable/models/User.java
@@ -66,6 +66,7 @@ public final class User implements JsonSerializable<User> {
     @Generated
     public static User fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/serialization/encodedname/json/models/JsonEncodedNameModel.java
+++ b/typespec-tests/src/main/java/com/serialization/encodedname/json/models/JsonEncodedNameModel.java
@@ -66,6 +66,7 @@ public final class JsonEncodedNameModel implements JsonSerializable<JsonEncodedN
     @Generated
     public static JsonEncodedNameModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             boolean defaultName = false;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/And.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/And.java
@@ -66,6 +66,7 @@ public final class And implements JsonSerializable<And> {
     @Generated
     public static And fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/As.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/As.java
@@ -66,6 +66,7 @@ public final class As implements JsonSerializable<As> {
     @Generated
     public static As fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/Assert.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/Assert.java
@@ -66,6 +66,7 @@ public final class Assert implements JsonSerializable<Assert> {
     @Generated
     public static Assert fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/Async.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/Async.java
@@ -66,6 +66,7 @@ public final class Async implements JsonSerializable<Async> {
     @Generated
     public static Async fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/Await.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/Await.java
@@ -66,6 +66,7 @@ public final class Await implements JsonSerializable<Await> {
     @Generated
     public static Await fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/Break.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/Break.java
@@ -66,6 +66,7 @@ public final class Break implements JsonSerializable<Break> {
     @Generated
     public static Break fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/ClassModel.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/ClassModel.java
@@ -66,6 +66,7 @@ public final class ClassModel implements JsonSerializable<ClassModel> {
     @Generated
     public static ClassModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/Constructor.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/Constructor.java
@@ -66,6 +66,7 @@ public final class Constructor implements JsonSerializable<Constructor> {
     @Generated
     public static Constructor fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/Continue.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/Continue.java
@@ -66,6 +66,7 @@ public final class Continue implements JsonSerializable<Continue> {
     @Generated
     public static Continue fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/Def.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/Def.java
@@ -66,6 +66,7 @@ public final class Def implements JsonSerializable<Def> {
     @Generated
     public static Def fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/Del.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/Del.java
@@ -66,6 +66,7 @@ public final class Del implements JsonSerializable<Del> {
     @Generated
     public static Del fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/Elif.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/Elif.java
@@ -66,6 +66,7 @@ public final class Elif implements JsonSerializable<Elif> {
     @Generated
     public static Elif fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/Else.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/Else.java
@@ -66,6 +66,7 @@ public final class Else implements JsonSerializable<Else> {
     @Generated
     public static Else fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/Except.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/Except.java
@@ -66,6 +66,7 @@ public final class Except implements JsonSerializable<Except> {
     @Generated
     public static Except fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/Exec.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/Exec.java
@@ -66,6 +66,7 @@ public final class Exec implements JsonSerializable<Exec> {
     @Generated
     public static Exec fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/Finally.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/Finally.java
@@ -66,6 +66,7 @@ public final class Finally implements JsonSerializable<Finally> {
     @Generated
     public static Finally fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/For.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/For.java
@@ -66,6 +66,7 @@ public final class For implements JsonSerializable<For> {
     @Generated
     public static For fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/From.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/From.java
@@ -66,6 +66,7 @@ public final class From implements JsonSerializable<From> {
     @Generated
     public static From fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/Global.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/Global.java
@@ -66,6 +66,7 @@ public final class Global implements JsonSerializable<Global> {
     @Generated
     public static Global fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/If.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/If.java
@@ -66,6 +66,7 @@ public final class If implements JsonSerializable<If> {
     @Generated
     public static If fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/Import.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/Import.java
@@ -66,6 +66,7 @@ public final class Import implements JsonSerializable<Import> {
     @Generated
     public static Import fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/In.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/In.java
@@ -66,6 +66,7 @@ public final class In implements JsonSerializable<In> {
     @Generated
     public static In fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/Is.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/Is.java
@@ -66,6 +66,7 @@ public final class Is implements JsonSerializable<Is> {
     @Generated
     public static Is fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/Lambda.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/Lambda.java
@@ -66,6 +66,7 @@ public final class Lambda implements JsonSerializable<Lambda> {
     @Generated
     public static Lambda fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/Not.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/Not.java
@@ -66,6 +66,7 @@ public final class Not implements JsonSerializable<Not> {
     @Generated
     public static Not fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/Or.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/Or.java
@@ -66,6 +66,7 @@ public final class Or implements JsonSerializable<Or> {
     @Generated
     public static Or fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/Pass.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/Pass.java
@@ -66,6 +66,7 @@ public final class Pass implements JsonSerializable<Pass> {
     @Generated
     public static Pass fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/Raise.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/Raise.java
@@ -66,6 +66,7 @@ public final class Raise implements JsonSerializable<Raise> {
     @Generated
     public static Raise fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/Return.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/Return.java
@@ -66,6 +66,7 @@ public final class Return implements JsonSerializable<Return> {
     @Generated
     public static Return fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/SameAsModel.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/SameAsModel.java
@@ -66,6 +66,7 @@ public final class SameAsModel implements JsonSerializable<SameAsModel> {
     @Generated
     public static SameAsModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String sameAsModel = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/Try.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/Try.java
@@ -66,6 +66,7 @@ public final class Try implements JsonSerializable<Try> {
     @Generated
     public static Try fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/While.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/While.java
@@ -66,6 +66,7 @@ public final class While implements JsonSerializable<While> {
     @Generated
     public static While fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/With.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/With.java
@@ -66,6 +66,7 @@ public final class With implements JsonSerializable<With> {
     @Generated
     public static With fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/specialwords/models/Yield.java
+++ b/typespec-tests/src/main/java/com/specialwords/models/Yield.java
@@ -66,6 +66,7 @@ public final class Yield implements JsonSerializable<Yield> {
     @Generated
     public static Yield fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/array/models/InnerModel.java
+++ b/typespec-tests/src/main/java/com/type/array/models/InnerModel.java
@@ -96,6 +96,7 @@ public final class InnerModel implements JsonSerializable<InnerModel> {
     @Generated
     public static InnerModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String property = null;
             List<InnerModel> children = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/dictionary/models/InnerModel.java
+++ b/typespec-tests/src/main/java/com/type/dictionary/models/InnerModel.java
@@ -96,6 +96,7 @@ public final class InnerModel implements JsonSerializable<InnerModel> {
     @Generated
     public static InnerModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String property = null;
             Map<String, InnerModel> children = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/model/flatten/models/ChildFlattenModel.java
+++ b/typespec-tests/src/main/java/com/type/model/flatten/models/ChildFlattenModel.java
@@ -85,6 +85,7 @@ public final class ChildFlattenModel implements JsonSerializable<ChildFlattenMod
     @Generated
     public static ChildFlattenModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String summary = null;
             ChildModel properties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/model/flatten/models/ChildModel.java
+++ b/typespec-tests/src/main/java/com/type/model/flatten/models/ChildModel.java
@@ -85,6 +85,7 @@ public final class ChildModel implements JsonSerializable<ChildModel> {
     @Generated
     public static ChildModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String description = null;
             int age = 0;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/model/flatten/models/FlattenModel.java
+++ b/typespec-tests/src/main/java/com/type/model/flatten/models/FlattenModel.java
@@ -85,6 +85,7 @@ public final class FlattenModel implements JsonSerializable<FlattenModel> {
     @Generated
     public static FlattenModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             ChildModel properties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/model/flatten/models/NestedFlattenModel.java
+++ b/typespec-tests/src/main/java/com/type/model/flatten/models/NestedFlattenModel.java
@@ -85,6 +85,7 @@ public final class NestedFlattenModel implements JsonSerializable<NestedFlattenM
     @Generated
     public static NestedFlattenModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             ChildFlattenModel properties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/model/inheritance/enumdiscriminator/models/Cobra.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/enumdiscriminator/models/Cobra.java
@@ -67,6 +67,7 @@ public final class Cobra extends Snake {
     @Generated
     public static Cobra fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             int length = 0;
             SnakeKind kind = SnakeKind.COBRA;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/model/inheritance/enumdiscriminator/models/Dog.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/enumdiscriminator/models/Dog.java
@@ -109,6 +109,7 @@ public class Dog implements JsonSerializable<Dog> {
     @Generated
     static Dog fromJsonKnownDiscriminator(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             int weight = 0;
             DogKind kind = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/model/inheritance/enumdiscriminator/models/Golden.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/enumdiscriminator/models/Golden.java
@@ -67,6 +67,7 @@ public final class Golden extends Dog {
     @Generated
     public static Golden fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             int weight = 0;
             DogKind kind = DogKind.GOLDEN;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/model/inheritance/enumdiscriminator/models/Snake.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/enumdiscriminator/models/Snake.java
@@ -109,6 +109,7 @@ public class Snake implements JsonSerializable<Snake> {
     @Generated
     static Snake fromJsonKnownDiscriminator(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             int length = 0;
             SnakeKind kind = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/model/inheritance/enumnesteddiscriminator/models/Fish.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/enumnesteddiscriminator/models/Fish.java
@@ -111,6 +111,7 @@ public class Fish implements JsonSerializable<Fish> {
     @Generated
     static Fish fromJsonKnownDiscriminator(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             int age = 0;
             FishKind kind = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/model/inheritance/enumnesteddiscriminator/models/GoblinShark.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/enumnesteddiscriminator/models/GoblinShark.java
@@ -85,6 +85,7 @@ public final class GoblinShark extends Shark {
     @Generated
     public static GoblinShark fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             int age = 0;
             SharkKind sharktype = SharkKind.GOBLIN;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/model/inheritance/enumnesteddiscriminator/models/Salmon.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/enumnesteddiscriminator/models/Salmon.java
@@ -157,6 +157,7 @@ public final class Salmon extends Fish {
     @Generated
     public static Salmon fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             int age = 0;
             FishKind kind = FishKind.SALMON;
             List<Fish> friends = null;

--- a/typespec-tests/src/main/java/com/type/model/inheritance/enumnesteddiscriminator/models/SawShark.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/enumnesteddiscriminator/models/SawShark.java
@@ -85,6 +85,7 @@ public final class SawShark extends Shark {
     @Generated
     public static SawShark fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             int age = 0;
             SharkKind sharktype = SharkKind.SAW;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/model/inheritance/enumnesteddiscriminator/models/Shark.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/enumnesteddiscriminator/models/Shark.java
@@ -112,6 +112,7 @@ public class Shark extends Fish {
     @Generated
     static Shark fromJsonKnownDiscriminator(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             int age = 0;
             SharkKind sharktype = SharkKind.fromString("shark");
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/Fish.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/Fish.java
@@ -111,6 +111,7 @@ public class Fish implements JsonSerializable<Fish> {
     @Generated
     static Fish fromJsonKnownDiscriminator(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             int age = 0;
             String kind = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/GoblinShark.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/GoblinShark.java
@@ -85,6 +85,7 @@ public final class GoblinShark extends Shark {
     @Generated
     public static GoblinShark fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             int age = 0;
             String sharktype = "goblin";
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/Salmon.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/Salmon.java
@@ -157,6 +157,7 @@ public final class Salmon extends Fish {
     @Generated
     public static Salmon fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             int age = 0;
             String kind = "salmon";
             List<Fish> friends = null;

--- a/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/SawShark.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/SawShark.java
@@ -85,6 +85,7 @@ public final class SawShark extends Shark {
     @Generated
     public static SawShark fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             int age = 0;
             String sharktype = "saw";
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/Shark.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/nesteddiscriminator/models/Shark.java
@@ -112,6 +112,7 @@ public class Shark extends Fish {
     @Generated
     static Shark fromJsonKnownDiscriminator(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             int age = 0;
             String sharktype = "shark";
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/model/inheritance/notdiscriminated/models/Cat.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/notdiscriminated/models/Cat.java
@@ -68,6 +68,7 @@ public class Cat extends Pet {
     @Generated
     public static Cat fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             int age = 0;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/model/inheritance/notdiscriminated/models/Pet.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/notdiscriminated/models/Pet.java
@@ -66,6 +66,7 @@ public class Pet implements JsonSerializable<Pet> {
     @Generated
     public static Pet fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/model/inheritance/notdiscriminated/models/Siamese.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/notdiscriminated/models/Siamese.java
@@ -70,6 +70,7 @@ public final class Siamese extends Cat {
     @Generated
     public static Siamese fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             int age = 0;
             boolean smart = false;

--- a/typespec-tests/src/main/java/com/type/model/inheritance/recursive/models/Extension.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/recursive/models/Extension.java
@@ -77,6 +77,7 @@ public final class Extension extends Element {
     @Generated
     public static Extension fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             List<Extension> extension = null;
             int level = 0;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/model/inheritance/recursive/models/Extension.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/recursive/models/Extension.java
@@ -34,16 +34,6 @@ public final class Extension extends Element {
     }
 
     /**
-     * Get the level property: The level property.
-     * 
-     * @return the level value.
-     */
-    @Generated
-    public int getLevel() {
-        return this.level;
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Generated
@@ -51,6 +41,16 @@ public final class Extension extends Element {
     public Extension setExtension(List<Extension> extension) {
         super.setExtension(extension);
         return this;
+    }
+
+    /**
+     * Get the level property: The level property.
+     * 
+     * @return the level value.
+     */
+    @Generated
+    public int getLevel() {
+        return this.level;
     }
 
     /**

--- a/typespec-tests/src/main/java/com/type/model/inheritance/singlediscriminator/models/Bird.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/singlediscriminator/models/Bird.java
@@ -115,6 +115,7 @@ public class Bird implements JsonSerializable<Bird> {
     @Generated
     static Bird fromJsonKnownDiscriminator(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             int wingspan = 0;
             String kind = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/model/inheritance/singlediscriminator/models/Dinosaur.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/singlediscriminator/models/Dinosaur.java
@@ -109,6 +109,7 @@ public class Dinosaur implements JsonSerializable<Dinosaur> {
     @Generated
     static Dinosaur fromJsonKnownDiscriminator(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             int size = 0;
             String kind = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/model/inheritance/singlediscriminator/models/Eagle.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/singlediscriminator/models/Eagle.java
@@ -157,6 +157,7 @@ public final class Eagle extends Bird {
     @Generated
     public static Eagle fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             int wingspan = 0;
             String kind = "eagle";
             List<Bird> friends = null;

--- a/typespec-tests/src/main/java/com/type/model/inheritance/singlediscriminator/models/Goose.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/singlediscriminator/models/Goose.java
@@ -67,6 +67,7 @@ public final class Goose extends Bird {
     @Generated
     public static Goose fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             int wingspan = 0;
             String kind = "goose";
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/model/inheritance/singlediscriminator/models/SeaGull.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/singlediscriminator/models/SeaGull.java
@@ -67,6 +67,7 @@ public final class SeaGull extends Bird {
     @Generated
     public static SeaGull fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             int wingspan = 0;
             String kind = "seagull";
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/model/inheritance/singlediscriminator/models/Sparrow.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/singlediscriminator/models/Sparrow.java
@@ -67,6 +67,7 @@ public final class Sparrow extends Bird {
     @Generated
     public static Sparrow fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             int wingspan = 0;
             String kind = "sparrow";
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/model/inheritance/singlediscriminator/models/TRex.java
+++ b/typespec-tests/src/main/java/com/type/model/inheritance/singlediscriminator/models/TRex.java
@@ -67,6 +67,7 @@ public final class TRex extends Dinosaur {
     @Generated
     public static TRex fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             int size = 0;
             String kind = "t-rex";
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/model/usage/models/InputOutputRecord.java
+++ b/typespec-tests/src/main/java/com/type/model/usage/models/InputOutputRecord.java
@@ -66,6 +66,7 @@ public final class InputOutputRecord implements JsonSerializable<InputOutputReco
     @Generated
     public static InputOutputRecord fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String requiredProp = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/model/usage/models/InputRecord.java
+++ b/typespec-tests/src/main/java/com/type/model/usage/models/InputRecord.java
@@ -66,6 +66,7 @@ public final class InputRecord implements JsonSerializable<InputRecord> {
     @Generated
     public static InputRecord fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String requiredProp = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/model/usage/models/OutputRecord.java
+++ b/typespec-tests/src/main/java/com/type/model/usage/models/OutputRecord.java
@@ -66,6 +66,7 @@ public final class OutputRecord implements JsonSerializable<OutputRecord> {
     @Generated
     public static OutputRecord fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String requiredProp = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/model/visibility/models/VisibilityModel.java
+++ b/typespec-tests/src/main/java/com/type/model/visibility/models/VisibilityModel.java
@@ -140,6 +140,7 @@ public final class VisibilityModel implements JsonSerializable<VisibilityModel> 
     @Generated
     public static VisibilityModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String readProp = null;
             Integer queryProp = null;
             List<String> createProp = null;

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/DifferentSpreadFloatDerived.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/DifferentSpreadFloatDerived.java
@@ -75,6 +75,7 @@ public final class DifferentSpreadFloatDerived extends DifferentSpreadFloatRecor
     @Generated
     public static DifferentSpreadFloatDerived fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             double derivedProp = 0.0;
             Map<String, Double> additionalProperties = null;

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/DifferentSpreadFloatRecord.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/DifferentSpreadFloatRecord.java
@@ -101,6 +101,7 @@ public class DifferentSpreadFloatRecord implements JsonSerializable<DifferentSpr
     @Generated
     public static DifferentSpreadFloatRecord fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             Map<String, Double> additionalProperties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/DifferentSpreadModelArrayDerived.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/DifferentSpreadModelArrayDerived.java
@@ -76,6 +76,7 @@ public final class DifferentSpreadModelArrayDerived extends DifferentSpreadModel
     @Generated
     public static DifferentSpreadModelArrayDerived fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String knownProp = null;
             List<ModelForRecord> derivedProp = null;
             Map<String, List<ModelForRecord>> additionalProperties = null;

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/DifferentSpreadModelArrayRecord.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/DifferentSpreadModelArrayRecord.java
@@ -103,6 +103,7 @@ public class DifferentSpreadModelArrayRecord implements JsonSerializable<Differe
     @Generated
     public static DifferentSpreadModelArrayRecord fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String knownProp = null;
             Map<String, List<ModelForRecord>> additionalProperties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/DifferentSpreadModelDerived.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/DifferentSpreadModelDerived.java
@@ -75,6 +75,7 @@ public final class DifferentSpreadModelDerived extends DifferentSpreadModelRecor
     @Generated
     public static DifferentSpreadModelDerived fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String knownProp = null;
             ModelForRecord derivedProp = null;
             Map<String, ModelForRecord> additionalProperties = null;

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/DifferentSpreadModelRecord.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/DifferentSpreadModelRecord.java
@@ -101,6 +101,7 @@ public class DifferentSpreadModelRecord implements JsonSerializable<DifferentSpr
     @Generated
     public static DifferentSpreadModelRecord fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String knownProp = null;
             Map<String, ModelForRecord> additionalProperties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/DifferentSpreadStringDerived.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/DifferentSpreadStringDerived.java
@@ -75,6 +75,7 @@ public final class DifferentSpreadStringDerived extends DifferentSpreadStringRec
     @Generated
     public static DifferentSpreadStringDerived fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             double id = 0.0;
             String derivedProp = null;
             Map<String, String> additionalProperties = null;

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/DifferentSpreadStringRecord.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/DifferentSpreadStringRecord.java
@@ -101,6 +101,7 @@ public class DifferentSpreadStringRecord implements JsonSerializable<DifferentSp
     @Generated
     public static DifferentSpreadStringRecord fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             double id = 0.0;
             Map<String, String> additionalProperties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/ExtendsFloatAdditionalProperties.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/ExtendsFloatAdditionalProperties.java
@@ -101,6 +101,7 @@ public final class ExtendsFloatAdditionalProperties implements JsonSerializable<
     @Generated
     public static ExtendsFloatAdditionalProperties fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             double id = 0.0;
             Map<String, Double> additionalProperties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/ExtendsModelAdditionalProperties.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/ExtendsModelAdditionalProperties.java
@@ -101,6 +101,7 @@ public final class ExtendsModelAdditionalProperties implements JsonSerializable<
     @Generated
     public static ExtendsModelAdditionalProperties fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             ModelForRecord knownProp = null;
             Map<String, ModelForRecord> additionalProperties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/ExtendsModelArrayAdditionalProperties.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/ExtendsModelArrayAdditionalProperties.java
@@ -104,6 +104,7 @@ public final class ExtendsModelArrayAdditionalProperties
     @Generated
     public static ExtendsModelArrayAdditionalProperties fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             List<ModelForRecord> knownProp = null;
             Map<String, List<ModelForRecord>> additionalProperties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/ExtendsStringAdditionalProperties.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/ExtendsStringAdditionalProperties.java
@@ -101,6 +101,7 @@ public final class ExtendsStringAdditionalProperties implements JsonSerializable
     @Generated
     public static ExtendsStringAdditionalProperties fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             Map<String, String> additionalProperties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/ExtendsUnknownAdditionalProperties.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/ExtendsUnknownAdditionalProperties.java
@@ -101,6 +101,7 @@ public class ExtendsUnknownAdditionalProperties implements JsonSerializable<Exte
     @Generated
     public static ExtendsUnknownAdditionalProperties fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             Map<String, Object> additionalProperties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/ExtendsUnknownAdditionalPropertiesDerived.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/ExtendsUnknownAdditionalPropertiesDerived.java
@@ -104,6 +104,7 @@ public final class ExtendsUnknownAdditionalPropertiesDerived extends ExtendsUnkn
     @Generated
     public static ExtendsUnknownAdditionalPropertiesDerived fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             int index = 0;
             Double age = null;

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/ExtendsUnknownAdditionalPropertiesDiscriminated.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/ExtendsUnknownAdditionalPropertiesDiscriminated.java
@@ -147,6 +147,7 @@ public class ExtendsUnknownAdditionalPropertiesDiscriminated
     static ExtendsUnknownAdditionalPropertiesDiscriminated fromJsonKnownDiscriminator(JsonReader jsonReader)
         throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             String kind = null;
             Map<String, Object> additionalProperties = null;

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/ExtendsUnknownAdditionalPropertiesDiscriminatedDerived.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/ExtendsUnknownAdditionalPropertiesDiscriminatedDerived.java
@@ -124,6 +124,7 @@ public final class ExtendsUnknownAdditionalPropertiesDiscriminatedDerived
     public static ExtendsUnknownAdditionalPropertiesDiscriminatedDerived fromJson(JsonReader jsonReader)
         throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             int index = 0;
             String kind = "derived";

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/IsFloatAdditionalProperties.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/IsFloatAdditionalProperties.java
@@ -101,6 +101,7 @@ public final class IsFloatAdditionalProperties implements JsonSerializable<IsFlo
     @Generated
     public static IsFloatAdditionalProperties fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             double id = 0.0;
             Map<String, Double> additionalProperties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/IsModelAdditionalProperties.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/IsModelAdditionalProperties.java
@@ -101,6 +101,7 @@ public final class IsModelAdditionalProperties implements JsonSerializable<IsMod
     @Generated
     public static IsModelAdditionalProperties fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             ModelForRecord knownProp = null;
             Map<String, ModelForRecord> additionalProperties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/IsModelArrayAdditionalProperties.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/IsModelArrayAdditionalProperties.java
@@ -103,6 +103,7 @@ public final class IsModelArrayAdditionalProperties implements JsonSerializable<
     @Generated
     public static IsModelArrayAdditionalProperties fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             List<ModelForRecord> knownProp = null;
             Map<String, List<ModelForRecord>> additionalProperties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/IsStringAdditionalProperties.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/IsStringAdditionalProperties.java
@@ -101,6 +101,7 @@ public final class IsStringAdditionalProperties implements JsonSerializable<IsSt
     @Generated
     public static IsStringAdditionalProperties fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             Map<String, String> additionalProperties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/IsUnknownAdditionalProperties.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/IsUnknownAdditionalProperties.java
@@ -101,6 +101,7 @@ public class IsUnknownAdditionalProperties implements JsonSerializable<IsUnknown
     @Generated
     public static IsUnknownAdditionalProperties fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             Map<String, Object> additionalProperties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/IsUnknownAdditionalPropertiesDerived.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/IsUnknownAdditionalPropertiesDerived.java
@@ -104,6 +104,7 @@ public final class IsUnknownAdditionalPropertiesDerived extends IsUnknownAdditio
     @Generated
     public static IsUnknownAdditionalPropertiesDerived fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             int index = 0;
             Double age = null;

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/IsUnknownAdditionalPropertiesDiscriminated.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/IsUnknownAdditionalPropertiesDiscriminated.java
@@ -147,6 +147,7 @@ public class IsUnknownAdditionalPropertiesDiscriminated
     static IsUnknownAdditionalPropertiesDiscriminated fromJsonKnownDiscriminator(JsonReader jsonReader)
         throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             String kind = null;
             Map<String, Object> additionalProperties = null;

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/IsUnknownAdditionalPropertiesDiscriminatedDerived.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/IsUnknownAdditionalPropertiesDiscriminatedDerived.java
@@ -123,6 +123,7 @@ public final class IsUnknownAdditionalPropertiesDiscriminatedDerived
     @Generated
     public static IsUnknownAdditionalPropertiesDiscriminatedDerived fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             int index = 0;
             String kind = "derived";

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/ModelForRecord.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/ModelForRecord.java
@@ -66,6 +66,7 @@ public final class ModelForRecord implements JsonSerializable<ModelForRecord> {
     @Generated
     public static ModelForRecord fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String state = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/MultipleSpreadRecord.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/MultipleSpreadRecord.java
@@ -105,6 +105,7 @@ public final class MultipleSpreadRecord implements JsonSerializable<MultipleSpre
     @Generated
     public static MultipleSpreadRecord fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             boolean flag = false;
             Map<String, BinaryData> additionalProperties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/SpreadFloatRecord.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/SpreadFloatRecord.java
@@ -101,6 +101,7 @@ public final class SpreadFloatRecord implements JsonSerializable<SpreadFloatReco
     @Generated
     public static SpreadFloatRecord fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             double id = 0.0;
             Map<String, Double> additionalProperties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/SpreadModelArrayRecord.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/SpreadModelArrayRecord.java
@@ -102,6 +102,7 @@ public final class SpreadModelArrayRecord implements JsonSerializable<SpreadMode
     @Generated
     public static SpreadModelArrayRecord fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             List<ModelForRecord> knownProp = null;
             Map<String, List<ModelForRecord>> additionalProperties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/SpreadModelRecord.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/SpreadModelRecord.java
@@ -101,6 +101,7 @@ public final class SpreadModelRecord implements JsonSerializable<SpreadModelReco
     @Generated
     public static SpreadModelRecord fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             ModelForRecord knownProp = null;
             Map<String, ModelForRecord> additionalProperties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/SpreadRecordForDiscriminatedUnion.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/SpreadRecordForDiscriminatedUnion.java
@@ -105,6 +105,7 @@ public final class SpreadRecordForDiscriminatedUnion implements JsonSerializable
     @Generated
     public static SpreadRecordForDiscriminatedUnion fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             Map<String, BinaryData> additionalProperties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/SpreadRecordForNonDiscriminatedUnion.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/SpreadRecordForNonDiscriminatedUnion.java
@@ -106,6 +106,7 @@ public final class SpreadRecordForNonDiscriminatedUnion
     @Generated
     public static SpreadRecordForNonDiscriminatedUnion fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             Map<String, BinaryData> additionalProperties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/SpreadRecordForNonDiscriminatedUnion2.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/SpreadRecordForNonDiscriminatedUnion2.java
@@ -106,6 +106,7 @@ public final class SpreadRecordForNonDiscriminatedUnion2
     @Generated
     public static SpreadRecordForNonDiscriminatedUnion2 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             Map<String, BinaryData> additionalProperties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/SpreadRecordForNonDiscriminatedUnion3.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/SpreadRecordForNonDiscriminatedUnion3.java
@@ -106,6 +106,7 @@ public final class SpreadRecordForNonDiscriminatedUnion3
     @Generated
     public static SpreadRecordForNonDiscriminatedUnion3 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             Map<String, BinaryData> additionalProperties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/SpreadRecordForUnion.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/SpreadRecordForUnion.java
@@ -105,6 +105,7 @@ public final class SpreadRecordForUnion implements JsonSerializable<SpreadRecord
     @Generated
     public static SpreadRecordForUnion fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             boolean flag = false;
             Map<String, BinaryData> additionalProperties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/SpreadStringRecord.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/SpreadStringRecord.java
@@ -101,6 +101,7 @@ public final class SpreadStringRecord implements JsonSerializable<SpreadStringRe
     @Generated
     public static SpreadStringRecord fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             Map<String, String> additionalProperties = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/WidgetData0.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/WidgetData0.java
@@ -83,6 +83,7 @@ public final class WidgetData0 implements JsonSerializable<WidgetData0> {
     @Generated
     public static WidgetData0 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String fooProp = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/WidgetData1.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/WidgetData1.java
@@ -117,6 +117,7 @@ public final class WidgetData1 implements JsonSerializable<WidgetData1> {
     @Generated
     public static WidgetData1 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             OffsetDateTime start = null;
             OffsetDateTime end = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/property/additionalproperties/models/WidgetData2.java
+++ b/typespec-tests/src/main/java/com/type/property/additionalproperties/models/WidgetData2.java
@@ -83,6 +83,7 @@ public final class WidgetData2 implements JsonSerializable<WidgetData2> {
     @Generated
     public static WidgetData2 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String start = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/property/nullable/models/BytesProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/nullable/models/BytesProperty.java
@@ -13,8 +13,6 @@ import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
 import com.type.property.nullable.implementation.JsonMergePatchHelper;
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * Template type for testing models with nullable property. Pass in the type of the property you are looking for.
@@ -37,7 +35,7 @@ public final class BytesProperty implements JsonSerializable<BytesProperty> {
      * Stores updated model property, the value is property name, not serialized name.
      */
     @Generated
-    private final Set<String> updatedProperties = new HashSet<>();
+    private long updatedProperties = 0L;
 
     @Generated
     private boolean jsonMergePatch;
@@ -89,7 +87,7 @@ public final class BytesProperty implements JsonSerializable<BytesProperty> {
     @Generated
     public BytesProperty setRequiredProperty(String requiredProperty) {
         this.requiredProperty = requiredProperty;
-        this.updatedProperties.add("requiredProperty");
+        this.updatedProperties |= 1;
         return this;
     }
 
@@ -113,7 +111,7 @@ public final class BytesProperty implements JsonSerializable<BytesProperty> {
     @Generated
     public BytesProperty setNullableProperty(byte[] nullableProperty) {
         this.nullableProperty = CoreUtils.clone(nullableProperty);
-        this.updatedProperties.add("nullableProperty");
+        this.updatedProperties |= 2;
         return this;
     }
 
@@ -136,14 +134,14 @@ public final class BytesProperty implements JsonSerializable<BytesProperty> {
     @Generated
     private JsonWriter toJsonMergePatch(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        if (updatedProperties.contains("requiredProperty")) {
+        if ((this.updatedProperties & 1) == 1) {
             if (this.requiredProperty == null) {
                 jsonWriter.writeNullField("requiredProperty");
             } else {
                 jsonWriter.writeStringField("requiredProperty", this.requiredProperty);
             }
         }
-        if (updatedProperties.contains("nullableProperty")) {
+        if ((this.updatedProperties & 2) == 2) {
             if (this.nullableProperty == null) {
                 jsonWriter.writeNullField("nullableProperty");
             } else {

--- a/typespec-tests/src/main/java/com/type/property/nullable/models/CollectionsByteProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/nullable/models/CollectionsByteProperty.java
@@ -12,9 +12,7 @@ import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
 import com.type.property.nullable.implementation.JsonMergePatchHelper;
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 /**
  * Model with collection bytes properties.
@@ -37,7 +35,7 @@ public final class CollectionsByteProperty implements JsonSerializable<Collectio
      * Stores updated model property, the value is property name, not serialized name.
      */
     @Generated
-    private final Set<String> updatedProperties = new HashSet<>();
+    private long updatedProperties = 0L;
 
     @Generated
     private boolean jsonMergePatch;
@@ -91,7 +89,7 @@ public final class CollectionsByteProperty implements JsonSerializable<Collectio
     @Generated
     public CollectionsByteProperty setRequiredProperty(String requiredProperty) {
         this.requiredProperty = requiredProperty;
-        this.updatedProperties.add("requiredProperty");
+        this.updatedProperties |= 1;
         return this;
     }
 
@@ -115,7 +113,7 @@ public final class CollectionsByteProperty implements JsonSerializable<Collectio
     @Generated
     public CollectionsByteProperty setNullableProperty(List<byte[]> nullableProperty) {
         this.nullableProperty = nullableProperty;
-        this.updatedProperties.add("nullableProperty");
+        this.updatedProperties |= 2;
         return this;
     }
 
@@ -139,14 +137,14 @@ public final class CollectionsByteProperty implements JsonSerializable<Collectio
     @Generated
     private JsonWriter toJsonMergePatch(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        if (updatedProperties.contains("requiredProperty")) {
+        if ((this.updatedProperties & 1) == 1) {
             if (this.requiredProperty == null) {
                 jsonWriter.writeNullField("requiredProperty");
             } else {
                 jsonWriter.writeStringField("requiredProperty", this.requiredProperty);
             }
         }
-        if (updatedProperties.contains("nullableProperty")) {
+        if ((this.updatedProperties & 2) == 2) {
             if (this.nullableProperty == null) {
                 jsonWriter.writeNullField("nullableProperty");
             } else {

--- a/typespec-tests/src/main/java/com/type/property/nullable/models/CollectionsModelProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/nullable/models/CollectionsModelProperty.java
@@ -12,9 +12,7 @@ import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
 import com.type.property.nullable.implementation.JsonMergePatchHelper;
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 /**
  * Model with collection models properties.
@@ -37,7 +35,7 @@ public final class CollectionsModelProperty implements JsonSerializable<Collecti
      * Stores updated model property, the value is property name, not serialized name.
      */
     @Generated
-    private final Set<String> updatedProperties = new HashSet<>();
+    private long updatedProperties = 0L;
 
     @Generated
     private boolean jsonMergePatch;
@@ -91,7 +89,7 @@ public final class CollectionsModelProperty implements JsonSerializable<Collecti
     @Generated
     public CollectionsModelProperty setRequiredProperty(String requiredProperty) {
         this.requiredProperty = requiredProperty;
-        this.updatedProperties.add("requiredProperty");
+        this.updatedProperties |= 1;
         return this;
     }
 
@@ -115,7 +113,7 @@ public final class CollectionsModelProperty implements JsonSerializable<Collecti
     @Generated
     public CollectionsModelProperty setNullableProperty(List<InnerModel> nullableProperty) {
         this.nullableProperty = nullableProperty;
-        this.updatedProperties.add("nullableProperty");
+        this.updatedProperties |= 2;
         return this;
     }
 
@@ -139,14 +137,14 @@ public final class CollectionsModelProperty implements JsonSerializable<Collecti
     @Generated
     private JsonWriter toJsonMergePatch(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        if (updatedProperties.contains("requiredProperty")) {
+        if ((this.updatedProperties & 1) == 1) {
             if (this.requiredProperty == null) {
                 jsonWriter.writeNullField("requiredProperty");
             } else {
                 jsonWriter.writeStringField("requiredProperty", this.requiredProperty);
             }
         }
-        if (updatedProperties.contains("nullableProperty")) {
+        if ((this.updatedProperties & 2) == 2) {
             if (this.nullableProperty == null) {
                 jsonWriter.writeNullField("nullableProperty");
             } else {

--- a/typespec-tests/src/main/java/com/type/property/nullable/models/CollectionsStringProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/nullable/models/CollectionsStringProperty.java
@@ -12,9 +12,7 @@ import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
 import com.type.property.nullable.implementation.JsonMergePatchHelper;
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 /**
  * Model with collection string properties.
@@ -37,7 +35,7 @@ public final class CollectionsStringProperty implements JsonSerializable<Collect
      * Stores updated model property, the value is property name, not serialized name.
      */
     @Generated
-    private final Set<String> updatedProperties = new HashSet<>();
+    private long updatedProperties = 0L;
 
     @Generated
     private boolean jsonMergePatch;
@@ -91,7 +89,7 @@ public final class CollectionsStringProperty implements JsonSerializable<Collect
     @Generated
     public CollectionsStringProperty setRequiredProperty(String requiredProperty) {
         this.requiredProperty = requiredProperty;
-        this.updatedProperties.add("requiredProperty");
+        this.updatedProperties |= 1;
         return this;
     }
 
@@ -115,7 +113,7 @@ public final class CollectionsStringProperty implements JsonSerializable<Collect
     @Generated
     public CollectionsStringProperty setNullableProperty(List<String> nullableProperty) {
         this.nullableProperty = nullableProperty;
-        this.updatedProperties.add("nullableProperty");
+        this.updatedProperties |= 2;
         return this;
     }
 
@@ -139,14 +137,14 @@ public final class CollectionsStringProperty implements JsonSerializable<Collect
     @Generated
     private JsonWriter toJsonMergePatch(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        if (updatedProperties.contains("requiredProperty")) {
+        if ((this.updatedProperties & 1) == 1) {
             if (this.requiredProperty == null) {
                 jsonWriter.writeNullField("requiredProperty");
             } else {
                 jsonWriter.writeStringField("requiredProperty", this.requiredProperty);
             }
         }
-        if (updatedProperties.contains("nullableProperty")) {
+        if ((this.updatedProperties & 2) == 2) {
             if (this.nullableProperty == null) {
                 jsonWriter.writeNullField("nullableProperty");
             } else {

--- a/typespec-tests/src/main/java/com/type/property/nullable/models/DatetimeProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/nullable/models/DatetimeProperty.java
@@ -15,8 +15,6 @@ import com.type.property.nullable.implementation.JsonMergePatchHelper;
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * Model with a datetime property.
@@ -39,7 +37,7 @@ public final class DatetimeProperty implements JsonSerializable<DatetimeProperty
      * Stores updated model property, the value is property name, not serialized name.
      */
     @Generated
-    private final Set<String> updatedProperties = new HashSet<>();
+    private long updatedProperties = 0L;
 
     @Generated
     private boolean jsonMergePatch;
@@ -92,7 +90,7 @@ public final class DatetimeProperty implements JsonSerializable<DatetimeProperty
     @Generated
     public DatetimeProperty setRequiredProperty(String requiredProperty) {
         this.requiredProperty = requiredProperty;
-        this.updatedProperties.add("requiredProperty");
+        this.updatedProperties |= 1;
         return this;
     }
 
@@ -116,7 +114,7 @@ public final class DatetimeProperty implements JsonSerializable<DatetimeProperty
     @Generated
     public DatetimeProperty setNullableProperty(OffsetDateTime nullableProperty) {
         this.nullableProperty = nullableProperty;
-        this.updatedProperties.add("nullableProperty");
+        this.updatedProperties |= 2;
         return this;
     }
 
@@ -142,14 +140,14 @@ public final class DatetimeProperty implements JsonSerializable<DatetimeProperty
     @Generated
     private JsonWriter toJsonMergePatch(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        if (updatedProperties.contains("requiredProperty")) {
+        if ((this.updatedProperties & 1) == 1) {
             if (this.requiredProperty == null) {
                 jsonWriter.writeNullField("requiredProperty");
             } else {
                 jsonWriter.writeStringField("requiredProperty", this.requiredProperty);
             }
         }
-        if (updatedProperties.contains("nullableProperty")) {
+        if ((this.updatedProperties & 2) == 2) {
             if (this.nullableProperty == null) {
                 jsonWriter.writeNullField("nullableProperty");
             } else {

--- a/typespec-tests/src/main/java/com/type/property/nullable/models/DurationProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/nullable/models/DurationProperty.java
@@ -14,8 +14,6 @@ import com.azure.json.JsonWriter;
 import com.type.property.nullable.implementation.JsonMergePatchHelper;
 import java.io.IOException;
 import java.time.Duration;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * Model with a duration property.
@@ -38,7 +36,7 @@ public final class DurationProperty implements JsonSerializable<DurationProperty
      * Stores updated model property, the value is property name, not serialized name.
      */
     @Generated
-    private final Set<String> updatedProperties = new HashSet<>();
+    private long updatedProperties = 0L;
 
     @Generated
     private boolean jsonMergePatch;
@@ -91,7 +89,7 @@ public final class DurationProperty implements JsonSerializable<DurationProperty
     @Generated
     public DurationProperty setRequiredProperty(String requiredProperty) {
         this.requiredProperty = requiredProperty;
-        this.updatedProperties.add("requiredProperty");
+        this.updatedProperties |= 1;
         return this;
     }
 
@@ -115,7 +113,7 @@ public final class DurationProperty implements JsonSerializable<DurationProperty
     @Generated
     public DurationProperty setNullableProperty(Duration nullableProperty) {
         this.nullableProperty = nullableProperty;
-        this.updatedProperties.add("nullableProperty");
+        this.updatedProperties |= 2;
         return this;
     }
 
@@ -138,14 +136,14 @@ public final class DurationProperty implements JsonSerializable<DurationProperty
     @Generated
     private JsonWriter toJsonMergePatch(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        if (updatedProperties.contains("requiredProperty")) {
+        if ((this.updatedProperties & 1) == 1) {
             if (this.requiredProperty == null) {
                 jsonWriter.writeNullField("requiredProperty");
             } else {
                 jsonWriter.writeStringField("requiredProperty", this.requiredProperty);
             }
         }
-        if (updatedProperties.contains("nullableProperty")) {
+        if ((this.updatedProperties & 2) == 2) {
             if (this.nullableProperty == null) {
                 jsonWriter.writeNullField("nullableProperty");
             } else {

--- a/typespec-tests/src/main/java/com/type/property/nullable/models/InnerModel.java
+++ b/typespec-tests/src/main/java/com/type/property/nullable/models/InnerModel.java
@@ -12,8 +12,6 @@ import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
 import com.type.property.nullable.implementation.JsonMergePatchHelper;
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * Inner model used in collections model property.
@@ -30,7 +28,7 @@ public final class InnerModel implements JsonSerializable<InnerModel> {
      * Stores updated model property, the value is property name, not serialized name.
      */
     @Generated
-    private final Set<String> updatedProperties = new HashSet<>();
+    private long updatedProperties = 0L;
 
     @Generated
     private boolean jsonMergePatch;
@@ -82,7 +80,7 @@ public final class InnerModel implements JsonSerializable<InnerModel> {
     @Generated
     public InnerModel setProperty(String property) {
         this.property = property;
-        this.updatedProperties.add("property");
+        this.updatedProperties |= 1;
         return this;
     }
 
@@ -104,7 +102,7 @@ public final class InnerModel implements JsonSerializable<InnerModel> {
     @Generated
     private JsonWriter toJsonMergePatch(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        if (updatedProperties.contains("property")) {
+        if ((this.updatedProperties & 1) == 1) {
             if (this.property == null) {
                 jsonWriter.writeNullField("property");
             } else {

--- a/typespec-tests/src/main/java/com/type/property/nullable/models/StringProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/nullable/models/StringProperty.java
@@ -12,8 +12,6 @@ import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
 import com.type.property.nullable.implementation.JsonMergePatchHelper;
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * Template type for testing models with nullable property. Pass in the type of the property you are looking for.
@@ -36,7 +34,7 @@ public final class StringProperty implements JsonSerializable<StringProperty> {
      * Stores updated model property, the value is property name, not serialized name.
      */
     @Generated
-    private final Set<String> updatedProperties = new HashSet<>();
+    private long updatedProperties = 0L;
 
     @Generated
     private boolean jsonMergePatch;
@@ -88,7 +86,7 @@ public final class StringProperty implements JsonSerializable<StringProperty> {
     @Generated
     public StringProperty setRequiredProperty(String requiredProperty) {
         this.requiredProperty = requiredProperty;
-        this.updatedProperties.add("requiredProperty");
+        this.updatedProperties |= 1;
         return this;
     }
 
@@ -112,7 +110,7 @@ public final class StringProperty implements JsonSerializable<StringProperty> {
     @Generated
     public StringProperty setNullableProperty(String nullableProperty) {
         this.nullableProperty = nullableProperty;
-        this.updatedProperties.add("nullableProperty");
+        this.updatedProperties |= 2;
         return this;
     }
 
@@ -135,14 +133,14 @@ public final class StringProperty implements JsonSerializable<StringProperty> {
     @Generated
     private JsonWriter toJsonMergePatch(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
-        if (updatedProperties.contains("requiredProperty")) {
+        if ((this.updatedProperties & 1) == 1) {
             if (this.requiredProperty == null) {
                 jsonWriter.writeNullField("requiredProperty");
             } else {
                 jsonWriter.writeStringField("requiredProperty", this.requiredProperty);
             }
         }
-        if (updatedProperties.contains("nullableProperty")) {
+        if ((this.updatedProperties & 2) == 2) {
             if (this.nullableProperty == null) {
                 jsonWriter.writeNullField("nullableProperty");
             } else {

--- a/typespec-tests/src/main/java/com/type/property/optional/models/RequiredAndOptionalProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/optional/models/RequiredAndOptionalProperty.java
@@ -95,6 +95,7 @@ public final class RequiredAndOptionalProperty implements JsonSerializable<Requi
     @Generated
     public static RequiredAndOptionalProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             int requiredProperty = 0;
             String optionalProperty = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/property/valuetypes/models/BooleanProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/valuetypes/models/BooleanProperty.java
@@ -66,6 +66,7 @@ public final class BooleanProperty implements JsonSerializable<BooleanProperty> 
     @Generated
     public static BooleanProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             boolean property = false;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/property/valuetypes/models/BytesProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/valuetypes/models/BytesProperty.java
@@ -67,6 +67,7 @@ public final class BytesProperty implements JsonSerializable<BytesProperty> {
     @Generated
     public static BytesProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             byte[] property = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/property/valuetypes/models/CollectionsIntProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/valuetypes/models/CollectionsIntProperty.java
@@ -67,6 +67,7 @@ public final class CollectionsIntProperty implements JsonSerializable<Collection
     @Generated
     public static CollectionsIntProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             List<Integer> property = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/property/valuetypes/models/CollectionsModelProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/valuetypes/models/CollectionsModelProperty.java
@@ -67,6 +67,7 @@ public final class CollectionsModelProperty implements JsonSerializable<Collecti
     @Generated
     public static CollectionsModelProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             List<InnerModel> property = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/property/valuetypes/models/CollectionsStringProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/valuetypes/models/CollectionsStringProperty.java
@@ -67,6 +67,7 @@ public final class CollectionsStringProperty implements JsonSerializable<Collect
     @Generated
     public static CollectionsStringProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             List<String> property = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/property/valuetypes/models/DatetimeProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/valuetypes/models/DatetimeProperty.java
@@ -70,6 +70,7 @@ public final class DatetimeProperty implements JsonSerializable<DatetimeProperty
     @Generated
     public static DatetimeProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             OffsetDateTime property = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/property/valuetypes/models/Decimal128Property.java
+++ b/typespec-tests/src/main/java/com/type/property/valuetypes/models/Decimal128Property.java
@@ -67,6 +67,7 @@ public final class Decimal128Property implements JsonSerializable<Decimal128Prop
     @Generated
     public static Decimal128Property fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             BigDecimal property = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/property/valuetypes/models/DecimalProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/valuetypes/models/DecimalProperty.java
@@ -67,6 +67,7 @@ public final class DecimalProperty implements JsonSerializable<DecimalProperty> 
     @Generated
     public static DecimalProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             BigDecimal property = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/property/valuetypes/models/DictionaryStringProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/valuetypes/models/DictionaryStringProperty.java
@@ -67,6 +67,7 @@ public final class DictionaryStringProperty implements JsonSerializable<Dictiona
     @Generated
     public static DictionaryStringProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             Map<String, String> property = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/property/valuetypes/models/DurationProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/valuetypes/models/DurationProperty.java
@@ -68,6 +68,7 @@ public final class DurationProperty implements JsonSerializable<DurationProperty
     @Generated
     public static DurationProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             Duration property = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/property/valuetypes/models/EnumProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/valuetypes/models/EnumProperty.java
@@ -66,6 +66,7 @@ public final class EnumProperty implements JsonSerializable<EnumProperty> {
     @Generated
     public static EnumProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             FixedInnerEnum property = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/property/valuetypes/models/ExtensibleEnumProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/valuetypes/models/ExtensibleEnumProperty.java
@@ -66,6 +66,7 @@ public final class ExtensibleEnumProperty implements JsonSerializable<Extensible
     @Generated
     public static ExtensibleEnumProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             InnerEnum property = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/property/valuetypes/models/FloatProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/valuetypes/models/FloatProperty.java
@@ -66,6 +66,7 @@ public final class FloatProperty implements JsonSerializable<FloatProperty> {
     @Generated
     public static FloatProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             double property = 0.0;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/property/valuetypes/models/InnerModel.java
+++ b/typespec-tests/src/main/java/com/type/property/valuetypes/models/InnerModel.java
@@ -66,6 +66,7 @@ public final class InnerModel implements JsonSerializable<InnerModel> {
     @Generated
     public static InnerModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String property = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/property/valuetypes/models/IntProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/valuetypes/models/IntProperty.java
@@ -66,6 +66,7 @@ public final class IntProperty implements JsonSerializable<IntProperty> {
     @Generated
     public static IntProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             int property = 0;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/property/valuetypes/models/ModelProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/valuetypes/models/ModelProperty.java
@@ -66,6 +66,7 @@ public final class ModelProperty implements JsonSerializable<ModelProperty> {
     @Generated
     public static ModelProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             InnerModel property = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/property/valuetypes/models/StringProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/valuetypes/models/StringProperty.java
@@ -66,6 +66,7 @@ public final class StringProperty implements JsonSerializable<StringProperty> {
     @Generated
     public static StringProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String property = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/property/valuetypes/models/UnionFloatLiteralProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/valuetypes/models/UnionFloatLiteralProperty.java
@@ -66,6 +66,7 @@ public final class UnionFloatLiteralProperty implements JsonSerializable<UnionFl
     @Generated
     public static UnionFloatLiteralProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             UnionFloatLiteralPropertyProperty property = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/property/valuetypes/models/UnionIntLiteralProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/valuetypes/models/UnionIntLiteralProperty.java
@@ -66,6 +66,7 @@ public final class UnionIntLiteralProperty implements JsonSerializable<UnionIntL
     @Generated
     public static UnionIntLiteralProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             UnionIntLiteralPropertyProperty property = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/property/valuetypes/models/UnionStringLiteralProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/valuetypes/models/UnionStringLiteralProperty.java
@@ -66,6 +66,7 @@ public final class UnionStringLiteralProperty implements JsonSerializable<UnionS
     @Generated
     public static UnionStringLiteralProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             UnionStringLiteralPropertyProperty property = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/property/valuetypes/models/UnknownArrayProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/valuetypes/models/UnknownArrayProperty.java
@@ -66,6 +66,7 @@ public final class UnknownArrayProperty implements JsonSerializable<UnknownArray
     @Generated
     public static UnknownArrayProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             Object property = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/property/valuetypes/models/UnknownDictProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/valuetypes/models/UnknownDictProperty.java
@@ -66,6 +66,7 @@ public final class UnknownDictProperty implements JsonSerializable<UnknownDictPr
     @Generated
     public static UnknownDictProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             Object property = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/property/valuetypes/models/UnknownIntProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/valuetypes/models/UnknownIntProperty.java
@@ -66,6 +66,7 @@ public final class UnknownIntProperty implements JsonSerializable<UnknownIntProp
     @Generated
     public static UnknownIntProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             Object property = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/property/valuetypes/models/UnknownStringProperty.java
+++ b/typespec-tests/src/main/java/com/type/property/valuetypes/models/UnknownStringProperty.java
@@ -66,6 +66,7 @@ public final class UnknownStringProperty implements JsonSerializable<UnknownStri
     @Generated
     public static UnknownStringProperty fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             Object property = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/union/implementation/models/SendRequest.java
+++ b/typespec-tests/src/main/java/com/type/union/implementation/models/SendRequest.java
@@ -67,6 +67,7 @@ public final class SendRequest implements JsonSerializable<SendRequest> {
     @Generated
     public static SendRequest fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             GetResponseProp4 prop = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/union/implementation/models/SendRequest1.java
+++ b/typespec-tests/src/main/java/com/type/union/implementation/models/SendRequest1.java
@@ -67,6 +67,7 @@ public final class SendRequest1 implements JsonSerializable<SendRequest1> {
     @Generated
     public static SendRequest1 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             GetResponseProp3 prop = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/union/implementation/models/SendRequest2.java
+++ b/typespec-tests/src/main/java/com/type/union/implementation/models/SendRequest2.java
@@ -67,6 +67,7 @@ public final class SendRequest2 implements JsonSerializable<SendRequest2> {
     @Generated
     public static SendRequest2 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             StringExtensibleNamedUnion prop = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/union/implementation/models/SendRequest3.java
+++ b/typespec-tests/src/main/java/com/type/union/implementation/models/SendRequest3.java
@@ -67,6 +67,7 @@ public final class SendRequest3 implements JsonSerializable<SendRequest3> {
     @Generated
     public static SendRequest3 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             GetResponseProp2 prop = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/union/implementation/models/SendRequest4.java
+++ b/typespec-tests/src/main/java/com/type/union/implementation/models/SendRequest4.java
@@ -67,6 +67,7 @@ public final class SendRequest4 implements JsonSerializable<SendRequest4> {
     @Generated
     public static SendRequest4 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             GetResponseProp1 prop = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/union/implementation/models/SendRequest5.java
+++ b/typespec-tests/src/main/java/com/type/union/implementation/models/SendRequest5.java
@@ -67,6 +67,7 @@ public final class SendRequest5 implements JsonSerializable<SendRequest5> {
     @Generated
     public static SendRequest5 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             BinaryData prop = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/union/implementation/models/SendRequest6.java
+++ b/typespec-tests/src/main/java/com/type/union/implementation/models/SendRequest6.java
@@ -67,6 +67,7 @@ public final class SendRequest6 implements JsonSerializable<SendRequest6> {
     @Generated
     public static SendRequest6 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             EnumsOnlyCases prop = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/union/implementation/models/SendRequest7.java
+++ b/typespec-tests/src/main/java/com/type/union/implementation/models/SendRequest7.java
@@ -67,6 +67,7 @@ public final class SendRequest7 implements JsonSerializable<SendRequest7> {
     @Generated
     public static SendRequest7 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             StringAndArrayCases prop = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/union/implementation/models/SendRequest8.java
+++ b/typespec-tests/src/main/java/com/type/union/implementation/models/SendRequest8.java
@@ -67,6 +67,7 @@ public final class SendRequest8 implements JsonSerializable<SendRequest8> {
     @Generated
     public static SendRequest8 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             MixedLiteralsCases prop = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/union/implementation/models/SendRequest9.java
+++ b/typespec-tests/src/main/java/com/type/union/implementation/models/SendRequest9.java
@@ -67,6 +67,7 @@ public final class SendRequest9 implements JsonSerializable<SendRequest9> {
     @Generated
     public static SendRequest9 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             MixedTypesCases prop = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/union/models/Cat.java
+++ b/typespec-tests/src/main/java/com/type/union/models/Cat.java
@@ -66,6 +66,7 @@ public final class Cat implements JsonSerializable<Cat> {
     @Generated
     public static Cat fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/union/models/Dog.java
+++ b/typespec-tests/src/main/java/com/type/union/models/Dog.java
@@ -66,6 +66,7 @@ public final class Dog implements JsonSerializable<Dog> {
     @Generated
     public static Dog fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String bark = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/union/models/EnumsOnlyCases.java
+++ b/typespec-tests/src/main/java/com/type/union/models/EnumsOnlyCases.java
@@ -85,6 +85,7 @@ public final class EnumsOnlyCases implements JsonSerializable<EnumsOnlyCases> {
     @Generated
     public static EnumsOnlyCases fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             EnumsOnlyCasesLr lr = null;
             EnumsOnlyCasesUd ud = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/type/union/models/GetResponse.java
+++ b/typespec-tests/src/main/java/com/type/union/models/GetResponse.java
@@ -66,6 +66,7 @@ public final class GetResponse implements JsonSerializable<GetResponse> {
     @Generated
     public static GetResponse fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             MixedTypesCases prop = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/union/models/GetResponse1.java
+++ b/typespec-tests/src/main/java/com/type/union/models/GetResponse1.java
@@ -66,6 +66,7 @@ public final class GetResponse1 implements JsonSerializable<GetResponse1> {
     @Generated
     public static GetResponse1 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             MixedLiteralsCases prop = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/union/models/GetResponse2.java
+++ b/typespec-tests/src/main/java/com/type/union/models/GetResponse2.java
@@ -66,6 +66,7 @@ public final class GetResponse2 implements JsonSerializable<GetResponse2> {
     @Generated
     public static GetResponse2 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             StringAndArrayCases prop = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/union/models/GetResponse3.java
+++ b/typespec-tests/src/main/java/com/type/union/models/GetResponse3.java
@@ -66,6 +66,7 @@ public final class GetResponse3 implements JsonSerializable<GetResponse3> {
     @Generated
     public static GetResponse3 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             EnumsOnlyCases prop = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/union/models/GetResponse4.java
+++ b/typespec-tests/src/main/java/com/type/union/models/GetResponse4.java
@@ -67,6 +67,7 @@ public final class GetResponse4 implements JsonSerializable<GetResponse4> {
     @Generated
     public static GetResponse4 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             BinaryData prop = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/union/models/GetResponse5.java
+++ b/typespec-tests/src/main/java/com/type/union/models/GetResponse5.java
@@ -66,6 +66,7 @@ public final class GetResponse5 implements JsonSerializable<GetResponse5> {
     @Generated
     public static GetResponse5 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             GetResponseProp1 prop = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/union/models/GetResponse6.java
+++ b/typespec-tests/src/main/java/com/type/union/models/GetResponse6.java
@@ -66,6 +66,7 @@ public final class GetResponse6 implements JsonSerializable<GetResponse6> {
     @Generated
     public static GetResponse6 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             GetResponseProp2 prop = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/union/models/GetResponse7.java
+++ b/typespec-tests/src/main/java/com/type/union/models/GetResponse7.java
@@ -66,6 +66,7 @@ public final class GetResponse7 implements JsonSerializable<GetResponse7> {
     @Generated
     public static GetResponse7 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             StringExtensibleNamedUnion prop = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/union/models/GetResponse8.java
+++ b/typespec-tests/src/main/java/com/type/union/models/GetResponse8.java
@@ -66,6 +66,7 @@ public final class GetResponse8 implements JsonSerializable<GetResponse8> {
     @Generated
     public static GetResponse8 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             GetResponseProp3 prop = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/union/models/GetResponse9.java
+++ b/typespec-tests/src/main/java/com/type/union/models/GetResponse9.java
@@ -66,6 +66,7 @@ public final class GetResponse9 implements JsonSerializable<GetResponse9> {
     @Generated
     public static GetResponse9 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             GetResponseProp4 prop = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();

--- a/typespec-tests/src/main/java/com/type/union/models/MixedLiteralsCases.java
+++ b/typespec-tests/src/main/java/com/type/union/models/MixedLiteralsCases.java
@@ -125,6 +125,7 @@ public final class MixedLiteralsCases implements JsonSerializable<MixedLiteralsC
     @Generated
     public static MixedLiteralsCases fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             BinaryData stringLiteral = null;
             BinaryData intLiteral = null;
             BinaryData floatLiteral = null;

--- a/typespec-tests/src/main/java/com/type/union/models/MixedTypesCases.java
+++ b/typespec-tests/src/main/java/com/type/union/models/MixedTypesCases.java
@@ -146,6 +146,7 @@ public final class MixedTypesCases implements JsonSerializable<MixedTypesCases> 
     @Generated
     public static MixedTypesCases fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             BinaryData model = null;
             BinaryData literal = null;
             BinaryData intProperty = null;

--- a/typespec-tests/src/main/java/com/type/union/models/StringAndArrayCases.java
+++ b/typespec-tests/src/main/java/com/type/union/models/StringAndArrayCases.java
@@ -86,6 +86,7 @@ public final class StringAndArrayCases implements JsonSerializable<StringAndArra
     @Generated
     public static StringAndArrayCases fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             BinaryData string = null;
             BinaryData array = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/versioning/added/models/ModelV1.java
+++ b/typespec-tests/src/main/java/com/versioning/added/models/ModelV1.java
@@ -105,6 +105,7 @@ public final class ModelV1 implements JsonSerializable<ModelV1> {
     @Generated
     public static ModelV1 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String prop = null;
             EnumV1 enumProp = null;
             BinaryData unionProp = null;

--- a/typespec-tests/src/main/java/com/versioning/added/models/ModelV2.java
+++ b/typespec-tests/src/main/java/com/versioning/added/models/ModelV2.java
@@ -105,6 +105,7 @@ public final class ModelV2 implements JsonSerializable<ModelV2> {
     @Generated
     public static ModelV2 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String prop = null;
             EnumV2 enumProp = null;
             BinaryData unionProp = null;

--- a/typespec-tests/src/main/java/com/versioning/madeoptional/models/TestModel.java
+++ b/typespec-tests/src/main/java/com/versioning/madeoptional/models/TestModel.java
@@ -95,6 +95,7 @@ public final class TestModel implements JsonSerializable<TestModel> {
     @Generated
     public static TestModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String prop = null;
             String changedProp = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/typespec-tests/src/main/java/com/versioning/removed/models/ModelV2.java
+++ b/typespec-tests/src/main/java/com/versioning/removed/models/ModelV2.java
@@ -105,6 +105,7 @@ public final class ModelV2 implements JsonSerializable<ModelV2> {
     @Generated
     public static ModelV2 fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String prop = null;
             EnumV2 enumProp = null;
             BinaryData unionProp = null;

--- a/typespec-tests/src/main/java/com/versioning/renamedfrom/models/NewModel.java
+++ b/typespec-tests/src/main/java/com/versioning/renamedfrom/models/NewModel.java
@@ -105,6 +105,7 @@ public final class NewModel implements JsonSerializable<NewModel> {
     @Generated
     public static NewModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String newProp = null;
             NewEnum enumProp = null;
             BinaryData unionProp = null;

--- a/typespec-tests/src/main/java/com/versioning/typechangedfrom/models/TestModel.java
+++ b/typespec-tests/src/main/java/com/versioning/typechangedfrom/models/TestModel.java
@@ -85,6 +85,7 @@ public final class TestModel implements JsonSerializable<TestModel> {
     @Generated
     public static TestModel fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            long foundTracker = 0;
             String prop = null;
             String changedProp = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {

--- a/vanilla-tests/src/main/java/fixtures/additionalproperties/models/CatAPTrue.java
+++ b/vanilla-tests/src/main/java/fixtures/additionalproperties/models/CatAPTrue.java
@@ -34,6 +34,24 @@ public final class CatAPTrue extends PetAPTrue {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CatAPTrue setId(int id) {
+        super.setId(id);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CatAPTrue setName(String name) {
+        super.setName(name);
+        return this;
+    }
+
+    /**
      * Get the friendly property: The friendly property.
      * 
      * @return the friendly value.
@@ -61,24 +79,6 @@ public final class CatAPTrue extends PetAPTrue {
     @Override
     public Boolean isStatus() {
         return this.status;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public CatAPTrue setId(int id) {
-        super.setId(id);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public CatAPTrue setName(String name) {
-        super.setName(name);
-        return this;
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Cat.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Cat.java
@@ -32,6 +32,24 @@ public class Cat extends Pet {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Cat setId(Integer id) {
+        super.setId(id);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Cat setName(String name) {
+        super.setName(name);
+        return this;
+    }
+
+    /**
      * Get the color property: The color property.
      * 
      * @return the color value.
@@ -68,24 +86,6 @@ public class Cat extends Pet {
      */
     public Cat setHates(List<Dog> hates) {
         this.hates = hates;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Cat setId(Integer id) {
-        super.setId(id);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Cat setName(String name) {
-        super.setName(name);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Cookiecuttershark.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Cookiecuttershark.java
@@ -40,16 +40,6 @@ public final class Cookiecuttershark extends Shark {
     }
 
     /**
-     * Get the fishtype property: The fishtype property.
-     * 
-     * @return the fishtype value.
-     */
-    @Override
-    public String getFishtype() {
-        return this.fishtype;
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override
@@ -74,6 +64,16 @@ public final class Cookiecuttershark extends Shark {
     public Cookiecuttershark setSiblings(List<Fish> siblings) {
         super.setSiblings(siblings);
         return this;
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Dog.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Dog.java
@@ -25,6 +25,24 @@ public final class Dog extends Pet {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Dog setId(Integer id) {
+        super.setId(id);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Dog setName(String name) {
+        super.setName(name);
+        return this;
+    }
+
+    /**
      * Get the food property: The food property.
      * 
      * @return the food value.
@@ -41,24 +59,6 @@ public final class Dog extends Pet {
      */
     public Dog setFood(String food) {
         this.food = food;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Dog setId(Integer id) {
-        super.setId(id);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Dog setName(String name) {
-        super.setName(name);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Goblinshark.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Goblinshark.java
@@ -52,6 +52,33 @@ public final class Goblinshark extends Shark {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Goblinshark setAge(Integer age) {
+        super.setAge(age);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Goblinshark setSpecies(String species) {
+        super.setSpecies(species);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Goblinshark setSiblings(List<Fish> siblings) {
+        super.setSiblings(siblings);
+        return this;
+    }
+
+    /**
      * Get the fishtype property: The fishtype property.
      * 
      * @return the fishtype value.
@@ -98,33 +125,6 @@ public final class Goblinshark extends Shark {
      */
     public Goblinshark setColor(GoblinSharkColor color) {
         this.color = color;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Goblinshark setAge(Integer age) {
-        super.setAge(age);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Goblinshark setSpecies(String species) {
-        super.setSpecies(species);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Goblinshark setSiblings(List<Fish> siblings) {
-        super.setSiblings(siblings);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Salmon.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Salmon.java
@@ -51,6 +51,24 @@ public class Salmon extends Fish {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Salmon setSpecies(String species) {
+        super.setSpecies(species);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Salmon setSiblings(List<Fish> siblings) {
+        super.setSiblings(siblings);
+        return this;
+    }
+
+    /**
      * Get the fishtype property: The fishtype property.
      * 
      * @return the fishtype value.
@@ -97,24 +115,6 @@ public class Salmon extends Fish {
      */
     public Salmon setIswild(Boolean iswild) {
         this.iswild = iswild;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Salmon setSpecies(String species) {
-        super.setSpecies(species);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Salmon setSiblings(List<Fish> siblings) {
-        super.setSiblings(siblings);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Sawshark.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Sawshark.java
@@ -47,6 +47,33 @@ public final class Sawshark extends Shark {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Sawshark setAge(Integer age) {
+        super.setAge(age);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Sawshark setSpecies(String species) {
+        super.setSpecies(species);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Sawshark setSiblings(List<Fish> siblings) {
+        super.setSiblings(siblings);
+        return this;
+    }
+
+    /**
      * Get the fishtype property: The fishtype property.
      * 
      * @return the fishtype value.
@@ -73,33 +100,6 @@ public final class Sawshark extends Shark {
      */
     public Sawshark setPicture(byte[] picture) {
         this.picture = CoreUtils.clone(picture);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Sawshark setAge(Integer age) {
-        super.setAge(age);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Sawshark setSpecies(String species) {
-        super.setSpecies(species);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Sawshark setSiblings(List<Fish> siblings) {
-        super.setSiblings(siblings);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Shark.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Shark.java
@@ -59,6 +59,24 @@ public class Shark extends Fish {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Shark setSpecies(String species) {
+        super.setSpecies(species);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Shark setSiblings(List<Fish> siblings) {
+        super.setSiblings(siblings);
+        return this;
+    }
+
+    /**
      * Get the fishtype property: The fishtype property.
      * 
      * @return the fishtype value.
@@ -95,24 +113,6 @@ public class Shark extends Fish {
      */
     public OffsetDateTime getBirthday() {
         return this.birthday;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Shark setSpecies(String species) {
-        super.setSpecies(species);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Shark setSiblings(List<Fish> siblings) {
-        super.setSiblings(siblings);
-        return this;
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Siamese.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Siamese.java
@@ -26,26 +26,6 @@ public final class Siamese extends Cat {
     }
 
     /**
-     * Get the breed property: The breed property.
-     * 
-     * @return the breed value.
-     */
-    public String getBreed() {
-        return this.breed;
-    }
-
-    /**
-     * Set the breed property: The breed property.
-     * 
-     * @param breed the breed value to set.
-     * @return the Siamese object itself.
-     */
-    public Siamese setBreed(String breed) {
-        this.breed = breed;
-        return this;
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override
@@ -78,6 +58,26 @@ public final class Siamese extends Cat {
     @Override
     public Siamese setName(String name) {
         super.setName(name);
+        return this;
+    }
+
+    /**
+     * Get the breed property: The breed property.
+     * 
+     * @return the breed value.
+     */
+    public String getBreed() {
+        return this.breed;
+    }
+
+    /**
+     * Set the breed property: The breed property.
+     * 
+     * @param breed the breed value to set.
+     * @return the Siamese object itself.
+     */
+    public Siamese setBreed(String breed) {
+        this.breed = breed;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/SmartSalmon.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/SmartSalmon.java
@@ -54,6 +54,42 @@ public final class SmartSalmon extends Salmon {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SmartSalmon setLocation(String location) {
+        super.setLocation(location);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SmartSalmon setIswild(Boolean iswild) {
+        super.setIswild(iswild);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SmartSalmon setSpecies(String species) {
+        super.setSpecies(species);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SmartSalmon setSiblings(List<Fish> siblings) {
+        super.setSiblings(siblings);
+        return this;
+    }
+
+    /**
      * Get the fishtype property: The fishtype property.
      * 
      * @return the fishtype value.
@@ -110,42 +146,6 @@ public final class SmartSalmon extends Salmon {
             additionalProperties = new LinkedHashMap<>();
         }
         additionalProperties.put(key, value);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SmartSalmon setLocation(String location) {
-        super.setLocation(location);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SmartSalmon setIswild(Boolean iswild) {
-        super.setIswild(iswild);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SmartSalmon setSpecies(String species) {
-        super.setSpecies(species);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SmartSalmon setSiblings(List<Fish> siblings) {
-        super.setSiblings(siblings);
-        return this;
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/discriminatorenum/models/Golden.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorenum/models/Golden.java
@@ -27,6 +27,15 @@ public final class Golden extends Dog {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Golden setWeight(int weight) {
+        super.setWeight(weight);
+        return this;
+    }
+
+    /**
      * Get the kind property: discriminator property.
      * 
      * @return the kind value.
@@ -34,15 +43,6 @@ public final class Golden extends Dog {
     @Override
     public DogKind getKind() {
         return this.kind;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Golden setWeight(int weight) {
-        super.setWeight(weight);
-        return this;
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/discriminatorsetter/models/Golden.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorsetter/models/Golden.java
@@ -29,6 +29,15 @@ public final class Golden extends Dog {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Golden setWeight(int weight) {
+        super.setWeight(weight);
+        return this;
+    }
+
+    /**
      * Get the kind property: discriminator property.
      * 
      * @return the kind value.
@@ -36,15 +45,6 @@ public final class Golden extends Dog {
     @Override
     public DogKind getKind() {
         return this.kind;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Golden setWeight(int weight) {
-        super.setWeight(weight);
-        return this;
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/httpinfrastructure/models/B.java
+++ b/vanilla-tests/src/main/java/fixtures/httpinfrastructure/models/B.java
@@ -27,6 +27,15 @@ public final class B extends MyException {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public B setStatusCode(String statusCode) {
+        super.setStatusCode(statusCode);
+        return this;
+    }
+
+    /**
      * Get the textStatusCode property: The textStatusCode property.
      * 
      * @return the textStatusCode value.
@@ -43,15 +52,6 @@ public final class B extends MyException {
      */
     public B setTextStatusCode(String textStatusCode) {
         this.textStatusCode = textStatusCode;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public B setStatusCode(String statusCode) {
-        super.setStatusCode(statusCode);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/lro/models/Product.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/Product.java
@@ -34,6 +34,24 @@ public class Product extends Resource {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Product setTags(Map<String, String> tags) {
+        super.setTags(tags);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Product setLocation(String location) {
+        super.setLocation(location);
+        return this;
+    }
+
+    /**
      * Get the provisioningState property: The provisioningState property.
      * 
      * @return the provisioningState value.
@@ -60,24 +78,6 @@ public class Product extends Resource {
      */
     public ProductPropertiesProvisioningStateValues getProvisioningStateValues() {
         return this.provisioningStateValues;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Product setTags(Map<String, String> tags) {
-        super.setTags(tags);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Product setLocation(String location) {
-        super.setLocation(location);
-        return this;
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/modelflattening/models/FlattenedProduct.java
+++ b/vanilla-tests/src/main/java/fixtures/modelflattening/models/FlattenedProduct.java
@@ -58,6 +58,24 @@ public class FlattenedProduct extends Resource {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public FlattenedProduct setTags(Map<String, String> tags) {
+        super.setTags(tags);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public FlattenedProduct setLocation(String location) {
+        super.setLocation(location);
+        return this;
+    }
+
+    /**
      * Get the pName property: The p.name property.
      * 
      * @return the pName value.
@@ -154,24 +172,6 @@ public class FlattenedProduct extends Resource {
     @Override
     public String getId() {
         return this.id;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public FlattenedProduct setTags(Map<String, String> tags) {
-        super.setTags(tags);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public FlattenedProduct setLocation(String location) {
-        super.setLocation(location);
-        return this;
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/modelflattening/models/ProductUrl.java
+++ b/vanilla-tests/src/main/java/fixtures/modelflattening/models/ProductUrl.java
@@ -27,6 +27,15 @@ public final class ProductUrl extends GenericUrl {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ProductUrl setGenericValue(String genericValue) {
+        super.setGenericValue(genericValue);
+        return this;
+    }
+
+    /**
      * Get the odataValue property: URL value.
      * 
      * @return the odataValue value.
@@ -43,15 +52,6 @@ public final class ProductUrl extends GenericUrl {
      */
     public ProductUrl setOdataValue(String odataValue) {
         this.odataValue = odataValue;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public ProductUrl setGenericValue(String genericValue) {
-        super.setGenericValue(genericValue);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/modelflattening/models/SimpleProduct.java
+++ b/vanilla-tests/src/main/java/fixtures/modelflattening/models/SimpleProduct.java
@@ -42,6 +42,24 @@ public class SimpleProduct extends BaseProduct {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SimpleProduct setProductId(String productId) {
+        super.setProductId(productId);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SimpleProduct setDescription(String description) {
+        super.setDescription(description);
+        return this;
+    }
+
+    /**
      * Get the maxProductDisplayName property: Display name of product.
      * 
      * @return the maxProductDisplayName value.
@@ -118,24 +136,6 @@ public class SimpleProduct extends BaseProduct {
      */
     public SimpleProduct setOdataValue(String odataValue) {
         this.odataValue = odataValue;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SimpleProduct setProductId(String productId) {
-        super.setProductId(productId);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SimpleProduct setDescription(String description) {
-        super.setDescription(description);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/multipleinheritance/models/Cat.java
+++ b/vanilla-tests/src/main/java/fixtures/multipleinheritance/models/Cat.java
@@ -37,6 +37,15 @@ public class Cat extends Pet {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Cat setName(String name) {
+        super.setName(name);
+        return this;
+    }
+
+    /**
      * Get the likesMilk property: The likesMilk property.
      * 
      * @return the likesMilk value.
@@ -93,15 +102,6 @@ public class Cat extends Pet {
      */
     public Cat setHisses(Boolean hisses) {
         this.hisses = hisses;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Cat setName(String name) {
-        super.setName(name);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/multipleinheritance/models/Horse.java
+++ b/vanilla-tests/src/main/java/fixtures/multipleinheritance/models/Horse.java
@@ -27,6 +27,15 @@ public final class Horse extends Pet {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Horse setName(String name) {
+        super.setName(name);
+        return this;
+    }
+
+    /**
      * Get the isAShowHorse property: The isAShowHorse property.
      * 
      * @return the isAShowHorse value.
@@ -43,15 +52,6 @@ public final class Horse extends Pet {
      */
     public Horse setIsAShowHorse(Boolean isAShowHorse) {
         this.isAShowHorse = isAShowHorse;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Horse setName(String name) {
-        super.setName(name);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/multipleinheritance/models/Kitten.java
+++ b/vanilla-tests/src/main/java/fixtures/multipleinheritance/models/Kitten.java
@@ -27,26 +27,6 @@ public final class Kitten extends Cat {
     }
 
     /**
-     * Get the eatsMiceYet property: The eatsMiceYet property.
-     * 
-     * @return the eatsMiceYet value.
-     */
-    public Boolean isEatsMiceYet() {
-        return this.eatsMiceYet;
-    }
-
-    /**
-     * Set the eatsMiceYet property: The eatsMiceYet property.
-     * 
-     * @param eatsMiceYet the eatsMiceYet value to set.
-     * @return the Kitten object itself.
-     */
-    public Kitten setEatsMiceYet(Boolean eatsMiceYet) {
-        this.eatsMiceYet = eatsMiceYet;
-        return this;
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override
@@ -79,6 +59,26 @@ public final class Kitten extends Cat {
     @Override
     public Kitten setName(String name) {
         super.setName(name);
+        return this;
+    }
+
+    /**
+     * Get the eatsMiceYet property: The eatsMiceYet property.
+     * 
+     * @return the eatsMiceYet value.
+     */
+    public Boolean isEatsMiceYet() {
+        return this.eatsMiceYet;
+    }
+
+    /**
+     * Set the eatsMiceYet property: The eatsMiceYet property.
+     * 
+     * @param eatsMiceYet the eatsMiceYet value to set.
+     * @return the Kitten object itself.
+     */
+    public Kitten setEatsMiceYet(Boolean eatsMiceYet) {
+        this.eatsMiceYet = eatsMiceYet;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/requiredfieldsascotrargstransformation/models/TransformationAsParentRequiredFields.java
+++ b/vanilla-tests/src/main/java/fixtures/requiredfieldsascotrargstransformation/models/TransformationAsParentRequiredFields.java
@@ -175,18 +175,13 @@ public final class TransformationAsParentRequiredFields extends TransformationAs
      */
     public static TransformationAsParentRequiredFields fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
-            boolean rfc1123RequiredFound = false;
+            long foundTracker = 0;
             OffsetDateTime rfc1123Required = null;
-            boolean nameRequiredFound = false;
             String nameRequired = null;
-            boolean urlBase64EncodedRequiredFound = false;
             byte[] urlBase64EncodedRequired = EMPTY_BYTE_ARRAY;
-            boolean unixTimeLongRequiredFound = false;
             OffsetDateTime unixTimeLongRequired = null;
-            boolean unixTimeDateTimeRequiredFound = false;
             OffsetDateTime unixTimeDateTimeRequired = null;
             DateTimeRfc1123 rfc1123NonRequired = null;
-            boolean rfc1123RequiredChildFound = false;
             OffsetDateTime rfc1123RequiredChild = null;
             DateTimeRfc1123 rfc1123NonRequiredChild = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
@@ -199,25 +194,25 @@ public final class TransformationAsParentRequiredFields extends TransformationAs
                     if (rfc1123RequiredHolder != null) {
                         rfc1123Required = rfc1123RequiredHolder.getDateTime();
                     }
-                    rfc1123RequiredFound = true;
+                    foundTracker |= 1;
                 } else if ("nameRequired".equals(fieldName)) {
                     nameRequired = reader.getString();
-                    nameRequiredFound = true;
+                    foundTracker |= 2;
                 } else if ("urlBase64EncodedRequired".equals(fieldName)) {
                     Base64Url urlBase64EncodedRequiredHolder
                         = reader.getNullable(nonNullReader -> new Base64Url(nonNullReader.getString()));
                     if (urlBase64EncodedRequiredHolder != null) {
                         urlBase64EncodedRequired = urlBase64EncodedRequiredHolder.decodedBytes();
                     }
-                    urlBase64EncodedRequiredFound = true;
+                    foundTracker |= 4;
                 } else if ("unixTimeLongRequired".equals(fieldName)) {
                     unixTimeLongRequired
                         = OffsetDateTime.ofInstant(Instant.ofEpochSecond(reader.getLong()), ZoneOffset.UTC);
-                    unixTimeLongRequiredFound = true;
+                    foundTracker |= 8;
                 } else if ("unixTimeDateTimeRequired".equals(fieldName)) {
                     unixTimeDateTimeRequired = reader
                         .getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString()));
-                    unixTimeDateTimeRequiredFound = true;
+                    foundTracker |= 16;
                 } else if ("rfc1123NonRequired".equals(fieldName)) {
                     rfc1123NonRequired
                         = reader.getNullable(nonNullReader -> new DateTimeRfc1123(nonNullReader.getString()));
@@ -227,7 +222,7 @@ public final class TransformationAsParentRequiredFields extends TransformationAs
                     if (rfc1123RequiredChildHolder != null) {
                         rfc1123RequiredChild = rfc1123RequiredChildHolder.getDateTime();
                     }
-                    rfc1123RequiredChildFound = true;
+                    foundTracker |= 32;
                 } else if ("rfc1123NonRequiredChild".equals(fieldName)) {
                     rfc1123NonRequiredChild
                         = reader.getNullable(nonNullReader -> new DateTimeRfc1123(nonNullReader.getString()));
@@ -235,12 +230,7 @@ public final class TransformationAsParentRequiredFields extends TransformationAs
                     reader.skipChildren();
                 }
             }
-            if (rfc1123RequiredFound
-                && nameRequiredFound
-                && urlBase64EncodedRequiredFound
-                && unixTimeLongRequiredFound
-                && unixTimeDateTimeRequiredFound
-                && rfc1123RequiredChildFound) {
+            if (foundTracker == 63) {
                 TransformationAsParentRequiredFields deserializedTransformationAsParentRequiredFields
                     = new TransformationAsParentRequiredFields(rfc1123Required, nameRequired, urlBase64EncodedRequired,
                         unixTimeLongRequired, unixTimeDateTimeRequired, rfc1123RequiredChild);
@@ -250,22 +240,22 @@ public final class TransformationAsParentRequiredFields extends TransformationAs
                 return deserializedTransformationAsParentRequiredFields;
             }
             List<String> missingProperties = new ArrayList<>();
-            if (!rfc1123RequiredFound) {
+            if ((foundTracker & 1) != 1) {
                 missingProperties.add("rfc1123Required");
             }
-            if (!nameRequiredFound) {
+            if ((foundTracker & 2) != 2) {
                 missingProperties.add("nameRequired");
             }
-            if (!urlBase64EncodedRequiredFound) {
+            if ((foundTracker & 4) != 4) {
                 missingProperties.add("urlBase64EncodedRequired");
             }
-            if (!unixTimeLongRequiredFound) {
+            if ((foundTracker & 8) != 8) {
                 missingProperties.add("unixTimeLongRequired");
             }
-            if (!unixTimeDateTimeRequiredFound) {
+            if ((foundTracker & 16) != 16) {
                 missingProperties.add("unixTimeDateTimeRequired");
             }
-            if (!rfc1123RequiredChildFound) {
+            if ((foundTracker & 32) != 32) {
                 missingProperties.add("rfc1123RequiredChild");
             }
 

--- a/vanilla-tests/src/main/java/fixtures/requiredfieldsascotrargstransformation/models/TransformationAsRequiredFields.java
+++ b/vanilla-tests/src/main/java/fixtures/requiredfieldsascotrargstransformation/models/TransformationAsRequiredFields.java
@@ -223,15 +223,11 @@ public class TransformationAsRequiredFields implements JsonSerializable<Transfor
      */
     public static TransformationAsRequiredFields fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
-            boolean rfc1123RequiredFound = false;
+            long foundTracker = 0;
             OffsetDateTime rfc1123Required = null;
-            boolean nameRequiredFound = false;
             String nameRequired = null;
-            boolean urlBase64EncodedRequiredFound = false;
             byte[] urlBase64EncodedRequired = EMPTY_BYTE_ARRAY;
-            boolean unixTimeLongRequiredFound = false;
             OffsetDateTime unixTimeLongRequired = null;
-            boolean unixTimeDateTimeRequiredFound = false;
             OffsetDateTime unixTimeDateTimeRequired = null;
             DateTimeRfc1123 rfc1123NonRequired = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
@@ -244,25 +240,25 @@ public class TransformationAsRequiredFields implements JsonSerializable<Transfor
                     if (rfc1123RequiredHolder != null) {
                         rfc1123Required = rfc1123RequiredHolder.getDateTime();
                     }
-                    rfc1123RequiredFound = true;
+                    foundTracker |= 1;
                 } else if ("nameRequired".equals(fieldName)) {
                     nameRequired = reader.getString();
-                    nameRequiredFound = true;
+                    foundTracker |= 2;
                 } else if ("urlBase64EncodedRequired".equals(fieldName)) {
                     Base64Url urlBase64EncodedRequiredHolder
                         = reader.getNullable(nonNullReader -> new Base64Url(nonNullReader.getString()));
                     if (urlBase64EncodedRequiredHolder != null) {
                         urlBase64EncodedRequired = urlBase64EncodedRequiredHolder.decodedBytes();
                     }
-                    urlBase64EncodedRequiredFound = true;
+                    foundTracker |= 4;
                 } else if ("unixTimeLongRequired".equals(fieldName)) {
                     unixTimeLongRequired
                         = OffsetDateTime.ofInstant(Instant.ofEpochSecond(reader.getLong()), ZoneOffset.UTC);
-                    unixTimeLongRequiredFound = true;
+                    foundTracker |= 8;
                 } else if ("unixTimeDateTimeRequired".equals(fieldName)) {
                     unixTimeDateTimeRequired = reader
                         .getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString()));
-                    unixTimeDateTimeRequiredFound = true;
+                    foundTracker |= 16;
                 } else if ("rfc1123NonRequired".equals(fieldName)) {
                     rfc1123NonRequired
                         = reader.getNullable(nonNullReader -> new DateTimeRfc1123(nonNullReader.getString()));
@@ -270,11 +266,7 @@ public class TransformationAsRequiredFields implements JsonSerializable<Transfor
                     reader.skipChildren();
                 }
             }
-            if (rfc1123RequiredFound
-                && nameRequiredFound
-                && urlBase64EncodedRequiredFound
-                && unixTimeLongRequiredFound
-                && unixTimeDateTimeRequiredFound) {
+            if (foundTracker == 31) {
                 TransformationAsRequiredFields deserializedTransformationAsRequiredFields
                     = new TransformationAsRequiredFields(rfc1123Required, nameRequired, urlBase64EncodedRequired,
                         unixTimeLongRequired, unixTimeDateTimeRequired);
@@ -283,19 +275,19 @@ public class TransformationAsRequiredFields implements JsonSerializable<Transfor
                 return deserializedTransformationAsRequiredFields;
             }
             List<String> missingProperties = new ArrayList<>();
-            if (!rfc1123RequiredFound) {
+            if ((foundTracker & 1) != 1) {
                 missingProperties.add("rfc1123Required");
             }
-            if (!nameRequiredFound) {
+            if ((foundTracker & 2) != 2) {
                 missingProperties.add("nameRequired");
             }
-            if (!urlBase64EncodedRequiredFound) {
+            if ((foundTracker & 4) != 4) {
                 missingProperties.add("urlBase64EncodedRequired");
             }
-            if (!unixTimeLongRequiredFound) {
+            if ((foundTracker & 8) != 8) {
                 missingProperties.add("unixTimeLongRequired");
             }
-            if (!unixTimeDateTimeRequiredFound) {
+            if ((foundTracker & 16) != 16) {
                 missingProperties.add("unixTimeDateTimeRequired");
             }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Cat.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Cat.java
@@ -33,6 +33,24 @@ public class Cat extends Pet {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Cat setId(Integer id) {
+        super.setId(id);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Cat setName(String name) {
+        super.setName(name);
+        return this;
+    }
+
+    /**
      * Get the color property: The color property.
      * 
      * @return the color value.
@@ -69,24 +87,6 @@ public class Cat extends Pet {
      */
     public Cat setHates(List<Dog> hates) {
         this.hates = hates;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Cat setId(Integer id) {
-        super.setId(id);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Cat setName(String name) {
-        super.setName(name);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Cookiecuttershark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Cookiecuttershark.java
@@ -32,16 +32,6 @@ public final class Cookiecuttershark extends Shark {
     }
 
     /**
-     * Get the fishtype property: The fishtype property.
-     * 
-     * @return the fishtype value.
-     */
-    @Override
-    public String getFishtype() {
-        return this.fishtype;
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override
@@ -84,6 +74,16 @@ public final class Cookiecuttershark extends Shark {
     public Cookiecuttershark setSiblings(List<Fish> siblings) {
         super.setSiblings(siblings);
         return this;
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Dog.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Dog.java
@@ -27,6 +27,24 @@ public final class Dog extends Pet {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Dog setId(Integer id) {
+        super.setId(id);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Dog setName(String name) {
+        super.setName(name);
+        return this;
+    }
+
+    /**
      * Get the food property: The food property.
      * 
      * @return the food value.
@@ -43,24 +61,6 @@ public final class Dog extends Pet {
      */
     public Dog setFood(String food) {
         this.food = food;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Dog setId(Integer id) {
-        super.setId(id);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Dog setName(String name) {
-        super.setName(name);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/DotSalmon.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/DotSalmon.java
@@ -37,6 +37,15 @@ public final class DotSalmon extends DotFish {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public DotSalmon setSpecies(String species) {
+        super.setSpecies(species);
+        return this;
+    }
+
+    /**
      * Get the fishType property: The fish.type property.
      * 
      * @return the fishType value.
@@ -83,15 +92,6 @@ public final class DotSalmon extends DotFish {
      */
     public DotSalmon setIswild(Boolean iswild) {
         this.iswild = iswild;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public DotSalmon setSpecies(String species) {
-        super.setSpecies(species);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Goblinshark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Goblinshark.java
@@ -42,6 +42,51 @@ public final class Goblinshark extends Shark {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Goblinshark setAge(Integer age) {
+        super.setAge(age);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Goblinshark setBirthday(OffsetDateTime birthday) {
+        super.setBirthday(birthday);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Goblinshark setSpecies(String species) {
+        super.setSpecies(species);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Goblinshark setLength(float length) {
+        super.setLength(length);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Goblinshark setSiblings(List<Fish> siblings) {
+        super.setSiblings(siblings);
+        return this;
+    }
+
+    /**
      * Get the fishtype property: The fishtype property.
      * 
      * @return the fishtype value.
@@ -88,51 +133,6 @@ public final class Goblinshark extends Shark {
      */
     public Goblinshark setColor(GoblinSharkColor color) {
         this.color = color;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Goblinshark setAge(Integer age) {
-        super.setAge(age);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Goblinshark setBirthday(OffsetDateTime birthday) {
-        super.setBirthday(birthday);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Goblinshark setSpecies(String species) {
-        super.setSpecies(species);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Goblinshark setLength(float length) {
-        super.setLength(length);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Goblinshark setSiblings(List<Fish> siblings) {
-        super.setSiblings(siblings);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/MyDerivedType.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/MyDerivedType.java
@@ -32,6 +32,24 @@ public final class MyDerivedType extends MyBaseType {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public MyDerivedType setPropB1(String propB1) {
+        super.setPropB1(propB1);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public MyDerivedType setPropBH1(String propBH1) {
+        super.setPropBH1(propBH1);
+        return this;
+    }
+
+    /**
      * Get the kind property: The kind property.
      * 
      * @return the kind value.
@@ -58,24 +76,6 @@ public final class MyDerivedType extends MyBaseType {
      */
     public MyDerivedType setPropD1(String propD1) {
         this.propD1 = propD1;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public MyDerivedType setPropB1(String propB1) {
-        super.setPropB1(propB1);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public MyDerivedType setPropBH1(String propBH1) {
-        super.setPropBH1(propBH1);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Salmon.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Salmon.java
@@ -38,6 +38,33 @@ public class Salmon extends Fish {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Salmon setSpecies(String species) {
+        super.setSpecies(species);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Salmon setLength(float length) {
+        super.setLength(length);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Salmon setSiblings(List<Fish> siblings) {
+        super.setSiblings(siblings);
+        return this;
+    }
+
+    /**
      * Get the fishtype property: The fishtype property.
      * 
      * @return the fishtype value.
@@ -84,33 +111,6 @@ public class Salmon extends Fish {
      */
     public Salmon setIswild(Boolean iswild) {
         this.iswild = iswild;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Salmon setSpecies(String species) {
-        super.setSpecies(species);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Salmon setLength(float length) {
-        super.setLength(length);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Salmon setSiblings(List<Fish> siblings) {
-        super.setSiblings(siblings);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Sawshark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Sawshark.java
@@ -37,36 +37,6 @@ public final class Sawshark extends Shark {
     }
 
     /**
-     * Get the fishtype property: The fishtype property.
-     * 
-     * @return the fishtype value.
-     */
-    @Override
-    public String getFishtype() {
-        return this.fishtype;
-    }
-
-    /**
-     * Get the picture property: The picture property.
-     * 
-     * @return the picture value.
-     */
-    public byte[] getPicture() {
-        return CoreUtils.clone(this.picture);
-    }
-
-    /**
-     * Set the picture property: The picture property.
-     * 
-     * @param picture the picture value to set.
-     * @return the Sawshark object itself.
-     */
-    public Sawshark setPicture(byte[] picture) {
-        this.picture = CoreUtils.clone(picture);
-        return this;
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override
@@ -108,6 +78,36 @@ public final class Sawshark extends Shark {
     @Override
     public Sawshark setSiblings(List<Fish> siblings) {
         super.setSiblings(siblings);
+        return this;
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
+    }
+
+    /**
+     * Get the picture property: The picture property.
+     * 
+     * @return the picture value.
+     */
+    public byte[] getPicture() {
+        return CoreUtils.clone(this.picture);
+    }
+
+    /**
+     * Set the picture property: The picture property.
+     * 
+     * @param picture the picture value to set.
+     * @return the Sawshark object itself.
+     */
+    public Sawshark setPicture(byte[] picture) {
+        this.picture = CoreUtils.clone(picture);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Shark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Shark.java
@@ -42,6 +42,33 @@ public class Shark extends Fish {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Shark setSpecies(String species) {
+        super.setSpecies(species);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Shark setLength(float length) {
+        super.setLength(length);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Shark setSiblings(List<Fish> siblings) {
+        super.setSiblings(siblings);
+        return this;
+    }
+
+    /**
      * Get the fishtype property: The fishtype property.
      * 
      * @return the fishtype value.
@@ -88,33 +115,6 @@ public class Shark extends Fish {
      */
     public Shark setBirthday(OffsetDateTime birthday) {
         this.birthday = birthday;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Shark setSpecies(String species) {
-        super.setSpecies(species);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Shark setLength(float length) {
-        super.setLength(length);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Shark setSiblings(List<Fish> siblings) {
-        super.setSiblings(siblings);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Siamese.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Siamese.java
@@ -28,26 +28,6 @@ public final class Siamese extends Cat {
     }
 
     /**
-     * Get the breed property: The breed property.
-     * 
-     * @return the breed value.
-     */
-    public String getBreed() {
-        return this.breed;
-    }
-
-    /**
-     * Set the breed property: The breed property.
-     * 
-     * @param breed the breed value to set.
-     * @return the Siamese object itself.
-     */
-    public Siamese setBreed(String breed) {
-        this.breed = breed;
-        return this;
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override
@@ -80,6 +60,26 @@ public final class Siamese extends Cat {
     @Override
     public Siamese setName(String name) {
         super.setName(name);
+        return this;
+    }
+
+    /**
+     * Get the breed property: The breed property.
+     * 
+     * @return the breed value.
+     */
+    public String getBreed() {
+        return this.breed;
+    }
+
+    /**
+     * Set the breed property: The breed property.
+     * 
+     * @param breed the breed value to set.
+     * @return the Siamese object itself.
+     */
+    public Siamese setBreed(String breed) {
+        this.breed = breed;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/SmartSalmon.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/SmartSalmon.java
@@ -40,6 +40,51 @@ public final class SmartSalmon extends Salmon {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SmartSalmon setLocation(String location) {
+        super.setLocation(location);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SmartSalmon setIswild(Boolean iswild) {
+        super.setIswild(iswild);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SmartSalmon setSpecies(String species) {
+        super.setSpecies(species);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SmartSalmon setLength(float length) {
+        super.setLength(length);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SmartSalmon setSiblings(List<Fish> siblings) {
+        super.setSiblings(siblings);
+        return this;
+    }
+
+    /**
      * Get the fishtype property: The fishtype property.
      * 
      * @return the fishtype value.
@@ -86,51 +131,6 @@ public final class SmartSalmon extends Salmon {
      */
     public SmartSalmon setAdditionalProperties(Map<String, Object> additionalProperties) {
         this.additionalProperties = additionalProperties;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SmartSalmon setLocation(String location) {
-        super.setLocation(location);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SmartSalmon setIswild(Boolean iswild) {
-        super.setIswild(iswild);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SmartSalmon setSpecies(String species) {
-        super.setSpecies(species);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SmartSalmon setLength(float length) {
-        super.setLength(length);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SmartSalmon setSiblings(List<Fish> siblings) {
-        super.setSiblings(siblings);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Cat.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Cat.java
@@ -33,6 +33,24 @@ public class Cat extends Pet {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Cat setId(Integer id) {
+        super.setId(id);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Cat setName(String name) {
+        super.setName(name);
+        return this;
+    }
+
+    /**
      * Get the color property: The color property.
      * 
      * @return the color value.
@@ -69,24 +87,6 @@ public class Cat extends Pet {
      */
     public Cat setHates(List<Dog> hates) {
         this.hates = hates;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Cat setId(Integer id) {
-        super.setId(id);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Cat setName(String name) {
-        super.setName(name);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Cookiecuttershark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Cookiecuttershark.java
@@ -37,16 +37,6 @@ public final class Cookiecuttershark extends Shark {
     }
 
     /**
-     * Get the fishtype property: The fishtype property.
-     * 
-     * @return the fishtype value.
-     */
-    @Override
-    public String getFishtype() {
-        return this.fishtype;
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override
@@ -71,6 +61,16 @@ public final class Cookiecuttershark extends Shark {
     public Cookiecuttershark setSiblings(List<Fish> siblings) {
         super.setSiblings(siblings);
         return this;
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**
@@ -118,9 +118,8 @@ public final class Cookiecuttershark extends Shark {
      */
     public static Cookiecuttershark fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
-            boolean lengthFound = false;
+            long foundTracker = 0;
             float length = 0.0f;
-            boolean birthdayFound = false;
             OffsetDateTime birthday = null;
             String species = null;
             List<Fish> siblings = null;
@@ -132,11 +131,11 @@ public final class Cookiecuttershark extends Shark {
 
                 if ("length".equals(fieldName)) {
                     length = reader.getFloat();
-                    lengthFound = true;
+                    foundTracker |= 1;
                 } else if ("birthday".equals(fieldName)) {
                     birthday = reader
                         .getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString()));
-                    birthdayFound = true;
+                    foundTracker |= 2;
                 } else if ("species".equals(fieldName)) {
                     species = reader.getString();
                 } else if ("siblings".equals(fieldName)) {
@@ -149,7 +148,7 @@ public final class Cookiecuttershark extends Shark {
                     reader.skipChildren();
                 }
             }
-            if (lengthFound && birthdayFound) {
+            if (foundTracker == 3) {
                 Cookiecuttershark deserializedCookiecuttershark = new Cookiecuttershark(length, birthday);
                 deserializedCookiecuttershark.setSpecies(species);
                 deserializedCookiecuttershark.setSiblings(siblings);
@@ -159,10 +158,10 @@ public final class Cookiecuttershark extends Shark {
                 return deserializedCookiecuttershark;
             }
             List<String> missingProperties = new ArrayList<>();
-            if (!lengthFound) {
+            if ((foundTracker & 1) != 1) {
                 missingProperties.add("length");
             }
-            if (!birthdayFound) {
+            if ((foundTracker & 2) != 2) {
                 missingProperties.add("birthday");
             }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Dog.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Dog.java
@@ -27,6 +27,24 @@ public final class Dog extends Pet {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Dog setId(Integer id) {
+        super.setId(id);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Dog setName(String name) {
+        super.setName(name);
+        return this;
+    }
+
+    /**
      * Get the food property: The food property.
      * 
      * @return the food value.
@@ -43,24 +61,6 @@ public final class Dog extends Pet {
      */
     public Dog setFood(String food) {
         this.food = food;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Dog setId(Integer id) {
-        super.setId(id);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Dog setName(String name) {
-        super.setName(name);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/DotSalmon.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/DotSalmon.java
@@ -37,6 +37,15 @@ public final class DotSalmon extends DotFish {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public DotSalmon setSpecies(String species) {
+        super.setSpecies(species);
+        return this;
+    }
+
+    /**
      * Get the fishType property: The fish.type property.
      * 
      * @return the fishType value.
@@ -83,15 +92,6 @@ public final class DotSalmon extends DotFish {
      */
     public DotSalmon setIswild(Boolean iswild) {
         this.iswild = iswild;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public DotSalmon setSpecies(String species) {
-        super.setSpecies(species);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Fish.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Fish.java
@@ -174,7 +174,7 @@ public class Fish implements JsonSerializable<Fish> {
 
     static Fish fromJsonKnownDiscriminator(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
-            boolean lengthFound = false;
+            long foundTracker = 0;
             float length = 0.0f;
             String fishtype = null;
             String species = null;
@@ -185,7 +185,7 @@ public class Fish implements JsonSerializable<Fish> {
 
                 if ("length".equals(fieldName)) {
                     length = reader.getFloat();
-                    lengthFound = true;
+                    foundTracker |= 1;
                 } else if ("fishtype".equals(fieldName)) {
                     fishtype = reader.getString();
                 } else if ("species".equals(fieldName)) {
@@ -196,7 +196,7 @@ public class Fish implements JsonSerializable<Fish> {
                     reader.skipChildren();
                 }
             }
-            if (lengthFound) {
+            if (foundTracker == 1) {
                 Fish deserializedFish = new Fish(length);
                 deserializedFish.fishtype = fishtype;
                 deserializedFish.species = species;

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Goblinshark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Goblinshark.java
@@ -47,6 +47,33 @@ public final class Goblinshark extends Shark {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Goblinshark setAge(Integer age) {
+        super.setAge(age);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Goblinshark setSpecies(String species) {
+        super.setSpecies(species);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Goblinshark setSiblings(List<Fish> siblings) {
+        super.setSiblings(siblings);
+        return this;
+    }
+
+    /**
      * Get the fishtype property: The fishtype property.
      * 
      * @return the fishtype value.
@@ -97,33 +124,6 @@ public final class Goblinshark extends Shark {
     }
 
     /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Goblinshark setAge(Integer age) {
-        super.setAge(age);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Goblinshark setSpecies(String species) {
-        super.setSpecies(species);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Goblinshark setSiblings(List<Fish> siblings) {
-        super.setSiblings(siblings);
-        return this;
-    }
-
-    /**
      * Validates the instance.
      * 
      * @throws IllegalArgumentException thrown if the instance is not valid.
@@ -170,9 +170,8 @@ public final class Goblinshark extends Shark {
      */
     public static Goblinshark fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
-            boolean lengthFound = false;
+            long foundTracker = 0;
             float length = 0.0f;
-            boolean birthdayFound = false;
             OffsetDateTime birthday = null;
             String species = null;
             List<Fish> siblings = null;
@@ -186,11 +185,11 @@ public final class Goblinshark extends Shark {
 
                 if ("length".equals(fieldName)) {
                     length = reader.getFloat();
-                    lengthFound = true;
+                    foundTracker |= 1;
                 } else if ("birthday".equals(fieldName)) {
                     birthday = reader
                         .getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString()));
-                    birthdayFound = true;
+                    foundTracker |= 2;
                 } else if ("species".equals(fieldName)) {
                     species = reader.getString();
                 } else if ("siblings".equals(fieldName)) {
@@ -207,7 +206,7 @@ public final class Goblinshark extends Shark {
                     reader.skipChildren();
                 }
             }
-            if (lengthFound && birthdayFound) {
+            if (foundTracker == 3) {
                 Goblinshark deserializedGoblinshark = new Goblinshark(length, birthday);
                 deserializedGoblinshark.setSpecies(species);
                 deserializedGoblinshark.setSiblings(siblings);
@@ -219,10 +218,10 @@ public final class Goblinshark extends Shark {
                 return deserializedGoblinshark;
             }
             List<String> missingProperties = new ArrayList<>();
-            if (!lengthFound) {
+            if ((foundTracker & 1) != 1) {
                 missingProperties.add("length");
             }
-            if (!birthdayFound) {
+            if ((foundTracker & 2) != 2) {
                 missingProperties.add("birthday");
             }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/MyDerivedType.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/MyDerivedType.java
@@ -32,6 +32,24 @@ public final class MyDerivedType extends MyBaseType {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public MyDerivedType setPropB1(String propB1) {
+        super.setPropB1(propB1);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public MyDerivedType setPropBH1(String propBH1) {
+        super.setPropBH1(propBH1);
+        return this;
+    }
+
+    /**
      * Get the kind property: The kind property.
      * 
      * @return the kind value.
@@ -58,24 +76,6 @@ public final class MyDerivedType extends MyBaseType {
      */
     public MyDerivedType setPropD1(String propD1) {
         this.propD1 = propD1;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public MyDerivedType setPropB1(String propB1) {
-        super.setPropB1(propB1);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public MyDerivedType setPropBH1(String propBH1) {
-        super.setPropBH1(propBH1);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Salmon.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Salmon.java
@@ -41,6 +41,24 @@ public class Salmon extends Fish {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Salmon setSpecies(String species) {
+        super.setSpecies(species);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Salmon setSiblings(List<Fish> siblings) {
+        super.setSiblings(siblings);
+        return this;
+    }
+
+    /**
      * Get the fishtype property: The fishtype property.
      * 
      * @return the fishtype value.
@@ -87,24 +105,6 @@ public class Salmon extends Fish {
      */
     public Salmon setIswild(Boolean iswild) {
         this.iswild = iswild;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Salmon setSpecies(String species) {
-        super.setSpecies(species);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Salmon setSiblings(List<Fish> siblings) {
-        super.setSiblings(siblings);
         return this;
     }
 
@@ -171,7 +171,7 @@ public class Salmon extends Fish {
 
     static Salmon fromJsonKnownDiscriminator(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
-            boolean lengthFound = false;
+            long foundTracker = 0;
             float length = 0.0f;
             String species = null;
             List<Fish> siblings = null;
@@ -184,7 +184,7 @@ public class Salmon extends Fish {
 
                 if ("length".equals(fieldName)) {
                     length = reader.getFloat();
-                    lengthFound = true;
+                    foundTracker |= 1;
                 } else if ("species".equals(fieldName)) {
                     species = reader.getString();
                 } else if ("siblings".equals(fieldName)) {
@@ -199,7 +199,7 @@ public class Salmon extends Fish {
                     reader.skipChildren();
                 }
             }
-            if (lengthFound) {
+            if (foundTracker == 1) {
                 Salmon deserializedSalmon = new Salmon(length);
                 deserializedSalmon.setSpecies(species);
                 deserializedSalmon.setSiblings(siblings);

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Sawshark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Sawshark.java
@@ -42,6 +42,33 @@ public final class Sawshark extends Shark {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Sawshark setAge(Integer age) {
+        super.setAge(age);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Sawshark setSpecies(String species) {
+        super.setSpecies(species);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Sawshark setSiblings(List<Fish> siblings) {
+        super.setSiblings(siblings);
+        return this;
+    }
+
+    /**
      * Get the fishtype property: The fishtype property.
      * 
      * @return the fishtype value.
@@ -68,33 +95,6 @@ public final class Sawshark extends Shark {
      */
     public Sawshark setPicture(byte[] picture) {
         this.picture = CoreUtils.clone(picture);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Sawshark setAge(Integer age) {
-        super.setAge(age);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Sawshark setSpecies(String species) {
-        super.setSpecies(species);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Sawshark setSiblings(List<Fish> siblings) {
-        super.setSiblings(siblings);
         return this;
     }
 
@@ -144,9 +144,8 @@ public final class Sawshark extends Shark {
      */
     public static Sawshark fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
-            boolean lengthFound = false;
+            long foundTracker = 0;
             float length = 0.0f;
-            boolean birthdayFound = false;
             OffsetDateTime birthday = null;
             String species = null;
             List<Fish> siblings = null;
@@ -159,11 +158,11 @@ public final class Sawshark extends Shark {
 
                 if ("length".equals(fieldName)) {
                     length = reader.getFloat();
-                    lengthFound = true;
+                    foundTracker |= 1;
                 } else if ("birthday".equals(fieldName)) {
                     birthday = reader
                         .getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString()));
-                    birthdayFound = true;
+                    foundTracker |= 2;
                 } else if ("species".equals(fieldName)) {
                     species = reader.getString();
                 } else if ("siblings".equals(fieldName)) {
@@ -178,7 +177,7 @@ public final class Sawshark extends Shark {
                     reader.skipChildren();
                 }
             }
-            if (lengthFound && birthdayFound) {
+            if (foundTracker == 3) {
                 Sawshark deserializedSawshark = new Sawshark(length, birthday);
                 deserializedSawshark.setSpecies(species);
                 deserializedSawshark.setSiblings(siblings);
@@ -189,10 +188,10 @@ public final class Sawshark extends Shark {
                 return deserializedSawshark;
             }
             List<String> missingProperties = new ArrayList<>();
-            if (!lengthFound) {
+            if ((foundTracker & 1) != 1) {
                 missingProperties.add("length");
             }
-            if (!birthdayFound) {
+            if ((foundTracker & 2) != 2) {
                 missingProperties.add("birthday");
             }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Shark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Shark.java
@@ -48,6 +48,24 @@ public class Shark extends Fish {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Shark setSpecies(String species) {
+        super.setSpecies(species);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Shark setSiblings(List<Fish> siblings) {
+        super.setSiblings(siblings);
+        return this;
+    }
+
+    /**
      * Get the fishtype property: The fishtype property.
      * 
      * @return the fishtype value.
@@ -84,24 +102,6 @@ public class Shark extends Fish {
      */
     public OffsetDateTime getBirthday() {
         return this.birthday;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Shark setSpecies(String species) {
-        super.setSpecies(species);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Shark setSiblings(List<Fish> siblings) {
-        super.setSiblings(siblings);
-        return this;
     }
 
     /**
@@ -178,11 +178,10 @@ public class Shark extends Fish {
 
     static Shark fromJsonKnownDiscriminator(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
-            boolean lengthFound = false;
+            long foundTracker = 0;
             float length = 0.0f;
             String species = null;
             List<Fish> siblings = null;
-            boolean birthdayFound = false;
             OffsetDateTime birthday = null;
             String fishtype = "shark";
             Integer age = null;
@@ -192,7 +191,7 @@ public class Shark extends Fish {
 
                 if ("length".equals(fieldName)) {
                     length = reader.getFloat();
-                    lengthFound = true;
+                    foundTracker |= 1;
                 } else if ("species".equals(fieldName)) {
                     species = reader.getString();
                 } else if ("siblings".equals(fieldName)) {
@@ -200,7 +199,7 @@ public class Shark extends Fish {
                 } else if ("birthday".equals(fieldName)) {
                     birthday = reader
                         .getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString()));
-                    birthdayFound = true;
+                    foundTracker |= 2;
                 } else if ("fishtype".equals(fieldName)) {
                     fishtype = reader.getString();
                 } else if ("age".equals(fieldName)) {
@@ -209,7 +208,7 @@ public class Shark extends Fish {
                     reader.skipChildren();
                 }
             }
-            if (lengthFound && birthdayFound) {
+            if (foundTracker == 3) {
                 Shark deserializedShark = new Shark(length, birthday);
                 deserializedShark.setSpecies(species);
                 deserializedShark.setSiblings(siblings);
@@ -219,10 +218,10 @@ public class Shark extends Fish {
                 return deserializedShark;
             }
             List<String> missingProperties = new ArrayList<>();
-            if (!lengthFound) {
+            if ((foundTracker & 1) != 1) {
                 missingProperties.add("length");
             }
-            if (!birthdayFound) {
+            if ((foundTracker & 2) != 2) {
                 missingProperties.add("birthday");
             }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Siamese.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/Siamese.java
@@ -28,26 +28,6 @@ public final class Siamese extends Cat {
     }
 
     /**
-     * Get the breed property: The breed property.
-     * 
-     * @return the breed value.
-     */
-    public String getBreed() {
-        return this.breed;
-    }
-
-    /**
-     * Set the breed property: The breed property.
-     * 
-     * @param breed the breed value to set.
-     * @return the Siamese object itself.
-     */
-    public Siamese setBreed(String breed) {
-        this.breed = breed;
-        return this;
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override
@@ -80,6 +60,26 @@ public final class Siamese extends Cat {
     @Override
     public Siamese setName(String name) {
         super.setName(name);
+        return this;
+    }
+
+    /**
+     * Get the breed property: The breed property.
+     * 
+     * @return the breed value.
+     */
+    public String getBreed() {
+        return this.breed;
+    }
+
+    /**
+     * Set the breed property: The breed property.
+     * 
+     * @param breed the breed value to set.
+     * @return the Siamese object itself.
+     */
+    public Siamese setBreed(String breed) {
+        this.breed = breed;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/SmartSalmon.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/SmartSalmon.java
@@ -43,6 +43,42 @@ public final class SmartSalmon extends Salmon {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SmartSalmon setLocation(String location) {
+        super.setLocation(location);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SmartSalmon setIswild(Boolean iswild) {
+        super.setIswild(iswild);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SmartSalmon setSpecies(String species) {
+        super.setSpecies(species);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SmartSalmon setSiblings(List<Fish> siblings) {
+        super.setSiblings(siblings);
+        return this;
+    }
+
+    /**
      * Get the fishtype property: The fishtype property.
      * 
      * @return the fishtype value.
@@ -93,42 +129,6 @@ public final class SmartSalmon extends Salmon {
     }
 
     /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SmartSalmon setLocation(String location) {
-        super.setLocation(location);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SmartSalmon setIswild(Boolean iswild) {
-        super.setIswild(iswild);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SmartSalmon setSpecies(String species) {
-        super.setSpecies(species);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SmartSalmon setSiblings(List<Fish> siblings) {
-        super.setSiblings(siblings);
-        return this;
-    }
-
-    /**
      * Validates the instance.
      * 
      * @throws IllegalArgumentException thrown if the instance is not valid.
@@ -172,7 +172,7 @@ public final class SmartSalmon extends Salmon {
      */
     public static SmartSalmon fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
-            boolean lengthFound = false;
+            long foundTracker = 0;
             float length = 0.0f;
             String species = null;
             List<Fish> siblings = null;
@@ -187,7 +187,7 @@ public final class SmartSalmon extends Salmon {
 
                 if ("length".equals(fieldName)) {
                     length = reader.getFloat();
-                    lengthFound = true;
+                    foundTracker |= 1;
                 } else if ("species".equals(fieldName)) {
                     species = reader.getString();
                 } else if ("siblings".equals(fieldName)) {
@@ -208,7 +208,7 @@ public final class SmartSalmon extends Salmon {
                     additionalProperties.put(fieldName, reader.readUntyped());
                 }
             }
-            if (lengthFound) {
+            if (foundTracker == 1) {
                 SmartSalmon deserializedSmartSalmon = new SmartSalmon(length);
                 deserializedSmartSalmon.setSpecies(species);
                 deserializedSmartSalmon.setSiblings(siblings);

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Cat.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Cat.java
@@ -33,6 +33,24 @@ public class Cat extends Pet {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Cat setId(Integer id) {
+        super.setId(id);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Cat setName(String name) {
+        super.setName(name);
+        return this;
+    }
+
+    /**
      * Get the color property: The color property.
      * 
      * @return the color value.
@@ -69,24 +87,6 @@ public class Cat extends Pet {
      */
     public Cat setHates(List<Dog> hates) {
         this.hates = hates;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Cat setId(Integer id) {
-        super.setId(id);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Cat setName(String name) {
-        super.setName(name);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Cookiecuttershark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Cookiecuttershark.java
@@ -32,16 +32,6 @@ public final class Cookiecuttershark extends Shark {
     }
 
     /**
-     * Get the fishtype property: The fishtype property.
-     * 
-     * @return the fishtype value.
-     */
-    @Override
-    public String getFishtype() {
-        return this.fishtype;
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override
@@ -84,6 +74,16 @@ public final class Cookiecuttershark extends Shark {
     public Cookiecuttershark setSiblings(List<Fish> siblings) {
         super.setSiblings(siblings);
         return this;
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Dog.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Dog.java
@@ -27,6 +27,24 @@ public final class Dog extends Pet {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Dog setId(Integer id) {
+        super.setId(id);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Dog setName(String name) {
+        super.setName(name);
+        return this;
+    }
+
+    /**
      * Get the food property: The food property.
      * 
      * @return the food value.
@@ -43,24 +61,6 @@ public final class Dog extends Pet {
      */
     public Dog setFood(String food) {
         this.food = food;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Dog setId(Integer id) {
-        super.setId(id);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Dog setName(String name) {
-        super.setName(name);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Goblinshark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Goblinshark.java
@@ -42,6 +42,51 @@ public final class Goblinshark extends Shark {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Goblinshark setAge(Integer age) {
+        super.setAge(age);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Goblinshark setBirthday(OffsetDateTime birthday) {
+        super.setBirthday(birthday);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Goblinshark setSpecies(String species) {
+        super.setSpecies(species);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Goblinshark setLength(float length) {
+        super.setLength(length);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Goblinshark setSiblings(List<Fish> siblings) {
+        super.setSiblings(siblings);
+        return this;
+    }
+
+    /**
      * Get the fishtype property: The fishtype property.
      * 
      * @return the fishtype value.
@@ -88,51 +133,6 @@ public final class Goblinshark extends Shark {
      */
     public Goblinshark setColor(GoblinSharkColor color) {
         this.color = color;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Goblinshark setAge(Integer age) {
-        super.setAge(age);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Goblinshark setBirthday(OffsetDateTime birthday) {
-        super.setBirthday(birthday);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Goblinshark setSpecies(String species) {
-        super.setSpecies(species);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Goblinshark setLength(float length) {
-        super.setLength(length);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Goblinshark setSiblings(List<Fish> siblings) {
-        super.setSiblings(siblings);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Salmon.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Salmon.java
@@ -38,6 +38,33 @@ public class Salmon extends Fish {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Salmon setSpecies(String species) {
+        super.setSpecies(species);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Salmon setLength(float length) {
+        super.setLength(length);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Salmon setSiblings(List<Fish> siblings) {
+        super.setSiblings(siblings);
+        return this;
+    }
+
+    /**
      * Get the fishtype property: The fishtype property.
      * 
      * @return the fishtype value.
@@ -84,33 +111,6 @@ public class Salmon extends Fish {
      */
     public Salmon setIswild(Boolean iswild) {
         this.iswild = iswild;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Salmon setSpecies(String species) {
-        super.setSpecies(species);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Salmon setLength(float length) {
-        super.setLength(length);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Salmon setSiblings(List<Fish> siblings) {
-        super.setSiblings(siblings);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Sawshark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Sawshark.java
@@ -37,36 +37,6 @@ public final class Sawshark extends Shark {
     }
 
     /**
-     * Get the fishtype property: The fishtype property.
-     * 
-     * @return the fishtype value.
-     */
-    @Override
-    public String getFishtype() {
-        return this.fishtype;
-    }
-
-    /**
-     * Get the picture property: The picture property.
-     * 
-     * @return the picture value.
-     */
-    public byte[] getPicture() {
-        return CoreUtils.clone(this.picture);
-    }
-
-    /**
-     * Set the picture property: The picture property.
-     * 
-     * @param picture the picture value to set.
-     * @return the Sawshark object itself.
-     */
-    public Sawshark setPicture(byte[] picture) {
-        this.picture = CoreUtils.clone(picture);
-        return this;
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override
@@ -108,6 +78,36 @@ public final class Sawshark extends Shark {
     @Override
     public Sawshark setSiblings(List<Fish> siblings) {
         super.setSiblings(siblings);
+        return this;
+    }
+
+    /**
+     * Get the fishtype property: The fishtype property.
+     * 
+     * @return the fishtype value.
+     */
+    @Override
+    public String getFishtype() {
+        return this.fishtype;
+    }
+
+    /**
+     * Get the picture property: The picture property.
+     * 
+     * @return the picture value.
+     */
+    public byte[] getPicture() {
+        return CoreUtils.clone(this.picture);
+    }
+
+    /**
+     * Set the picture property: The picture property.
+     * 
+     * @param picture the picture value to set.
+     * @return the Sawshark object itself.
+     */
+    public Sawshark setPicture(byte[] picture) {
+        this.picture = CoreUtils.clone(picture);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Shark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Shark.java
@@ -42,6 +42,33 @@ public class Shark extends Fish {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Shark setSpecies(String species) {
+        super.setSpecies(species);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Shark setLength(float length) {
+        super.setLength(length);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Shark setSiblings(List<Fish> siblings) {
+        super.setSiblings(siblings);
+        return this;
+    }
+
+    /**
      * Get the fishtype property: The fishtype property.
      * 
      * @return the fishtype value.
@@ -88,33 +115,6 @@ public class Shark extends Fish {
      */
     public Shark setBirthday(OffsetDateTime birthday) {
         this.birthday = birthday;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Shark setSpecies(String species) {
-        super.setSpecies(species);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Shark setLength(float length) {
-        super.setLength(length);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Shark setSiblings(List<Fish> siblings) {
-        super.setSiblings(siblings);
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Siamese.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Siamese.java
@@ -28,26 +28,6 @@ public final class Siamese extends Cat {
     }
 
     /**
-     * Get the breed property: The breed property.
-     * 
-     * @return the breed value.
-     */
-    public String getBreed() {
-        return this.breed;
-    }
-
-    /**
-     * Set the breed property: The breed property.
-     * 
-     * @param breed the breed value to set.
-     * @return the Siamese object itself.
-     */
-    public Siamese setBreed(String breed) {
-        this.breed = breed;
-        return this;
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override
@@ -80,6 +60,26 @@ public final class Siamese extends Cat {
     @Override
     public Siamese setName(String name) {
         super.setName(name);
+        return this;
+    }
+
+    /**
+     * Get the breed property: The breed property.
+     * 
+     * @return the breed value.
+     */
+    public String getBreed() {
+        return this.breed;
+    }
+
+    /**
+     * Set the breed property: The breed property.
+     * 
+     * @param breed the breed value to set.
+     * @return the Siamese object itself.
+     */
+    public Siamese setBreed(String breed) {
+        this.breed = breed;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/SmartSalmon.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/SmartSalmon.java
@@ -40,6 +40,51 @@ public final class SmartSalmon extends Salmon {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SmartSalmon setLocation(String location) {
+        super.setLocation(location);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SmartSalmon setIswild(Boolean iswild) {
+        super.setIswild(iswild);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SmartSalmon setSpecies(String species) {
+        super.setSpecies(species);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SmartSalmon setLength(float length) {
+        super.setLength(length);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SmartSalmon setSiblings(List<Fish> siblings) {
+        super.setSiblings(siblings);
+        return this;
+    }
+
+    /**
      * Get the fishtype property: The fishtype property.
      * 
      * @return the fishtype value.
@@ -86,51 +131,6 @@ public final class SmartSalmon extends Salmon {
      */
     public SmartSalmon setAdditionalProperties(Map<String, Object> additionalProperties) {
         this.additionalProperties = additionalProperties;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SmartSalmon setLocation(String location) {
-        super.setLocation(location);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SmartSalmon setIswild(Boolean iswild) {
-        super.setIswild(iswild);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SmartSalmon setSpecies(String species) {
-        super.setSpecies(species);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SmartSalmon setLength(float length) {
-        super.setLength(length);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SmartSalmon setSiblings(List<Fish> siblings) {
-        super.setSiblings(siblings);
         return this;
     }
 


### PR DESCRIPTION
Updates JSON merge patch and `fromJson` code to use bitwise tracking instead of a `Set<String>` and a `boolean` per tracking instance.