### PR TITLE
Prepare patch release v4.1.60

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@autorest/java",
-  "version": "4.1.59",
+  "version": "4.1.60",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@autorest/java",
-      "version": "4.1.59",
+      "version": "4.1.60",
       "license": "MIT",
       "devDependencies": {
         "@microsoft.azure/autorest.testserver": "3.3.50",


### PR DESCRIPTION
## Patch Release v4.1.60

This pull request prepares a patch release for autorest.java version 4.1.60.

### Changes since v4.1.59:
- Update Node.js dependencies and prepare TypeSpec extension patch release 0.36.2
- Add backward compatibility options (`float32-as-double` and `uuid-as-string`)
- Update documentation for TypeSpec options
- Security update: Bump vite from 7.1.5 to 7.1.11
- Update JAR dependencies

### Files Changed:
- `package.json` - version bump from 4.1.59 to 4.1.60
- `package-lock.json` - corresponding lock file update

### Release Notes:
**Bug Fixes and Improvements:**
- Updated Node.js dependencies to latest versions for improved security and performance
- Added support for backward compatibility options in TypeSpec extension
- Enhanced documentation for TypeSpec options
- Updated various dependencies including security updates

This is a patch release that includes dependency updates and bug fixes since the last release.