### PR TITLE
tsp, fix nightly

### DIFF
--- a/typespec-tests/src/test/java/com/azure/resourcemanager/models/commontypes/managedidentity/ManagedIdentityManagerTests.java
+++ b/typespec-tests/src/test/java/com/azure/resourcemanager/models/commontypes/managedidentity/ManagedIdentityManagerTests.java
@@ -45,10 +45,10 @@ public class ManagedIdentityManagerTests {
         Map<String, UserAssignedIdentity> userAssignedIdentityMap = new HashMap<>();
         userAssignedIdentityMap.put(USER_ASSIGNED_IDENTITIES_KEY, new UserAssignedIdentity());
         resource.update()
-            .withIdentity(new ManagedServiceIdentity().withType(ManagedServiceIdentityType.SYSTEM_AND_USER_ASSIGNED_V3)
+            .withIdentity(new ManagedServiceIdentity().withType(ManagedServiceIdentityType.fromString("SystemAssigned,UserAssigned"))
                 .withUserAssignedIdentities(userAssignedIdentityMap))
             .apply();
-        Assertions.assertEquals(ManagedServiceIdentityType.SYSTEM_AND_USER_ASSIGNED_V3, resource.identity().type());
+        Assertions.assertEquals(ManagedServiceIdentityType.fromString("SystemAssigned,UserAssigned"), resource.identity().type());
         Assertions.assertNotNull(resource.identity().principalId());
         Assertions.assertNotNull(resource.identity().tenantId());
         Assertions.assertNotNull(resource.identity().userAssignedIdentities());


### PR DESCRIPTION
nightly failure: https://dev.azure.com/azure-sdk/public/_build/results?buildId=4167764&view=logs&j=ca395085-040a-526b-2ce8-bdc85f692774&t=1fb2445c-3c92-5f9b-bcad-710222d02bc3

cause: 0.46.1 didn't include the `ManagedIdentityType` fix, though nightly does.