### PR TITLE
Switch to Maven Shade plugin

### DIFF
--- a/androidgen/pom.xml
+++ b/androidgen/pom.xml
@@ -33,6 +33,10 @@
     </dependency>
   </dependencies>
 
+  <properties>
+    <shade.mainClass>com.azure.autorest.android.Main</shade.mainClass>
+  </properties>
+
   <profiles>
     <!-- Use -Dlocal to enable this profile when running autorest.java locally -->
     <profile>
@@ -43,27 +47,16 @@
         </property>
       </activation>
       <build>
-        <finalName>${project.artifactId}</finalName>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-assembly-plugin</artifactId>
+            <artifactId>maven-shade-plugin</artifactId>
             <executions>
               <execution>
                 <phase>package</phase>
                 <goals>
-                  <goal>single</goal>
+                  <goal>shade</goal>
                 </goals>
-                <configuration>
-                  <archive>
-                    <manifest>
-                      <mainClass>com.azure.autorest.android.Main</mainClass>
-                    </manifest>
-                  </archive>
-                  <descriptorRefs>
-                    <descriptorRef>jar-with-dependencies</descriptorRef>
-                  </descriptorRefs>
-                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/customization-base/src/main/resources/pom.xml
+++ b/customization-base/src/main/resources/pom.xml
@@ -62,11 +62,6 @@
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.7.1</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.13.0</version>
           <configuration>

--- a/docs/developer/readme.md
+++ b/docs/developer/readme.md
@@ -15,7 +15,7 @@ As AutoRest plugin, it is defined by the [YAML section in `readme.md`](https://g
 Build is configured via Maven.
 
 There is several build profiles:
-- `local` profile. It is required to be enabled. It uses `maven-assembly-plugin` to combine project output to a single jar.
+- `local` profile. It is required to be enabled. It uses `maven-shade-plugin` to combine project output to a single jar.
 - `testVanilla` profile. It enables the integrated vanilla tests, which is the common ground for all modules.
 - `testAzure` profile. It enables the integrated Azure tests, which tests handling of some advanced [AutoRest Extensions for OpenAPI 2.0](https://github.com/Azure/autorest/blob/main/docs/extensions/readme.md).
 - `testFluent` profile. It enables the integrated Fluent tests, which tests generation of Fluent management SDKs for [ARM](https://docs.microsoft.com/azure/azure-resource-manager/management/overview).

--- a/eng/versioning/external_dependencies.txt
+++ b/eng/versioning/external_dependencies.txt
@@ -27,7 +27,6 @@ com.github.spotbugs:spotbugs-maven-plugin
 com.puppycrawl.tools:checkstyle
 
 org.apache.maven.plugins:maven-antrun-plugin
-org.apache.maven.plugins:maven-assembly-plugin
 org.apache.maven.plugins:maven-checkstyle-plugin
 org.apache.maven.plugins:maven-clean-plugin
 org.apache.maven.plugins:maven-compiler-plugin

--- a/fluentgen/pom.xml
+++ b/fluentgen/pom.xml
@@ -24,6 +24,8 @@
 
     <!-- Tests requires shared static class, like FluentStatic. -->
     <parallelizeTests>false</parallelizeTests>
+
+    <shade.mainClass>com.azure.autorest.fluent.Main</shade.mainClass>
   </properties>
 
   <dependencies>
@@ -79,27 +81,16 @@
         </property>
       </activation>
       <build>
-        <finalName>${project.artifactId}</finalName>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-assembly-plugin</artifactId>
+            <artifactId>maven-shade-plugin</artifactId>
             <executions>
               <execution>
                 <phase>package</phase>
                 <goals>
-                  <goal>single</goal>
+                  <goal>shade</goal>
                 </goals>
-                <configuration>
-                  <archive>
-                    <manifest>
-                      <mainClass>com.azure.autorest.fluent.Main</mainClass>
-                    </manifest>
-                  </archive>
-                  <descriptorRefs>
-                    <descriptorRef>jar-with-dependencies</descriptorRef>
-                  </descriptorRefs>
-                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/javagen/pom.xml
+++ b/javagen/pom.xml
@@ -89,12 +89,16 @@
       <version>5.9.3</version>
       <scope>test</scope>
     </dependency>
-<!--    <dependency>-->
-<!--      <groupId>io.clientcore</groupId>-->
-<!--      <artifactId>core</artifactId>-->
-<!--      <version>1.0.0-beta.1</version>-->
-<!--    </dependency>-->
+    <!--    <dependency>-->
+    <!--      <groupId>io.clientcore</groupId>-->
+    <!--      <artifactId>core</artifactId>-->
+    <!--      <version>1.0.0-beta.1</version>-->
+    <!--    </dependency>-->
   </dependencies>
+
+  <properties>
+    <shade.mainClass>com.azure.autorest.Main</shade.mainClass>
+  </properties>
 
   <profiles>
     <!-- Use -Dlocal to enable this profile when running autorest.java locally -->
@@ -106,27 +110,16 @@
         </property>
       </activation>
       <build>
-        <finalName>${project.artifactId}</finalName>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-assembly-plugin</artifactId>
+            <artifactId>maven-shade-plugin</artifactId>
             <executions>
               <execution>
                 <phase>package</phase>
                 <goals>
-                  <goal>single</goal>
+                  <goal>shade</goal>
                 </goals>
-                <configuration>
-                  <archive>
-                    <manifest>
-                      <mainClass>com.azure.autorest.Main</mainClass>
-                    </manifest>
-                  </archive>
-                  <descriptorRefs>
-                    <descriptorRef>jar-with-dependencies</descriptorRef>
-                  </descriptorRefs>
-                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,9 @@
     <parallelizeTests>true</parallelizeTests>
 
     <maven.javadoc.failOnWarnings>false</maven.javadoc.failOnWarnings>
+
+    <shade.finalName>${project.artifactId}-jar-with-dependencies</shade.finalName>
+    <shade.mainClass></shade.mainClass>
   </properties>
 
   <dependencyManagement>
@@ -91,8 +94,35 @@
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.7.1</version>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>3.6.0</version>
+          <configuration>
+            <finalName>${shade.finalName}</finalName>
+            <minimizeJar>true</minimizeJar>
+            <entryPoints>
+              <entryPoint>${shade.mainClass}</entryPoint>
+            </entryPoints>
+            <transformers>
+              <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                <mainClass>${shade.mainClass}</mainClass>
+              </transformer>
+
+              <!-- this handles and properly merges the content of META-INF/services in the dependencies -->
+              <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+            </transformers>
+            <filters>
+              <filter>
+                <artifact>*:*</artifact>
+                <excludes>
+                  <!-- remove the dependencies signature as not relevant-->
+                  <exclude>META-INF/*.MF</exclude>
+                  <exclude>META-INF/*.SF</exclude>
+                  <exclude>META-INF/*.DSA</exclude>
+                  <exclude>META-INF/*.RSA</exclude>
+                </excludes>
+              </filter>
+            </filters>
+          </configuration>
         </plugin>
 
         <!-- This plugin runs tests -->

--- a/typespec-extension/pom.xml
+++ b/typespec-extension/pom.xml
@@ -101,6 +101,11 @@
     </dependency>
   </dependencies>
 
+  <properties>
+    <shade.finalName>emitter</shade.finalName>
+    <shade.mainClass>com.azure.typespec.Main</shade.mainClass>
+  </properties>
+
   <profiles>
     <profile>
       <id>local</id>
@@ -114,24 +119,13 @@
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-assembly-plugin</artifactId>
+            <artifactId>maven-shade-plugin</artifactId>
             <executions>
               <execution>
                 <phase>package</phase>
                 <goals>
-                  <goal>single</goal>
+                  <goal>shade</goal>
                 </goals>
-                <configuration>
-                  <appendAssemblyId>false</appendAssemblyId>
-                  <archive>
-                    <manifest>
-                      <mainClass>com.azure.typespec.Main</mainClass>
-                    </manifest>
-                  </archive>
-                  <descriptorRefs>
-                    <descriptorRef>jar-with-dependencies</descriptorRef>
-                  </descriptorRefs>
-                </configuration>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
Switch from `maven-assembly-plugin` to the more fine-tuned `maven-shade-plugin`. This enables richer creation of JARs with dependencies and allows for features such as minimizing JARs (reducing their size).

Size of JARs shipping with the `autorest.java` NPM package should be about 15-20% smaller, saving about 10-15 MB in total size. `typespec-java` should also be saving about 4-5 MB.