### PR TITLE
Allow sharing fromJson code

### DIFF
--- a/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/DocumentModelBuildOperationDetails.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/DocumentModelBuildOperationDetails.java
@@ -5,7 +5,6 @@
 package com.azure.ai.formrecognizer.documentanalysis.implementation.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.util.CoreUtils;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
@@ -159,31 +158,9 @@ public final class DocumentModelBuildOperationDetails extends OperationDetails {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("operationId".equals(fieldName)) {
-                    deserializedDocumentModelBuildOperationDetails.setOperationId(reader.getString());
-                } else if ("status".equals(fieldName)) {
-                    deserializedDocumentModelBuildOperationDetails
-                        .setStatus(OperationStatus.fromString(reader.getString()));
-                } else if ("createdDateTime".equals(fieldName)) {
-                    deserializedDocumentModelBuildOperationDetails.setCreatedDateTime(reader
-                        .getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString())));
-                } else if ("lastUpdatedDateTime".equals(fieldName)) {
-                    deserializedDocumentModelBuildOperationDetails.setLastUpdatedDateTime(reader
-                        .getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString())));
-                } else if ("resourceLocation".equals(fieldName)) {
-                    deserializedDocumentModelBuildOperationDetails.setResourceLocation(reader.getString());
-                } else if ("percentCompleted".equals(fieldName)) {
-                    deserializedDocumentModelBuildOperationDetails
-                        .setPercentCompleted(reader.getNullable(JsonReader::getInt));
-                } else if ("apiVersion".equals(fieldName)) {
-                    deserializedDocumentModelBuildOperationDetails.setApiVersion(reader.getString());
-                } else if ("tags".equals(fieldName)) {
-                    Map<String, String> tags = reader.readMap(reader1 -> reader1.getString());
-                    deserializedDocumentModelBuildOperationDetails.setTags(tags);
-                } else if ("error".equals(fieldName)) {
-                    deserializedDocumentModelBuildOperationDetails.setError(Error.fromJson(reader));
-                } else if ("kind".equals(fieldName)) {
-                    deserializedDocumentModelBuildOperationDetails.kind = reader.getString();
+                if (OperationDetails.fromJsonShared(reader, fieldName,
+                    deserializedDocumentModelBuildOperationDetails)) {
+                    continue;
                 } else if ("result".equals(fieldName)) {
                     deserializedDocumentModelBuildOperationDetails.result = DocumentModelDetails.fromJson(reader);
                 } else {

--- a/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/DocumentModelComposeOperationDetails.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/DocumentModelComposeOperationDetails.java
@@ -5,7 +5,6 @@
 package com.azure.ai.formrecognizer.documentanalysis.implementation.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.util.CoreUtils;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
@@ -159,31 +158,9 @@ public final class DocumentModelComposeOperationDetails extends OperationDetails
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("operationId".equals(fieldName)) {
-                    deserializedDocumentModelComposeOperationDetails.setOperationId(reader.getString());
-                } else if ("status".equals(fieldName)) {
-                    deserializedDocumentModelComposeOperationDetails
-                        .setStatus(OperationStatus.fromString(reader.getString()));
-                } else if ("createdDateTime".equals(fieldName)) {
-                    deserializedDocumentModelComposeOperationDetails.setCreatedDateTime(reader
-                        .getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString())));
-                } else if ("lastUpdatedDateTime".equals(fieldName)) {
-                    deserializedDocumentModelComposeOperationDetails.setLastUpdatedDateTime(reader
-                        .getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString())));
-                } else if ("resourceLocation".equals(fieldName)) {
-                    deserializedDocumentModelComposeOperationDetails.setResourceLocation(reader.getString());
-                } else if ("percentCompleted".equals(fieldName)) {
-                    deserializedDocumentModelComposeOperationDetails
-                        .setPercentCompleted(reader.getNullable(JsonReader::getInt));
-                } else if ("apiVersion".equals(fieldName)) {
-                    deserializedDocumentModelComposeOperationDetails.setApiVersion(reader.getString());
-                } else if ("tags".equals(fieldName)) {
-                    Map<String, String> tags = reader.readMap(reader1 -> reader1.getString());
-                    deserializedDocumentModelComposeOperationDetails.setTags(tags);
-                } else if ("error".equals(fieldName)) {
-                    deserializedDocumentModelComposeOperationDetails.setError(Error.fromJson(reader));
-                } else if ("kind".equals(fieldName)) {
-                    deserializedDocumentModelComposeOperationDetails.kind = reader.getString();
+                if (OperationDetails.fromJsonShared(reader, fieldName,
+                    deserializedDocumentModelComposeOperationDetails)) {
+                    continue;
                 } else if ("result".equals(fieldName)) {
                     deserializedDocumentModelComposeOperationDetails.result = DocumentModelDetails.fromJson(reader);
                 } else {

--- a/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/DocumentModelCopyToOperationDetails.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/DocumentModelCopyToOperationDetails.java
@@ -5,7 +5,6 @@
 package com.azure.ai.formrecognizer.documentanalysis.implementation.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.util.CoreUtils;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
@@ -159,31 +158,9 @@ public final class DocumentModelCopyToOperationDetails extends OperationDetails 
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("operationId".equals(fieldName)) {
-                    deserializedDocumentModelCopyToOperationDetails.setOperationId(reader.getString());
-                } else if ("status".equals(fieldName)) {
-                    deserializedDocumentModelCopyToOperationDetails
-                        .setStatus(OperationStatus.fromString(reader.getString()));
-                } else if ("createdDateTime".equals(fieldName)) {
-                    deserializedDocumentModelCopyToOperationDetails.setCreatedDateTime(reader
-                        .getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString())));
-                } else if ("lastUpdatedDateTime".equals(fieldName)) {
-                    deserializedDocumentModelCopyToOperationDetails.setLastUpdatedDateTime(reader
-                        .getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString())));
-                } else if ("resourceLocation".equals(fieldName)) {
-                    deserializedDocumentModelCopyToOperationDetails.setResourceLocation(reader.getString());
-                } else if ("percentCompleted".equals(fieldName)) {
-                    deserializedDocumentModelCopyToOperationDetails
-                        .setPercentCompleted(reader.getNullable(JsonReader::getInt));
-                } else if ("apiVersion".equals(fieldName)) {
-                    deserializedDocumentModelCopyToOperationDetails.setApiVersion(reader.getString());
-                } else if ("tags".equals(fieldName)) {
-                    Map<String, String> tags = reader.readMap(reader1 -> reader1.getString());
-                    deserializedDocumentModelCopyToOperationDetails.setTags(tags);
-                } else if ("error".equals(fieldName)) {
-                    deserializedDocumentModelCopyToOperationDetails.setError(Error.fromJson(reader));
-                } else if ("kind".equals(fieldName)) {
-                    deserializedDocumentModelCopyToOperationDetails.kind = reader.getString();
+                if (OperationDetails.fromJsonShared(reader, fieldName,
+                    deserializedDocumentModelCopyToOperationDetails)) {
+                    continue;
                 } else if ("result".equals(fieldName)) {
                     deserializedDocumentModelCopyToOperationDetails.result = DocumentModelDetails.fromJson(reader);
                 } else {

--- a/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/OperationDetails.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/ai/formrecognizer/documentanalysis/implementation/models/OperationDetails.java
@@ -338,35 +338,51 @@ public class OperationDetails implements JsonSerializable<OperationDetails> {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("operationId".equals(fieldName)) {
-                    deserializedOperationDetails.operationId = reader.getString();
-                } else if ("status".equals(fieldName)) {
-                    deserializedOperationDetails.status = OperationStatus.fromString(reader.getString());
-                } else if ("createdDateTime".equals(fieldName)) {
-                    deserializedOperationDetails.createdDateTime = reader
-                        .getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString()));
-                } else if ("lastUpdatedDateTime".equals(fieldName)) {
-                    deserializedOperationDetails.lastUpdatedDateTime = reader
-                        .getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString()));
-                } else if ("resourceLocation".equals(fieldName)) {
-                    deserializedOperationDetails.resourceLocation = reader.getString();
-                } else if ("kind".equals(fieldName)) {
-                    deserializedOperationDetails.kind = reader.getString();
-                } else if ("percentCompleted".equals(fieldName)) {
-                    deserializedOperationDetails.percentCompleted = reader.getNullable(JsonReader::getInt);
-                } else if ("apiVersion".equals(fieldName)) {
-                    deserializedOperationDetails.apiVersion = reader.getString();
-                } else if ("tags".equals(fieldName)) {
-                    Map<String, String> tags = reader.readMap(reader1 -> reader1.getString());
-                    deserializedOperationDetails.tags = tags;
-                } else if ("error".equals(fieldName)) {
-                    deserializedOperationDetails.error = Error.fromJson(reader);
-                } else {
+                if (!OperationDetails.fromJsonShared(reader, fieldName, deserializedOperationDetails)) {
                     reader.skipChildren();
                 }
             }
 
             return deserializedOperationDetails;
         });
+    }
+
+    static boolean fromJsonShared(JsonReader reader, String fieldName, OperationDetails deserializedOperationDetails)
+        throws IOException {
+        if ("operationId".equals(fieldName)) {
+            deserializedOperationDetails.operationId = reader.getString();
+            return true;
+        } else if ("status".equals(fieldName)) {
+            deserializedOperationDetails.status = OperationStatus.fromString(reader.getString());
+            return true;
+        } else if ("createdDateTime".equals(fieldName)) {
+            deserializedOperationDetails.createdDateTime
+                = reader.getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString()));
+            return true;
+        } else if ("lastUpdatedDateTime".equals(fieldName)) {
+            deserializedOperationDetails.lastUpdatedDateTime
+                = reader.getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString()));
+            return true;
+        } else if ("resourceLocation".equals(fieldName)) {
+            deserializedOperationDetails.resourceLocation = reader.getString();
+            return true;
+        } else if ("kind".equals(fieldName)) {
+            deserializedOperationDetails.kind = reader.getString();
+            return true;
+        } else if ("percentCompleted".equals(fieldName)) {
+            deserializedOperationDetails.percentCompleted = reader.getNullable(JsonReader::getInt);
+            return true;
+        } else if ("apiVersion".equals(fieldName)) {
+            deserializedOperationDetails.apiVersion = reader.getString();
+            return true;
+        } else if ("tags".equals(fieldName)) {
+            Map<String, String> tags = reader.readMap(reader1 -> reader1.getString());
+            deserializedOperationDetails.tags = tags;
+            return true;
+        } else if ("error".equals(fieldName)) {
+            deserializedOperationDetails.error = Error.fromJson(reader);
+            return true;
+        }
+        return false;
     }
 }

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Cookiecuttershark.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Cookiecuttershark.java
@@ -5,7 +5,6 @@
 package fixtures.bodycomplex.implementation.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.util.CoreUtils;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
@@ -96,20 +95,8 @@ public final class Cookiecuttershark extends Shark {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("length".equals(fieldName)) {
-                    deserializedCookiecuttershark.setLength(reader.getFloat());
-                } else if ("birthday".equals(fieldName)) {
-                    deserializedCookiecuttershark.setBirthday(reader
-                        .getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString())));
-                } else if ("species".equals(fieldName)) {
-                    deserializedCookiecuttershark.setSpecies(reader.getString());
-                } else if ("siblings".equals(fieldName)) {
-                    List<Fish> siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
-                    deserializedCookiecuttershark.setSiblings(siblings);
-                } else if ("age".equals(fieldName)) {
-                    deserializedCookiecuttershark.setAge(reader.getNullable(JsonReader::getInt));
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedCookiecuttershark.fishtype = reader.getString();
+                if (Shark.fromJsonShared(reader, fieldName, deserializedCookiecuttershark)) {
+                    continue;
                 } else {
                     reader.skipChildren();
                 }

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/DotFish.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/DotFish.java
@@ -117,16 +117,23 @@ public class DotFish implements JsonSerializable<DotFish> {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("fish.type".equals(fieldName)) {
-                    deserializedDotFish.fishType = reader.getString();
-                } else if ("species".equals(fieldName)) {
-                    deserializedDotFish.species = reader.getString();
-                } else {
+                if (!DotFish.fromJsonShared(reader, fieldName, deserializedDotFish)) {
                     reader.skipChildren();
                 }
             }
 
             return deserializedDotFish;
         });
+    }
+
+    static boolean fromJsonShared(JsonReader reader, String fieldName, DotFish deserializedDotFish) throws IOException {
+        if ("fish.type".equals(fieldName)) {
+            deserializedDotFish.fishType = reader.getString();
+            return true;
+        } else if ("species".equals(fieldName)) {
+            deserializedDotFish.species = reader.getString();
+            return true;
+        }
+        return false;
     }
 }

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/DotSalmon.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/DotSalmon.java
@@ -110,10 +110,8 @@ public final class DotSalmon extends DotFish {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("species".equals(fieldName)) {
-                    deserializedDotSalmon.setSpecies(reader.getString());
-                } else if ("fish.type".equals(fieldName)) {
-                    deserializedDotSalmon.fishType = reader.getString();
+                if (DotFish.fromJsonShared(reader, fieldName, deserializedDotSalmon)) {
+                    continue;
                 } else if ("location".equals(fieldName)) {
                     deserializedDotSalmon.location = reader.getString();
                 } else if ("iswild".equals(fieldName)) {

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Fish.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Fish.java
@@ -181,21 +181,30 @@ public class Fish implements JsonSerializable<Fish> {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("length".equals(fieldName)) {
-                    deserializedFish.length = reader.getFloat();
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedFish.fishtype = reader.getString();
-                } else if ("species".equals(fieldName)) {
-                    deserializedFish.species = reader.getString();
-                } else if ("siblings".equals(fieldName)) {
-                    List<Fish> siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
-                    deserializedFish.siblings = siblings;
-                } else {
+                if (!Fish.fromJsonShared(reader, fieldName, deserializedFish)) {
                     reader.skipChildren();
                 }
             }
 
             return deserializedFish;
         });
+    }
+
+    static boolean fromJsonShared(JsonReader reader, String fieldName, Fish deserializedFish) throws IOException {
+        if ("length".equals(fieldName)) {
+            deserializedFish.length = reader.getFloat();
+            return true;
+        } else if ("fishtype".equals(fieldName)) {
+            deserializedFish.fishtype = reader.getString();
+            return true;
+        } else if ("species".equals(fieldName)) {
+            deserializedFish.species = reader.getString();
+            return true;
+        } else if ("siblings".equals(fieldName)) {
+            List<Fish> siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
+            deserializedFish.siblings = siblings;
+            return true;
+        }
+        return false;
     }
 }

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/GoblinShark.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/GoblinShark.java
@@ -5,7 +5,6 @@
 package fixtures.bodycomplex.implementation.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.util.CoreUtils;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
@@ -148,20 +147,8 @@ public final class GoblinShark extends Shark {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("length".equals(fieldName)) {
-                    deserializedGoblinshark.setLength(reader.getFloat());
-                } else if ("birthday".equals(fieldName)) {
-                    deserializedGoblinshark.setBirthday(reader
-                        .getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString())));
-                } else if ("species".equals(fieldName)) {
-                    deserializedGoblinshark.setSpecies(reader.getString());
-                } else if ("siblings".equals(fieldName)) {
-                    List<Fish> siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
-                    deserializedGoblinshark.setSiblings(siblings);
-                } else if ("age".equals(fieldName)) {
-                    deserializedGoblinshark.setAge(reader.getNullable(JsonReader::getInt));
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedGoblinshark.fishtype = reader.getString();
+                if (Shark.fromJsonShared(reader, fieldName, deserializedGoblinshark)) {
+                    continue;
                 } else if ("jawsize".equals(fieldName)) {
                     deserializedGoblinshark.jawsize = reader.getNullable(JsonReader::getInt);
                 } else if ("color".equals(fieldName)) {

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/MyBaseType.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/MyBaseType.java
@@ -147,27 +147,34 @@ public class MyBaseType implements JsonSerializable<MyBaseType> {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("kind".equals(fieldName)) {
-                    deserializedMyBaseType.kind = MyKind.fromString(reader.getString());
-                } else if ("propB1".equals(fieldName)) {
-                    deserializedMyBaseType.propB1 = reader.getString();
-                } else if ("helper".equals(fieldName) && reader.currentToken() == JsonToken.START_OBJECT) {
-                    while (reader.nextToken() != JsonToken.END_OBJECT) {
-                        fieldName = reader.getFieldName();
-                        reader.nextToken();
-
-                        if ("propBH1".equals(fieldName)) {
-                            deserializedMyBaseType.propBH1 = reader.getString();
-                        } else {
-                            reader.skipChildren();
-                        }
-                    }
-                } else {
+                if (!MyBaseType.fromJsonShared(reader, fieldName, deserializedMyBaseType)) {
                     reader.skipChildren();
                 }
             }
 
             return deserializedMyBaseType;
         });
+    }
+
+    static boolean fromJsonShared(JsonReader reader, String fieldName, MyBaseType deserializedMyBaseType)
+        throws IOException {
+        if ("kind".equals(fieldName)) {
+            deserializedMyBaseType.kind = MyKind.fromString(reader.getString());
+            return true;
+        } else if ("propB1".equals(fieldName)) {
+            deserializedMyBaseType.propB1 = reader.getString();
+            return true;
+        } else if ("helper".equals(fieldName) && reader.currentToken() == JsonToken.START_OBJECT) {
+            while (reader.nextToken() != JsonToken.END_OBJECT) {
+                fieldName = reader.getFieldName();
+                reader.nextToken();
+
+                if ("propBH1".equals(fieldName)) {
+                    deserializedMyBaseType.propBH1 = reader.getString();
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/MyBaseType.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/MyBaseType.java
@@ -171,9 +171,11 @@ public class MyBaseType implements JsonSerializable<MyBaseType> {
 
                 if ("propBH1".equals(fieldName)) {
                     deserializedMyBaseType.propBH1 = reader.getString();
-                    return true;
+                } else {
+                    reader.skipChildren();
                 }
             }
+            return true;
         }
         return false;
     }

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/MyDerivedType.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/MyDerivedType.java
@@ -95,17 +95,6 @@ public final class MyDerivedType extends MyBaseType {
                     continue;
                 } else if ("propD1".equals(fieldName)) {
                     deserializedMyDerivedType.propD1 = reader.getString();
-                } else if ("helper".equals(fieldName) && reader.currentToken() == JsonToken.START_OBJECT) {
-                    while (reader.nextToken() != JsonToken.END_OBJECT) {
-                        fieldName = reader.getFieldName();
-                        reader.nextToken();
-
-                        if ("propBH1".equals(fieldName)) {
-                            deserializedMyDerivedType.setPropBH1(reader.getString());
-                        } else {
-                            reader.skipChildren();
-                        }
-                    }
                 } else {
                     reader.skipChildren();
                 }

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/MyDerivedType.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/MyDerivedType.java
@@ -91,10 +91,8 @@ public final class MyDerivedType extends MyBaseType {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("propB1".equals(fieldName)) {
-                    deserializedMyDerivedType.setPropB1(reader.getString());
-                } else if ("kind".equals(fieldName)) {
-                    deserializedMyDerivedType.kind = MyKind.fromString(reader.getString());
+                if (MyBaseType.fromJsonShared(reader, fieldName, deserializedMyDerivedType)) {
+                    continue;
                 } else if ("propD1".equals(fieldName)) {
                     deserializedMyDerivedType.propD1 = reader.getString();
                 } else if ("helper".equals(fieldName) && reader.currentToken() == JsonToken.START_OBJECT) {

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Salmon.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Salmon.java
@@ -157,25 +157,25 @@ public class Salmon extends Fish {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("length".equals(fieldName)) {
-                    deserializedSalmon.setLength(reader.getFloat());
-                } else if ("species".equals(fieldName)) {
-                    deserializedSalmon.setSpecies(reader.getString());
-                } else if ("siblings".equals(fieldName)) {
-                    List<Fish> siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
-                    deserializedSalmon.setSiblings(siblings);
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedSalmon.fishtype = reader.getString();
-                } else if ("location".equals(fieldName)) {
-                    deserializedSalmon.location = reader.getString();
-                } else if ("iswild".equals(fieldName)) {
-                    deserializedSalmon.iswild = reader.getNullable(JsonReader::getBoolean);
-                } else {
+                if (!Salmon.fromJsonShared(reader, fieldName, deserializedSalmon)) {
                     reader.skipChildren();
                 }
             }
 
             return deserializedSalmon;
         });
+    }
+
+    static boolean fromJsonShared(JsonReader reader, String fieldName, Salmon deserializedSalmon) throws IOException {
+        if (Fish.fromJsonShared(reader, fieldName, deserializedSalmon)) {
+            return true;
+        } else if ("location".equals(fieldName)) {
+            deserializedSalmon.location = reader.getString();
+            return true;
+        } else if ("iswild".equals(fieldName)) {
+            deserializedSalmon.iswild = reader.getNullable(JsonReader::getBoolean);
+            return true;
+        }
+        return false;
     }
 }

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Sawshark.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Sawshark.java
@@ -122,20 +122,8 @@ public final class Sawshark extends Shark {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("length".equals(fieldName)) {
-                    deserializedSawshark.setLength(reader.getFloat());
-                } else if ("birthday".equals(fieldName)) {
-                    deserializedSawshark.setBirthday(reader
-                        .getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString())));
-                } else if ("species".equals(fieldName)) {
-                    deserializedSawshark.setSpecies(reader.getString());
-                } else if ("siblings".equals(fieldName)) {
-                    List<Fish> siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
-                    deserializedSawshark.setSiblings(siblings);
-                } else if ("age".equals(fieldName)) {
-                    deserializedSawshark.setAge(reader.getNullable(JsonReader::getInt));
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedSawshark.fishtype = reader.getString();
+                if (Shark.fromJsonShared(reader, fieldName, deserializedSawshark)) {
+                    continue;
                 } else if ("picture".equals(fieldName)) {
                     deserializedSawshark.picture = reader.getBinary();
                 } else {

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Shark.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Shark.java
@@ -165,26 +165,26 @@ public class Shark extends Fish {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("length".equals(fieldName)) {
-                    deserializedShark.setLength(reader.getFloat());
-                } else if ("species".equals(fieldName)) {
-                    deserializedShark.setSpecies(reader.getString());
-                } else if ("siblings".equals(fieldName)) {
-                    List<Fish> siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
-                    deserializedShark.setSiblings(siblings);
-                } else if ("birthday".equals(fieldName)) {
-                    deserializedShark.birthday = reader
-                        .getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString()));
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedShark.fishtype = reader.getString();
-                } else if ("age".equals(fieldName)) {
-                    deserializedShark.age = reader.getNullable(JsonReader::getInt);
-                } else {
+                if (!Shark.fromJsonShared(reader, fieldName, deserializedShark)) {
                     reader.skipChildren();
                 }
             }
 
             return deserializedShark;
         });
+    }
+
+    static boolean fromJsonShared(JsonReader reader, String fieldName, Shark deserializedShark) throws IOException {
+        if (Fish.fromJsonShared(reader, fieldName, deserializedShark)) {
+            return true;
+        } else if ("birthday".equals(fieldName)) {
+            deserializedShark.birthday
+                = reader.getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString()));
+            return true;
+        } else if ("age".equals(fieldName)) {
+            deserializedShark.age = reader.getNullable(JsonReader::getInt);
+            return true;
+        }
+        return false;
     }
 }

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/SmartSalmon.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/SmartSalmon.java
@@ -153,19 +153,8 @@ public final class SmartSalmon extends Salmon {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("length".equals(fieldName)) {
-                    deserializedSmartSalmon.setLength(reader.getFloat());
-                } else if ("species".equals(fieldName)) {
-                    deserializedSmartSalmon.setSpecies(reader.getString());
-                } else if ("siblings".equals(fieldName)) {
-                    List<Fish> siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
-                    deserializedSmartSalmon.setSiblings(siblings);
-                } else if ("location".equals(fieldName)) {
-                    deserializedSmartSalmon.setLocation(reader.getString());
-                } else if ("iswild".equals(fieldName)) {
-                    deserializedSmartSalmon.setIswild(reader.getNullable(JsonReader::getBoolean));
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedSmartSalmon.fishtype = reader.getString();
+                if (Salmon.fromJsonShared(reader, fieldName, deserializedSmartSalmon)) {
+                    continue;
                 } else if ("college_degree".equals(fieldName)) {
                     deserializedSmartSalmon.collegeDegree = reader.getString();
                 } else {

--- a/javagen/src/main/java/com/azure/autorest/implementation/ClientModelPropertiesManager.java
+++ b/javagen/src/main/java/com/azure/autorest/implementation/ClientModelPropertiesManager.java
@@ -57,8 +57,6 @@ public final class ClientModelPropertiesManager {
     private final LinkedHashMap<String, ClientModelProperty> readOnlyProperties;
     private final ClientModelProperty additionalProperties;
     private final ClientModelPropertyWithMetadata discriminatorProperty;
-    private final boolean allPolymorphicModelsInSamePackage;
-    private final boolean polymorphicDiscriminatorDefinedByModel;
     private final String expectedDiscriminator;
     private final JsonFlattenedPropertiesTree jsonFlattenedPropertiesTree;
     private final boolean allFlattenedPropertiesFromParent;
@@ -242,15 +240,6 @@ public final class ClientModelPropertiesManager {
         this.hasXmlElements = hasXmlElements;
         this.hasXmlTexts = hasXmlTexts;
         this.discriminatorProperty = discriminatorProperty;
-        if (model.isPolymorphic()) {
-            this.allPolymorphicModelsInSamePackage
-                = PolymorphicDiscriminatorHandler.isAllPolymorphicModelsInSamePackage(model);
-            this.polymorphicDiscriminatorDefinedByModel = ClientModelUtil.modelDefinesProperty(model,
-                discriminatorProperty.getProperty());
-        } else {
-            this.allPolymorphicModelsInSamePackage = false;
-            this.polymorphicDiscriminatorDefinedByModel = false;
-        }
         this.additionalProperties = additionalProperties;
         this.jsonFlattenedPropertiesTree = getFlattenedPropertiesHierarchy(model.getPolymorphicDiscriminatorName(),
             flattenedProperties);
@@ -469,24 +458,6 @@ public final class ClientModelPropertiesManager {
      */
     public ClientModelPropertyWithMetadata getDiscriminatorProperty() {
         return discriminatorProperty;
-    }
-
-    /**
-     * Whether the polymorphic structure containing the model and all subtypes are in the same package.
-     *
-     * @return Whether the polymorphic structure containing the model and all subtypes are in the same package.
-     */
-    public boolean isAllPolymorphicModelsInSamePackage() {
-        return allPolymorphicModelsInSamePackage;
-    }
-
-    /**
-     * Whether the model defines the polymorphic discriminator property.
-     *
-     * @return Whether the model defines the polymorphic discriminator property.
-     */
-    public boolean isPolymorphicDiscriminatorDefinedByModel() {
-        return polymorphicDiscriminatorDefinedByModel;
     }
 
     /**

--- a/javagen/src/main/java/com/azure/autorest/implementation/ClientModelPropertiesManager.java
+++ b/javagen/src/main/java/com/azure/autorest/implementation/ClientModelPropertiesManager.java
@@ -57,6 +57,8 @@ public final class ClientModelPropertiesManager {
     private final LinkedHashMap<String, ClientModelProperty> readOnlyProperties;
     private final ClientModelProperty additionalProperties;
     private final ClientModelPropertyWithMetadata discriminatorProperty;
+    private final boolean allPolymorphicModelsInSamePackage;
+    private final boolean polymorphicDiscriminatorDefinedByModel;
     private final String expectedDiscriminator;
     private final JsonFlattenedPropertiesTree jsonFlattenedPropertiesTree;
     private final String jsonReaderFieldNameVariableName;
@@ -237,6 +239,15 @@ public final class ClientModelPropertiesManager {
         this.hasXmlElements = hasXmlElements;
         this.hasXmlTexts = hasXmlTexts;
         this.discriminatorProperty = discriminatorProperty;
+        if (model.isPolymorphic()) {
+            this.allPolymorphicModelsInSamePackage
+                = PolymorphicDiscriminatorHandler.isAllPolymorphicModelsInSamePackage(model);
+            this.polymorphicDiscriminatorDefinedByModel = ClientModelUtil.modelDefinesProperty(model,
+                discriminatorProperty.getProperty());
+        } else {
+            this.allPolymorphicModelsInSamePackage = false;
+            this.polymorphicDiscriminatorDefinedByModel = false;
+        }
         this.additionalProperties = additionalProperties;
         this.jsonFlattenedPropertiesTree = getFlattenedPropertiesHierarchy(model.getPolymorphicDiscriminatorName(),
             flattenedProperties);
@@ -454,6 +465,24 @@ public final class ClientModelPropertiesManager {
      */
     public ClientModelPropertyWithMetadata getDiscriminatorProperty() {
         return discriminatorProperty;
+    }
+
+    /**
+     * Whether the polymorphic structure containing the model and all subtypes are in the same package.
+     *
+     * @return Whether the polymorphic structure containing the model and all subtypes are in the same package.
+     */
+    public boolean isAllPolymorphicModelsInSamePackage() {
+        return allPolymorphicModelsInSamePackage;
+    }
+
+    /**
+     * Whether the model defines the polymorphic discriminator property.
+     *
+     * @return Whether the model defines the polymorphic discriminator property.
+     */
+    public boolean isPolymorphicDiscriminatorDefinedByModel() {
+        return polymorphicDiscriminatorDefinedByModel;
     }
 
     /**

--- a/javagen/src/main/java/com/azure/autorest/implementation/ClientModelPropertiesManager.java
+++ b/javagen/src/main/java/com/azure/autorest/implementation/ClientModelPropertiesManager.java
@@ -61,6 +61,7 @@ public final class ClientModelPropertiesManager {
     private final boolean polymorphicDiscriminatorDefinedByModel;
     private final String expectedDiscriminator;
     private final JsonFlattenedPropertiesTree jsonFlattenedPropertiesTree;
+    private final boolean allFlattenedPropertiesFromParent;
     private final String jsonReaderFieldNameVariableName;
 
     private final String xmlRootElementName;
@@ -111,6 +112,7 @@ public final class ClientModelPropertiesManager {
         xmlTexts = new ArrayList<>();
         superXmlElements = new ArrayList<>();
         xmlElements = new ArrayList<>();
+        boolean allFlattenedPropertiesFromParent = true;
 
         if (model.isPolymorphic()) {
             ClientModel superTypeModel = model;
@@ -209,6 +211,7 @@ public final class ClientModelPropertiesManager {
 
             if (property.getNeedsFlatten()) {
                 flattenedProperties.put(property.getName(), new ClientModelPropertyWithMetadata(model, property, false));
+                allFlattenedPropertiesFromParent = false;
             }
 
             possibleReaderFieldNameVariableNames.remove(property.getName());
@@ -251,6 +254,7 @@ public final class ClientModelPropertiesManager {
         this.additionalProperties = additionalProperties;
         this.jsonFlattenedPropertiesTree = getFlattenedPropertiesHierarchy(model.getPolymorphicDiscriminatorName(),
             flattenedProperties);
+        this.allFlattenedPropertiesFromParent = allFlattenedPropertiesFromParent;
         Iterator<String> possibleReaderFieldNameVariableNamesIterator = possibleReaderFieldNameVariableNames.iterator();
         if (possibleReaderFieldNameVariableNamesIterator.hasNext()) {
             this.jsonReaderFieldNameVariableName = possibleReaderFieldNameVariableNamesIterator.next();
@@ -507,6 +511,15 @@ public final class ClientModelPropertiesManager {
      */
     public JsonFlattenedPropertiesTree getJsonFlattenedPropertiesTree() {
         return jsonFlattenedPropertiesTree;
+    }
+
+    /**
+     * Whether all the flattened properties are from parent models.
+     *
+     * @return Whether all the flattened properties are from parent models.
+     */
+    public boolean isAllFlattenedPropertiesFromParent() {
+        return allFlattenedPropertiesFromParent;
     }
 
     /**

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModel.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModel.java
@@ -4,6 +4,7 @@
 package com.azure.autorest.model.clientmodel;
 
 import com.azure.autorest.extension.base.plugin.JavaSettings;
+import com.azure.autorest.util.ClientModelUtil;
 import com.azure.core.util.CoreUtils;
 
 import java.util.ArrayList;
@@ -127,6 +128,26 @@ public class ClientModel {
      * The cross language definition id for the model.
      */
     private final String crossLanguageDefinitionId;
+
+    // Set of non-final properties that are set on access.
+    // This pattern is used as when the ClientModel is initialized the ModelMapper may not have mapped all models
+    // related to the one being initialized. When that happens some properties may not be set correctly. For example,
+    // checks into the polymorphic hierarchy may not be correct. This pattern allows for the properties to be set
+    // correctly when they are accessed.
+
+    /**
+     * Whether all models in the polymorphic hierarchy containing this model are in the same package.
+     * <p>
+     * If this model isn't polymorphic, this will always be false.
+     */
+    private Boolean allPolymorphicModelsInSamePackage;
+
+    /**
+     * Whether the polymorphic discriminator for this model was defined by the model.
+     * <p>
+     * If this model isn't polymorphic, this will always be false.
+     */
+    private Boolean polymorphicDiscriminatorDefinedByModel;
 
     /**
      * Create a new ServiceModel with the provided properties.
@@ -509,6 +530,79 @@ public class ClientModel {
      */
     public Set<String> getSerializationFormats() {
         return serializationFormats;
+    }
+
+    /**
+     * Whether the polymorphic structure containing the model and all subtypes are in the same package.
+     * <p>
+     * If this model isn't polymorphic, this will always be false.
+     *
+     * @return Whether the polymorphic structure containing the model and all subtypes are in the same package.
+     */
+    public final boolean isAllPolymorphicModelsInSamePackage() {
+        if (!isPolymorphic) {
+            return false;
+        }
+
+        if (allPolymorphicModelsInSamePackage == null) {
+            allPolymorphicModelsInSamePackage = allPolymorphicModelsInSamePackageInternal(this);
+        }
+
+        return allPolymorphicModelsInSamePackage;
+    }
+
+    /**
+     * Whether the model defines the polymorphic discriminator property.
+     * <p>
+     * If this model isn't polymorphic, this will always be false.
+     *
+     * @return Whether the model defines the polymorphic discriminator property.
+     */
+    public final boolean isPolymorphicDiscriminatorDefinedByModel() {
+        if (!isPolymorphic) {
+            return false;
+        }
+
+        if (polymorphicDiscriminatorDefinedByModel == null) {
+            polymorphicDiscriminatorDefinedByModel = ClientModelUtil.modelDefinesProperty(this, polymorphicDiscriminator);
+        }
+
+        return polymorphicDiscriminatorDefinedByModel;
+    }
+
+    private static boolean allPolymorphicModelsInSamePackageInternal(ClientModel model) {
+        if (!model.isPolymorphic()) {
+            return false;
+        }
+
+        String packageName = model.getPackage();
+        ClientModel parent = ClientModelUtil.getClientModel(model.getParentModelName());
+        ClientModel lastParent = model;
+        while (parent != null) {
+            lastParent = parent;
+            if (!packageName.equals(parent.getPackage())) {
+                return false;
+            }
+
+            parent = ClientModelUtil.getClientModel(parent.getParentModelName());
+        }
+
+        return checkChildrenModelsPackage(lastParent, packageName);
+    }
+
+    private static boolean checkChildrenModelsPackage(ClientModel model, String packageName) {
+        List<ClientModel> children = model.getDerivedModels();
+        if (children == null || children.isEmpty()) {
+            return true;
+        }
+
+        for (ClientModel child : children) {
+            if (!packageName.equals(child.getPackage()) || !checkChildrenModelsPackage(child, packageName)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -332,7 +332,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
             return false;
         }
 
-        if (property.isPolymorphicDiscriminator() && PolymorphicDiscriminatorHandler.isAllPolymorphicModelsInSamePackage(model)) {
+        if (property.isPolymorphicDiscriminator() && model.isAllPolymorphicModelsInSamePackage()) {
             return false;
         }
 

--- a/typespec-tests/src/main/java/com/cadl/naming/models/Data.java
+++ b/typespec-tests/src/main/java/com/cadl/naming/models/Data.java
@@ -99,14 +99,21 @@ public class Data implements JsonSerializable<Data> {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("@data.kind".equals(fieldName)) {
-                    deserializedData.type = reader.getString();
-                } else {
+                if (!Data.fromJsonShared(reader, fieldName, deserializedData)) {
                     reader.skipChildren();
                 }
             }
 
             return deserializedData;
         });
+    }
+
+    @Generated
+    static boolean fromJsonShared(JsonReader reader, String fieldName, Data deserializedData) throws IOException {
+        if ("@data.kind".equals(fieldName)) {
+            deserializedData.type = reader.getString();
+            return true;
+        }
+        return false;
     }
 }

--- a/typespec-tests/src/main/java/com/cadl/patch/models/Fish.java
+++ b/typespec-tests/src/main/java/com/cadl/patch/models/Fish.java
@@ -263,22 +263,33 @@ public class Fish implements JsonSerializable<Fish> {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("id".equals(fieldName)) {
-                    deserializedFish.id = reader.getString();
-                } else if ("name".equals(fieldName)) {
-                    deserializedFish.name = reader.getString();
-                } else if ("kind".equals(fieldName)) {
-                    deserializedFish.kind = reader.getString();
-                } else if ("age".equals(fieldName)) {
-                    deserializedFish.age = reader.getInt();
-                } else if ("color".equals(fieldName)) {
-                    deserializedFish.color = reader.getString();
-                } else {
+                if (!Fish.fromJsonShared(reader, fieldName, deserializedFish)) {
                     reader.skipChildren();
                 }
             }
 
             return deserializedFish;
         });
+    }
+
+    @Generated
+    static boolean fromJsonShared(JsonReader reader, String fieldName, Fish deserializedFish) throws IOException {
+        if ("id".equals(fieldName)) {
+            deserializedFish.id = reader.getString();
+            return true;
+        } else if ("name".equals(fieldName)) {
+            deserializedFish.name = reader.getString();
+            return true;
+        } else if ("kind".equals(fieldName)) {
+            deserializedFish.kind = reader.getString();
+            return true;
+        } else if ("age".equals(fieldName)) {
+            deserializedFish.age = reader.getInt();
+            return true;
+        } else if ("color".equals(fieldName)) {
+            deserializedFish.color = reader.getString();
+            return true;
+        }
+        return false;
     }
 }

--- a/typespec-tests/src/main/java/com/cadl/patch/models/Salmon.java
+++ b/typespec-tests/src/main/java/com/cadl/patch/models/Salmon.java
@@ -230,16 +230,8 @@ public final class Salmon extends Fish {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("id".equals(fieldName)) {
-                    JsonMergePatchHelper.getFishAccessor().setId(deserializedSalmon, reader.getString());
-                } else if ("name".equals(fieldName)) {
-                    JsonMergePatchHelper.getFishAccessor().setName(deserializedSalmon, reader.getString());
-                } else if ("age".equals(fieldName)) {
-                    JsonMergePatchHelper.getFishAccessor().setAge(deserializedSalmon, reader.getInt());
-                } else if ("color".equals(fieldName)) {
-                    JsonMergePatchHelper.getFishAccessor().setColor(deserializedSalmon, reader.getString());
-                } else if ("kind".equals(fieldName)) {
-                    deserializedSalmon.kind = reader.getString();
+                if (Fish.fromJsonShared(reader, fieldName, deserializedSalmon)) {
+                    continue;
                 } else if ("friends".equals(fieldName)) {
                     List<Fish> friends = reader.readArray(reader1 -> Fish.fromJson(reader1));
                     deserializedSalmon.friends = friends;

--- a/typespec-tests/src/main/java/com/cadl/patch/models/SawShark.java
+++ b/typespec-tests/src/main/java/com/cadl/patch/models/SawShark.java
@@ -128,19 +128,8 @@ public final class SawShark extends Shark {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("id".equals(fieldName)) {
-                    JsonMergePatchHelper.getFishAccessor().setId(deserializedSawShark, reader.getString());
-                } else if ("name".equals(fieldName)) {
-                    JsonMergePatchHelper.getFishAccessor().setName(deserializedSawShark, reader.getString());
-                } else if ("age".equals(fieldName)) {
-                    JsonMergePatchHelper.getFishAccessor().setAge(deserializedSawShark, reader.getInt());
-                } else if ("color".equals(fieldName)) {
-                    JsonMergePatchHelper.getFishAccessor().setColor(deserializedSawShark, reader.getString());
-                } else if ("weight".equals(fieldName)) {
-                    JsonMergePatchHelper.getSharkAccessor()
-                        .setWeight(deserializedSawShark, reader.getNullable(JsonReader::getInt));
-                } else if ("sharktype".equals(fieldName)) {
-                    deserializedSawShark.sharktype = reader.getString();
+                if (Shark.fromJsonShared(reader, fieldName, deserializedSawShark)) {
+                    continue;
                 } else {
                     reader.skipChildren();
                 }

--- a/typespec-tests/src/main/java/com/cadl/patch/models/Shark.java
+++ b/typespec-tests/src/main/java/com/cadl/patch/models/Shark.java
@@ -197,24 +197,26 @@ public class Shark extends Fish {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("id".equals(fieldName)) {
-                    JsonMergePatchHelper.getFishAccessor().setId(deserializedShark, reader.getString());
-                } else if ("name".equals(fieldName)) {
-                    JsonMergePatchHelper.getFishAccessor().setName(deserializedShark, reader.getString());
-                } else if ("age".equals(fieldName)) {
-                    JsonMergePatchHelper.getFishAccessor().setAge(deserializedShark, reader.getInt());
-                } else if ("color".equals(fieldName)) {
-                    JsonMergePatchHelper.getFishAccessor().setColor(deserializedShark, reader.getString());
-                } else if ("sharktype".equals(fieldName)) {
-                    deserializedShark.sharktype = reader.getString();
-                } else if ("weight".equals(fieldName)) {
-                    deserializedShark.weight = reader.getNullable(JsonReader::getInt);
-                } else {
+                if (!Shark.fromJsonShared(reader, fieldName, deserializedShark)) {
                     reader.skipChildren();
                 }
             }
 
             return deserializedShark;
         });
+    }
+
+    @Generated
+    static boolean fromJsonShared(JsonReader reader, String fieldName, Shark deserializedShark) throws IOException {
+        if (Fish.fromJsonShared(reader, fieldName, deserializedShark)) {
+            return true;
+        } else if ("sharktype".equals(fieldName)) {
+            deserializedShark.sharktype = reader.getString();
+            return true;
+        } else if ("weight".equals(fieldName)) {
+            deserializedShark.weight = reader.getNullable(JsonReader::getInt);
+            return true;
+        }
+        return false;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/discriminatorenum/models/Dog.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorenum/models/Dog.java
@@ -126,16 +126,23 @@ public class Dog implements JsonSerializable<Dog> {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("weight".equals(fieldName)) {
-                    deserializedDog.weight = reader.getInt();
-                } else if ("kind".equals(fieldName)) {
-                    deserializedDog.kind = DogKind.fromString(reader.getString());
-                } else {
+                if (!Dog.fromJsonShared(reader, fieldName, deserializedDog)) {
                     reader.skipChildren();
                 }
             }
 
             return deserializedDog;
         });
+    }
+
+    static boolean fromJsonShared(JsonReader reader, String fieldName, Dog deserializedDog) throws IOException {
+        if ("weight".equals(fieldName)) {
+            deserializedDog.weight = reader.getInt();
+            return true;
+        } else if ("kind".equals(fieldName)) {
+            deserializedDog.kind = DogKind.fromString(reader.getString());
+            return true;
+        }
+        return false;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/discriminatorenum/models/Golden.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorenum/models/Golden.java
@@ -66,10 +66,8 @@ public final class Golden extends Dog {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("weight".equals(fieldName)) {
-                    deserializedGolden.setWeight(reader.getInt());
-                } else if ("kind".equals(fieldName)) {
-                    deserializedGolden.kind = DogKind.fromString(reader.getString());
+                if (Dog.fromJsonShared(reader, fieldName, deserializedGolden)) {
+                    continue;
                 } else {
                     reader.skipChildren();
                 }

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Cookiecuttershark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Cookiecuttershark.java
@@ -5,7 +5,6 @@
 package fixtures.streamstyleserialization.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.util.CoreUtils;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonToken;
@@ -115,20 +114,8 @@ public final class Cookiecuttershark extends Shark {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("length".equals(fieldName)) {
-                    deserializedCookiecuttershark.setLength(reader.getFloat());
-                } else if ("birthday".equals(fieldName)) {
-                    deserializedCookiecuttershark.setBirthday(reader
-                        .getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString())));
-                } else if ("species".equals(fieldName)) {
-                    deserializedCookiecuttershark.setSpecies(reader.getString());
-                } else if ("siblings".equals(fieldName)) {
-                    List<Fish> siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
-                    deserializedCookiecuttershark.setSiblings(siblings);
-                } else if ("age".equals(fieldName)) {
-                    deserializedCookiecuttershark.setAge(reader.getNullable(JsonReader::getInt));
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedCookiecuttershark.fishtype = reader.getString();
+                if (Shark.fromJsonShared(reader, fieldName, deserializedCookiecuttershark)) {
+                    continue;
                 } else {
                     reader.skipChildren();
                 }

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/DotFish.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/DotFish.java
@@ -125,16 +125,23 @@ public class DotFish implements JsonSerializable<DotFish> {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("fish.type".equals(fieldName)) {
-                    deserializedDotFish.fishType = reader.getString();
-                } else if ("species".equals(fieldName)) {
-                    deserializedDotFish.species = reader.getString();
-                } else {
+                if (!DotFish.fromJsonShared(reader, fieldName, deserializedDotFish)) {
                     reader.skipChildren();
                 }
             }
 
             return deserializedDotFish;
         });
+    }
+
+    static boolean fromJsonShared(JsonReader reader, String fieldName, DotFish deserializedDotFish) throws IOException {
+        if ("fish.type".equals(fieldName)) {
+            deserializedDotFish.fishType = reader.getString();
+            return true;
+        } else if ("species".equals(fieldName)) {
+            deserializedDotFish.species = reader.getString();
+            return true;
+        }
+        return false;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/DotSalmon.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/DotSalmon.java
@@ -117,10 +117,8 @@ public final class DotSalmon extends DotFish {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("species".equals(fieldName)) {
-                    deserializedDotSalmon.setSpecies(reader.getString());
-                } else if ("fish.type".equals(fieldName)) {
-                    deserializedDotSalmon.fishType = reader.getString();
+                if (DotFish.fromJsonShared(reader, fieldName, deserializedDotSalmon)) {
+                    continue;
                 } else if ("location".equals(fieldName)) {
                     deserializedDotSalmon.location = reader.getString();
                 } else if ("iswild".equals(fieldName)) {

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Fish.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Fish.java
@@ -192,21 +192,30 @@ public class Fish implements JsonSerializable<Fish> {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("length".equals(fieldName)) {
-                    deserializedFish.length = reader.getFloat();
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedFish.fishtype = reader.getString();
-                } else if ("species".equals(fieldName)) {
-                    deserializedFish.species = reader.getString();
-                } else if ("siblings".equals(fieldName)) {
-                    List<Fish> siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
-                    deserializedFish.siblings = siblings;
-                } else {
+                if (!Fish.fromJsonShared(reader, fieldName, deserializedFish)) {
                     reader.skipChildren();
                 }
             }
 
             return deserializedFish;
         });
+    }
+
+    static boolean fromJsonShared(JsonReader reader, String fieldName, Fish deserializedFish) throws IOException {
+        if ("length".equals(fieldName)) {
+            deserializedFish.length = reader.getFloat();
+            return true;
+        } else if ("fishtype".equals(fieldName)) {
+            deserializedFish.fishtype = reader.getString();
+            return true;
+        } else if ("species".equals(fieldName)) {
+            deserializedFish.species = reader.getString();
+            return true;
+        } else if ("siblings".equals(fieldName)) {
+            List<Fish> siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
+            deserializedFish.siblings = siblings;
+            return true;
+        }
+        return false;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Goblinshark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Goblinshark.java
@@ -5,7 +5,6 @@
 package fixtures.streamstyleserialization.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.util.CoreUtils;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonToken;
@@ -167,20 +166,8 @@ public final class Goblinshark extends Shark {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("length".equals(fieldName)) {
-                    deserializedGoblinshark.setLength(reader.getFloat());
-                } else if ("birthday".equals(fieldName)) {
-                    deserializedGoblinshark.setBirthday(reader
-                        .getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString())));
-                } else if ("species".equals(fieldName)) {
-                    deserializedGoblinshark.setSpecies(reader.getString());
-                } else if ("siblings".equals(fieldName)) {
-                    List<Fish> siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
-                    deserializedGoblinshark.setSiblings(siblings);
-                } else if ("age".equals(fieldName)) {
-                    deserializedGoblinshark.setAge(reader.getNullable(JsonReader::getInt));
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedGoblinshark.fishtype = reader.getString();
+                if (Shark.fromJsonShared(reader, fieldName, deserializedGoblinshark)) {
+                    continue;
                 } else if ("jawsize".equals(fieldName)) {
                     deserializedGoblinshark.jawsize = reader.getNullable(JsonReader::getInt);
                 } else if ("color".equals(fieldName)) {

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/MyBaseType.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/MyBaseType.java
@@ -179,9 +179,11 @@ public class MyBaseType implements JsonSerializable<MyBaseType> {
 
                 if ("propBH1".equals(fieldName)) {
                     deserializedMyBaseType.propBH1 = reader.getString();
-                    return true;
+                } else {
+                    reader.skipChildren();
                 }
             }
+            return true;
         }
         return false;
     }

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/MyBaseType.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/MyBaseType.java
@@ -155,27 +155,34 @@ public class MyBaseType implements JsonSerializable<MyBaseType> {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("kind".equals(fieldName)) {
-                    deserializedMyBaseType.kind = MyKind.fromString(reader.getString());
-                } else if ("propB1".equals(fieldName)) {
-                    deserializedMyBaseType.propB1 = reader.getString();
-                } else if ("helper".equals(fieldName) && reader.currentToken() == JsonToken.START_OBJECT) {
-                    while (reader.nextToken() != JsonToken.END_OBJECT) {
-                        fieldName = reader.getFieldName();
-                        reader.nextToken();
-
-                        if ("propBH1".equals(fieldName)) {
-                            deserializedMyBaseType.propBH1 = reader.getString();
-                        } else {
-                            reader.skipChildren();
-                        }
-                    }
-                } else {
+                if (!MyBaseType.fromJsonShared(reader, fieldName, deserializedMyBaseType)) {
                     reader.skipChildren();
                 }
             }
 
             return deserializedMyBaseType;
         });
+    }
+
+    static boolean fromJsonShared(JsonReader reader, String fieldName, MyBaseType deserializedMyBaseType)
+        throws IOException {
+        if ("kind".equals(fieldName)) {
+            deserializedMyBaseType.kind = MyKind.fromString(reader.getString());
+            return true;
+        } else if ("propB1".equals(fieldName)) {
+            deserializedMyBaseType.propB1 = reader.getString();
+            return true;
+        } else if ("helper".equals(fieldName) && reader.currentToken() == JsonToken.START_OBJECT) {
+            while (reader.nextToken() != JsonToken.END_OBJECT) {
+                fieldName = reader.getFieldName();
+                reader.nextToken();
+
+                if ("propBH1".equals(fieldName)) {
+                    deserializedMyBaseType.propBH1 = reader.getString();
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/MyDerivedType.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/MyDerivedType.java
@@ -100,10 +100,8 @@ public final class MyDerivedType extends MyBaseType {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("propB1".equals(fieldName)) {
-                    deserializedMyDerivedType.setPropB1(reader.getString());
-                } else if ("kind".equals(fieldName)) {
-                    deserializedMyDerivedType.kind = MyKind.fromString(reader.getString());
+                if (MyBaseType.fromJsonShared(reader, fieldName, deserializedMyDerivedType)) {
+                    continue;
                 } else if ("propD1".equals(fieldName)) {
                     deserializedMyDerivedType.propD1 = reader.getString();
                 } else if ("helper".equals(fieldName) && reader.currentToken() == JsonToken.START_OBJECT) {

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/MyDerivedType.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/MyDerivedType.java
@@ -104,17 +104,6 @@ public final class MyDerivedType extends MyBaseType {
                     continue;
                 } else if ("propD1".equals(fieldName)) {
                     deserializedMyDerivedType.propD1 = reader.getString();
-                } else if ("helper".equals(fieldName) && reader.currentToken() == JsonToken.START_OBJECT) {
-                    while (reader.nextToken() != JsonToken.END_OBJECT) {
-                        fieldName = reader.getFieldName();
-                        reader.nextToken();
-
-                        if ("propBH1".equals(fieldName)) {
-                            deserializedMyDerivedType.setPropBH1(reader.getString());
-                        } else {
-                            reader.skipChildren();
-                        }
-                    }
                 } else {
                     reader.skipChildren();
                 }

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Salmon.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Salmon.java
@@ -169,25 +169,25 @@ public class Salmon extends Fish {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("length".equals(fieldName)) {
-                    deserializedSalmon.setLength(reader.getFloat());
-                } else if ("species".equals(fieldName)) {
-                    deserializedSalmon.setSpecies(reader.getString());
-                } else if ("siblings".equals(fieldName)) {
-                    List<Fish> siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
-                    deserializedSalmon.setSiblings(siblings);
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedSalmon.fishtype = reader.getString();
-                } else if ("location".equals(fieldName)) {
-                    deserializedSalmon.location = reader.getString();
-                } else if ("iswild".equals(fieldName)) {
-                    deserializedSalmon.iswild = reader.getNullable(JsonReader::getBoolean);
-                } else {
+                if (!Salmon.fromJsonShared(reader, fieldName, deserializedSalmon)) {
                     reader.skipChildren();
                 }
             }
 
             return deserializedSalmon;
         });
+    }
+
+    static boolean fromJsonShared(JsonReader reader, String fieldName, Salmon deserializedSalmon) throws IOException {
+        if (Fish.fromJsonShared(reader, fieldName, deserializedSalmon)) {
+            return true;
+        } else if ("location".equals(fieldName)) {
+            deserializedSalmon.location = reader.getString();
+            return true;
+        } else if ("iswild".equals(fieldName)) {
+            deserializedSalmon.iswild = reader.getNullable(JsonReader::getBoolean);
+            return true;
+        }
+        return false;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Sawshark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Sawshark.java
@@ -141,20 +141,8 @@ public final class Sawshark extends Shark {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("length".equals(fieldName)) {
-                    deserializedSawshark.setLength(reader.getFloat());
-                } else if ("birthday".equals(fieldName)) {
-                    deserializedSawshark.setBirthday(reader
-                        .getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString())));
-                } else if ("species".equals(fieldName)) {
-                    deserializedSawshark.setSpecies(reader.getString());
-                } else if ("siblings".equals(fieldName)) {
-                    List<Fish> siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
-                    deserializedSawshark.setSiblings(siblings);
-                } else if ("age".equals(fieldName)) {
-                    deserializedSawshark.setAge(reader.getNullable(JsonReader::getInt));
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedSawshark.fishtype = reader.getString();
+                if (Shark.fromJsonShared(reader, fieldName, deserializedSawshark)) {
+                    continue;
                 } else if ("picture".equals(fieldName)) {
                     deserializedSawshark.picture = reader.getBinary();
                 } else {

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Shark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/Shark.java
@@ -184,26 +184,26 @@ public class Shark extends Fish {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("length".equals(fieldName)) {
-                    deserializedShark.setLength(reader.getFloat());
-                } else if ("species".equals(fieldName)) {
-                    deserializedShark.setSpecies(reader.getString());
-                } else if ("siblings".equals(fieldName)) {
-                    List<Fish> siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
-                    deserializedShark.setSiblings(siblings);
-                } else if ("birthday".equals(fieldName)) {
-                    deserializedShark.birthday = reader
-                        .getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString()));
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedShark.fishtype = reader.getString();
-                } else if ("age".equals(fieldName)) {
-                    deserializedShark.age = reader.getNullable(JsonReader::getInt);
-                } else {
+                if (!Shark.fromJsonShared(reader, fieldName, deserializedShark)) {
                     reader.skipChildren();
                 }
             }
 
             return deserializedShark;
         });
+    }
+
+    static boolean fromJsonShared(JsonReader reader, String fieldName, Shark deserializedShark) throws IOException {
+        if (Fish.fromJsonShared(reader, fieldName, deserializedShark)) {
+            return true;
+        } else if ("birthday".equals(fieldName)) {
+            deserializedShark.birthday
+                = reader.getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString()));
+            return true;
+        } else if ("age".equals(fieldName)) {
+            deserializedShark.age = reader.getNullable(JsonReader::getInt);
+            return true;
+        }
+        return false;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/SmartSalmon.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserialization/models/SmartSalmon.java
@@ -165,19 +165,8 @@ public final class SmartSalmon extends Salmon {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("length".equals(fieldName)) {
-                    deserializedSmartSalmon.setLength(reader.getFloat());
-                } else if ("species".equals(fieldName)) {
-                    deserializedSmartSalmon.setSpecies(reader.getString());
-                } else if ("siblings".equals(fieldName)) {
-                    List<Fish> siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
-                    deserializedSmartSalmon.setSiblings(siblings);
-                } else if ("location".equals(fieldName)) {
-                    deserializedSmartSalmon.setLocation(reader.getString());
-                } else if ("iswild".equals(fieldName)) {
-                    deserializedSmartSalmon.setIswild(reader.getNullable(JsonReader::getBoolean));
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedSmartSalmon.fishtype = reader.getString();
+                if (Salmon.fromJsonShared(reader, fieldName, deserializedSmartSalmon)) {
+                    continue;
                 } else if ("college_degree".equals(fieldName)) {
                     deserializedSmartSalmon.collegeDegree = reader.getString();
                 } else {

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/DotFish.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/DotFish.java
@@ -125,16 +125,23 @@ public class DotFish implements JsonSerializable<DotFish> {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("fish.type".equals(fieldName)) {
-                    deserializedDotFish.fishType = reader.getString();
-                } else if ("species".equals(fieldName)) {
-                    deserializedDotFish.species = reader.getString();
-                } else {
+                if (!DotFish.fromJsonShared(reader, fieldName, deserializedDotFish)) {
                     reader.skipChildren();
                 }
             }
 
             return deserializedDotFish;
         });
+    }
+
+    static boolean fromJsonShared(JsonReader reader, String fieldName, DotFish deserializedDotFish) throws IOException {
+        if ("fish.type".equals(fieldName)) {
+            deserializedDotFish.fishType = reader.getString();
+            return true;
+        } else if ("species".equals(fieldName)) {
+            deserializedDotFish.species = reader.getString();
+            return true;
+        }
+        return false;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/DotSalmon.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/DotSalmon.java
@@ -117,10 +117,8 @@ public final class DotSalmon extends DotFish {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("species".equals(fieldName)) {
-                    deserializedDotSalmon.setSpecies(reader.getString());
-                } else if ("fish.type".equals(fieldName)) {
-                    deserializedDotSalmon.fishType = reader.getString();
+                if (DotFish.fromJsonShared(reader, fieldName, deserializedDotSalmon)) {
+                    continue;
                 } else if ("location".equals(fieldName)) {
                     deserializedDotSalmon.location = reader.getString();
                 } else if ("iswild".equals(fieldName)) {

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/MyBaseType.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/MyBaseType.java
@@ -179,9 +179,11 @@ public class MyBaseType implements JsonSerializable<MyBaseType> {
 
                 if ("propBH1".equals(fieldName)) {
                     deserializedMyBaseType.propBH1 = reader.getString();
-                    return true;
+                } else {
+                    reader.skipChildren();
                 }
             }
+            return true;
         }
         return false;
     }

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/MyBaseType.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/MyBaseType.java
@@ -155,27 +155,34 @@ public class MyBaseType implements JsonSerializable<MyBaseType> {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("kind".equals(fieldName)) {
-                    deserializedMyBaseType.kind = MyKind.fromString(reader.getString());
-                } else if ("propB1".equals(fieldName)) {
-                    deserializedMyBaseType.propB1 = reader.getString();
-                } else if ("helper".equals(fieldName) && reader.currentToken() == JsonToken.START_OBJECT) {
-                    while (reader.nextToken() != JsonToken.END_OBJECT) {
-                        fieldName = reader.getFieldName();
-                        reader.nextToken();
-
-                        if ("propBH1".equals(fieldName)) {
-                            deserializedMyBaseType.propBH1 = reader.getString();
-                        } else {
-                            reader.skipChildren();
-                        }
-                    }
-                } else {
+                if (!MyBaseType.fromJsonShared(reader, fieldName, deserializedMyBaseType)) {
                     reader.skipChildren();
                 }
             }
 
             return deserializedMyBaseType;
         });
+    }
+
+    static boolean fromJsonShared(JsonReader reader, String fieldName, MyBaseType deserializedMyBaseType)
+        throws IOException {
+        if ("kind".equals(fieldName)) {
+            deserializedMyBaseType.kind = MyKind.fromString(reader.getString());
+            return true;
+        } else if ("propB1".equals(fieldName)) {
+            deserializedMyBaseType.propB1 = reader.getString();
+            return true;
+        } else if ("helper".equals(fieldName) && reader.currentToken() == JsonToken.START_OBJECT) {
+            while (reader.nextToken() != JsonToken.END_OBJECT) {
+                fieldName = reader.getFieldName();
+                reader.nextToken();
+
+                if ("propBH1".equals(fieldName)) {
+                    deserializedMyBaseType.propBH1 = reader.getString();
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/MyDerivedType.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/MyDerivedType.java
@@ -100,10 +100,8 @@ public final class MyDerivedType extends MyBaseType {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("propB1".equals(fieldName)) {
-                    deserializedMyDerivedType.setPropB1(reader.getString());
-                } else if ("kind".equals(fieldName)) {
-                    deserializedMyDerivedType.kind = MyKind.fromString(reader.getString());
+                if (MyBaseType.fromJsonShared(reader, fieldName, deserializedMyDerivedType)) {
+                    continue;
                 } else if ("propD1".equals(fieldName)) {
                     deserializedMyDerivedType.propD1 = reader.getString();
                 } else if ("helper".equals(fieldName) && reader.currentToken() == JsonToken.START_OBJECT) {

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/MyDerivedType.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationctorargs/models/MyDerivedType.java
@@ -104,17 +104,6 @@ public final class MyDerivedType extends MyBaseType {
                     continue;
                 } else if ("propD1".equals(fieldName)) {
                     deserializedMyDerivedType.propD1 = reader.getString();
-                } else if ("helper".equals(fieldName) && reader.currentToken() == JsonToken.START_OBJECT) {
-                    while (reader.nextToken() != JsonToken.END_OBJECT) {
-                        fieldName = reader.getFieldName();
-                        reader.nextToken();
-
-                        if ("propBH1".equals(fieldName)) {
-                            deserializedMyDerivedType.setPropBH1(reader.getString());
-                        } else {
-                            reader.skipChildren();
-                        }
-                    }
                 } else {
                     reader.skipChildren();
                 }

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Cookiecuttershark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Cookiecuttershark.java
@@ -5,7 +5,6 @@
 package fixtures.streamstyleserializationimmutableoutput.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.util.CoreUtils;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonToken;
@@ -115,20 +114,8 @@ public final class Cookiecuttershark extends Shark {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("length".equals(fieldName)) {
-                    deserializedCookiecuttershark.setLength(reader.getFloat());
-                } else if ("birthday".equals(fieldName)) {
-                    deserializedCookiecuttershark.setBirthday(reader
-                        .getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString())));
-                } else if ("species".equals(fieldName)) {
-                    deserializedCookiecuttershark.setSpecies(reader.getString());
-                } else if ("siblings".equals(fieldName)) {
-                    List<Fish> siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
-                    deserializedCookiecuttershark.setSiblings(siblings);
-                } else if ("age".equals(fieldName)) {
-                    deserializedCookiecuttershark.setAge(reader.getNullable(JsonReader::getInt));
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedCookiecuttershark.fishtype = reader.getString();
+                if (Shark.fromJsonShared(reader, fieldName, deserializedCookiecuttershark)) {
+                    continue;
                 } else {
                     reader.skipChildren();
                 }

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/DotFish.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/DotFish.java
@@ -125,16 +125,23 @@ public class DotFish implements JsonSerializable<DotFish> {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("fish.type".equals(fieldName)) {
-                    deserializedDotFish.fishType = reader.getString();
-                } else if ("species".equals(fieldName)) {
-                    deserializedDotFish.species = reader.getString();
-                } else {
+                if (!DotFish.fromJsonShared(reader, fieldName, deserializedDotFish)) {
                     reader.skipChildren();
                 }
             }
 
             return deserializedDotFish;
         });
+    }
+
+    static boolean fromJsonShared(JsonReader reader, String fieldName, DotFish deserializedDotFish) throws IOException {
+        if ("fish.type".equals(fieldName)) {
+            deserializedDotFish.fishType = reader.getString();
+            return true;
+        } else if ("species".equals(fieldName)) {
+            deserializedDotFish.species = reader.getString();
+            return true;
+        }
+        return false;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/DotSalmon.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/DotSalmon.java
@@ -25,11 +25,6 @@ public final class DotSalmon extends DotFish {
      */
     private Boolean iswild;
 
-    /*
-     * The species property.
-     */
-    private String species;
-
     /**
      * Creates an instance of DotSalmon class.
      */
@@ -53,16 +48,6 @@ public final class DotSalmon extends DotFish {
      */
     public Boolean iswild() {
         return this.iswild;
-    }
-
-    /**
-     * Get the species property: The species property.
-     * 
-     * @return the species value.
-     */
-    @Override
-    public String getSpecies() {
-        return this.species;
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/DotSalmon.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/DotSalmon.java
@@ -101,10 +101,8 @@ public final class DotSalmon extends DotFish {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("species".equals(fieldName)) {
-                    deserializedDotSalmon.species = reader.getString();
-                } else if ("fish.type".equals(fieldName)) {
-                    deserializedDotSalmon.fishType = reader.getString();
+                if (DotFish.fromJsonShared(reader, fieldName, deserializedDotSalmon)) {
+                    continue;
                 } else if ("location".equals(fieldName)) {
                     deserializedDotSalmon.location = reader.getString();
                 } else if ("iswild".equals(fieldName)) {

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Fish.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Fish.java
@@ -192,21 +192,30 @@ public class Fish implements JsonSerializable<Fish> {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("length".equals(fieldName)) {
-                    deserializedFish.length = reader.getFloat();
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedFish.fishtype = reader.getString();
-                } else if ("species".equals(fieldName)) {
-                    deserializedFish.species = reader.getString();
-                } else if ("siblings".equals(fieldName)) {
-                    List<Fish> siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
-                    deserializedFish.siblings = siblings;
-                } else {
+                if (!Fish.fromJsonShared(reader, fieldName, deserializedFish)) {
                     reader.skipChildren();
                 }
             }
 
             return deserializedFish;
         });
+    }
+
+    static boolean fromJsonShared(JsonReader reader, String fieldName, Fish deserializedFish) throws IOException {
+        if ("length".equals(fieldName)) {
+            deserializedFish.length = reader.getFloat();
+            return true;
+        } else if ("fishtype".equals(fieldName)) {
+            deserializedFish.fishtype = reader.getString();
+            return true;
+        } else if ("species".equals(fieldName)) {
+            deserializedFish.species = reader.getString();
+            return true;
+        } else if ("siblings".equals(fieldName)) {
+            List<Fish> siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
+            deserializedFish.siblings = siblings;
+            return true;
+        }
+        return false;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Goblinshark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Goblinshark.java
@@ -5,7 +5,6 @@
 package fixtures.streamstyleserializationimmutableoutput.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.util.CoreUtils;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonToken;
@@ -167,20 +166,8 @@ public final class Goblinshark extends Shark {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("length".equals(fieldName)) {
-                    deserializedGoblinshark.setLength(reader.getFloat());
-                } else if ("birthday".equals(fieldName)) {
-                    deserializedGoblinshark.setBirthday(reader
-                        .getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString())));
-                } else if ("species".equals(fieldName)) {
-                    deserializedGoblinshark.setSpecies(reader.getString());
-                } else if ("siblings".equals(fieldName)) {
-                    List<Fish> siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
-                    deserializedGoblinshark.setSiblings(siblings);
-                } else if ("age".equals(fieldName)) {
-                    deserializedGoblinshark.setAge(reader.getNullable(JsonReader::getInt));
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedGoblinshark.fishtype = reader.getString();
+                if (Shark.fromJsonShared(reader, fieldName, deserializedGoblinshark)) {
+                    continue;
                 } else if ("jawsize".equals(fieldName)) {
                     deserializedGoblinshark.jawsize = reader.getNullable(JsonReader::getInt);
                 } else if ("color".equals(fieldName)) {

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/MyBaseType.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/MyBaseType.java
@@ -179,9 +179,11 @@ public class MyBaseType implements JsonSerializable<MyBaseType> {
 
                 if ("propBH1".equals(fieldName)) {
                     deserializedMyBaseType.propBH1 = reader.getString();
-                    return true;
+                } else {
+                    reader.skipChildren();
                 }
             }
+            return true;
         }
         return false;
     }

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/MyBaseType.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/MyBaseType.java
@@ -155,27 +155,34 @@ public class MyBaseType implements JsonSerializable<MyBaseType> {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("kind".equals(fieldName)) {
-                    deserializedMyBaseType.kind = MyKind.fromString(reader.getString());
-                } else if ("propB1".equals(fieldName)) {
-                    deserializedMyBaseType.propB1 = reader.getString();
-                } else if ("helper".equals(fieldName) && reader.currentToken() == JsonToken.START_OBJECT) {
-                    while (reader.nextToken() != JsonToken.END_OBJECT) {
-                        fieldName = reader.getFieldName();
-                        reader.nextToken();
-
-                        if ("propBH1".equals(fieldName)) {
-                            deserializedMyBaseType.propBH1 = reader.getString();
-                        } else {
-                            reader.skipChildren();
-                        }
-                    }
-                } else {
+                if (!MyBaseType.fromJsonShared(reader, fieldName, deserializedMyBaseType)) {
                     reader.skipChildren();
                 }
             }
 
             return deserializedMyBaseType;
         });
+    }
+
+    static boolean fromJsonShared(JsonReader reader, String fieldName, MyBaseType deserializedMyBaseType)
+        throws IOException {
+        if ("kind".equals(fieldName)) {
+            deserializedMyBaseType.kind = MyKind.fromString(reader.getString());
+            return true;
+        } else if ("propB1".equals(fieldName)) {
+            deserializedMyBaseType.propB1 = reader.getString();
+            return true;
+        } else if ("helper".equals(fieldName) && reader.currentToken() == JsonToken.START_OBJECT) {
+            while (reader.nextToken() != JsonToken.END_OBJECT) {
+                fieldName = reader.getFieldName();
+                reader.nextToken();
+
+                if ("propBH1".equals(fieldName)) {
+                    deserializedMyBaseType.propBH1 = reader.getString();
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/MyDerivedType.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/MyDerivedType.java
@@ -105,17 +105,6 @@ public final class MyDerivedType extends MyBaseType {
                     continue;
                 } else if ("propD1".equals(fieldName)) {
                     deserializedMyDerivedType.propD1 = reader.getString();
-                } else if ("helper".equals(fieldName) && reader.currentToken() == JsonToken.START_OBJECT) {
-                    while (reader.nextToken() != JsonToken.END_OBJECT) {
-                        fieldName = reader.getFieldName();
-                        reader.nextToken();
-
-                        if ("propBH1".equals(fieldName)) {
-                            deserializedMyDerivedType.propBH1 = reader.getString();
-                        } else {
-                            reader.skipChildren();
-                        }
-                    }
                 } else {
                     reader.skipChildren();
                 }

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/MyDerivedType.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/MyDerivedType.java
@@ -20,16 +20,6 @@ public final class MyDerivedType extends MyBaseType {
      */
     private String propD1;
 
-    /*
-     * The propBH1 property.
-     */
-    private String propBH1;
-
-    /*
-     * The propB1 property.
-     */
-    private String propB1;
-
     /**
      * Creates an instance of MyDerivedType class.
      */
@@ -44,26 +34,6 @@ public final class MyDerivedType extends MyBaseType {
      */
     public String getPropD1() {
         return this.propD1;
-    }
-
-    /**
-     * Get the propBH1 property: The propBH1 property.
-     * 
-     * @return the propBH1 value.
-     */
-    @Override
-    public String getPropBH1() {
-        return this.propBH1;
-    }
-
-    /**
-     * Get the propB1 property: The propB1 property.
-     * 
-     * @return the propB1 value.
-     */
-    @Override
-    public String getPropB1() {
-        return this.propB1;
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/MyDerivedType.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/MyDerivedType.java
@@ -101,10 +101,8 @@ public final class MyDerivedType extends MyBaseType {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("propB1".equals(fieldName)) {
-                    deserializedMyDerivedType.propB1 = reader.getString();
-                } else if ("kind".equals(fieldName)) {
-                    deserializedMyDerivedType.kind = MyKind.fromString(reader.getString());
+                if (MyBaseType.fromJsonShared(reader, fieldName, deserializedMyDerivedType)) {
+                    continue;
                 } else if ("propD1".equals(fieldName)) {
                     deserializedMyDerivedType.propD1 = reader.getString();
                 } else if ("helper".equals(fieldName) && reader.currentToken() == JsonToken.START_OBJECT) {

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Salmon.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Salmon.java
@@ -169,25 +169,25 @@ public class Salmon extends Fish {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("length".equals(fieldName)) {
-                    deserializedSalmon.setLength(reader.getFloat());
-                } else if ("species".equals(fieldName)) {
-                    deserializedSalmon.setSpecies(reader.getString());
-                } else if ("siblings".equals(fieldName)) {
-                    List<Fish> siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
-                    deserializedSalmon.setSiblings(siblings);
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedSalmon.fishtype = reader.getString();
-                } else if ("location".equals(fieldName)) {
-                    deserializedSalmon.location = reader.getString();
-                } else if ("iswild".equals(fieldName)) {
-                    deserializedSalmon.iswild = reader.getNullable(JsonReader::getBoolean);
-                } else {
+                if (!Salmon.fromJsonShared(reader, fieldName, deserializedSalmon)) {
                     reader.skipChildren();
                 }
             }
 
             return deserializedSalmon;
         });
+    }
+
+    static boolean fromJsonShared(JsonReader reader, String fieldName, Salmon deserializedSalmon) throws IOException {
+        if (Fish.fromJsonShared(reader, fieldName, deserializedSalmon)) {
+            return true;
+        } else if ("location".equals(fieldName)) {
+            deserializedSalmon.location = reader.getString();
+            return true;
+        } else if ("iswild".equals(fieldName)) {
+            deserializedSalmon.iswild = reader.getNullable(JsonReader::getBoolean);
+            return true;
+        }
+        return false;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Sawshark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Sawshark.java
@@ -141,20 +141,8 @@ public final class Sawshark extends Shark {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("length".equals(fieldName)) {
-                    deserializedSawshark.setLength(reader.getFloat());
-                } else if ("birthday".equals(fieldName)) {
-                    deserializedSawshark.setBirthday(reader
-                        .getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString())));
-                } else if ("species".equals(fieldName)) {
-                    deserializedSawshark.setSpecies(reader.getString());
-                } else if ("siblings".equals(fieldName)) {
-                    List<Fish> siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
-                    deserializedSawshark.setSiblings(siblings);
-                } else if ("age".equals(fieldName)) {
-                    deserializedSawshark.setAge(reader.getNullable(JsonReader::getInt));
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedSawshark.fishtype = reader.getString();
+                if (Shark.fromJsonShared(reader, fieldName, deserializedSawshark)) {
+                    continue;
                 } else if ("picture".equals(fieldName)) {
                     deserializedSawshark.picture = reader.getBinary();
                 } else {

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Shark.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/Shark.java
@@ -184,26 +184,26 @@ public class Shark extends Fish {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("length".equals(fieldName)) {
-                    deserializedShark.setLength(reader.getFloat());
-                } else if ("species".equals(fieldName)) {
-                    deserializedShark.setSpecies(reader.getString());
-                } else if ("siblings".equals(fieldName)) {
-                    List<Fish> siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
-                    deserializedShark.setSiblings(siblings);
-                } else if ("birthday".equals(fieldName)) {
-                    deserializedShark.birthday = reader
-                        .getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString()));
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedShark.fishtype = reader.getString();
-                } else if ("age".equals(fieldName)) {
-                    deserializedShark.age = reader.getNullable(JsonReader::getInt);
-                } else {
+                if (!Shark.fromJsonShared(reader, fieldName, deserializedShark)) {
                     reader.skipChildren();
                 }
             }
 
             return deserializedShark;
         });
+    }
+
+    static boolean fromJsonShared(JsonReader reader, String fieldName, Shark deserializedShark) throws IOException {
+        if (Fish.fromJsonShared(reader, fieldName, deserializedShark)) {
+            return true;
+        } else if ("birthday".equals(fieldName)) {
+            deserializedShark.birthday
+                = reader.getNullable(nonNullReader -> CoreUtils.parseBestOffsetDateTime(nonNullReader.getString()));
+            return true;
+        } else if ("age".equals(fieldName)) {
+            deserializedShark.age = reader.getNullable(JsonReader::getInt);
+            return true;
+        }
+        return false;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/SmartSalmon.java
+++ b/vanilla-tests/src/main/java/fixtures/streamstyleserializationimmutableoutput/models/SmartSalmon.java
@@ -165,19 +165,8 @@ public final class SmartSalmon extends Salmon {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("length".equals(fieldName)) {
-                    deserializedSmartSalmon.setLength(reader.getFloat());
-                } else if ("species".equals(fieldName)) {
-                    deserializedSmartSalmon.setSpecies(reader.getString());
-                } else if ("siblings".equals(fieldName)) {
-                    List<Fish> siblings = reader.readArray(reader1 -> Fish.fromJson(reader1));
-                    deserializedSmartSalmon.setSiblings(siblings);
-                } else if ("location".equals(fieldName)) {
-                    deserializedSmartSalmon.setLocation(reader.getString());
-                } else if ("iswild".equals(fieldName)) {
-                    deserializedSmartSalmon.setIswild(reader.getNullable(JsonReader::getBoolean));
-                } else if ("fishtype".equals(fieldName)) {
-                    deserializedSmartSalmon.fishtype = reader.getString();
+                if (Salmon.fromJsonShared(reader, fieldName, deserializedSmartSalmon)) {
+                    continue;
                 } else if ("college_degree".equals(fieldName)) {
                     deserializedSmartSalmon.collegeDegree = reader.getString();
                 } else {


### PR DESCRIPTION
Add support for generating `fromJsonShared` methods, similar to what was done with `toJsonShared`, when polymorphic models meet the following requirements:

- The models doesn't have any constructor parameters. Sharing deserialization logic isn't helpful when the model has constructor parameters as we'd need to create container types and pass those to the shared logic. In the future more work could be done here to allow this for all polymorphic models, such as making fields non-final internally and having a private no-args constructor.
- All models in the polymorphic structure are in the same package.

When those requirements are met, polymorphic parent types will generate a `fromJsonShared` method for all the properties it defines. Child models will call into that rather than writing the deserialization logic themselves. `fromJsonShared` will return a boolean indicating whether a field was consumed during the call, if not the caller will either skip the unknown property or do further checks in the child type for the property. Intermediate parents will still call into their parent for shared properties as well.