### PR TITLE
docs: fix Node.js casing and clarify Maven version

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,9 +4,9 @@ This is the next gen (v4) of AutoRest Java generator. It's built on AutoRest v3,
 # Prerequisites
 You need to have the following installed on your machine:
 
-- Node.JS v12+
+- Node.js v12+
 - Java 11+
-- Maven 3
+- Maven 3.x
 
 You need to have [autorest](https://www.npmjs.com/package/autorest) installed through NPM:
 


### PR DESCRIPTION
Minor readme fixes: correct Node.JS → Node.js casing and clarify Maven version.   