### PR TITLE
eng, always=true for nightly build

### DIFF
--- a/eng/pipelines/ci-typespec-java-dev-nightly.yaml
+++ b/eng/pipelines/ci-typespec-java-dev-nightly.yaml
@@ -4,6 +4,7 @@ schedules:
   branches:
     include:
     - main
+  always: true
 
 trigger: none
 pr: none


### PR DESCRIPTION
The default behavior appears to be that scheduled run would only happen if code in repo changed since last run.

Here we want it run every night, regardless of whether code changed.