### PR TITLE
eng, bump typespec libs, prepare 0.27.0 release

### DIFF
--- a/typespec-extension/changelog.md
+++ b/typespec-extension/changelog.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 0.27.0 (2024-12-11)
+
+Compatible with compiler 0.63.
+
 ## 0.26.1 (2024-12-10)
 
 Compatible with compiler 0.62.

--- a/typespec-extension/package-lock.json
+++ b/typespec-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.26.1",
+  "version": "0.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/typespec-java",
-      "version": "0.26.1",
+      "version": "0.27.0",
       "license": "MIT",
       "dependencies": {
         "@autorest/codemodel": "~4.20.0",
@@ -14,46 +14,46 @@
         "lodash": "~4.17.21"
       },
       "devDependencies": {
-        "@azure-tools/typespec-autorest": "0.48.0",
-        "@azure-tools/typespec-azure-core": "0.48.0",
-        "@azure-tools/typespec-azure-resource-manager": "0.48.0",
-        "@azure-tools/typespec-azure-rulesets": "0.48.0",
-        "@azure-tools/typespec-client-generator-core": "0.48.5",
+        "@azure-tools/typespec-autorest": "0.49.0",
+        "@azure-tools/typespec-azure-core": "0.49.0",
+        "@azure-tools/typespec-azure-resource-manager": "0.49.0",
+        "@azure-tools/typespec-azure-rulesets": "0.49.0",
+        "@azure-tools/typespec-client-generator-core": "0.49.0",
         "@types/js-yaml": "~4.0.9",
         "@types/lodash": "~4.17.13",
-        "@types/mocha": "~10.0.9",
-        "@types/node": "~22.9.0",
-        "@typescript-eslint/eslint-plugin": "~8.14.0",
-        "@typescript-eslint/parser": "~8.14.0",
-        "@typespec/compiler": "0.62.0",
-        "@typespec/http": "0.62.0",
-        "@typespec/openapi": "0.62.0",
-        "@typespec/rest": "0.62.0",
-        "@typespec/versioning": "0.62.0",
-        "@typespec/xml": "0.62.0",
-        "c8": "~10.1.2",
+        "@types/mocha": "~10.0.10",
+        "@types/node": "~22.10.1",
+        "@typescript-eslint/eslint-plugin": "~8.18.0",
+        "@typescript-eslint/parser": "~8.18.0",
+        "@typespec/compiler": "0.63.0",
+        "@typespec/http": "0.63.0",
+        "@typespec/openapi": "0.63.0",
+        "@typespec/rest": "0.63.0",
+        "@typespec/versioning": "0.63.0",
+        "@typespec/xml": "0.63.0",
+        "c8": "~10.1.3",
         "eslint": "~8.57.0",
         "eslint-plugin-deprecation": "~3.0.0",
-        "mocha": "~10.8.2",
-        "prettier": "~3.3.3",
+        "mocha": "~11.0.1",
+        "prettier": "~3.4.2",
         "rimraf": "~6.0.1",
-        "typescript": "~5.6.3"
+        "typescript": "~5.7.2"
       },
       "engines": {
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-autorest": ">=0.48.0 <1.0.0",
-        "@azure-tools/typespec-azure-core": ">=0.48.0 <1.0.0",
-        "@azure-tools/typespec-azure-resource-manager": ">=0.48.0 <1.0.0",
-        "@azure-tools/typespec-azure-rulesets": ">=0.48.0 <1.0.0",
-        "@azure-tools/typespec-client-generator-core": ">=0.48.5 <1.0.0",
-        "@typespec/compiler": ">=0.62.0 <1.0.0",
-        "@typespec/http": ">=0.62.0 <1.0.0",
-        "@typespec/openapi": ">=0.62.0 <1.0.0",
-        "@typespec/rest": ">=0.62.0 <1.0.0",
-        "@typespec/versioning": ">=0.62.0 <1.0.0",
-        "@typespec/xml": ">=0.62.0 <1.0.0"
+        "@azure-tools/typespec-autorest": ">=0.49.0 <1.0.0",
+        "@azure-tools/typespec-azure-core": ">=0.49.0 <1.0.0",
+        "@azure-tools/typespec-azure-resource-manager": ">=0.49.0 <1.0.0",
+        "@azure-tools/typespec-azure-rulesets": ">=0.49.0 <1.0.0",
+        "@azure-tools/typespec-client-generator-core": ">=0.49.0 <1.0.0",
+        "@typespec/compiler": ">=0.63.0 <1.0.0",
+        "@typespec/http": ">=0.63.0 <1.0.0",
+        "@typespec/openapi": ">=0.63.0 <1.0.0",
+        "@typespec/rest": ">=0.63.0 <1.0.0",
+        "@typespec/versioning": ">=0.63.0 <1.0.0",
+        "@typespec/xml": ">=0.63.0 <1.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -106,78 +106,44 @@
       }
     },
     "node_modules/@azure-tools/typespec-autorest": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.48.0.tgz",
-      "integrity": "sha512-AyoNMq3EORugHynFF8bN0TJh+zYxui/ApU5DoVEL7Xr1yMD6k9p5b90VD4HiCsP0dz8470ApFnjt5Vl6xCSzig==",
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.49.0.tgz",
+      "integrity": "sha512-stwfhmEc3yPeXbM8yfLKVCtaX5mR0H+sL74Xy/eMdEWoJgiE3aJxkgRWESu/7/vo99vugzo/HRwIEO5ELnyfRg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "~0.48.0",
-        "@azure-tools/typespec-azure-resource-manager": "~0.48.0",
-        "@azure-tools/typespec-client-generator-core": "~0.48.0",
-        "@typespec/compiler": "~0.62.0",
-        "@typespec/http": "~0.62.0",
-        "@typespec/openapi": "~0.62.0",
-        "@typespec/rest": "~0.62.0",
-        "@typespec/versioning": "~0.62.0"
+        "@azure-tools/typespec-azure-core": "~0.49.0",
+        "@azure-tools/typespec-azure-resource-manager": "~0.49.0",
+        "@azure-tools/typespec-client-generator-core": "~0.49.0",
+        "@typespec/compiler": "~0.63.0",
+        "@typespec/http": "~0.63.0",
+        "@typespec/openapi": "~0.63.0",
+        "@typespec/rest": "~0.63.0",
+        "@typespec/versioning": "~0.63.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-core": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.48.0.tgz",
-      "integrity": "sha512-80qyqgTgBbrnCGXtz6eWAMBdEAjYVVL780L0Ye+rBEd6VoA0m3JrgzUqf5bC0Iwju6lEtBAb8o6sefKD/NGA7g==",
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.49.0.tgz",
+      "integrity": "sha512-hNKy+aePmPkB1brHQkO1tsJXqXPzt/9ehy10dv0rKdp9xq5dE3yBctHF5Aj3Nr8kr8GRG5z4KYpYPbV5guoT5w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~0.62.0",
-        "@typespec/http": "~0.62.0",
-        "@typespec/rest": "~0.62.0"
+        "@typespec/compiler": "~0.63.0",
+        "@typespec/http": "~0.63.0",
+        "@typespec/rest": "~0.63.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-resource-manager": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.48.0.tgz",
-      "integrity": "sha512-4JxPbKxd3EJ98sLbtfBlqyANWVrU6tT2nk3iLspg7MITPLhiMTeRT9BprsJXH18ks8qw8scR7/am5r57YERTmQ==",
-      "dev": true,
-      "dependencies": {
-        "change-case": "~5.4.4",
-        "pluralize": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "~0.48.0",
-        "@typespec/compiler": "~0.62.0",
-        "@typespec/http": "~0.62.0",
-        "@typespec/openapi": "~0.62.0",
-        "@typespec/rest": "~0.62.0",
-        "@typespec/versioning": "~0.62.0"
-      }
-    },
-    "node_modules/@azure-tools/typespec-azure-rulesets": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.48.0.tgz",
-      "integrity": "sha512-IkPxC8v9wVSl/eKU7N4NhqD3RPh+bIYpxDW5LBAhkuQVcE3RumAkWqh2pmkckihQRhgwiCXhcJVZAzBpVa5SUA==",
-      "dev": true,
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "~0.48.0",
-        "@azure-tools/typespec-azure-resource-manager": "~0.48.0",
-        "@azure-tools/typespec-client-generator-core": "~0.48.0",
-        "@typespec/compiler": "~0.62.0"
-      }
-    },
-    "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.48.5",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.48.5.tgz",
-      "integrity": "sha512-oAGyH99f3FMzTVE82A/hHupMlpDhxBUTL63wCUab9DM6Rqk+liBGobGl/EPdiOxpvcvhm1drEhkFCkqJt6JenA==",
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.49.0.tgz",
+      "integrity": "sha512-1xWuG8OBJDykYM6BFD2owV9WH+oC32zt7XteXA0T4nH2T+D+sEFKppkCOMtIjX7ENBAlecmbdwgSNTZYQf4vaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -188,12 +154,51 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "~0.48.0",
-        "@typespec/compiler": "~0.62.0",
-        "@typespec/http": "~0.62.0",
-        "@typespec/openapi": "~0.62.0",
-        "@typespec/rest": "~0.62.0",
-        "@typespec/versioning": "~0.62.0"
+        "@azure-tools/typespec-azure-core": "~0.49.0",
+        "@typespec/compiler": "~0.63.0",
+        "@typespec/http": "~0.63.0",
+        "@typespec/openapi": "~0.63.0",
+        "@typespec/rest": "~0.63.0",
+        "@typespec/versioning": "~0.63.0"
+      }
+    },
+    "node_modules/@azure-tools/typespec-azure-rulesets": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.49.0.tgz",
+      "integrity": "sha512-qKynK3lp+eqlt6QPGFSptrt9uqJUfeuv6yVXYDuaX1Jqu7tbTAgGf0HtN8mqPzfu3eAb84bdq6VgNspxyXLDOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@azure-tools/typespec-azure-core": "~0.49.0",
+        "@azure-tools/typespec-azure-resource-manager": "~0.49.0",
+        "@azure-tools/typespec-client-generator-core": "~0.49.0",
+        "@typespec/compiler": "~0.63.0"
+      }
+    },
+    "node_modules/@azure-tools/typespec-client-generator-core": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.49.0.tgz",
+      "integrity": "sha512-inFLRIeTU0mQg4PT19O3YwT/4YODLuTgIsXuhKDdG/sEsx8PG8AEFTabtnZJ0w3Lc4xuxKFJrzZ2ZH2iiAAbig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "change-case": "~5.4.4",
+        "pluralize": "^8.0.0",
+        "yaml": "~2.5.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@azure-tools/typespec-azure-core": "~0.49.0",
+        "@typespec/compiler": "~0.63.0",
+        "@typespec/http": "~0.63.0",
+        "@typespec/openapi": "~0.63.0",
+        "@typespec/rest": "~0.63.0",
+        "@typespec/versioning": "~0.63.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -234,9 +239,14 @@
       }
     },
     "node_modules/@bcoe/v8-coverage": {
-      "version": "0.2.3",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.1.tgz",
+      "integrity": "sha512-W+a0/JpU28AqH4IKtwUPcEUnUyXMDLALcn5/JLczGGT9fHE2sIby/xP/oQnx3nxkForzgzPy201RAKcB4xPAFQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -593,33 +603,34 @@
       "license": "MIT"
     },
     "node_modules/@types/mocha": {
-      "version": "10.0.9",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.9.tgz",
-      "integrity": "sha512-sicdRoWtYevwxjOHNMPTl3vSfJM6oyW8o1wXeI7uww6b6xHg8eBznQDNSGBCDJmsE8UMxP05JgZRtsKbTqt//Q==",
-      "dev": true
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
-      "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
+      "version": "22.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
+      "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.8"
+        "undici-types": "~6.20.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.14.0.tgz",
-      "integrity": "sha512-tqp8H7UWFaZj0yNO6bycd5YjMwxa6wIHOLZvWPkidwbgLCsBMetQoGj7DPuAlWa2yGO3H48xmPwjhsSPPCGU5w==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.18.0.tgz",
+      "integrity": "sha512-NR2yS7qUqCL7AIxdJUQf2MKKNDVNaig/dEB0GBLU7D+ZdHgK1NoH/3wsgO3OnPVipn51tG3MAwaODEGil70WEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.14.0",
-        "@typescript-eslint/type-utils": "8.14.0",
-        "@typescript-eslint/utils": "8.14.0",
-        "@typescript-eslint/visitor-keys": "8.14.0",
+        "@typescript-eslint/scope-manager": "8.18.0",
+        "@typescript-eslint/type-utils": "8.18.0",
+        "@typescript-eslint/utils": "8.18.0",
+        "@typescript-eslint/visitor-keys": "8.18.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -634,25 +645,21 @@
       },
       "peerDependencies": {
         "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
-        "eslint": "^8.57.0 || ^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.8.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.14.0.tgz",
-      "integrity": "sha512-2p82Yn9juUJq0XynBXtFCyrBDb6/dJombnz6vbo6mgQEtWHfvHbQuEa9kAOVIt1c9YFwi7H6WxtPj1kg+80+RA==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.18.0.tgz",
+      "integrity": "sha512-hgUZ3kTEpVzKaK3uNibExUYm6SKKOmTU2BOxBSvOYwtJEPdVQ70kZJpPjstlnhCHcuc2WGfSbpKlb/69ttyN5Q==",
       "dev": true,
-      "license": "BSD-2-Clause",
+      "license": "MITClause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.14.0",
-        "@typescript-eslint/types": "8.14.0",
-        "@typescript-eslint/typescript-estree": "8.14.0",
-        "@typescript-eslint/visitor-keys": "8.14.0",
+        "@typescript-eslint/scope-manager": "8.18.0",
+        "@typescript-eslint/types": "8.18.0",
+        "@typescript-eslint/typescript-estree": "8.18.0",
+        "@typescript-eslint/visitor-keys": "8.18.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -663,23 +670,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.8.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.14.0.tgz",
-      "integrity": "sha512-aBbBrnW9ARIDn92Zbo7rguLnqQ/pOrUguVpbUwzOhkFg2npFDwTgPGqFqE0H5feXcOoJOfX3SxlJaKEVtq54dw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.18.0.tgz",
+      "integrity": "sha512-PNGcHop0jkK2WVYGotk/hxj+UFLhXtGPiGtiaWgVBVP1jhMoMCHlTyJA+hEj4rszoSdLTK3fN4oOatrL0Cp+Xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.14.0",
-        "@typescript-eslint/visitor-keys": "8.14.0"
+        "@typescript-eslint/types": "8.18.0",
+        "@typescript-eslint/visitor-keys": "8.18.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -690,14 +693,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.14.0.tgz",
-      "integrity": "sha512-Xcz9qOtZuGusVOH5Uk07NGs39wrKkf3AxlkK79RBK6aJC1l03CobXjJbwBPSidetAOV+5rEVuiT1VSBUOAsanQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.18.0.tgz",
+      "integrity": "sha512-er224jRepVAVLnMF2Q7MZJCq5CsdH2oqjP4dT7K6ij09Kyd+R21r7UVJrF0buMVdZS5QRhDzpvzAxHxabQadow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.14.0",
-        "@typescript-eslint/utils": "8.14.0",
+        "@typescript-eslint/typescript-estree": "8.18.0",
+        "@typescript-eslint/utils": "8.18.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -708,16 +711,15 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.8.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.14.0.tgz",
-      "integrity": "sha512-yjeB9fnO/opvLJFAsPNYlKPnEM8+z4og09Pk504dkqonT02AyL5Z9SSqlE0XqezS93v6CXn49VHvB2G7XSsl0g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.18.0.tgz",
+      "integrity": "sha512-FNYxgyTCAnFwTrzpBGq+zrnoTO4x0c1CKYY5MuUTzpScqmY5fmsh2o3+57lqdI3NZucBDCzDgdEbIaNfAjAHQA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -729,14 +731,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.14.0.tgz",
-      "integrity": "sha512-OPXPLYKGZi9XS/49rdaCbR5j/S14HazviBlUQFvSKz3npr3NikF+mrgK7CFVur6XEt95DZp/cmke9d5i3vtVnQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.18.0.tgz",
+      "integrity": "sha512-rqQgFRu6yPkauz+ms3nQpohwejS8bvgbPyIDq13cgEDbkXt4LH4OkDMT0/fN1RUtzG8e8AKJyDBoocuQh8qNeg==",
       "dev": true,
-      "license": "BSD-2-Clause",
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.14.0",
-        "@typescript-eslint/visitor-keys": "8.14.0",
+        "@typescript-eslint/types": "8.18.0",
+        "@typescript-eslint/visitor-keys": "8.18.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -751,23 +753,21 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.8.0"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.14.0.tgz",
-      "integrity": "sha512-OGqj6uB8THhrHj0Fk27DcHPojW7zKwKkPmHXHvQ58pLYp4hy8CSUdTKykKeh+5vFqTTVmjz0zCOOPKRovdsgHA==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.18.0.tgz",
+      "integrity": "sha512-p6GLdY383i7h5b0Qrfbix3Vc3+J2k6QWw6UMUeY5JGfm3C5LbZ4QIZzJNoNOfgyRe0uuYKjvVOsO/jD4SJO+xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.14.0",
-        "@typescript-eslint/types": "8.14.0",
-        "@typescript-eslint/typescript-estree": "8.14.0"
+        "@typescript-eslint/scope-manager": "8.18.0",
+        "@typescript-eslint/types": "8.18.0",
+        "@typescript-eslint/typescript-estree": "8.18.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -777,18 +777,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0"
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.8.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.14.0.tgz",
-      "integrity": "sha512-vG0XZo8AdTH9OE6VFRwAZldNc7qtJ/6NLGWak+BtENuEUXGZgFpihILPiBvKXvJ2nFu27XNGC6rKiwuaoMbYzQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.18.0.tgz",
+      "integrity": "sha512-pCh/qEA8Lb1wVIqNvBke8UaRjJ6wrAWkJO5yyIbs8Yx6TNGYyfNjOo61tLv+WwLvoLPp4BQ8B7AHKijl8NGUfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.14.0",
-        "eslint-visitor-keys": "^3.4.3"
+        "@typescript-eslint/types": "8.18.0",
+        "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -798,18 +799,32 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typespec/compiler": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-0.62.0.tgz",
-      "integrity": "sha512-RfKJ/rF2Wjxu7dl74oJE8yEfSkeL7NopFlyJ4dW1JQXpRN2IOJYPxas12qZA6H9ZEIB8rBjyrHNxJSQbvn/UDQ==",
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
       "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@typespec/compiler": {
+      "version": "0.63.0",
+      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-0.63.0.tgz",
+      "integrity": "sha512-cC3YniwbFghn1fASX3r1IgNjMrwaY4gmzznkHT4f/NxE+HK4XoXWn4EG7287QgVMCaHUykzJCIfW9k7kIleW5A==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "~7.25.7",
         "ajv": "~8.17.1",
         "change-case": "~5.4.4",
         "globby": "~14.0.2",
         "mustache": "~4.2.0",
-        "picocolors": "~1.1.0",
+        "picocolors": "~1.1.1",
         "prettier": "~3.3.3",
         "prompts": "~2.4.2",
         "semver": "^7.6.3",
@@ -857,6 +872,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@typespec/compiler/node_modules/prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/@typespec/compiler/node_modules/slash": {
       "version": "5.1.0",
       "dev": true,
@@ -869,16 +900,17 @@
       }
     },
     "node_modules/@typespec/http": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-0.62.0.tgz",
-      "integrity": "sha512-6H9y9e32lb2s76MMy29ITCwSZNG42sa/qWthiByUvfbTEXMpu5a1fQHNj7RXg+xmDKmVIHv3gAfjGPAWfXhkaQ==",
+      "version": "0.63.0",
+      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-0.63.0.tgz",
+      "integrity": "sha512-SYVbBmLPAPdWZfdMs0QlbpTnFREDnkINu2FR+0kRX12qzbRgpRbLsdhg59qx4TfKoh4IAPgSV+Fq84w7BWGsyQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~0.62.0",
-        "@typespec/streams": "~0.62.0"
+        "@typespec/compiler": "~0.63.0",
+        "@typespec/streams": "~0.63.0"
       },
       "peerDependenciesMeta": {
         "@typespec/streams": {
@@ -887,53 +919,57 @@
       }
     },
     "node_modules/@typespec/openapi": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-0.62.0.tgz",
-      "integrity": "sha512-Xtm0Nd2BuSmEfSWGtc10ok22jyomYm9L2jY+kVTy+v5J89DrVh0o6+YpipUl1QhcItM1YMBphWHIHPfwkDRbnw==",
+      "version": "0.63.0",
+      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-0.63.0.tgz",
+      "integrity": "sha512-/KzR60mj3P/LnNWd/QfH0KTN/If4+mjrsWNSB7/uab6c8Qu/lNsGlZDkmWq4EFiwBR7VmpdFz9FP7d/m3O+tGw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~0.62.0",
-        "@typespec/http": "~0.62.0"
+        "@typespec/compiler": "~0.63.0",
+        "@typespec/http": "~0.63.0"
       }
     },
     "node_modules/@typespec/rest": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.62.0.tgz",
-      "integrity": "sha512-ci5UjelEKFwsPTdpgysoUoDCcw02EnbG4GBuYJdR5mRrFCBZMxrbro+OJLgSN3g/TORSsWlW7dEOWLfbyrmlZQ==",
+      "version": "0.63.0",
+      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.63.0.tgz",
+      "integrity": "sha512-HftzMjSDHAYX+ILE9C6pFS4oAq7oBHMCtpA8QgSFPDF4V5a8l1k2K8c4x1B+7yl+GkREmIdtpc6S0xZm2G7hXg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~0.62.0",
-        "@typespec/http": "~0.62.0"
+        "@typespec/compiler": "~0.63.0",
+        "@typespec/http": "~0.63.0"
       }
     },
     "node_modules/@typespec/versioning": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.62.0.tgz",
-      "integrity": "sha512-M5KTCVH5fBniZU8eQlw+NV13vAmPr58HyBLDIyxeOuV+SHNlx+f+qanUEDIPaJheKlaSSNTEZKsDhs83/iIMMA==",
+      "version": "0.63.0",
+      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.63.0.tgz",
+      "integrity": "sha512-BPvmPL+g20yEmSA8XRfbIHdToNOjssq4QfwOU6D7kKLLXnZHFb1hmuwW0tf0Wa/lYgoaUC60ONAeoXgNT1ZOIQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~0.62.0"
+        "@typespec/compiler": "~0.63.0"
       }
     },
     "node_modules/@typespec/xml": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.62.0.tgz",
-      "integrity": "sha512-DexGTQHB75fncDcYfs5CIbNwO6NOhjwCaaNoHYAsVVzs4T8qwzw6WQdEEMzZRbgsxwnllFkxKwGhLtRMQdv/cQ==",
+      "version": "0.63.0",
+      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.63.0.tgz",
+      "integrity": "sha512-2aQxWWqc5f4OTmC2nNafHi+ppr8GqwwMXx/2DnNjeshZF/JD0FNCYH8gV4gFZe7mfRfB9bAxNkcKj2AF01ntqA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~0.62.0"
+        "@typespec/compiler": "~0.63.0"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -1075,11 +1111,13 @@
       "license": "ISC"
     },
     "node_modules/c8": {
-      "version": "10.1.2",
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-10.1.3.tgz",
+      "integrity": "sha512-LvcyrOAaOnrrlMpW22n690PUvxiq4Uf9WMhQwNJ9vgagkL/ph1+D4uvjvDA5XCbykrc0sx+ay6pVi9YZ1GnhyA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@bcoe/v8-coverage": "^0.2.3",
+        "@bcoe/v8-coverage": "^1.0.1",
         "@istanbuljs/schema": "^0.1.3",
         "find-up": "^5.0.0",
         "foreground-child": "^3.1.1",
@@ -2428,9 +2466,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "10.8.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
-      "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.0.1.tgz",
+      "integrity": "sha512-+3GkODfsDG71KSCQhc4IekSW+ItCK/kiez1Z28ksWvYhKXV/syxMlerR/sC7whDp7IyreZ4YxceMLdTs5hQE8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2441,7 +2479,7 @@
         "diff": "^5.2.0",
         "escape-string-regexp": "^4.0.0",
         "find-up": "^5.0.0",
-        "glob": "^8.1.0",
+        "glob": "^10.4.5",
         "he": "^1.2.0",
         "js-yaml": "^4.1.0",
         "log-symbols": "^4.1.0",
@@ -2460,7 +2498,7 @@
         "mocha": "bin/mocha.js"
       },
       "engines": {
-        "node": ">= 14.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/mocha/node_modules/cliui": {
@@ -2485,18 +2523,37 @@
       }
     },
     "node_modules/mocha/node_modules/glob": {
-      "version": "8.1.0",
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2510,8 +2567,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/mocha/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/mocha/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/mocha/node_modules/minimatch": {
       "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2525,6 +2607,23 @@
       "version": "2.1.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mocha/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/mocha/node_modules/supports-color": {
       "version": "8.1.1",
@@ -2745,7 +2844,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.3",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3243,10 +3344,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3256,10 +3358,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unicorn-magic": {
       "version": "0.1.0",

--- a/typespec-extension/package.json
+++ b/typespec-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.26.1",
+  "version": "0.27.0",
   "description": "TypeSpec library for emitting Java client from the TypeSpec REST protocol binding",
   "keywords": [
     "TypeSpec"
@@ -45,17 +45,17 @@
     "generator/http-client-generator/target/emitter.jar"
   ],
   "peerDependencies": {
-    "@azure-tools/typespec-azure-core": ">=0.48.0 <1.0.0",
-    "@azure-tools/typespec-azure-resource-manager": ">=0.48.0 <1.0.0",
-    "@azure-tools/typespec-autorest": ">=0.48.0 <1.0.0",
-    "@azure-tools/typespec-azure-rulesets": ">=0.48.0 <1.0.0",
-    "@azure-tools/typespec-client-generator-core": ">=0.48.5 <1.0.0",
-    "@typespec/compiler": ">=0.62.0 <1.0.0",
-    "@typespec/http": ">=0.62.0 <1.0.0",
-    "@typespec/openapi": ">=0.62.0 <1.0.0",
-    "@typespec/rest": ">=0.62.0 <1.0.0",
-    "@typespec/versioning": ">=0.62.0 <1.0.0",
-    "@typespec/xml": ">=0.62.0 <1.0.0"
+    "@azure-tools/typespec-azure-core": ">=0.49.0 <1.0.0",
+    "@azure-tools/typespec-azure-resource-manager": ">=0.49.0 <1.0.0",
+    "@azure-tools/typespec-autorest": ">=0.49.0 <1.0.0",
+    "@azure-tools/typespec-azure-rulesets": ">=0.49.0 <1.0.0",
+    "@azure-tools/typespec-client-generator-core": ">=0.49.0 <1.0.0",
+    "@typespec/compiler": ">=0.63.0 <1.0.0",
+    "@typespec/http": ">=0.63.0 <1.0.0",
+    "@typespec/openapi": ">=0.63.0 <1.0.0",
+    "@typespec/rest": ">=0.63.0 <1.0.0",
+    "@typespec/versioning": ">=0.63.0 <1.0.0",
+    "@typespec/xml": ">=0.63.0 <1.0.0"
   },
   "dependencies": {
     "@autorest/codemodel": "~4.20.0",
@@ -63,29 +63,29 @@
     "lodash": "~4.17.21"
   },
   "devDependencies": {
-    "@azure-tools/typespec-azure-core": "0.48.0",
-    "@azure-tools/typespec-azure-resource-manager": "0.48.0",
-    "@azure-tools/typespec-autorest": "0.48.0",
-    "@azure-tools/typespec-azure-rulesets": "0.48.0",
-    "@azure-tools/typespec-client-generator-core": "0.48.5",
+    "@azure-tools/typespec-azure-core": "0.49.0",
+    "@azure-tools/typespec-azure-resource-manager": "0.49.0",
+    "@azure-tools/typespec-autorest": "0.49.0",
+    "@azure-tools/typespec-azure-rulesets": "0.49.0",
+    "@azure-tools/typespec-client-generator-core": "0.49.0",
     "@types/js-yaml": "~4.0.9",
     "@types/lodash": "~4.17.13",
-    "@types/mocha": "~10.0.9",
-    "@types/node": "~22.9.0",
-    "@typescript-eslint/eslint-plugin": "~8.14.0",
-    "@typescript-eslint/parser": "~8.14.0",
-    "@typespec/compiler": "0.62.0",
-    "@typespec/http": "0.62.0",
-    "@typespec/openapi": "0.62.0",
-    "@typespec/rest": "0.62.0",
-    "@typespec/versioning": "0.62.0",
-    "@typespec/xml": "0.62.0",
-    "c8": "~10.1.2",
+    "@types/mocha": "~10.0.10",
+    "@types/node": "~22.10.1",
+    "@typescript-eslint/eslint-plugin": "~8.18.0",
+    "@typescript-eslint/parser": "~8.18.0",
+    "@typespec/compiler": "0.63.0",
+    "@typespec/http": "0.63.0",
+    "@typespec/openapi": "0.63.0",
+    "@typespec/rest": "0.63.0",
+    "@typespec/versioning": "0.63.0",
+    "@typespec/xml": "0.63.0",
+    "c8": "~10.1.3",
     "eslint": "~8.57.0",
     "eslint-plugin-deprecation": "~3.0.0",
-    "mocha": "~10.8.2",
-    "prettier": "~3.3.3",
+    "mocha": "~11.0.1",
+    "prettier": "~3.4.2",
     "rimraf": "~6.0.1",
-    "typescript": "~5.6.3"
+    "typescript": "~5.7.2"
   }
 }

--- a/typespec-extension/readme.md
+++ b/typespec-extension/readme.md
@@ -6,7 +6,7 @@ Install [Java](https://docs.microsoft.com/java/openjdk/download) 11 or above. (V
 
 Install [Maven](https://maven.apache.org/install.html). (Verify by running `mvn --version`)
 
-Install [TypeSpec](https://typespec.io/) 0.62.
+Install [TypeSpec](https://typespec.io/) 0.63.
 
 # Initialize TypeSpec Project
 

--- a/typespec-tests/package.json
+++ b/typespec-tests/package.json
@@ -9,7 +9,7 @@
     "testserver-run": "npx cadl-ranch serve ./node_modules/@azure-tools/cadl-ranch-specs/http --coverageFile ./cadl-ranch-coverage-java.json"
   },
   "dependencies": {
-    "@azure-tools/cadl-ranch-specs": "0.39.4",
+    "@azure-tools/cadl-ranch-specs": "0.39.5",
     "@azure-tools/typespec-java": "file:/../typespec-extension/azure-tools-typespec-java-0.26.1.tgz"
   },
   "devDependencies": {

--- a/typespec-tests/package.json
+++ b/typespec-tests/package.json
@@ -10,24 +10,24 @@
   },
   "dependencies": {
     "@azure-tools/cadl-ranch-specs": "0.39.5",
-    "@azure-tools/typespec-java": "file:/../typespec-extension/azure-tools-typespec-java-0.26.1.tgz"
+    "@azure-tools/typespec-java": "file:/../typespec-extension/azure-tools-typespec-java-0.27.0.tgz"
   },
   "devDependencies": {
-    "@typespec/prettier-plugin-typespec": "~0.62.0",
+    "@typespec/prettier-plugin-typespec": "~0.63.0",
     "prettier-plugin-organize-imports": "4.1.0",
-    "prettier": "~3.3.3"
+    "prettier": "~3.4.2"
   },
   "overrides": {
-    "@typespec/compiler": "~0.62.0",
-    "@typespec/http": "~0.62.0",
-    "@typespec/rest": "~0.62.0",
-    "@typespec/versioning": "~0.62.0",
-    "@typespec/openapi": "~0.62.0",
-    "@typespec/xml": "~0.62.0",
-    "@azure-tools/typespec-azure-core": "~0.48.0",
-    "@azure-tools/typespec-client-generator-core": "~0.48.0",
-    "@azure-tools/typespec-azure-resource-manager": "~0.48.0",
-    "@azure-tools/typespec-autorest": "~0.48.0"
+    "@typespec/compiler": "~0.63.0",
+    "@typespec/http": "~0.63.0",
+    "@typespec/rest": "~0.63.0",
+    "@typespec/versioning": "~0.63.0",
+    "@typespec/openapi": "~0.63.0",
+    "@typespec/xml": "~0.63.0",
+    "@azure-tools/typespec-azure-core": "~0.49.0",
+    "@azure-tools/typespec-client-generator-core": "~0.49.0",
+    "@azure-tools/typespec-azure-resource-manager": "~0.49.0",
+    "@azure-tools/typespec-autorest": "~0.49.0"
   },
   "private": true
 }

--- a/typespec-tests/src/main/java/tsptest/armresourceprovider/fluent/models/OperationInner.java
+++ b/typespec-tests/src/main/java/tsptest/armresourceprovider/fluent/models/OperationInner.java
@@ -32,7 +32,7 @@ public final class OperationInner {
     /*
      * Localized display information for this particular operation.
      */
-    @JsonProperty(value = "display", access = JsonProperty.Access.WRITE_ONLY)
+    @JsonProperty(value = "display")
     private OperationDisplay display;
 
     /*
@@ -45,7 +45,7 @@ public final class OperationInner {
     /*
      * Extensible enum. Indicates the action type. "Internal" refers to actions that are for internal only APIs.
      */
-    @JsonProperty(value = "actionType")
+    @JsonProperty(value = "actionType", access = JsonProperty.Access.WRITE_ONLY)
     private ActionType actionType;
 
     /**

--- a/typespec-tests/src/main/java/tsptest/response/implementation/ResponseClientImpl.java
+++ b/typespec-tests/src/main/java/tsptest/response/implementation/ResponseClientImpl.java
@@ -407,26 +407,6 @@ public final class ResponseClientImpl {
         Response<BinaryData> listStringsNextSync(@PathParam(value = "nextLink", encoded = true) String nextLink,
             @HostParam("endpoint") String endpoint, @HeaderParam("Accept") String accept, RequestOptions requestOptions,
             Context context);
-
-        @Get("{nextLink}")
-        @ExpectedResponses({ 200 })
-        @UnexpectedResponseExceptionType(value = ClientAuthenticationException.class, code = { 401 })
-        @UnexpectedResponseExceptionType(value = ResourceNotFoundException.class, code = { 404 })
-        @UnexpectedResponseExceptionType(value = ResourceModifiedException.class, code = { 409 })
-        @UnexpectedResponseExceptionType(HttpResponseException.class)
-        Mono<Response<BinaryData>> listIntegersNext(@PathParam(value = "nextLink", encoded = true) String nextLink,
-            @HostParam("endpoint") String endpoint, @HeaderParam("Accept") String accept, RequestOptions requestOptions,
-            Context context);
-
-        @Get("{nextLink}")
-        @ExpectedResponses({ 200 })
-        @UnexpectedResponseExceptionType(value = ClientAuthenticationException.class, code = { 401 })
-        @UnexpectedResponseExceptionType(value = ResourceNotFoundException.class, code = { 404 })
-        @UnexpectedResponseExceptionType(value = ResourceModifiedException.class, code = { 409 })
-        @UnexpectedResponseExceptionType(HttpResponseException.class)
-        Response<BinaryData> listIntegersNextSync(@PathParam(value = "nextLink", encoded = true) String nextLink,
-            @HostParam("endpoint") String endpoint, @HeaderParam("Accept") String accept, RequestOptions requestOptions,
-            Context context);
     }
 
     /**
@@ -1290,7 +1270,7 @@ public final class ResponseClientImpl {
         return FluxUtil
             .withContext(context -> service.listIntegers(this.getEndpoint(), accept, requestOptions, context))
             .map(res -> new PagedResponseBase<>(res.getRequest(), res.getStatusCode(), res.getHeaders(),
-                getValues(res.getValue(), "value"), getNextLink(res.getValue(), "nextLink"), null));
+                getValues(res.getValue(), "value"), null, null));
     }
 
     /**
@@ -1312,11 +1292,7 @@ public final class ResponseClientImpl {
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedFlux<BinaryData> listIntegersAsync(RequestOptions requestOptions) {
-        RequestOptions requestOptionsForNextPage = new RequestOptions();
-        requestOptionsForNextPage.setContext(
-            requestOptions != null && requestOptions.getContext() != null ? requestOptions.getContext() : Context.NONE);
-        return new PagedFlux<>(() -> listIntegersSinglePageAsync(requestOptions),
-            nextLink -> listIntegersNextSinglePageAsync(nextLink, requestOptionsForNextPage));
+        return new PagedFlux<>(() -> listIntegersSinglePageAsync(requestOptions));
     }
 
     /**
@@ -1341,7 +1317,7 @@ public final class ResponseClientImpl {
         final String accept = "application/json";
         Response<BinaryData> res = service.listIntegersSync(this.getEndpoint(), accept, requestOptions, Context.NONE);
         return new PagedResponseBase<>(res.getRequest(), res.getStatusCode(), res.getHeaders(),
-            getValues(res.getValue(), "value"), getNextLink(res.getValue(), "nextLink"), null);
+            getValues(res.getValue(), "value"), null, null);
     }
 
     /**
@@ -1363,11 +1339,7 @@ public final class ResponseClientImpl {
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedIterable<BinaryData> listIntegers(RequestOptions requestOptions) {
-        RequestOptions requestOptionsForNextPage = new RequestOptions();
-        requestOptionsForNextPage.setContext(
-            requestOptions != null && requestOptions.getContext() != null ? requestOptions.getContext() : Context.NONE);
-        return new PagedIterable<>(() -> listIntegersSinglePage(requestOptions),
-            nextLink -> listIntegersNextSinglePage(nextLink, requestOptionsForNextPage));
+        return new PagedIterable<>(() -> listIntegersSinglePage(requestOptions));
     }
 
     /**
@@ -1536,62 +1508,6 @@ public final class ResponseClientImpl {
         final String accept = "application/json";
         Response<BinaryData> res
             = service.listStringsNextSync(nextLink, this.getEndpoint(), accept, requestOptions, Context.NONE);
-        return new PagedResponseBase<>(res.getRequest(), res.getStatusCode(), res.getHeaders(),
-            getValues(res.getValue(), "value"), getNextLink(res.getValue(), "nextLink"), null);
-    }
-
-    /**
-     * Get the next page of items.
-     * <p><strong>Response Body Schema</strong></p>
-     * 
-     * <pre>
-     * {@code
-     * int
-     * }
-     * </pre>
-     * 
-     * @param nextLink The URL to get the next list of items.
-     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @return the response body along with {@link PagedResponse} on successful completion of {@link Mono}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<BinaryData>> listIntegersNextSinglePageAsync(String nextLink,
-        RequestOptions requestOptions) {
-        final String accept = "application/json";
-        return FluxUtil
-            .withContext(
-                context -> service.listIntegersNext(nextLink, this.getEndpoint(), accept, requestOptions, context))
-            .map(res -> new PagedResponseBase<>(res.getRequest(), res.getStatusCode(), res.getHeaders(),
-                getValues(res.getValue(), "value"), getNextLink(res.getValue(), "nextLink"), null));
-    }
-
-    /**
-     * Get the next page of items.
-     * <p><strong>Response Body Schema</strong></p>
-     * 
-     * <pre>
-     * {@code
-     * int
-     * }
-     * </pre>
-     * 
-     * @param nextLink The URL to get the next list of items.
-     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @return the response body along with {@link PagedResponse}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    private PagedResponse<BinaryData> listIntegersNextSinglePage(String nextLink, RequestOptions requestOptions) {
-        final String accept = "application/json";
-        Response<BinaryData> res
-            = service.listIntegersNextSync(nextLink, this.getEndpoint(), accept, requestOptions, Context.NONE);
         return new PagedResponseBase<>(res.getRequest(), res.getStatusCode(), res.getHeaders(),
             getValues(res.getValue(), "value"), getNextLink(res.getValue(), "nextLink"), null);
     }

--- a/typespec-tests/src/main/java/tsptest/visibility/VisibilityAsyncClient.java
+++ b/typespec-tests/src/main/java/tsptest/visibility/VisibilityAsyncClient.java
@@ -75,6 +75,7 @@ public final class VisibilityAsyncClient {
      * <pre>
      * {@code
      * {
+     *     secretName: String (Required)
      *     name: String (Required)
      * }
      * }
@@ -113,7 +114,7 @@ public final class VisibilityAsyncClient {
      * <pre>
      * {@code
      * {
-     *     id: int (Required)
+     *     secretName: String (Required)
      *     name: String (Required)
      * }
      * }
@@ -125,7 +126,6 @@ public final class VisibilityAsyncClient {
      * {@code
      * {
      *     id: int (Required)
-     *     secretName: String (Required)
      *     name: String (Required)
      * }
      * }
@@ -237,11 +237,11 @@ public final class VisibilityAsyncClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Dog> query(ReadDog dog) {
+    public Mono<ReadDog> query(WriteDog dog) {
         // Generated convenience method for queryWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return queryWithResponse(BinaryData.fromObject(dog), requestOptions).flatMap(FluxUtil::toMono)
-            .map(protocolMethodData -> protocolMethodData.toObject(Dog.class));
+            .map(protocolMethodData -> protocolMethodData.toObject(ReadDog.class));
     }
 
     /**

--- a/typespec-tests/src/main/java/tsptest/visibility/VisibilityClient.java
+++ b/typespec-tests/src/main/java/tsptest/visibility/VisibilityClient.java
@@ -73,6 +73,7 @@ public final class VisibilityClient {
      * <pre>
      * {@code
      * {
+     *     secretName: String (Required)
      *     name: String (Required)
      * }
      * }
@@ -111,7 +112,7 @@ public final class VisibilityClient {
      * <pre>
      * {@code
      * {
-     *     id: int (Required)
+     *     secretName: String (Required)
      *     name: String (Required)
      * }
      * }
@@ -123,7 +124,6 @@ public final class VisibilityClient {
      * {@code
      * {
      *     id: int (Required)
-     *     secretName: String (Required)
      *     name: String (Required)
      * }
      * }
@@ -233,10 +233,10 @@ public final class VisibilityClient {
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Dog query(ReadDog dog) {
+    public ReadDog query(WriteDog dog) {
         // Generated convenience method for queryWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        return queryWithResponse(BinaryData.fromObject(dog), requestOptions).getValue().toObject(Dog.class);
+        return queryWithResponse(BinaryData.fromObject(dog), requestOptions).getValue().toObject(ReadDog.class);
     }
 
     /**

--- a/typespec-tests/src/main/java/tsptest/visibility/VisibilityWriteAsyncClient.java
+++ b/typespec-tests/src/main/java/tsptest/visibility/VisibilityWriteAsyncClient.java
@@ -46,6 +46,7 @@ public final class VisibilityWriteAsyncClient {
      * <pre>
      * {@code
      * {
+     *     secretName: String (Required)
      *     name: String (Required)
      * }
      * }

--- a/typespec-tests/src/main/java/tsptest/visibility/VisibilityWriteClient.java
+++ b/typespec-tests/src/main/java/tsptest/visibility/VisibilityWriteClient.java
@@ -44,6 +44,7 @@ public final class VisibilityWriteClient {
      * <pre>
      * {@code
      * {
+     *     secretName: String (Required)
      *     name: String (Required)
      * }
      * }

--- a/typespec-tests/src/main/java/tsptest/visibility/implementation/VisibilityClientImpl.java
+++ b/typespec-tests/src/main/java/tsptest/visibility/implementation/VisibilityClientImpl.java
@@ -296,6 +296,7 @@ public final class VisibilityClientImpl {
      * <pre>
      * {@code
      * {
+     *     secretName: String (Required)
      *     name: String (Required)
      * }
      * }
@@ -336,6 +337,7 @@ public final class VisibilityClientImpl {
      * <pre>
      * {@code
      * {
+     *     secretName: String (Required)
      *     name: String (Required)
      * }
      * }
@@ -375,7 +377,7 @@ public final class VisibilityClientImpl {
      * <pre>
      * {@code
      * {
-     *     id: int (Required)
+     *     secretName: String (Required)
      *     name: String (Required)
      * }
      * }
@@ -387,7 +389,6 @@ public final class VisibilityClientImpl {
      * {@code
      * {
      *     id: int (Required)
-     *     secretName: String (Required)
      *     name: String (Required)
      * }
      * }
@@ -416,7 +417,7 @@ public final class VisibilityClientImpl {
      * <pre>
      * {@code
      * {
-     *     id: int (Required)
+     *     secretName: String (Required)
      *     name: String (Required)
      * }
      * }
@@ -428,7 +429,6 @@ public final class VisibilityClientImpl {
      * {@code
      * {
      *     id: int (Required)
-     *     secretName: String (Required)
      *     name: String (Required)
      * }
      * }

--- a/typespec-tests/src/main/java/tsptest/visibility/implementation/VisibilityWritesImpl.java
+++ b/typespec-tests/src/main/java/tsptest/visibility/implementation/VisibilityWritesImpl.java
@@ -86,6 +86,7 @@ public final class VisibilityWritesImpl {
      * <pre>
      * {@code
      * {
+     *     secretName: String (Required)
      *     name: String (Required)
      * }
      * }
@@ -126,6 +127,7 @@ public final class VisibilityWritesImpl {
      * <pre>
      * {@code
      * {
+     *     secretName: String (Required)
      *     name: String (Required)
      * }
      * }

--- a/typespec-tests/src/main/java/tsptest/visibility/models/ReadDog.java
+++ b/typespec-tests/src/main/java/tsptest/visibility/models/ReadDog.java
@@ -36,7 +36,7 @@ public final class ReadDog implements JsonSerializable<ReadDog> {
      * @param name the name value to set.
      */
     @Generated
-    public ReadDog(int id, String name) {
+    private ReadDog(int id, String name) {
         this.id = id;
         this.name = name;
     }

--- a/typespec-tests/src/main/java/tsptest/visibility/models/WriteDog.java
+++ b/typespec-tests/src/main/java/tsptest/visibility/models/WriteDog.java
@@ -18,6 +18,12 @@ import java.io.IOException;
 @Immutable
 public final class WriteDog implements JsonSerializable<WriteDog> {
     /*
+     * The secretName property.
+     */
+    @Generated
+    private final String secretName;
+
+    /*
      * The name property.
      */
     @Generated
@@ -26,11 +32,23 @@ public final class WriteDog implements JsonSerializable<WriteDog> {
     /**
      * Creates an instance of WriteDog class.
      * 
+     * @param secretName the secretName value to set.
      * @param name the name value to set.
      */
     @Generated
-    public WriteDog(String name) {
+    public WriteDog(String secretName, String name) {
+        this.secretName = secretName;
         this.name = name;
+    }
+
+    /**
+     * Get the secretName property: The secretName property.
+     * 
+     * @return the secretName value.
+     */
+    @Generated
+    public String getSecretName() {
+        return this.secretName;
     }
 
     /**
@@ -50,6 +68,7 @@ public final class WriteDog implements JsonSerializable<WriteDog> {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
+        jsonWriter.writeStringField("secretName", this.secretName);
         jsonWriter.writeStringField("name", this.name);
         return jsonWriter.writeEndObject();
     }
@@ -66,18 +85,21 @@ public final class WriteDog implements JsonSerializable<WriteDog> {
     @Generated
     public static WriteDog fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
+            String secretName = null;
             String name = null;
             while (reader.nextToken() != JsonToken.END_OBJECT) {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("name".equals(fieldName)) {
+                if ("secretName".equals(fieldName)) {
+                    secretName = reader.getString();
+                } else if ("name".equals(fieldName)) {
                     name = reader.getString();
                 } else {
                     reader.skipChildren();
                 }
             }
-            return new WriteDog(name);
+            return new WriteDog(secretName, name);
         });
     }
 }

--- a/typespec-tests/tsp/error.tsp
+++ b/typespec-tests/tsp/error.tsp
@@ -16,7 +16,10 @@ model Diagnostic {
   error: Error;
 }
 
+@error
+model NotFoundErrorResponse is NotFoundResponse;
+
 @route("/error")
 interface ErrorOp {
-  read(): ResourceCreatedOrOkResponse<Diagnostic> | ErrorResponse;
+  read(): ResourceCreatedOrOkResponse<Diagnostic> | NotFoundErrorResponse | ErrorResponse;
 }

--- a/typespec-tests/tsp/naming.tsp
+++ b/typespec-tests/tsp/naming.tsp
@@ -72,7 +72,6 @@ model BytesData extends Data {
   @doc("Data as {@code byte[]}")
   @clientName("dataAsBytes")
   @encodedName("application/json", "data_bytes")
-  @projectedName("client", "noeffect")
   data: bytes;
 }
 

--- a/typespec-tests/tsp/response.tsp
+++ b/typespec-tests/tsp/response.tsp
@@ -94,18 +94,12 @@ model StringsList {
 model Int32sList {
   @items
   value: int32[];
-
-  @nextLink
-  nextLink?: string;
 }
 
 @pagedResult
 model DateTimesList {
   @items
   value: utcDateTime[];
-
-  @nextLink
-  nextLink?: string;
 }
 
 op CustomLongRunningOperation<

--- a/typespec-tests/tsp/response.tsp
+++ b/typespec-tests/tsp/response.tsp
@@ -86,7 +86,7 @@ model StringsList {
   @items
   value: string[];
 
-  @global.Azure.Core.nextLink
+  @nextLink
   nextLink?: string;
 }
 
@@ -95,7 +95,7 @@ model Int32sList {
   @items
   value: int32[];
 
-  @global.Azure.Core.nextLink
+  @nextLink
   nextLink?: string;
 }
 
@@ -104,7 +104,7 @@ model DateTimesList {
   @items
   value: utcDateTime[];
 
-  @global.Azure.Core.nextLink
+  @nextLink
   nextLink?: string;
 }
 

--- a/typespec-tests/tsp/visibility.tsp
+++ b/typespec-tests/tsp/visibility.tsp
@@ -10,28 +10,27 @@ using Azure.ClientGenerator.Core;
 namespace TspTest.Visibility;
 
 model Dog {
-  @visibility("read") id: int32;
-  @visibility("update") secretName: string;
+  @visibility(Lifecycle.Read) id: int32;
+  @visibility(Lifecycle.Create, Lifecycle.Update) secretName: string;
 
-  // no flags are like specifying all flags at once, so in this case
-  // equivalent to @visibility("read", "write")
+  // no flags are same as specifying all Lifecycle
   name: string;
 }
 
 model RoundTripModel {
   name: string;
-  @visibility("create", "update") secretName: string;
+  @visibility(Lifecycle.Create, Lifecycle.Update) secretName: string;
 }
 
 // The spread operator will copy all the properties of Dog into ReadDog,
 // and withVisibility will remove any that don't match the current
 // visibility setting
-@withVisibility("read")
+@withVisibility(Lifecycle.Read)
 model ReadDog {
   ...Dog;
 }
 
-@withVisibility("write")
+@withVisibility(Lifecycle.Create, Lifecycle.Update)
 model WriteDog {
   ...Dog;
 }
@@ -58,8 +57,8 @@ interface VisibilityWrite {
 interface VisibilityOp extends VisibilityRead, VisibilityWrite {
   @post
   @route("/query")
-  query(@body dog: ReadDog): {
-    @body body: Dog;
+  query(@body dog: WriteDog): {
+    @body body: ReadDog;
   };
 
   @put


### PR DESCRIPTION
for TypeSpec 0.63 / 0.49

There is 5 lib failure, likely due to `nextLink` break.
Will sync after specs PR https://github.com/Azure/azure-rest-api-specs/pull/31832

Also there be added `resourceId` property https://github.com/Azure/typespec-azure/blob/main/packages/typespec-azure-resource-manager/lib/common-types/types.tsp#L222-L223