### PR TITLE
Switch PAT to GitHubApps

### DIFF
--- a/eng/pipelines/publish-autorest-java.yaml
+++ b/eng/pipelines/publish-autorest-java.yaml
@@ -75,6 +75,8 @@ extends:
                     $PACKAGE_VERSION = node -p -e "require('./package.json').version"
                     Write-Host("##vso[task.setvariable variable=PackageVersion]$PACKAGE_VERSION")
 
+              - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+
               - task: PowerShell@2
                 displayName: 'Create GitHub Releases'
                 inputs:
@@ -87,7 +89,7 @@ extends:
                   pwsh: true
                 timeoutInMinutes: 5
                 env:
-                  GH_TOKEN: $(azuresdk-github-pat)
+                  GH_TOKEN: $(GH_TOKEN)
 
               - script: |
                   npm config set //registry.npmjs.org/:_authToken=$(azure-sdk-npm-token)


### PR DESCRIPTION
This pull request updates the `eng/pipelines/publish-autorest-java.yaml` pipeline to improve security and reliability when publishing releases. The main changes involve updating GitHub authentication and adding a login step.

Authentication and security improvements:

* Added a step to log in to GitHub using the shared template `login-to-github.yml` to ensure authenticated operations before release steps.
* Changed the environment variable used for the GitHub token from `azuresdk-github-pat` to `GH_TOKEN` for consistency and improved secret management.