### PR TITLE
eng, sync PR https://github.com/microsoft/typespec/pull/7149

### DIFF
--- a/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/ContainerRegistriesCreateManifestHeaders.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/ContainerRegistriesCreateManifestHeaders.java
@@ -40,6 +40,8 @@ public final class ContainerRegistriesCreateManifestHeaders {
         String contentLength = rawHeaders.getValue(HttpHeaderName.CONTENT_LENGTH);
         if (contentLength != null) {
             this.contentLength = Long.parseLong(contentLength);
+        } else {
+            this.contentLength = null;
         }
         this.dockerContentDigest = rawHeaders.getValue(DOCKER_CONTENT_DIGEST);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/ContainerRegistryBlobsCheckBlobExistsHeaders.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/ContainerRegistryBlobsCheckBlobExistsHeaders.java
@@ -40,6 +40,8 @@ public final class ContainerRegistryBlobsCheckBlobExistsHeaders {
         String contentLength = rawHeaders.getValue(HttpHeaderName.CONTENT_LENGTH);
         if (contentLength != null) {
             this.contentLength = Long.parseLong(contentLength);
+        } else {
+            this.contentLength = null;
         }
         this.dockerContentDigest = rawHeaders.getValue(DOCKER_CONTENT_DIGEST);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/ContainerRegistryBlobsCheckChunkExistsHeaders.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/ContainerRegistryBlobsCheckChunkExistsHeaders.java
@@ -34,6 +34,8 @@ public final class ContainerRegistryBlobsCheckChunkExistsHeaders {
         String contentLength = rawHeaders.getValue(HttpHeaderName.CONTENT_LENGTH);
         if (contentLength != null) {
             this.contentLength = Long.parseLong(contentLength);
+        } else {
+            this.contentLength = null;
         }
     }
 

--- a/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/ContainerRegistryBlobsGetBlobHeaders.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/ContainerRegistryBlobsGetBlobHeaders.java
@@ -40,6 +40,8 @@ public final class ContainerRegistryBlobsGetBlobHeaders {
         String contentLength = rawHeaders.getValue(HttpHeaderName.CONTENT_LENGTH);
         if (contentLength != null) {
             this.contentLength = Long.parseLong(contentLength);
+        } else {
+            this.contentLength = null;
         }
         this.dockerContentDigest = rawHeaders.getValue(DOCKER_CONTENT_DIGEST);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/ContainerRegistryBlobsGetChunkHeaders.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/containers/containerregistry/implementation/models/ContainerRegistryBlobsGetChunkHeaders.java
@@ -34,6 +34,8 @@ public final class ContainerRegistryBlobsGetChunkHeaders {
         String contentLength = rawHeaders.getValue(HttpHeaderName.CONTENT_LENGTH);
         if (contentLength != null) {
             this.contentLength = Long.parseLong(contentLength);
+        } else {
+            this.contentLength = null;
         }
     }
 

--- a/azure-dataplane-tests/src/main/java/com/azure/data/schemaregistry/implementation/models/SchemasGetByIdHeaders.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/data/schemaregistry/implementation/models/SchemasGetByIdHeaders.java
@@ -68,6 +68,8 @@ public final class SchemasGetByIdHeaders {
         String schemaVersion = rawHeaders.getValue(SCHEMA_VERSION);
         if (schemaVersion != null) {
             this.schemaVersion = Integer.parseInt(schemaVersion);
+        } else {
+            this.schemaVersion = null;
         }
         this.schemaId = rawHeaders.getValue(SCHEMA_ID);
         this.schemaGroupName = rawHeaders.getValue(SCHEMA_GROUP_NAME);
@@ -77,6 +79,8 @@ public final class SchemasGetByIdHeaders {
         String contentType = rawHeaders.getValue(HttpHeaderName.CONTENT_TYPE);
         if (contentType != null) {
             this.contentType = SchemaFormat.fromString(contentType);
+        } else {
+            this.contentType = null;
         }
     }
 

--- a/azure-dataplane-tests/src/main/java/com/azure/data/schemaregistry/implementation/models/SchemasGetSchemaVersionHeaders.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/data/schemaregistry/implementation/models/SchemasGetSchemaVersionHeaders.java
@@ -68,6 +68,8 @@ public final class SchemasGetSchemaVersionHeaders {
         String schemaVersion = rawHeaders.getValue(SCHEMA_VERSION);
         if (schemaVersion != null) {
             this.schemaVersion = Integer.parseInt(schemaVersion);
+        } else {
+            this.schemaVersion = null;
         }
         this.schemaId = rawHeaders.getValue(SCHEMA_ID);
         this.schemaGroupName = rawHeaders.getValue(SCHEMA_GROUP_NAME);
@@ -77,6 +79,8 @@ public final class SchemasGetSchemaVersionHeaders {
         String contentType = rawHeaders.getValue(HttpHeaderName.CONTENT_TYPE);
         if (contentType != null) {
             this.contentType = SchemaFormat.fromString(contentType);
+        } else {
+            this.contentType = null;
         }
     }
 

--- a/azure-dataplane-tests/src/main/java/com/azure/data/schemaregistry/implementation/models/SchemasQueryIdByContentHeaders.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/data/schemaregistry/implementation/models/SchemasQueryIdByContentHeaders.java
@@ -63,6 +63,8 @@ public final class SchemasQueryIdByContentHeaders {
         String schemaVersion = rawHeaders.getValue(SCHEMA_VERSION);
         if (schemaVersion != null) {
             this.schemaVersion = Integer.parseInt(schemaVersion);
+        } else {
+            this.schemaVersion = null;
         }
         this.schemaId = rawHeaders.getValue(SCHEMA_ID);
         this.schemaGroupName = rawHeaders.getValue(SCHEMA_GROUP_NAME);

--- a/azure-dataplane-tests/src/main/java/com/azure/data/schemaregistry/implementation/models/SchemasRegisterHeaders.java
+++ b/azure-dataplane-tests/src/main/java/com/azure/data/schemaregistry/implementation/models/SchemasRegisterHeaders.java
@@ -63,6 +63,8 @@ public final class SchemasRegisterHeaders {
         String schemaVersion = rawHeaders.getValue(SCHEMA_VERSION);
         if (schemaVersion != null) {
             this.schemaVersion = Integer.parseInt(schemaVersion);
+        } else {
+            this.schemaVersion = null;
         }
         this.schemaId = rawHeaders.getValue(SCHEMA_ID);
         this.schemaGroupName = rawHeaders.getValue(SCHEMA_GROUP_NAME);

--- a/eng/sdk/sync_sdk.py
+++ b/eng/sdk/sync_sdk.py
@@ -17,10 +17,10 @@ sdk_root: str
 
 skip_artifacts: List[str] = [
     "azure-ai-anomalydetector",  # deprecated
-    "azure-developer-devcenter",  # 2 breaks introduced into stable api-version
-    "azure-compute-batch",  # Large change in same api-verion
-    "azure-ai-vision-face",  # SDK in development
-    "azure-health-insights-radiologyinsights",  # SDK in development
+    # expect failure on below
+    # "azure-developer-devcenter",  # 2 breaks introduced into stable api-version
+    # "azure-ai-vision-face",  # SDK in development
+    # "azure-health-insights-radiologyinsights",  # SDK in development
 ]
 
 

--- a/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseBoolHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseBoolHeaders.java
@@ -30,6 +30,8 @@ public final class HeadersResponseBoolHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = Boolean.parseBoolean(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseByteHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseByteHeaders.java
@@ -32,6 +32,8 @@ public final class HeadersResponseByteHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = Base64.getDecoder().decode(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseDateHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseDateHeaders.java
@@ -31,6 +31,8 @@ public final class HeadersResponseDateHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = LocalDate.parse(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseDatetimeHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseDatetimeHeaders.java
@@ -31,6 +31,8 @@ public final class HeadersResponseDatetimeHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = OffsetDateTime.parse(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseDatetimeRfc1123Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseDatetimeRfc1123Headers.java
@@ -32,6 +32,8 @@ public final class HeadersResponseDatetimeRfc1123Headers {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = new DateTimeRfc1123(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseDoubleHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseDoubleHeaders.java
@@ -30,6 +30,8 @@ public final class HeadersResponseDoubleHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = Double.parseDouble(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseDurationHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseDurationHeaders.java
@@ -31,6 +31,8 @@ public final class HeadersResponseDurationHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = Duration.parse(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseEnumHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseEnumHeaders.java
@@ -30,6 +30,8 @@ public final class HeadersResponseEnumHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = GreyscaleColors.fromString(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseFloatHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseFloatHeaders.java
@@ -30,6 +30,8 @@ public final class HeadersResponseFloatHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = Float.parseFloat(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseIntegerHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseIntegerHeaders.java
@@ -30,6 +30,8 @@ public final class HeadersResponseIntegerHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = Integer.parseInt(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseLongHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseLongHeaders.java
@@ -30,6 +30,8 @@ public final class HeadersResponseLongHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = Long.parseLong(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LRORetrysDelete202Retry200Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LRORetrysDelete202Retry200Headers.java
@@ -36,6 +36,8 @@ public final class LRORetrysDelete202Retry200Headers {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LRORetrysDeleteAsyncRelativeRetrySucceededHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LRORetrysDeleteAsyncRelativeRetrySucceededHeaders.java
@@ -42,6 +42,8 @@ public final class LRORetrysDeleteAsyncRelativeRetrySucceededHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.azureAsyncOperation = rawHeaders.getValue(HttpHeaderName.AZURE_ASYNCOPERATION);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LRORetrysDeleteProvisioning202Accepted200SucceededHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LRORetrysDeleteProvisioning202Accepted200SucceededHeaders.java
@@ -36,6 +36,8 @@ public final class LRORetrysDeleteProvisioning202Accepted200SucceededHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LRORetrysPost202Retry200Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LRORetrysPost202Retry200Headers.java
@@ -36,6 +36,8 @@ public final class LRORetrysPost202Retry200Headers {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LRORetrysPostAsyncRelativeRetrySucceededHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LRORetrysPostAsyncRelativeRetrySucceededHeaders.java
@@ -42,6 +42,8 @@ public final class LRORetrysPostAsyncRelativeRetrySucceededHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.azureAsyncOperation = rawHeaders.getValue(HttpHeaderName.AZURE_ASYNCOPERATION);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LRORetrysPutAsyncRelativeRetrySucceededHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LRORetrysPutAsyncRelativeRetrySucceededHeaders.java
@@ -42,6 +42,8 @@ public final class LRORetrysPutAsyncRelativeRetrySucceededHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.azureAsyncOperation = rawHeaders.getValue(HttpHeaderName.AZURE_ASYNCOPERATION);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsCustomHeadersPost202Retry200Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsCustomHeadersPost202Retry200Headers.java
@@ -36,6 +36,8 @@ public final class LROsCustomHeadersPost202Retry200Headers {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsCustomHeadersPostAsyncRetrySucceededHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsCustomHeadersPostAsyncRetrySucceededHeaders.java
@@ -42,6 +42,8 @@ public final class LROsCustomHeadersPostAsyncRetrySucceededHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.azureAsyncOperation = rawHeaders.getValue(HttpHeaderName.AZURE_ASYNCOPERATION);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsCustomHeadersPutAsyncRetrySucceededHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsCustomHeadersPutAsyncRetrySucceededHeaders.java
@@ -42,6 +42,8 @@ public final class LROsCustomHeadersPutAsyncRetrySucceededHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.azureAsyncOperation = rawHeaders.getValue(HttpHeaderName.AZURE_ASYNCOPERATION);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsDelete202NoRetry204Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsDelete202NoRetry204Headers.java
@@ -36,6 +36,8 @@ public final class LROsDelete202NoRetry204Headers {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsDelete202Retry200Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsDelete202Retry200Headers.java
@@ -36,6 +36,8 @@ public final class LROsDelete202Retry200Headers {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteAsyncNoRetrySucceededHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteAsyncNoRetrySucceededHeaders.java
@@ -42,6 +42,8 @@ public final class LROsDeleteAsyncNoRetrySucceededHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.azureAsyncOperation = rawHeaders.getValue(HttpHeaderName.AZURE_ASYNCOPERATION);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteAsyncRetryFailedHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteAsyncRetryFailedHeaders.java
@@ -42,6 +42,8 @@ public final class LROsDeleteAsyncRetryFailedHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.azureAsyncOperation = rawHeaders.getValue(HttpHeaderName.AZURE_ASYNCOPERATION);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteAsyncRetrySucceededHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteAsyncRetrySucceededHeaders.java
@@ -42,6 +42,8 @@ public final class LROsDeleteAsyncRetrySucceededHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.azureAsyncOperation = rawHeaders.getValue(HttpHeaderName.AZURE_ASYNCOPERATION);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteAsyncRetrycanceledHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteAsyncRetrycanceledHeaders.java
@@ -42,6 +42,8 @@ public final class LROsDeleteAsyncRetrycanceledHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.azureAsyncOperation = rawHeaders.getValue(HttpHeaderName.AZURE_ASYNCOPERATION);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteProvisioning202Accepted200SucceededHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteProvisioning202Accepted200SucceededHeaders.java
@@ -36,6 +36,8 @@ public final class LROsDeleteProvisioning202Accepted200SucceededHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteProvisioning202DeletingFailed200Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteProvisioning202DeletingFailed200Headers.java
@@ -36,6 +36,8 @@ public final class LROsDeleteProvisioning202DeletingFailed200Headers {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteProvisioning202Deletingcanceled200Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteProvisioning202Deletingcanceled200Headers.java
@@ -36,6 +36,8 @@ public final class LROsDeleteProvisioning202Deletingcanceled200Headers {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPost202NoRetry204Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPost202NoRetry204Headers.java
@@ -36,6 +36,8 @@ public final class LROsPost202NoRetry204Headers {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPost202Retry200Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPost202Retry200Headers.java
@@ -36,6 +36,8 @@ public final class LROsPost202Retry200Headers {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPostAsyncNoRetrySucceededHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPostAsyncNoRetrySucceededHeaders.java
@@ -42,6 +42,8 @@ public final class LROsPostAsyncNoRetrySucceededHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.azureAsyncOperation = rawHeaders.getValue(HttpHeaderName.AZURE_ASYNCOPERATION);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPostAsyncRetryFailedHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPostAsyncRetryFailedHeaders.java
@@ -42,6 +42,8 @@ public final class LROsPostAsyncRetryFailedHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.azureAsyncOperation = rawHeaders.getValue(HttpHeaderName.AZURE_ASYNCOPERATION);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPostAsyncRetrySucceededHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPostAsyncRetrySucceededHeaders.java
@@ -42,6 +42,8 @@ public final class LROsPostAsyncRetrySucceededHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.azureAsyncOperation = rawHeaders.getValue(HttpHeaderName.AZURE_ASYNCOPERATION);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPostAsyncRetrycanceledHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPostAsyncRetrycanceledHeaders.java
@@ -42,6 +42,8 @@ public final class LROsPostAsyncRetrycanceledHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.azureAsyncOperation = rawHeaders.getValue(HttpHeaderName.AZURE_ASYNCOPERATION);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPutAsyncRetryFailedHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPutAsyncRetryFailedHeaders.java
@@ -42,6 +42,8 @@ public final class LROsPutAsyncRetryFailedHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.azureAsyncOperation = rawHeaders.getValue(HttpHeaderName.AZURE_ASYNCOPERATION);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPutAsyncRetrySucceededHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPutAsyncRetrySucceededHeaders.java
@@ -42,6 +42,8 @@ public final class LROsPutAsyncRetrySucceededHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.azureAsyncOperation = rawHeaders.getValue(HttpHeaderName.AZURE_ASYNCOPERATION);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsDelete202NonRetry400Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsDelete202NonRetry400Headers.java
@@ -36,6 +36,8 @@ public final class LrosaDsDelete202NonRetry400Headers {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsDelete202RetryInvalidHeaderHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsDelete202RetryInvalidHeaderHeaders.java
@@ -36,6 +36,8 @@ public final class LrosaDsDelete202RetryInvalidHeaderHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsDeleteAsyncRelativeRetry400Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsDeleteAsyncRelativeRetry400Headers.java
@@ -42,6 +42,8 @@ public final class LrosaDsDeleteAsyncRelativeRetry400Headers {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.azureAsyncOperation = rawHeaders.getValue(HttpHeaderName.AZURE_ASYNCOPERATION);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsDeleteAsyncRelativeRetryInvalidHeaderHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsDeleteAsyncRelativeRetryInvalidHeaderHeaders.java
@@ -42,6 +42,8 @@ public final class LrosaDsDeleteAsyncRelativeRetryInvalidHeaderHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.azureAsyncOperation = rawHeaders.getValue(HttpHeaderName.AZURE_ASYNCOPERATION);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders.java
@@ -42,6 +42,8 @@ public final class LrosaDsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.azureAsyncOperation = rawHeaders.getValue(HttpHeaderName.AZURE_ASYNCOPERATION);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsDeleteAsyncRelativeRetryNoStatusHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsDeleteAsyncRelativeRetryNoStatusHeaders.java
@@ -42,6 +42,8 @@ public final class LrosaDsDeleteAsyncRelativeRetryNoStatusHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.azureAsyncOperation = rawHeaders.getValue(HttpHeaderName.AZURE_ASYNCOPERATION);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsDeleteNonRetry400Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsDeleteNonRetry400Headers.java
@@ -36,6 +36,8 @@ public final class LrosaDsDeleteNonRetry400Headers {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPost202NoLocationHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPost202NoLocationHeaders.java
@@ -36,6 +36,8 @@ public final class LrosaDsPost202NoLocationHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPost202NonRetry400Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPost202NonRetry400Headers.java
@@ -36,6 +36,8 @@ public final class LrosaDsPost202NonRetry400Headers {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPost202RetryInvalidHeaderHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPost202RetryInvalidHeaderHeaders.java
@@ -36,6 +36,8 @@ public final class LrosaDsPost202RetryInvalidHeaderHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPostAsyncRelativeRetry400Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPostAsyncRelativeRetry400Headers.java
@@ -42,6 +42,8 @@ public final class LrosaDsPostAsyncRelativeRetry400Headers {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.azureAsyncOperation = rawHeaders.getValue(HttpHeaderName.AZURE_ASYNCOPERATION);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPostAsyncRelativeRetryInvalidHeaderHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPostAsyncRelativeRetryInvalidHeaderHeaders.java
@@ -42,6 +42,8 @@ public final class LrosaDsPostAsyncRelativeRetryInvalidHeaderHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.azureAsyncOperation = rawHeaders.getValue(HttpHeaderName.AZURE_ASYNCOPERATION);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPostAsyncRelativeRetryInvalidJsonPollingHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPostAsyncRelativeRetryInvalidJsonPollingHeaders.java
@@ -42,6 +42,8 @@ public final class LrosaDsPostAsyncRelativeRetryInvalidJsonPollingHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.azureAsyncOperation = rawHeaders.getValue(HttpHeaderName.AZURE_ASYNCOPERATION);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPostAsyncRelativeRetryNoPayloadHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPostAsyncRelativeRetryNoPayloadHeaders.java
@@ -42,6 +42,8 @@ public final class LrosaDsPostAsyncRelativeRetryNoPayloadHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.azureAsyncOperation = rawHeaders.getValue(HttpHeaderName.AZURE_ASYNCOPERATION);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPostNonRetry400Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPostNonRetry400Headers.java
@@ -36,6 +36,8 @@ public final class LrosaDsPostNonRetry400Headers {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetry400Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetry400Headers.java
@@ -42,6 +42,8 @@ public final class LrosaDsPutAsyncRelativeRetry400Headers {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.azureAsyncOperation = rawHeaders.getValue(HttpHeaderName.AZURE_ASYNCOPERATION);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetryInvalidHeaderHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetryInvalidHeaderHeaders.java
@@ -42,6 +42,8 @@ public final class LrosaDsPutAsyncRelativeRetryInvalidHeaderHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.azureAsyncOperation = rawHeaders.getValue(HttpHeaderName.AZURE_ASYNCOPERATION);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetryInvalidJsonPollingHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetryInvalidJsonPollingHeaders.java
@@ -42,6 +42,8 @@ public final class LrosaDsPutAsyncRelativeRetryInvalidJsonPollingHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.azureAsyncOperation = rawHeaders.getValue(HttpHeaderName.AZURE_ASYNCOPERATION);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetryNoStatusHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetryNoStatusHeaders.java
@@ -42,6 +42,8 @@ public final class LrosaDsPutAsyncRelativeRetryNoStatusHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.azureAsyncOperation = rawHeaders.getValue(HttpHeaderName.AZURE_ASYNCOPERATION);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetryNoStatusPayloadHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetryNoStatusPayloadHeaders.java
@@ -42,6 +42,8 @@ public final class LrosaDsPutAsyncRelativeRetryNoStatusPayloadHeaders {
         String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
         if (retryAfter != null) {
             this.retryAfter = Integer.parseInt(retryAfter);
+        } else {
+            this.retryAfter = null;
         }
         this.azureAsyncOperation = rawHeaders.getValue(HttpHeaderName.AZURE_ASYNCOPERATION);
         this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);

--- a/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseBoolHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseBoolHeaders.java
@@ -30,6 +30,8 @@ public final class HeadersResponseBoolHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = Boolean.parseBoolean(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseByteHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseByteHeaders.java
@@ -32,6 +32,8 @@ public final class HeadersResponseByteHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = Base64.getDecoder().decode(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseDateHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseDateHeaders.java
@@ -31,6 +31,8 @@ public final class HeadersResponseDateHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = LocalDate.parse(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseDatetimeHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseDatetimeHeaders.java
@@ -31,6 +31,8 @@ public final class HeadersResponseDatetimeHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = OffsetDateTime.parse(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseDatetimeRfc1123Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseDatetimeRfc1123Headers.java
@@ -32,6 +32,8 @@ public final class HeadersResponseDatetimeRfc1123Headers {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = new DateTimeRfc1123(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseDoubleHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseDoubleHeaders.java
@@ -30,6 +30,8 @@ public final class HeadersResponseDoubleHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = Double.parseDouble(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseDurationHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseDurationHeaders.java
@@ -31,6 +31,8 @@ public final class HeadersResponseDurationHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = Duration.parse(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseEnumHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseEnumHeaders.java
@@ -30,6 +30,8 @@ public final class HeadersResponseEnumHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = GreyscaleColors.fromString(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseFloatHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseFloatHeaders.java
@@ -30,6 +30,8 @@ public final class HeadersResponseFloatHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = Float.parseFloat(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseIntegerHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseIntegerHeaders.java
@@ -30,6 +30,8 @@ public final class HeadersResponseIntegerHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = Integer.parseInt(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseLongHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseLongHeaders.java
@@ -30,6 +30,8 @@ public final class HeadersResponseLongHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = Long.parseLong(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/notypedheadersmethods/models/HeadersResponseBoolHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/notypedheadersmethods/models/HeadersResponseBoolHeaders.java
@@ -30,6 +30,8 @@ public final class HeadersResponseBoolHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = Boolean.parseBoolean(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/notypedheadersmethods/models/HeadersResponseByteHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/notypedheadersmethods/models/HeadersResponseByteHeaders.java
@@ -32,6 +32,8 @@ public final class HeadersResponseByteHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = Base64.getDecoder().decode(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/notypedheadersmethods/models/HeadersResponseDateHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/notypedheadersmethods/models/HeadersResponseDateHeaders.java
@@ -31,6 +31,8 @@ public final class HeadersResponseDateHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = LocalDate.parse(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/notypedheadersmethods/models/HeadersResponseDatetimeHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/notypedheadersmethods/models/HeadersResponseDatetimeHeaders.java
@@ -31,6 +31,8 @@ public final class HeadersResponseDatetimeHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = OffsetDateTime.parse(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/notypedheadersmethods/models/HeadersResponseDatetimeRfc1123Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/notypedheadersmethods/models/HeadersResponseDatetimeRfc1123Headers.java
@@ -32,6 +32,8 @@ public final class HeadersResponseDatetimeRfc1123Headers {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = new DateTimeRfc1123(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/notypedheadersmethods/models/HeadersResponseDoubleHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/notypedheadersmethods/models/HeadersResponseDoubleHeaders.java
@@ -30,6 +30,8 @@ public final class HeadersResponseDoubleHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = Double.parseDouble(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/notypedheadersmethods/models/HeadersResponseDurationHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/notypedheadersmethods/models/HeadersResponseDurationHeaders.java
@@ -31,6 +31,8 @@ public final class HeadersResponseDurationHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = Duration.parse(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/notypedheadersmethods/models/HeadersResponseEnumHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/notypedheadersmethods/models/HeadersResponseEnumHeaders.java
@@ -30,6 +30,8 @@ public final class HeadersResponseEnumHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = GreyscaleColors.fromString(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/notypedheadersmethods/models/HeadersResponseFloatHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/notypedheadersmethods/models/HeadersResponseFloatHeaders.java
@@ -30,6 +30,8 @@ public final class HeadersResponseFloatHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = Float.parseFloat(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/notypedheadersmethods/models/HeadersResponseIntegerHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/notypedheadersmethods/models/HeadersResponseIntegerHeaders.java
@@ -30,6 +30,8 @@ public final class HeadersResponseIntegerHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = Integer.parseInt(value);
+        } else {
+            this.value = null;
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/notypedheadersmethods/models/HeadersResponseLongHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/notypedheadersmethods/models/HeadersResponseLongHeaders.java
@@ -30,6 +30,8 @@ public final class HeadersResponseLongHeaders {
         String value = rawHeaders.getValue(VALUE);
         if (value != null) {
             this.value = Long.parseLong(value);
+        } else {
+            this.value = null;
         }
     }
 


### PR DESCRIPTION
for PR https://github.com/microsoft/typespec/pull/7149

diff on vanilla due to PR https://github.com/microsoft/typespec/pull/7139
I think it does not do harm, as the value of the class variable would be `null` anyway, if not initialized.