### PR TITLE
mgmt, add mock test for CAE

### DIFF
--- a/typespec-tests/src/test/java/tsptest/armresourceprovider/ArmTests.java
+++ b/typespec-tests/src/test/java/tsptest/armresourceprovider/ArmTests.java
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package tsptest.armresourceprovider;
+
+import com.azure.core.credential.AccessToken;
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.http.HttpClient;
+import com.azure.core.http.HttpHeaderName;
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.management.AzureEnvironment;
+import com.azure.core.management.profile.AzureProfile;
+import com.azure.core.test.http.MockHttpResponse;
+import tsptest.armresourceprovider.models.Operation;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ArmTests {
+
+    private static final String VALID_CHALLENGE_HEADER = "Bearer realm=\"\", authorization_uri=\"https://login.microsoftonline.com/common/oauth2/authorize\", error=\"insufficient_claims\", claims=\"eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwidmFsdWUiOiIxNzI2MDc3NTk1In0sInhtc19jYWVlcnJvciI6eyJ2YWx1ZSI6IjEwMDEyIn19fQ==\"";
+
+    @Test
+    public void testCaeBehaviorForBearerTokenAuthenticationPolicy() {
+        AtomicInteger tokenGetCount = new AtomicInteger();
+        ArmResourceProviderManager armResourceProviderManager = ArmResourceProviderManager
+                .configure()
+                .withHttpClient(mockCaeHttpClient(tokenGetCount))
+                .authenticate(mockCaeTokenCredential(tokenGetCount), new AzureProfile(AzureEnvironment.AZURE));
+        Operation operation = armResourceProviderManager.operations()
+                .list().stream().iterator().next();
+        Assertions.assertEquals("mockOperation", operation.name());
+        Assertions.assertEquals(2, tokenGetCount.get());
+    }
+
+    private HttpClient mockCaeHttpClient(AtomicInteger tokenGetCount) {
+        return request -> {
+            if (tokenGetCount.get() <= 1) {
+                return Mono.just(new MockHttpResponse(
+                        request,
+                        401,
+                        new HttpHeaders().add(HttpHeaderName.WWW_AUTHENTICATE, VALID_CHALLENGE_HEADER)));
+            }
+            return Mono.just(new MockHttpResponse(request, 200, mockOperationListResponse()));
+        };
+    }
+
+    private Object mockOperationListResponse() {
+        return Map.of("value", Collections.singletonList(Map.of("name", "mockOperation", "isDataAction", "false")));
+    }
+
+    private TokenCredential mockCaeTokenCredential(AtomicInteger tokenGetCount) {
+        return tokenRequestContext -> {
+            tokenGetCount.incrementAndGet();
+            return Mono.just(new AccessToken("fake_token", OffsetDateTime.MAX));
+        };
+    }
+}

--- a/typespec-tests/src/test/java/tsptest/armstreamstyleserialization/StreamStyleSerializationTests.java
+++ b/typespec-tests/src/test/java/tsptest/armstreamstyleserialization/StreamStyleSerializationTests.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package tsptest.armstreamstyleserialization;
 
 import com.azure.core.management.serializer.SerializerFactory;


### PR DESCRIPTION
- fix https://github.com/Azure/azure-sdk-for-java/issues/42935
- Per @archerzz 's ask, add e2e test for SDK CAE behavior. Personally, I think [HttpPipeline test](https://github.com/Azure/azure-sdk-for-java/blob/4cf3d9f1c9a1e5c8d3696079940cc94fc65545fe/sdk/core/azure-core/src/test/java/com/azure/core/http/policy/BearerTokenAuthenticationPolicyTests.java#L44) in azure-core should suffice, though it doesn't hurt to have an e2e test for generated SDK. 