### PR TITLE
eng, use nodejs 24 as default (for typespec)

### DIFF
--- a/eng/pipelines/jobs/build-autorest-mgmt.yml
+++ b/eng/pipelines/jobs/build-autorest-mgmt.yml
@@ -11,6 +11,8 @@ jobs:
   variables:
     - template: /eng/pipelines/variables/globals.yml
     - template: /eng/pipelines/variables/image.yml
+    - name: NodeVersion
+      value: '20.x'
 
   pool:
     name: $(LINUXPOOL)

--- a/eng/pipelines/jobs/build-autorest.yml
+++ b/eng/pipelines/jobs/build-autorest.yml
@@ -11,6 +11,8 @@ jobs:
   variables:
     - template: /eng/pipelines/variables/globals.yml
     - template: /eng/pipelines/variables/image.yml
+    - name: NodeVersion
+      value: '20.x'
 
   pool:
     name: $(LINUXPOOL)

--- a/eng/pipelines/variables/globals.yml
+++ b/eng/pipelines/variables/globals.yml
@@ -1,6 +1,6 @@
 variables:
   JavaVersion: '1.11'
-  NodeVersion: '20.x'
+  NodeVersion: '24.x'
   AutorestVersion: '3.7.2'
 
   # Sets the Maven log level to either the LogLevel passed in the manual pipeline run or the default 'warn'


### PR DESCRIPTION
node 20 is EOL

24 got this on autorest
```
(node:10164) [DEP0060] DeprecationWarning: The `util._extend` API is deprecated. Please use Object.assign() instead.
```