### PR TITLE
eng, report error, but do not fail during regen SDK

### DIFF
--- a/eng/pipelines/post-publish-sdk.yaml
+++ b/eng/pipelines/post-publish-sdk.yaml
@@ -56,7 +56,9 @@ jobs:
       filePath: $(Build.SourcesDirectory)/autorest.java/Build-TypeSpec.ps1
       workingDirectory: $(Build.SourcesDirectory)/autorest.java
 
-  - script: npm install -g @azure-tools/typespec-client-generator-cli@0.13.0
+  - script: |
+      npm install -g @azure-tools/typespec-client-generator-cli@0.13.0
+      npm install -g @typespec/compiler@0.61.0
     displayName: 'Install tsp-client'
 
   - task: PowerShell@2

--- a/eng/pipelines/post-publish-sdk.yaml
+++ b/eng/pipelines/post-publish-sdk.yaml
@@ -57,8 +57,7 @@ jobs:
       workingDirectory: $(Build.SourcesDirectory)/autorest.java
 
   - script: |
-      npm install -g @azure-tools/typespec-client-generator-cli@0.13.0
-      npm install -g @typespec/compiler@0.61.0
+      npm install -g @azure-tools/typespec-client-generator-cli
     displayName: 'Install tsp-client'
 
   - task: PowerShell@2

--- a/eng/sdk/sync_sdk.py
+++ b/eng/sdk/sync_sdk.py
@@ -144,7 +144,7 @@ def update_sdks():
     subprocess.check_call(cmd, cwd=sdk_root)
 
     if failed_artifact:
-        logging.error(f'Failed modules f{failed_artifact}')
+        logging.error(f'Failed modules {failed_artifact}')
 
 
 def main():

--- a/eng/sdk/sync_sdk.py
+++ b/eng/sdk/sync_sdk.py
@@ -17,7 +17,9 @@ sdk_root: str
 
 skip_artifacts: List[str] = [
     'azure-ai-anomalydetector',         # deprecated
-    'azure-ai-vision-imageanalysis'     # temporary disabled for modification on Javadoc
+    'azure-ai-vision-imageanalysis',    # temporary disabled for modification on Javadoc
+    'azure-health-insights-cancerprofiling',
+    'azure-health-insights-clinicalmatching'
 ]
 
 

--- a/eng/sdk/sync_sdk.py
+++ b/eng/sdk/sync_sdk.py
@@ -90,7 +90,7 @@ def get_generated_folder_from_artifact(module_path: str, artifact: str, type: st
 
 
 def update_sdks():
-    failed_artifact = []
+    failed_modules = []
     for tsp_location_file in glob.glob(os.path.join(sdk_root, 'sdk/*/*/tsp-location.yaml')):
         module_path = os.path.dirname(tsp_location_file)
         artifact = os.path.basename(module_path)
@@ -122,7 +122,7 @@ def update_sdks():
                 subprocess.check_call(['tsp-client', 'update', '--debug'], cwd=module_path)
             except subprocess.CalledProcessError:
                 logging.error(f'Failed to generate for module {artifact}')
-                failed_artifact.append(artifact)
+                failed_modules.append(artifact)
 
         if arm_module:
             # revert mock test code
@@ -143,8 +143,8 @@ def update_sdks():
     cmd = ['git', 'add', '.']
     subprocess.check_call(cmd, cwd=sdk_root)
 
-    if failed_artifact:
-        logging.error(f'Failed modules {failed_artifact}')
+    if failed_modules:
+        logging.error(f'Failed modules {failed_modules}')
 
 
 def main():

--- a/eng/sdk/sync_sdk.py
+++ b/eng/sdk/sync_sdk.py
@@ -17,9 +17,8 @@ sdk_root: str
 
 skip_artifacts: List[str] = [
     'azure-ai-anomalydetector',         # deprecated
-    'azure-ai-vision-imageanalysis',    # temporary disabled for modification on Javadoc
-    'azure-health-insights-cancerprofiling',
-    'azure-health-insights-clinicalmatching'
+    'azure-health-insights-cancerprofiling', # deprecated
+    'azure-ai-vision-imageanalysis'     # temporary disabled for modification on Javadoc
 ]
 
 
@@ -91,6 +90,7 @@ def get_generated_folder_from_artifact(module_path: str, artifact: str, type: st
 
 
 def update_sdks():
+    failed_artifact = []
     for tsp_location_file in glob.glob(os.path.join(sdk_root, 'sdk/*/*/tsp-location.yaml')):
         module_path = os.path.dirname(tsp_location_file)
         artifact = os.path.basename(module_path)
@@ -118,7 +118,11 @@ def update_sdks():
             # one retry
             # sometimes customization have intermittent failure
             logging.warning(f'Retry generate for module {artifact}')
-            subprocess.check_call(['tsp-client', 'update', '--debug'], cwd=module_path)
+            try:
+                subprocess.check_call(['tsp-client', 'update', '--debug'], cwd=module_path)
+            except subprocess.CalledProcessError:
+                logging.error(f'Failed to generate for module {artifact}')
+                failed_artifact.append(artifact)
 
         if arm_module:
             # revert mock test code
@@ -138,6 +142,9 @@ def update_sdks():
 
     cmd = ['git', 'add', '.']
     subprocess.check_call(cmd, cwd=sdk_root)
+
+    if failed_artifact:
+        logging.error(f'Failed modules f{failed_artifact}')
 
 
 def main():


### PR DESCRIPTION
Problem:
1. some lib fails, but we are not able to bump the commit ID because problem on specs repo (e.g. tspconfig removed from https://github.com/Azure/azure-rest-api-specs/tree/main/specification/ai/HealthInsights/HealthInsights.TrialMatcher)
2. typespec source change frequently require us to bump commit ID; it would be easier to see what's fails, and do a batch update

Dev need to check the sync SDK CI to see if there is failure.

At present, known failure is
- azure-health-insights-clinicalmatching