### PR TITLE
eng sync, pin spector and spec-api

### DIFF
--- a/typespec-tests/package.json
+++ b/typespec-tests/package.json
@@ -9,6 +9,8 @@
     "spector-serve": "tsp-spector serve ./node_modules/@typespec/http-specs/specs ./node_modules/@azure-tools/azure-http-specs/specs --coverageFile ./tsp-spector-coverage-java.json"
   },
   "dependencies": {
+    "@typespec/spec-api": "0.1.0-alpha.2",
+    "@typespec/spector": "0.1.0-alpha.9",
     "@typespec/http-specs": "0.1.0-alpha.15",
     "@azure-tools/azure-http-specs": "0.1.0-alpha.10",
     "@azure-tools/typespec-java": "file:/../typespec-extension/azure-tools-typespec-java-0.28.0.tgz"


### PR DESCRIPTION
I kind of remember why a lock file is hard in test.

We build locally the tgz of emitter package and use it in test, so generally we do `npm install` instead of `npm ci` in test module.