### PR TITLE
eng, unify pool from image.yml

### DIFF
--- a/eng/pipelines/ci-typespec-java-dev-nightly.yaml
+++ b/eng/pipelines/ci-typespec-java-dev-nightly.yaml
@@ -16,10 +16,12 @@ jobs:
 
     variables:
       - template: /eng/pipelines/variables/globals.yml
+      - template: /eng/pipelines/variables/image.yml
 
     pool:
-      name: "azsdk-pool-mms-ubuntu-2004-general"
-      vmImage: "MMSUbuntu20.04"
+      name: $(LINUXPOOL)
+      image: $(LINUXVMIMAGE)
+      os: linux
 
     steps:
       - checkout: self

--- a/eng/pipelines/ci-typespec-java.yaml
+++ b/eng/pipelines/ci-typespec-java.yaml
@@ -30,12 +30,14 @@ jobs:
 
     variables:
       - template: /eng/pipelines/variables/globals.yml
+      - template: /eng/pipelines/variables/image.yml
       - name: isMain
         value: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
 
     pool:
-      name: "azsdk-pool-mms-ubuntu-2004-general"
-      vmImage: "MMSUbuntu20.04"
+      name: $(LINUXPOOL)
+      image: $(LINUXVMIMAGE)
+      os: linux
 
     steps:
       - checkout: self

--- a/eng/pipelines/ci.yaml
+++ b/eng/pipelines/ci.yaml
@@ -26,10 +26,12 @@ jobs:
 
     variables:
       - template: /eng/pipelines/variables/globals.yml
+      - template: /eng/pipelines/variables/image.yml
 
     pool:
-      name: "azsdk-pool-mms-ubuntu-2004-general"
-      vmImage: "MMSUbuntu20.04"
+      name: $(LINUXPOOL)
+      image: $(LINUXVMIMAGE)
+      os: linux
 
     steps:
       - checkout: self

--- a/eng/pipelines/fluent_integration.yaml
+++ b/eng/pipelines/fluent_integration.yaml
@@ -21,12 +21,15 @@ pr:
 jobs:
 - job: 'Build'
   timeoutInMinutes: 60
-  pool:
-    name: "azsdk-pool-mms-ubuntu-2004-general"
-    vmImage: "MMSUbuntu20.04"
 
   variables:
     - template: /eng/pipelines/variables/globals.yml
+    - template: /eng/pipelines/variables/image.yml
+
+  pool:
+    name: $(LINUXPOOL)
+    image: $(LINUXVMIMAGE)
+    os: linux
 
   steps:
   - checkout: self

--- a/eng/pipelines/post-publish-sdk.yaml
+++ b/eng/pipelines/post-publish-sdk.yaml
@@ -8,10 +8,6 @@ parameters:
   - false
   - true
 
-pool:
-  name: "azsdk-pool-mms-ubuntu-2004-general"
-  vmImage: "MMSUbuntu20.04"
-
 variables:
 - group: Release Secrets for GitHub
 
@@ -35,6 +31,11 @@ jobs:
       value: " DEV"
     ${{ else }}:
       value: ""
+
+  pool:
+    name: $(LINUXPOOL)
+    image: $(LINUXVMIMAGE)
+    os: linux
 
   steps:
   - checkout: self


### PR DESCRIPTION
Unify the pipeline pool/image as from image.yml, so that if e.g. we need upgrade ubuntu, only image.yml need to be changed.

Ideally we should go connect with azure-sdk-tools/eng, but maybe later.