### PR TITLE
eng, release npm first

### DIFF
--- a/eng/pipelines/publish-typespec-java.yaml
+++ b/eng/pipelines/publish-typespec-java.yaml
@@ -55,40 +55,10 @@ extends:
                 $PACKAGE_VERSION = node -p -e "require('./typespec-extension/package.json').version"
                 Write-Host("##vso[task.setvariable variable=PackageVersion]$PACKAGE_VERSION")
 
-          - task: PowerShell@2
-            displayName: 'Create GitHub Releases'
-            inputs:
-              filePath: eng/scripts/Create-Release.ps1
-              arguments: >
-                -releaseSha '$(Build.SourceVersion)'
-                -tagName '@azure-tools/typespec-java_$(PackageVersion)'
-                -title '@azure-tools/typespec-java_$(PackageVersion)'
-                -releaseNotes '- Bug fix'
-              pwsh: true
-            timeoutInMinutes: 5
-            env:
-              GH_TOKEN: $(azuresdk-github-pat)
-
           - pwsh: |
               New-Item -ItemType Directory -Path "$(buildArtifactsPath)/packages" -Force
               Copy-Item -Path "./typespec-extension/*.tgz" -Destination "$(buildArtifactsPath)/packages"
             displayName: 'Copy packages to artifacts staging directory'
-
-          # create npmrc file with auth
-          - template: /eng/pipelines/templates/steps/create-authenticated-npmrc.yml
-            parameters:
-              npmrcPath: $(buildArtifactsPath)/packages/.npmrc
-              registryUrl: https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/
-
-          # publish to devops feed
-          - pwsh: |
-              $packageFiles = Get-ChildItem -Path . -Filter '*.tgz'
-              foreach ($file in $packageFiles.Name) {
-                Write-Host "npm publish $file --verbose --access public"
-                npm publish $file --verbose --access public
-              }
-            displayName: Publish to DevOps feed
-            workingDirectory: $(buildArtifactsPath)/packages
 
           # publish to npmjs.org
           - task: EsrpRelease@11
@@ -107,5 +77,35 @@ extends:
               Approvers: ${{ coalesce(variables['Build.RequestedForEmail'], 'azuresdk@microsoft.com') }}
               ServiceEndpointUrl: https://api.esrp.microsoft.com
               MainPublisher: ESRPRELPACMANTEST
+
+          - task: PowerShell@2
+            displayName: 'Create GitHub Releases'
+            inputs:
+              filePath: eng/scripts/Create-Release.ps1
+              arguments: >
+                -releaseSha '$(Build.SourceVersion)'
+                -tagName '@azure-tools/typespec-java_$(PackageVersion)'
+                -title '@azure-tools/typespec-java_$(PackageVersion)'
+                -releaseNotes '- Bug fix'
+              pwsh: true
+            timeoutInMinutes: 5
+            env:
+              GH_TOKEN: $(azuresdk-github-pat)
+
+          # create npmrc file with auth
+          - template: /eng/pipelines/templates/steps/create-authenticated-npmrc.yml
+            parameters:
+              npmrcPath: $(buildArtifactsPath)/packages/.npmrc
+              registryUrl: https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/
+
+          # publish to devops feed
+          - pwsh: |
+              $packageFiles = Get-ChildItem -Path . -Filter '*.tgz'
+              foreach ($file in $packageFiles.Name) {
+                Write-Host "npm publish $file --verbose --access public"
+                npm publish $file --verbose --access public
+              }
+            displayName: Publish to DevOps feed
+            workingDirectory: $(buildArtifactsPath)/packages
 
           - template: /eng/pipelines/steps/cleanup-maven-local-cache.yml

--- a/eng/sdk/patches/0001-revert-azure-ai-speech-transcription.patch
+++ b/eng/sdk/patches/0001-revert-azure-ai-speech-transcription.patch
@@ -1,0 +1,113 @@
+From bc30c29232e16f5b29af07159d6f9bac6d3bf36c Mon Sep 17 00:00:00 2001
+From: Weidong Xu <weidxu@microsoft.com>
+Date: Thu, 21 May 2026 11:20:39 +0800
+Subject: [PATCH] revert azure-ai-speech-transcription
+
+---
+ .../generated/TranscribeAudioFileTests.java            | 10 +++++-----
+ .../generated/TranscribeAudioFromURLTests.java         | 10 +++++-----
+ .../generated/TranscribeWithEnhancedModeTests.java     | 10 +++++-----
+ 3 files changed, 15 insertions(+), 15 deletions(-)
+
+diff --git a/sdk/transcription/azure-ai-speech-transcription/src/test/java/com/azure/ai/speech/transcription/generated/TranscribeAudioFileTests.java b/sdk/transcription/azure-ai-speech-transcription/src/test/java/com/azure/ai/speech/transcription/generated/TranscribeAudioFileTests.java
+index a6285e1cfe2..ac8c847552a 100644
+--- a/sdk/transcription/azure-ai-speech-transcription/src/test/java/com/azure/ai/speech/transcription/generated/TranscribeAudioFileTests.java
++++ b/sdk/transcription/azure-ai-speech-transcription/src/test/java/com/azure/ai/speech/transcription/generated/TranscribeAudioFileTests.java
+@@ -24,7 +24,7 @@ public final class TranscribeAudioFileTests extends TranscriptionClientTestBase
+         // response assertion
+         Assertions.assertNotNull(response);
+         // verify property "duration"
+-        Assertions.assertEquals(2000, response.getDuration());
++        Assertions.assertEquals(2000, response.getDuration().toMillis());
+         // verify property "combinedPhrases"
+         List<ChannelCombinedPhrases> responseCombinedPhrases = response.getCombinedPhrases();
+         ChannelCombinedPhrases responseCombinedPhrasesFirstItem = responseCombinedPhrases.iterator().next();
+@@ -34,15 +34,15 @@ public final class TranscribeAudioFileTests extends TranscriptionClientTestBase
+         List<TranscribedPhrase> responsePhrases = response.getPhrases();
+         TranscribedPhrase responsePhrasesFirstItem = responsePhrases.iterator().next();
+         Assertions.assertNotNull(responsePhrasesFirstItem);
+-        Assertions.assertEquals(40, responsePhrasesFirstItem.getOffset());
+-        Assertions.assertEquals(320, responsePhrasesFirstItem.getDuration());
++        Assertions.assertEquals(40, responsePhrasesFirstItem.getOffset().toMillis());
++        Assertions.assertEquals(320, responsePhrasesFirstItem.getDuration().toMillis());
+         Assertions.assertEquals("Weather", responsePhrasesFirstItem.getText());
+         List<TranscribedWord> responsePhrasesFirstItemWords = responsePhrasesFirstItem.getWords();
+         TranscribedWord responsePhrasesFirstItemWordsFirstItem = responsePhrasesFirstItemWords.iterator().next();
+         Assertions.assertNotNull(responsePhrasesFirstItemWordsFirstItem);
+         Assertions.assertEquals("weather", responsePhrasesFirstItemWordsFirstItem.getText());
+-        Assertions.assertEquals(40, responsePhrasesFirstItemWordsFirstItem.getOffset());
+-        Assertions.assertEquals(320, responsePhrasesFirstItemWordsFirstItem.getDuration());
++        Assertions.assertEquals(40, responsePhrasesFirstItemWordsFirstItem.getOffset().toMillis());
++        Assertions.assertEquals(320, responsePhrasesFirstItemWordsFirstItem.getDuration().toMillis());
+         Assertions.assertEquals("en-US", responsePhrasesFirstItem.getLocale());
+         Assertions.assertEquals(0.78983736, responsePhrasesFirstItem.getConfidence());
+     }
+diff --git a/sdk/transcription/azure-ai-speech-transcription/src/test/java/com/azure/ai/speech/transcription/generated/TranscribeAudioFromURLTests.java b/sdk/transcription/azure-ai-speech-transcription/src/test/java/com/azure/ai/speech/transcription/generated/TranscribeAudioFromURLTests.java
+index c904299bcab..e431b89cc08 100644
+--- a/sdk/transcription/azure-ai-speech-transcription/src/test/java/com/azure/ai/speech/transcription/generated/TranscribeAudioFromURLTests.java
++++ b/sdk/transcription/azure-ai-speech-transcription/src/test/java/com/azure/ai/speech/transcription/generated/TranscribeAudioFromURLTests.java
+@@ -24,7 +24,7 @@ public final class TranscribeAudioFromURLTests extends TranscriptionClientTestBa
+         // response assertion
+         Assertions.assertNotNull(response);
+         // verify property "duration"
+-        Assertions.assertEquals(2000, response.getDuration());
++        Assertions.assertEquals(2000, response.getDuration().toMillis());
+         // verify property "combinedPhrases"
+         List<ChannelCombinedPhrases> responseCombinedPhrases = response.getCombinedPhrases();
+         ChannelCombinedPhrases responseCombinedPhrasesFirstItem = responseCombinedPhrases.iterator().next();
+@@ -34,15 +34,15 @@ public final class TranscribeAudioFromURLTests extends TranscriptionClientTestBa
+         List<TranscribedPhrase> responsePhrases = response.getPhrases();
+         TranscribedPhrase responsePhrasesFirstItem = responsePhrases.iterator().next();
+         Assertions.assertNotNull(responsePhrasesFirstItem);
+-        Assertions.assertEquals(40, responsePhrasesFirstItem.getOffset());
+-        Assertions.assertEquals(320, responsePhrasesFirstItem.getDuration());
++        Assertions.assertEquals(40, responsePhrasesFirstItem.getOffset().toMillis());
++        Assertions.assertEquals(320, responsePhrasesFirstItem.getDuration().toMillis());
+         Assertions.assertEquals("Weather", responsePhrasesFirstItem.getText());
+         List<TranscribedWord> responsePhrasesFirstItemWords = responsePhrasesFirstItem.getWords();
+         TranscribedWord responsePhrasesFirstItemWordsFirstItem = responsePhrasesFirstItemWords.iterator().next();
+         Assertions.assertNotNull(responsePhrasesFirstItemWordsFirstItem);
+         Assertions.assertEquals("weather", responsePhrasesFirstItemWordsFirstItem.getText());
+-        Assertions.assertEquals(40, responsePhrasesFirstItemWordsFirstItem.getOffset());
+-        Assertions.assertEquals(320, responsePhrasesFirstItemWordsFirstItem.getDuration());
++        Assertions.assertEquals(40, responsePhrasesFirstItemWordsFirstItem.getOffset().toMillis());
++        Assertions.assertEquals(320, responsePhrasesFirstItemWordsFirstItem.getDuration().toMillis());
+         Assertions.assertEquals("en-US", responsePhrasesFirstItem.getLocale());
+         Assertions.assertEquals(0.78983736, responsePhrasesFirstItem.getConfidence());
+     }
+diff --git a/sdk/transcription/azure-ai-speech-transcription/src/test/java/com/azure/ai/speech/transcription/generated/TranscribeWithEnhancedModeTests.java b/sdk/transcription/azure-ai-speech-transcription/src/test/java/com/azure/ai/speech/transcription/generated/TranscribeWithEnhancedModeTests.java
+index 926e39c0905..b92423bd969 100644
+--- a/sdk/transcription/azure-ai-speech-transcription/src/test/java/com/azure/ai/speech/transcription/generated/TranscribeWithEnhancedModeTests.java
++++ b/sdk/transcription/azure-ai-speech-transcription/src/test/java/com/azure/ai/speech/transcription/generated/TranscribeWithEnhancedModeTests.java
+@@ -24,7 +24,7 @@ public final class TranscribeWithEnhancedModeTests extends TranscriptionClientTe
+         // response assertion
+         Assertions.assertNotNull(response);
+         // verify property "duration"
+-        Assertions.assertEquals(2000, response.getDuration());
++        Assertions.assertEquals(2000, response.getDuration().toMillis());
+         // verify property "combinedPhrases"
+         List<ChannelCombinedPhrases> responseCombinedPhrases = response.getCombinedPhrases();
+         ChannelCombinedPhrases responseCombinedPhrasesFirstItem = responseCombinedPhrases.iterator().next();
+@@ -34,15 +34,15 @@ public final class TranscribeWithEnhancedModeTests extends TranscriptionClientTe
+         List<TranscribedPhrase> responsePhrases = response.getPhrases();
+         TranscribedPhrase responsePhrasesFirstItem = responsePhrases.iterator().next();
+         Assertions.assertNotNull(responsePhrasesFirstItem);
+-        Assertions.assertEquals(40, responsePhrasesFirstItem.getOffset());
+-        Assertions.assertEquals(320, responsePhrasesFirstItem.getDuration());
++        Assertions.assertEquals(40, responsePhrasesFirstItem.getOffset().toMillis());
++        Assertions.assertEquals(320, responsePhrasesFirstItem.getDuration().toMillis());
+         Assertions.assertEquals("天气", responsePhrasesFirstItem.getText());
+         List<TranscribedWord> responsePhrasesFirstItemWords = responsePhrasesFirstItem.getWords();
+         TranscribedWord responsePhrasesFirstItemWordsFirstItem = responsePhrasesFirstItemWords.iterator().next();
+         Assertions.assertNotNull(responsePhrasesFirstItemWordsFirstItem);
+         Assertions.assertEquals("天", responsePhrasesFirstItemWordsFirstItem.getText());
+-        Assertions.assertEquals(0, responsePhrasesFirstItemWordsFirstItem.getOffset());
+-        Assertions.assertEquals(0, responsePhrasesFirstItemWordsFirstItem.getDuration());
++        Assertions.assertEquals(0, responsePhrasesFirstItemWordsFirstItem.getOffset().toMillis());
++        Assertions.assertEquals(0, responsePhrasesFirstItemWordsFirstItem.getDuration().toMillis());
+         Assertions.assertEquals("zh-CN", responsePhrasesFirstItem.getLocale());
+         Assertions.assertEquals(0.78983736, responsePhrasesFirstItem.getConfidence());
+     }
+-- 
+2.53.0.windows.2
+


### PR DESCRIPTION
Release npm first, before create GitHub release and devop feed.

So that if npm release fails, we can just run it again.