### PR TITLE
release azure autorest customization 1.0.0 beta.9

### DIFF
--- a/core.diff
+++ b/core.diff
@@ -35,7 +35,7 @@ index afa83e5c4..db70c748e 100644
 +    <dependency>
 +      <groupId>com.azure.tools</groupId>
 +      <artifactId>azure-autorest-customization</artifactId>
-+      <version>1.0.0-beta.8</version>
++      <version>1.0.0-beta.9</version>
 +    </dependency>
      <dependency>
        <groupId>com.azure</groupId>
@@ -69,7 +69,7 @@ index c99896650..358938595 100644
 -      <version>1.0.0-beta.1</version>
 +      <groupId>com.azure.tools</groupId>
 +      <artifactId>azure-autorest-customization</artifactId>
-+      <version>1.0.0-beta.8</version>
++      <version>1.0.0-beta.9</version>
      </dependency>
    </dependencies>
  

--- a/customization-base/CHANGELOG.md
+++ b/customization-base/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.0-beta.9 (2024-11-21)
+
+### Other Changes
+
+- Replaced model types in Eclipse language server with a dependency of LSP4J.
+
 ## 1.0.0-beta.8 (2023-11-03)
 
 ### Other Changes

--- a/customization-base/pom.xml
+++ b/customization-base/pom.xml
@@ -16,7 +16,7 @@
 
   <groupId>com.azure.tools</groupId>
   <artifactId>azure-autorest-customization</artifactId>
-  <version>1.0.0-beta.8</version>
+  <version>1.0.0-beta.9</version>
 
   <name>Microsoft Azure AutoRest for Java Customization</name>
   <description>This module contains the base classes needed for customizing a generated library.</description>

--- a/customization-tests/swagger/pom.xml
+++ b/customization-tests/swagger/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>com.azure.tools</groupId>
       <artifactId>azure-autorest-customization</artifactId>
-      <version>1.0.0-beta.8</version>
+      <version>1.0.0-beta.9</version>
     </dependency>
   </dependencies>
 </project>

--- a/fluentgen/src/main/resources/readme/pom.xml
+++ b/fluentgen/src/main/resources/readme/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.azure.tools</groupId>
       <artifactId>azure-autorest-customization</artifactId>
-      <version>1.0.0-beta.8</version>
+      <version>1.0.0-beta.9</version>
     </dependency>
   </dependencies>
 

--- a/javagen/src/main/resources/readme/pom.xml
+++ b/javagen/src/main/resources/readme/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.azure.tools</groupId>
       <artifactId>azure-autorest-customization</artifactId>
-      <version>1.0.0-beta.8</version>
+      <version>1.0.0-beta.9</version>
     </dependency>
   </dependencies>
 

--- a/typespec-tests/customization/pom.xml
+++ b/typespec-tests/customization/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>com.azure.tools</groupId>
       <artifactId>azure-autorest-customization</artifactId>
-      <version>1.0.0-beta.8</version>
+      <version>1.0.0-beta.9</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
There seems some problem in customization test. It appears to loading the azure-autorest-customization lib from Maven, instead of getting it from local installed lib (which we are testing). Not sure why though.